### PR TITLE
Add Jira subtask creation support

### DIFF
--- a/scripts/test_with_real_data.sh
+++ b/scripts/test_with_real_data.sh
@@ -130,7 +130,7 @@ run_api_tests() {
         sleep 5
 
         # Run the write operation tests
-        uv run pytest tests/test_real_api_validation.py::test_jira_create_issue tests/test_real_api_validation.py::test_jira_add_comment tests/test_real_api_validation.py::test_confluence_create_page tests/test_real_api_validation.py::test_confluence_update_page $VERBOSITY
+        uv run pytest tests/test_real_api_validation.py::test_jira_create_issue tests/test_real_api_validation.py::test_jira_create_subtask tests/test_real_api_validation.py::test_jira_add_comment tests/test_real_api_validation.py::test_confluence_create_page tests/test_real_api_validation.py::test_confluence_update_page $VERBOSITY
 
         # Run the skipped transition test if explicitly requested write tests
         echo ""

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -589,7 +589,7 @@ async def list_tools() -> list[Tool]:
                 ),
                 Tool(
                     name="jira_create_issue",
-                    description="Create a new Jira issue with optional Epic link",
+                    description="Create a new Jira issue with optional Epic link or parent for subtasks",
                     inputSchema={
                         "type": "object",
                         "properties": {
@@ -606,8 +606,9 @@ async def list_tools() -> list[Tool]:
                             "issue_type": {
                                 "type": "string",
                                 "description": (
-                                    "Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic'). "
-                                    "The available types depend on your project configuration."
+                                    "Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). "
+                                    "The available types depend on your project configuration. "
+                                    "For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields."
                                 ),
                             },
                             "assignee": {
@@ -622,8 +623,12 @@ async def list_tools() -> list[Tool]:
                             "additional_fields": {
                                 "type": "string",
                                 "description": "Optional JSON string of additional fields to set. "
-                                'Example: \'{"priority": {"name": "High"}, "labels": ["frontend", "urgent"], '
-                                '"components": [{"name": "UI"}]}\'',
+                                "Examples:\n"
+                                '- Set priority: {"priority": {"name": "High"}}\n'
+                                '- Add labels: {"labels": ["frontend", "urgent"]}\n'
+                                '- Add components: {"components": [{"name": "UI"}]}\n'
+                                '- Link to parent (for subtasks): {"parent": "PROJ-123"}\n'
+                                '- Custom fields: {"customfield_10010": "value"}',
                                 "default": "{}",
                             },
                         },

--- a/tests/unit/jira/test_fields.py
+++ b/tests/unit/jira/test_fields.py
@@ -58,7 +58,7 @@ class TestFieldsMixin:
 
         # Verify cache was used
         assert result == mock_fields
-        fields_mixin.jira.fields.assert_not_called()
+        fields_mixin.jira.get_all_fields.assert_not_called()
 
     def test_get_fields_refresh(self, fields_mixin, mock_fields):
         """Test get_fields refreshes data when requested."""
@@ -66,13 +66,13 @@ class TestFieldsMixin:
         fields_mixin._fields_cache = ["old data"]
 
         # Mock the API response
-        fields_mixin.jira.fields.return_value = mock_fields
+        fields_mixin.jira.get_all_fields.return_value = mock_fields
 
         # Call the method with refresh=True
         result = fields_mixin.get_fields(refresh=True)
 
         # Verify API was called
-        fields_mixin.jira.fields.assert_called_once()
+        fields_mixin.jira.get_all_fields.assert_called_once()
         assert result == mock_fields
         # Verify cache was updated
         assert fields_mixin._fields_cache == mock_fields
@@ -84,13 +84,13 @@ class TestFieldsMixin:
             delattr(fields_mixin, "_fields_cache")
 
         # Mock the API response
-        fields_mixin.jira.fields.return_value = mock_fields
+        fields_mixin.jira.get_all_fields.return_value = mock_fields
 
         # Call the method
         result = fields_mixin.get_fields()
 
         # Verify API was called
-        fields_mixin.jira.fields.assert_called_once()
+        fields_mixin.jira.get_all_fields.assert_called_once()
         assert result == mock_fields
         # Verify cache was created
         assert fields_mixin._fields_cache == mock_fields
@@ -102,7 +102,7 @@ class TestFieldsMixin:
             delattr(fields_mixin, "_fields_cache")
 
         # Mock API error
-        fields_mixin.jira.fields.side_effect = Exception("API error")
+        fields_mixin.jira.get_all_fields.side_effect = Exception("API error")
 
         # Call the method
         result = fields_mixin.get_fields()


### PR DESCRIPTION
## Description
This PR adds support for creating subtasks in Jira, allowing users to link issues to parent tasks and properly structure their work hierarchy.

This is a follow up PR of #110.

## Features
- Add support for creating subtasks with proper parent relationship
- Update tool documentation to include subtask examples
- Add integration test for the subtask creation workflow

## Changes
- Added `_prepare_parent_fields` method to handle parent-child relationships
- Updated the issue creation logic to detect subtask issue types
- Updated field processing to handle parent references
- Added detailed examples in the API description
- Fixed failing tests in the Jira fields tests (using correct method name)

## Testing
- Added a new integration test `test_jira_create_subtask`
- Updated test script to run the subtask creation test
- All tests now pass successfully