### PR TITLE
Fix duplicate "content" field in Confluence page metadata (#79)

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -816,12 +816,14 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             page = ctx.confluence.get_page_content(page_id)
 
             if include_metadata:
+                # The to_simplified_dict method already includes the content,
+                # so we don't need to include it separately at the root level
                 result = {
-                    "content": page.page_content,
                     "metadata": page.to_simplified_dict(),
                 }
             else:
-                result = {"content": page.page_content}
+                # For backward compatibility, keep returning content directly
+                result = {"content": page.content}
 
             return [
                 TextContent(


### PR DESCRIPTION
## Description
This PR fixes issue #79 where the `confluence_get_page` tool response contained duplicate content fields when used with `include_metadata=true`.

### The issue
When calling the `confluence_get_page` tool with `include_metadata=true`, the content field was duplicated in the response:
1. At the top level as `"content": page.page_content`
2. Inside the `metadata` object as part of `page.to_simplified_dict()`

### Changes made
- Modified the `confluence_get_page` tool implementation to only include content once:
  - When `include_metadata=true`, content is only included within the metadata object
  - When `include_metadata=false`, content is still returned at the top level (maintaining backward compatibility)
- Updated the code to use `page.content` instead of the deprecated `page.page_content` property
- Added a test to verify the response format has no duplicate content

Fixes #79