### PR TITLE
Fix call get_all_fields API in get_fields

### DIFF
--- a/src/mcp_atlassian/jira/fields.py
+++ b/src/mcp_atlassian/jira/fields.py
@@ -32,7 +32,7 @@ class FieldsMixin(JiraClient):
                 return self._fields_cache
 
             # Fetch fields from Jira API
-            fields = self.jira.fields()
+            fields = self.jira.get_all_fields()
 
             # Cache the fields
             self._fields_cache = fields


### PR DESCRIPTION
## WHAT

Call [get_all_fields()](https://github.com/atlassian-api/atlassian-python-api/blob/df25ee599ed61663b667b7d3b595111a7ab01c1d/atlassian/jira.py#L688) instead of `fields()`

## WHY

For example, when using the `jira_create_issue` tool with issue_type `Sub-task`, we get an error for something like this.

`ERROR:mcp-jira:Error getting Jira fields: 'Jira' object has no attribute 'fields'`