### PR TITLE
Add JIRA create and update capability

### DIFF
--- a/src/mcp_atlassian/jira.py
+++ b/src/mcp_atlassian/jira.py
@@ -48,6 +48,52 @@ class JiraFetcher:
 
         return self.preprocessor.clean_jira_text(text)
 
+    def create_issue(self, project_key: str, fields: dict) -> Document:
+        """
+        Create a new Jira issue.
+
+        Args:
+            fields: Dictionary of fields to create the issue. It must adhere with Jira API documentation.
+
+        Returns:
+            Document containing created issue content and metadata
+        """
+        try:
+            fields["project"] = {"key": project_key}
+            issue = self.jira.create_issue(fields)
+            return self.get_issue(issue["key"])
+        except Exception as e:
+            logger.error(f"Error creating issue: {e}")
+            raise
+
+    def update_issue(self, issue_key: str, fields: dict) -> Document:
+        """
+        Update an existing Jira issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+            fields: Dictionary of fields to update. Examples:
+                   {
+                       'summary': 'New title',
+                       'description': 'New description',
+                       'assignee': {'name': 'username'},
+                       'priority': {'name': 'High'}
+                   }
+
+        Returns:
+            Document containing updated issue content
+        """
+        try:
+            # Update the issue
+            self.jira.update_issue_field(issue_key, fields)
+
+            # Fetch and return the updated issue
+            return self.get_issue(issue_key)
+
+        except Exception as e:
+            logger.error(f"Error updating issue {issue_key}: {str(e)}")
+            raise
+
     def get_issue(self, issue_key: str, expand: Optional[str] = None) -> Document:
         """
         Get a single issue with all its details.

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -208,6 +208,39 @@ async def list_tools() -> list[Tool]:
                 "required": ["project_key"],
             },
         ),
+        Tool(
+            name="jira_create_issue",
+            description="Create a new Jira issue",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "project_key": {
+                        "type": "string",
+                        "description": "The JIRA project key. Never assume what it might be, always ask the user.",
+                    },
+                    "fields": {
+                        "type": "string",
+                        "description": "A valid JSON object of fields to create the issue. It must adhere with Jira API documentation.",
+                    },
+                },
+                "required": ["project_key", "fields"],
+            },
+        ),
+        Tool(
+            name="jira_update_issue",
+            description="Update an existing Jira issue",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "issue_key": {"type": "string", "description": "Jira issue key"},
+                    "fields": {
+                        "type": "string",
+                        "description": "A valid JSON object of fields to update. It must adhere with Jira API documentation. If there are no specific instructions, assume that most likely it is to update the summary or description.",
+                    },
+                },
+                "required": ["issue_key", "fields"],
+            },
+        )
     ]
 
 
@@ -297,6 +330,16 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 for doc in documents
             ]
             return [TextContent(type="text", text=json.dumps(project_issues, indent=2))]
+
+        elif name == "jira_create_issue":
+            doc = jira_fetcher.create_issue(arguments["project_key"], json.loads(arguments["fields"]))
+            result = json.dumps({"content": doc.page_content, "metadata": doc.metadata}, indent=2)
+            return [TextContent(type="text", text=f"Issue created successfully:\n{result}")]
+
+        elif name == "jira_update_issue":
+            doc = jira_fetcher.update_issue(arguments["issue_key"], json.loads(arguments["fields"]))
+            result = json.dumps({"content": doc.page_content, "metadata": doc.metadata}, indent=2)
+            return [TextContent(type="text", text=f"Issue updated successfully:\n{result}")]
 
         raise ValueError(f"Unknown tool: {name}")
 


### PR DESCRIPTION
Hi, this PR is adding write (create/update) capabilities.

The argument is intentionally kept as generic `fields` so the usage can be flexible based on user prompt. From my testing, the LLM model (Sonnet) can write a proper payload based on instruction.

This partially address issue https://github.com/sooperset/mcp-atlassian/issues/12 

## Sample prompt

<img width="1542" alt="mcp-atlassian" src="https://github.com/user-attachments/assets/ff71d4c8-e349-41fa-a398-f837b8a04b23" />

## Result

<img width="588" alt="image" src="https://github.com/user-attachments/assets/40c218b7-f92c-468e-899c-eb2098b2d406" />
