### PR TITLE
Fix Jira date parsing to handle various timezone formats

### DIFF
--- a/src/mcp_atlassian/jira.py
+++ b/src/mcp_atlassian/jira.py
@@ -48,6 +48,23 @@ class JiraFetcher:
 
         return self.preprocessor.clean_jira_text(text)
 
+    def _parse_date(self, date_str: str) -> str:
+        """Parse date string to handle various ISO formats."""
+        if not date_str:
+            return ""
+        # Convert +0000 format to +00:00 format
+        if "+0000" in date_str:
+            date_str = date_str.replace("+0000", "+00:00")
+        elif "-0000" in date_str:
+            date_str = date_str.replace("-0000", "+00:00")
+
+        try:
+            date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            return date.strftime("%Y-%m-%d")
+        except Exception as e:
+            logger.warning(f"Error parsing date {date_str}: {e}")
+            return date_str
+
     def get_issue(self, issue_key: str, expand: Optional[str] = None) -> Document:
         """
         Get a single issue with all its details.
@@ -70,22 +87,19 @@ class JiraFetcher:
             if "comment" in issue["fields"]:
                 for comment in issue["fields"]["comment"]["comments"]:
                     processed_comment = self._clean_text(comment["body"])
-                    created = datetime.fromisoformat(comment["created"].replace("Z", "+00:00"))
+                    created = self._parse_date(comment["created"])
                     author = comment["author"].get("displayName", "Unknown")
-                    comments.append(
-                        {"body": processed_comment, "created": created.strftime("%Y-%m-%d"), "author": author}
-                    )
+                    comments.append({"body": processed_comment, "created": created, "author": author})
 
-            # Format created date
-            created_date = datetime.fromisoformat(issue["fields"]["created"].replace("Z", "+00:00"))
-            formatted_created = created_date.strftime("%Y-%m-%d")
+            # Format created date using new parser
+            created_date = self._parse_date(issue["fields"]["created"])
 
             # Combine content in a more structured way
             content = f"""Issue: {issue_key}
 Title: {issue['fields'].get('summary', '')}
 Type: {issue['fields']['issuetype']['name']}
 Status: {issue['fields']['status']['name']}
-Created: {formatted_created}
+Created: {created_date}
 
 Description:
 {description}
@@ -101,7 +115,7 @@ Comments:
                 "title": issue["fields"].get("summary", ""),
                 "type": issue["fields"]["issuetype"]["name"],
                 "status": issue["fields"]["status"]["name"],
-                "created_date": formatted_created,
+                "created_date": created_date,
                 "priority": issue["fields"].get("priority", {}).get("name", "None"),
                 "link": f"{self.config.url.rstrip('/')}/browse/{issue_key}",
             }

--- a/src/mcp_atlassian/jira.py
+++ b/src/mcp_atlassian/jira.py
@@ -52,11 +52,16 @@ class JiraFetcher:
         """Parse date string to handle various ISO formats."""
         if not date_str:
             return ""
-        # Convert +0000 format to +00:00 format
+
+        # Handle various timezone formats
         if "+0000" in date_str:
             date_str = date_str.replace("+0000", "+00:00")
         elif "-0000" in date_str:
             date_str = date_str.replace("-0000", "+00:00")
+        # Handle other timezone formats like +0900, -0500, etc.
+        elif len(date_str) >= 5 and date_str[-5] in "+-" and date_str[-4:].isdigit():
+            # Insert colon between hours and minutes of timezone
+            date_str = date_str[:-2] + ":" + date_str[-2:]
 
         try:
             date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))


### PR DESCRIPTION
## Description
Fixed date parsing in the Jira fetcher to properly handle various timezone formats returned by the Jira API. The previous implementation failed to parse dates with formats like `+0000` and `+0900`.

### Changes
- Enhanced `_parse_date` method to handle multiple timezone formats:
  - `+0000` → `+00:00`
  - `+0900` → `+09:00`
  - Other similar timezone offsets (e.g., `-0500` → `-05:00`)
- Added proper error handling to return original date string if parsing fails
- Standardized date output format to `YYYY-MM-DD`

### Test Cases
Tested with various Jira issue dates including:
- Standard UTC format (`+0000`)
- JST timezone (`+0900`)
- Other timezone offsets

### Related Issues

#16 