### PR TITLE
Fix user mentions rendering in Confluence content

### DIFF
--- a/src/mcp_atlassian/confluence.py
+++ b/src/mcp_atlassian/confluence.py
@@ -34,7 +34,7 @@ class ConfluenceFetcher:
             password=self.config.api_token,  # API token is used as password
             cloud=True,
         )
-        self.preprocessor = TextPreprocessor(self.config.url)
+        self.preprocessor = TextPreprocessor(self.config.url, self.confluence)
 
     def _process_html_content(self, html_content: str, space_key: str) -> tuple[str, str]:
         return self.preprocessor.process_html_content(html_content, space_key)


### PR DESCRIPTION
## Description
Fixed user mentions not being properly rendered in Confluence content by implementing proper handling of `<ac:link>` and `<ri:user>` tags. User display names are now fetched and cached from the Confluence API.

## Changes
- Added user info fetching in TextPreprocessor
- Implemented caching for user display names
- Fixed HTML to Markdown conversion for user mentions
