### PR TITLE
Add SSE transport support and improve documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "markdown-to-confluence>=0.3.0",
     "pydantic>=2.10.6",
     "trio>=0.29.0",
+    "click>=8.1.7",
+    "uvicorn>=0.27.1",
+    "starlette>=0.37.1",
 ]
 [[project.authors]]
 name = "sooperset"

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -22,6 +22,17 @@ logger = logging.getLogger("mcp-atlassian")
     "--env-file", type=click.Path(exists=True, dir_okay=False), help="Path to .env file"
 )
 @click.option(
+    "--transport",
+    type=click.Choice(["stdio", "sse"]),
+    default="stdio",
+    help="Transport type (stdio or sse)",
+)
+@click.option(
+    "--port",
+    default=8000,
+    help="Port to listen on for SSE transport",
+)
+@click.option(
     "--confluence-url",
     help="Confluence URL (e.g., https://your-domain.atlassian.net/wiki)",
 )
@@ -54,6 +65,8 @@ logger = logging.getLogger("mcp-atlassian")
 def main(
     verbose: bool,
     env_file: str | None,
+    transport: str,
+    port: int,
     confluence_url: str | None,
     confluence_username: str | None,
     confluence_token: str | None,
@@ -112,8 +125,8 @@ def main(
 
     from . import server
 
-    # Run the server
-    asyncio.run(server.main())
+    # Run the server with specified transport
+    asyncio.run(server.run_server(transport=transport, port=port))
 
 
 __all__ = ["main", "server", "__version__"]

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -1430,16 +1430,39 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
         return [TextContent(type="text", text=f"Error: {str(e)}")]
 
 
-async def main() -> None:
-    """Run the MCP Atlassian server."""
-    # Import here to avoid issues with event loops
-    from mcp.server.stdio import stdio_server
+async def run_server(transport: str = "stdio", port: int = 8000) -> None:
+    """Run the MCP Atlassian server with the specified transport."""
+    if transport == "sse":
+        from mcp.server.sse import SseServerTransport
+        from starlette.applications import Starlette
+        from starlette.requests import Request
+        from starlette.routing import Mount, Route
 
-    async with stdio_server() as (read_stream, write_stream):
-        await app.run(read_stream, write_stream, app.create_initialization_options())
+        sse = SseServerTransport("/messages/")
 
+        async def handle_sse(request: Request) -> None:
+            async with sse.connect_sse(
+                request.scope, request.receive, request._send
+            ) as streams:
+                await app.run(
+                    streams[0], streams[1], app.create_initialization_options()
+                )
 
-if __name__ == "__main__":
-    import asyncio
+        starlette_app = Starlette(
+            debug=True,
+            routes=[
+                Route("/sse", endpoint=handle_sse),
+                Mount("/messages/", app=sse.handle_post_message),
+            ],
+        )
 
-    asyncio.run(main())
+        import uvicorn
+
+        uvicorn.run(starlette_app, host="0.0.0.0", port=port)  # noqa: S104
+    else:
+        from mcp.server.stdio import stdio_server
+
+        async with stdio_server() as (read_stream, write_stream):
+            await app.run(
+                read_stream, write_stream, app.create_initialization_options()
+            )

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -1458,7 +1458,11 @@ async def run_server(transport: str = "stdio", port: int = 8000) -> None:
 
         import uvicorn
 
-        uvicorn.run(starlette_app, host="0.0.0.0", port=port)  # noqa: S104
+        # Set up uvicorn config
+        config = uvicorn.Config(starlette_app, host="0.0.0.0", port=port)  # noqa: S104
+        server = uvicorn.Server(config)
+        # Use server.serve() instead of run() to stay in the same event loop
+        await server.serve()
     else:
         from mcp.server.stdio import stdio_server
 

--- a/uv.lock
+++ b/uv.lock
@@ -582,6 +582,7 @@ source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },
     { name = "beautifulsoup4" },
+    { name = "click" },
     { name = "httpx" },
     { name = "markdown" },
     { name = "markdown-to-confluence" },
@@ -589,7 +590,9 @@ dependencies = [
     { name = "mcp" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "starlette" },
     { name = "trio" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -608,6 +611,7 @@ dev = [
 requires-dist = [
     { name = "atlassian-python-api", specifier = ">=3.41.16" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
+    { name = "click", specifier = ">=8.1.7" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "markdown", specifier = ">=3.7.0" },
     { name = "markdown-to-confluence", specifier = ">=0.3.0" },
@@ -615,7 +619,9 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.3.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "starlette", specifier = ">=0.37.1" },
     { name = "trio", specifier = ">=0.29.0" },
+    { name = "uvicorn", specifier = ">=0.27.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Description
This PR adds Server-Sent Events (SSE) transport support to mcp-atlassian, providing an alternative to the default stdio transport. This enhancement allows the MCP server to run as a standalone HTTP server that clients can connect to, making it more flexible for different integration scenarios.

## Changes
- Added `--transport` CLI option to select between stdio (default) and SSE transports
- Added `--port` CLI option to configure the port for SSE transport (default: 8000)
- Implemented SSE transport using Starlette and Uvicorn
- Significantly improved documentation with:
  - Clearer configuration instructions
  - Setup guides for both transport types
  - Visual examples for IDE integration
  - Better organized installation and configuration sections

## Required Dependencies
- Added new dependencies: click, uvicorn, and starlette

## Testing
The SSE transport has been tested with Cursor IDE and works as expected.

Resolves #84