### PR TITLE
Add Jira Server/Data Center Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,12 @@ CONFLUENCE_URL=https://your-domain.atlassian.net/wiki  # Your Confluence cloud U
 CONFLUENCE_USERNAME=your.email@domain.com              # Your Atlassian account email
 CONFLUENCE_API_TOKEN=your_api_token                    # API token for Confluence
 #
-# Jira
+# Jira Cloud
 JIRA_URL=https://your-domain.atlassian.net            # Your Jira cloud URL
 JIRA_USERNAME=your.email@domain.com                   # Your Atlassian account email
-JIRA_API_TOKEN=your_api_token                         # API token for Jira
+JIRA_API_TOKEN=your_api_token                         # API token for Jira Cloud
+
+# Jira Server/Data Center (alternative to JIRA_USERNAME and JIRA_API_TOKEN)
+# JIRA_URL=https://jira.your-company.com              # Your Jira Server/Data Center URL
+# JIRA_PERSONAL_TOKEN=your_personal_access_token      # Personal Access Token for Jira Server/Data Center
+# JIRA_SSL_VERIFY=true                                # Set to 'false' for self-signed certificates

--- a/README.md
+++ b/README.md
@@ -2,12 +2,22 @@
 
 [![smithery badge](https://smithery.ai/badge/mcp-atlassian)](https://smithery.ai/server/mcp-atlassian)
 
-Model Context Protocol (MCP) server for Atlassian Cloud products (Confluence and Jira). This integration is designed specifically for Atlassian Cloud instances and does not support Atlassian Server or Data Center deployments.
+Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). This integration supports both Atlassian Cloud and Jira Server/Data Center deployments.
 
 <a href="https://glama.ai/mcp/servers/kc33m1kh5m"><img width="380" height="200" src="https://glama.ai/mcp/servers/kc33m1kh5m/badge" alt="Atlassian MCP server" /></a>
 
 ### Feature Demo
 ![Demo](https://github.com/user-attachments/assets/995d96a8-4cf3-4a03-abe1-a9f6aea27ac0)
+
+### Server/Data Center Compatibility
+
+This MCP server supports:
+
+- **Atlassian Cloud**: Fully supported for both Confluence and Jira
+- **Jira Server/Data Center**: Supported for on-premise Jira installations (version 8.14+)
+- **Confluence Server/Data Center**: Not yet supported
+
+> **Note for On-Premise Users:** When using with Jira Server/Data Center, you'll need to generate a Personal Access Token instead of using username/API token authentication. See the [Authentication](#authentication) section for details.
 
 ### Resources
 
@@ -174,16 +184,38 @@ npx -y @smithery/cli install mcp-atlassian --client claude
 
 The MCP Atlassian integration supports using either Confluence, Jira, or both services. You only need to provide the environment variables for the service(s) you want to use.
 
-### Usage with Claude Desktop
+### Authentication
+
+#### For Atlassian Cloud
 
 1. Get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
 
-2. Add to your `claude_desktop_config.json` using one of the following methods:
+#### For Jira Server/Data Center
+
+1. Generate a Personal Access Token in your Jira Server/Data Center (version 8.14 or later):
+   - Navigate to your profile by clicking on your avatar in the top right corner
+   - Select **Profile** → **Personal Access Tokens**
+     *(Alternative path in some versions: Account Settings → Security → Personal Access Tokens)*
+   - Click **Create token**
+   - Give your token a meaningful name (e.g., "MCP Integration")
+   - Set an expiry date (or choose "Never" if permitted by your organization)
+   - Copy the generated token immediately (you won't be able to see it again)
+
+   > **Important Notes:**
+   > - PATs inherit your existing Jira permissions - no separate permission configuration is needed during creation
+   > - Ensure your account has the necessary project access before creating the token
+   > - In Data Center, administrators can view/revoke all PATs via **System → Administering personal access tokens**
+   > - By default, users are limited to 10 active tokens
+   > - The implementation uses Bearer token authentication (`Authorization: Bearer <token>`)
+   > - Personal Access Tokens were introduced in Jira Server/Data Center 8.14
+
+### Usage with Claude Desktop
 
 > **Note:** For all configuration methods, include only the environment variables needed for your services:
-> - For Confluence only: Include `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, and `CONFLUENCE_API_TOKEN`
-> - For Jira only: Include `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN`
-> - For both services: Include all six variables
+> - For Confluence only (Cloud): Include `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, and `CONFLUENCE_API_TOKEN`
+> - For Jira Cloud: Include `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN`
+> - For Jira Server/Data Center: Include `JIRA_URL` and `JIRA_PERSONAL_TOKEN`
+> - For multiple services: Include the variables for each service you want to use
 
 <details>
 <summary>Using uvx</summary>
@@ -201,6 +233,26 @@ The MCP Atlassian integration supports using either Confluence, Jira, or both se
         "JIRA_URL": "https://your-domain.atlassian.net",
         "JIRA_USERNAME": "your.email@domain.com",
         "JIRA_API_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+For Jira Server/Data Center:
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": {
+        "CONFLUENCE_URL": "https://your-domain.atlassian.net/wiki",
+        "CONFLUENCE_USERNAME": "your.email@domain.com",
+        "CONFLUENCE_API_TOKEN": "your_api_token",
+        "JIRA_URL": "https://jira.your-company.com",
+        "JIRA_PERSONAL_TOKEN": "your_personal_access_token"
       }
     }
   }

--- a/src/mcp_atlassian/config.py
+++ b/src/mcp_atlassian/config.py
@@ -20,8 +20,10 @@ class JiraConfig:
     """Jira API configuration."""
 
     url: str  # Base URL for Jira
-    username: str  # Email or username
-    api_token: str  # API token used as password
+    username: str = ""  # Email or username
+    api_token: str = ""  # API token used as password for cloud
+    personal_token: str = ""  # Personal Access Token used for Server/Data Center
+    verify_ssl: bool = True  # Whether to verify SSL certificates
 
     @property
     def is_cloud(self) -> bool:

--- a/src/mcp_atlassian/jira.py
+++ b/src/mcp_atlassian/jira.py
@@ -31,7 +31,7 @@ class JiraFetcher:
         # Check authentication method
         is_cloud = "atlassian.net" in url
 
-        if is_cloud and not all([username, token]):
+        if is_cloud and (not username or not token):
             raise ValueError("Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN")
 
         if not is_cloud and not personal_token:

--- a/src/mcp_atlassian/jira.py
+++ b/src/mcp_atlassian/jira.py
@@ -17,20 +17,50 @@ class JiraFetcher:
     """Handles fetching and parsing content from Jira."""
 
     def __init__(self):
+        """Initialize the Jira client."""
         url = os.getenv("JIRA_URL")
-        username = os.getenv("JIRA_USERNAME")
-        token = os.getenv("JIRA_API_TOKEN")
+        username = os.getenv("JIRA_USERNAME", "")
+        token = os.getenv("JIRA_API_TOKEN", "")
+        personal_token = os.getenv("JIRA_PERSONAL_TOKEN", "")
+        # For self-signed certificates in on-premise installations
+        verify_ssl = os.getenv("JIRA_SSL_VERIFY", "true").lower() != "false"
 
-        if not all([url, username, token]):
-            raise ValueError("Missing required Jira environment variables")
+        if not url:
+            raise ValueError("Missing required JIRA_URL environment variable")
 
-        self.config = JiraConfig(url=url, username=username, api_token=token)
-        self.jira = Jira(
-            url=self.config.url,
-            username=self.config.username,
-            password=self.config.api_token,  # API token is used as password
-            cloud=True,
+        # Check authentication method
+        is_cloud = "atlassian.net" in url
+
+        if is_cloud and not all([username, token]):
+            raise ValueError("Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN")
+
+        if not is_cloud and not personal_token:
+            raise ValueError("Server/Data Center authentication requires JIRA_PERSONAL_TOKEN")
+
+        self.config = JiraConfig(
+            url=url, username=username, api_token=token, personal_token=personal_token, verify_ssl=verify_ssl
         )
+
+        # Initialize Jira client based on instance type
+        if self.config.is_cloud:
+            self.jira = Jira(
+                url=self.config.url,
+                username=self.config.username,
+                password=self.config.api_token,  # API token is used as password
+                cloud=True,
+                verify_ssl=self.config.verify_ssl,
+            )
+        else:
+            # For Server/Data Center, use token-based authentication
+            # Note: The token param is used for Bearer token authentication
+            # as per atlassian-python-api implementation
+            self.jira = Jira(
+                url=self.config.url,
+                token=self.config.personal_token,
+                cloud=False,
+                verify_ssl=self.config.verify_ssl,
+            )
+
         self.preprocessor = TextPreprocessor(self.config.url)
 
         # Field IDs cache


### PR DESCRIPTION
## Description
This PR adds support for Jira Server/Data Center installations (v8.14+) while maintaining compatibility with Atlassian Cloud.

## Changes
- Added Personal Access Token (PAT) authentication for Server/Data Center deployments
- Configured Bearer token authentication for on-premise installations 
- Added SSL verification control for self-signed certificates
- Enhanced JiraConfig class to support both authentication methods
- Added comprehensive documentation for Server/Data Center setup
- Added troubleshooting section for on-premise deployments

resolve #5 