### PR TITLE
fix: in confluence, no-ssl-verify doesn't have any effect issue while…

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -88,7 +88,7 @@ async def server_lifespan(server: Server) -> AsyncIterator[AppContext]:
             logger.info(f"Confluence URL: {confluence_url}")
             if not confluence.config.ssl_verify:
                 logger.warning(
-                    "SSL verifiaction is disabled for Confluence. This may be insecure."
+                    "SSL verification is disabled for Confluence. This may be insecure."
                 )
 
                 original_merge_settings = requests.Session.merge_environment_settings


### PR DESCRIPTION
… fetch space

### PROBLEM 
In mcp-attlanssian, there is a command line argument to handle no-*-ssl-verification (in env, CONFLUENCE_SSL_VERIFY), 
for those who use atlassian is installed in there system with self-signed certificates.

But eventhough you set that value as true,
```
--no-confluence-token,
...
# CONFLUENCE_SSL_VERIFY=false                                # Set to 'false' for self-signed certificates
```

when fetch to space, error occured.

### FIX
Made in server.py file,
added overriding env set for `requests`, if the flag enabled.
(I didn't added this logic to jira, because there isn't any prob in jira to use now. - I don't know why. -)