### PR TITLE
Fix Jira Server/Data Center Support

### DIFF
--- a/src/mcp_atlassian/jira.py
+++ b/src/mcp_atlassian/jira.py
@@ -32,11 +32,14 @@ class JiraFetcher:
         # Check authentication method
         is_cloud = "atlassian.net" in url
 
-        if is_cloud and (not username or not token):
-            raise ValueError("Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN")
-
-        if not is_cloud and not personal_token:
-            raise ValueError("Server/Data Center authentication requires JIRA_PERSONAL_TOKEN")
+        if is_cloud:
+            logger.info(f"Initializing Jira Cloud client for {url}")
+            if not username or not token:
+                raise ValueError("Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN")
+        else:
+            logger.info(f"Initializing Jira Server/Data Center client for {url}")
+            if not personal_token:
+                raise ValueError("Server/Data Center authentication requires JIRA_PERSONAL_TOKEN")
 
         self.config = JiraConfig(
             url=url, username=username, api_token=token, personal_token=personal_token, verify_ssl=verify_ssl

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -33,7 +33,19 @@ def get_available_services():
         ]
     )
 
-    jira_vars = all([os.getenv("JIRA_URL"), os.getenv("JIRA_USERNAME"), os.getenv("JIRA_API_TOKEN")])
+    # Check for either cloud authentication (URL + username + API token)
+    # or server/data center authentication (URL + personal token)
+    jira_url = os.getenv("JIRA_URL")
+    if jira_url:
+        is_cloud = "atlassian.net" in jira_url
+        if is_cloud:
+            jira_vars = all([jira_url, os.getenv("JIRA_USERNAME"), os.getenv("JIRA_API_TOKEN")])
+            logger.info("Using Jira Cloud authentication method")
+        else:
+            jira_vars = all([jira_url, os.getenv("JIRA_PERSONAL_TOKEN")])
+            logger.info("Using Jira Server/Data Center authentication method")
+    else:
+        jira_vars = False
 
     return {"confluence": confluence_vars, "jira": jira_vars}
 


### PR DESCRIPTION
## Description
This PR adds proper support for Jira Server/Data Center deployments by changing how environment variables are checked. Previously, the code always required JIRA_USERNAME and JIRA_API_TOKEN environment variables, which are only needed for Cloud deployments.

## Changes
- Update `get_available_services()` to detect instance type based on URL
- For Cloud deployments: Use JIRA_URL + JIRA_USERNAME + JIRA_API_TOKEN
- For Server/Data Center deployments: Use JIRA_URL + JIRA_PERSONAL_TOKEN
- Add logging to help diagnose authentication issues

## Related Issues
#5
