### PR TITLE
Fix metadata key mismatch in Confluence comments endpoint

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -244,8 +244,8 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             comments = confluence_fetcher.get_page_comments(arguments["page_id"])
             formatted_comments = [
                 {
-                    "author": comment.metadata["author"],
-                    "created": comment.metadata["created"],
+                    "author": comment.metadata["author_name"],
+                    "created": comment.metadata["last_modified"],
                     "content": comment.page_content,
                 }
                 for comment in comments


### PR DESCRIPTION
## Description
Fixes a runtime error in the `confluence_get_comments` tool where accessing comment metadata was failing due to mismatched keys.

### Changes
- Updated metadata key access in `server.py` to use:
  - `author_name` instead of `author`
  - `last_modified` instead of `created`
