### PR TITLE
feat: Optimize Confluence search performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.7] - 2024-03-20
+
+### Changed
+- Optimized Confluence search performance by removing individual page fetching
+- Updated search results format to use pre-generated excerpts
+
 ## [0.1.6] - 2024-03-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Model Context Protocol (MCP) server for Atlassian Cloud products (Confluence and
   - Inputs:
     - `query` (string): CQL query string
     - `limit` (number, optional): Results limit (1-50, default: 10)
+  - Returns:
+    - Array of search results with page_id, title, space, url, last_modified, type, and excerpt
 
 - **confluence_get_page**
   - Get content of a specific Confluence page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-atlassian"
-version = "0.1.6"
+version = "0.1.7"
 description = "The Model Context Protocol (MCP) Atlassian integration is an open-source implementation that bridges Atlassian products (Jira and Confluence) with AI language models following Anthropic's MCP specification. This project enables secure, contextual AI interactions with Atlassian tools while maintaining data privacy and security. Key features include:"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -2,10 +2,12 @@ import asyncio
 
 from . import server
 
+__version__ = "0.1.7"
+
 
 def main():
     """Main entry point for the package."""
     asyncio.run(server.main())
 
 
-__all__ = ["main", "server"]
+__all__ = ["main", "server", "__version__"]

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -222,9 +222,11 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 {
                     "page_id": doc.metadata["page_id"],
                     "title": doc.metadata["title"],
-                    "space": doc.metadata.get("space_key"),
-                    "excerpt": doc.page_content[:500] + "...",
-                    "url": doc.metadata.get("url", ""),
+                    "space": doc.metadata["space"],
+                    "url": doc.metadata["url"],
+                    "last_modified": doc.metadata["last_modified"],
+                    "type": doc.metadata["type"],
+                    "excerpt": doc.page_content,
                 }
                 for doc in documents
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "mcp-atlassian"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
## Description
This PR speed the Confluence search up by removing individual page fetching

### Changes
- Remove additional API calls to fetch individual pages in search results
- Use pre-generated excerpts from Confluence search API
- Update search response format in documentation
- Update version to 0.1.7
