### PR TITLE
Fix Confluence spaces listing in resource fetcher

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -26,18 +26,20 @@ async def list_resources() -> list[Resource]:
     resources = []
 
     # Add Confluence spaces
-    spaces = confluence_fetcher.get_spaces()
-    resources.extend(
-        [
-            Resource(
-                uri=AnyUrl(f"confluence://{space['key']}"),
-                name=f"Confluence Space: {space['name']}",
-                mimeType="text/plain",
-                description=space.get("description", {}).get("plain", {}).get("value", ""),
-            )
-            for space in spaces
-        ]
-    )
+    spaces_response = confluence_fetcher.get_spaces()
+    if isinstance(spaces_response, dict) and "results" in spaces_response:
+        spaces = spaces_response["results"]
+        resources.extend(
+            [
+                Resource(
+                    uri=AnyUrl(f"confluence://{space['key']}"),
+                    name=f"Confluence Space: {space['name']}",
+                    mimeType="text/plain",
+                    description=space.get("description", {}).get("plain", {}).get("value", ""),
+                )
+                for space in spaces
+            ]
+        )
 
     # Add Jira projects
     try:


### PR DESCRIPTION
## Description
Fixed a TypeError that occurred when listing Confluence spaces in the resource fetcher. The error was caused by incorrectly accessing the Confluence API response structure, which nests spaces under a 'results' key.

## Changes
- Added proper handling of nested 'results' structure from Confluence API
- Added type checking for API response
- Updated space access pattern to match API response format

## Related Issues
Fixes #7 