### PR TITLE
docs: Update .env.example with configuration note

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
+# Note: Do not use double quotes for any values in this file
 # 
 # Confluence
 CONFLUENCE_URL=https://your-domain.atlassian.net/wiki  # Your Confluence cloud URL


### PR DESCRIPTION
Add guidance about avoiding double quotes in environment variable values