### PR TITLE
Add Jira worklog tools for time tracking and estimate management

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,20 +128,37 @@ Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira)
 8. `jira_transition_issue`
    - Transition a Jira issue to a new status
    - Inputs:
-     - `issue_key` (string): Jira issue key (e.g. 'PROJ-123')
+     - `issue_key` (string): Jira issue key (e.g., 'PROJ-123')
      - `transition_id` (string): ID of the transition to perform (get this from jira_get_transitions)
      - `fields` (string, optional): JSON string of fields to update during the transition
      - `comment` (string, optional): Comment to add during the transition
    - Returns: Updated issue details including the new status
 
-9. `jira_link_to_epic`
-   - Link an issue to an Epic
+9. `jira_add_worklog`
+   - Add a worklog entry to a Jira issue
    - Inputs:
-     - `issue_key` (string): Jira issue key to link (e.g. 'PROJ-123')
-     - `epic_key` (string): Epic issue key to link to (e.g. 'PROJ-456')
-   - Returns: Linked issue details with confirmation message
+     - `issue_key` (string): Jira issue key (e.g., 'PROJ-123')
+     - `time_spent` (string): Time spent in Jira format (e.g., '1h 30m', '1d', '30m')
+     - `comment` (string, optional): Optional comment for the worklog in Markdown format
+     - `started` (string, optional): Optional start time in ISO format (e.g. '2023-08-01T12:00:00.000+0000')
+     - `original_estimate` (string, optional): Optional original estimate in Jira format (e.g., '1h 30m', '1d')
+     - `remaining_estimate` (string, optional): Optional remaining estimate in Jira format (e.g., '1h', '30m')
+   - Returns: Created worklog details with information about estimate updates
 
-10. `jira_get_epic_issues`
+10. `jira_get_worklog`
+    - Get worklog entries for a Jira issue
+    - Inputs:
+      - `issue_key` (string): Jira issue key (e.g., 'PROJ-123')
+    - Returns: Array of worklog entries with author, time spent, comments, and dates
+
+11. `jira_link_to_epic`
+    - Link an issue to an Epic
+    - Inputs:
+      - `issue_key` (string): Jira issue key to link (e.g. 'PROJ-123')
+      - `epic_key` (string): Epic issue key to link to (e.g. 'PROJ-456')
+    - Returns: Linked issue details with confirmation message
+
+12. `jira_get_epic_issues`
     - Get all issues linked to a specific Epic
     - Inputs:
       - `epic_key` (string): Epic issue key (e.g. 'PROJ-456')

--- a/src/mcp_atlassian/jira.py
+++ b/src/mcp_atlassian/jira.py
@@ -899,6 +899,159 @@ Description:
             logger.error(f"Error adding comment to issue {issue_key}: {str(e)}")
             raise
 
+    def _parse_time_spent(self, time_spent: str) -> int:
+        """
+        Parse Jira time format string (e.g., '1h 30m', '1d', '30m') to seconds.
+
+        Args:
+            time_spent: Time string in Jira format
+
+        Returns:
+            Time in seconds
+        """
+        if not time_spent:
+            raise ValueError("Time spent string cannot be empty")
+
+        # Define time unit conversions to seconds
+        units = {
+            "w": 7 * 24 * 60 * 60,  # weeks
+            "d": 24 * 60 * 60,  # days
+            "h": 60 * 60,  # hours
+            "m": 60,  # minutes
+        }
+
+        # Extract all time components (e.g., '1h', '30m')
+        pattern = r"(\d+)([wdhm])"
+        matches = re.findall(pattern, time_spent.lower())
+
+        if not matches:
+            raise ValueError(f"Invalid time format: {time_spent}. Expected format like '1h 30m', '1d', etc.")
+
+        # Calculate total seconds
+        total_seconds = 0
+        for value, unit in matches:
+            if unit in units:
+                total_seconds += int(value) * units[unit]
+
+        return total_seconds
+
+    def add_worklog(
+        self,
+        issue_key: str,
+        time_spent: str,
+        comment: str = None,
+        started: str = None,
+        original_estimate: str = None,
+        remaining_estimate: str = None,
+    ) -> dict:
+        """
+        Add a worklog to an issue with optional estimate updates.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+            time_spent: Time spent in Jira format (e.g., '1h 30m', '1d', '30m')
+            comment: Optional comment for the worklog (in Markdown format)
+            started: Optional start time in ISO format (e.g. '2023-08-01T12:00:00.000+0000').
+                     If not provided, current time will be used.
+            original_estimate: Optional original estimate in Jira format (e.g., '1h 30m', '1d')
+                              This will update the original estimate for the issue.
+            remaining_estimate: Optional remaining estimate in Jira format (e.g., '1h', '30m')
+                               This will update the remaining estimate for the issue.
+
+        Returns:
+            The created worklog details
+        """
+        try:
+            # Convert time_spent string to seconds
+            time_spent_seconds = self._parse_time_spent(time_spent)
+
+            # Convert Markdown comment to Jira format if provided
+            if comment:
+                comment = self._markdown_to_jira(comment)
+
+            # Step 1: Update original estimate if provided (separate API call)
+            original_estimate_updated = False
+            if original_estimate:
+                try:
+                    fields = {"timetracking": {"originalEstimate": original_estimate}}
+                    self.jira.edit_issue(issue_id_or_key=issue_key, fields=fields)
+                    original_estimate_updated = True
+                    logger.info(f"Updated original estimate for issue {issue_key}")
+                except Exception as e:
+                    logger.error(f"Failed to update original estimate for issue {issue_key}: {str(e)}")
+                    # Continue with worklog creation even if estimate update fails
+
+            # Step 2: Prepare worklog data
+            worklog_data = {"timeSpentSeconds": time_spent_seconds}
+            if comment:
+                worklog_data["comment"] = comment
+            if started:
+                worklog_data["started"] = started
+
+            # Step 3: Prepare query parameters for remaining estimate
+            params = {}
+            remaining_estimate_updated = False
+            if remaining_estimate:
+                params["adjustEstimate"] = "new"
+                params["newEstimate"] = remaining_estimate
+                remaining_estimate_updated = True
+
+            # Step 4: Add the worklog with remaining estimate adjustment
+            base_url = self.jira.resource_url("issue")
+            url = f"{base_url}/{issue_key}/worklog"
+            result = self.jira.post(url, data=worklog_data, params=params)
+
+            # Format and return the result
+            return {
+                "id": result.get("id"),
+                "comment": self._clean_text(result.get("comment", "")),
+                "created": self._parse_date(result.get("created", "")),
+                "updated": self._parse_date(result.get("updated", "")),
+                "started": self._parse_date(result.get("started", "")),
+                "timeSpent": result.get("timeSpent", ""),
+                "timeSpentSeconds": result.get("timeSpentSeconds", 0),
+                "author": result.get("author", {}).get("displayName", "Unknown"),
+                "original_estimate_updated": original_estimate_updated,
+                "remaining_estimate_updated": remaining_estimate_updated,
+            }
+        except Exception as e:
+            logger.error(f"Error adding worklog to issue {issue_key}: {str(e)}")
+            raise
+
+    def get_worklogs(self, issue_key: str) -> list[dict]:
+        """
+        Get worklogs for an issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+
+        Returns:
+            List of worklog entries
+        """
+        try:
+            result = self.jira.issue_get_worklog(issue_key)
+
+            # Process the worklogs
+            worklogs = []
+            for worklog in result.get("worklogs", []):
+                worklogs.append(
+                    {
+                        "id": worklog.get("id"),
+                        "comment": self._clean_text(worklog.get("comment", "")),
+                        "created": self._parse_date(worklog.get("created", "")),
+                        "updated": self._parse_date(worklog.get("updated", "")),
+                        "started": self._parse_date(worklog.get("started", "")),
+                        "timeSpent": worklog.get("timeSpent", ""),
+                        "timeSpentSeconds": worklog.get("timeSpentSeconds", 0),
+                        "author": worklog.get("author", {}).get("displayName", "Unknown"),
+                    }
+                )
+
+            return worklogs
+        except Exception as e:
+            logger.error(f"Error getting worklogs for issue {issue_key}: {str(e)}")
+            raise
+
     def _markdown_to_jira(self, markdown_text: str) -> str:
         """
         Convert Markdown syntax to Jira markup syntax.


### PR DESCRIPTION
This PR adds support for Jira worklog functionality, allowing users to:

- Add work logs to Jira issues with time tracking
- Update remaining estimates when logging work
- Update original estimates with proper error handling
- Retrieve all worklogs for an issue

resolve #64 