### PR TITLE
Add support for jira/confluence search filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,26 +10,24 @@
 CONFLUENCE_URL=https://your-domain.atlassian.net/wiki
 CONFLUENCE_USERNAME=your.email@domain.com
 CONFLUENCE_API_TOKEN=your_api_token
-
-# Optional Confluence filters (CLI: --confluence-spaces-filter)
 # CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC                # Optional: Filter Confluence spaces
 
 # Confluence Server/Data Center (CLI: --confluence-url, --confluence-personal-token, --[no-]confluence-ssl-verify)
 # CONFLUENCE_URL=https://confluence.your-company.com
 # CONFLUENCE_PERSONAL_TOKEN=your_personal_access_token
 # CONFLUENCE_SSL_VERIFY=true
+# CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC                # Optional: Filter Confluence spaces
 
 # Jira Cloud (CLI: --jira-url, --jira-username, --jira-token)
 JIRA_URL=https://your-domain.atlassian.net
 JIRA_USERNAME=your.email@domain.com
 JIRA_API_TOKEN=your_api_token
-
-# Optional Jira filters (CLI: --jira-projects-filter)
 # JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT              # Optional: Filter Jira projects
 
 # Jira Server/Data Center (CLI: --jira-url, --jira-personal-token, --[no-]jira-ssl-verify)
 # JIRA_URL=https://jira.your-company.com
 # JIRA_PERSONAL_TOKEN=your_personal_access_token
 # JIRA_SSL_VERIFY=true
+# JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT              # Optional: Filter Jira projects
 
 # Debug options (CLI: -v, --verbose)

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@
 CONFLUENCE_URL=https://your-domain.atlassian.net/wiki  # Your Confluence cloud URL
 CONFLUENCE_USERNAME=your.email@domain.com              # Your Atlassian account email
 CONFLUENCE_API_TOKEN=your_api_token                    # API token for Confluence
+CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC                  # Optional: Comma-separated list of space keys to filter search results
 
 # Confluence Server/Data Center (alternative to CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN)
 # CONFLUENCE_URL=https://confluence.your-company.com        # Your Confluence Server/Data Center URL
@@ -16,6 +17,7 @@ CONFLUENCE_API_TOKEN=your_api_token                    # API token for Confluenc
 JIRA_URL=https://your-domain.atlassian.net            # Your Jira cloud URL
 JIRA_USERNAME=your.email@domain.com                   # Your Atlassian account email
 JIRA_API_TOKEN=your_api_token                         # API token for Jira Cloud
+JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT                 # Optional: Comma-separated list of project keys to filter search results
 
 # Jira Server/Data Center (alternative to JIRA_USERNAME and JIRA_API_TOKEN)
 # JIRA_URL=https://jira.your-company.com              # Your Jira Server/Data Center URL

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ playground/
 
 # rules
 CLAUDE.md
+
+# cursor
+.cursor*

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ uvx mcp-atlassian \
   --jira-url=https://your.atlassian.net \
   --jira-username=email \
   --jira-token=token
+  # Optional filters:
+  # --confluence-spaces-filter=DEV,TEAM,DOC \
+  # --jira-projects-filter=PROJ,DEV,SUPPORT
 
 # For Server/DC (SSE transport)
 uvx mcp-atlassian \
@@ -119,24 +122,13 @@ uvx mcp-atlassian \
   --jira-personal-token=token \
   --transport sse \
   --port 8000
+  # Optional filters:
+  # --confluence-spaces-filter=DEV,TEAM,DOC \
+  # --jira-projects-filter=PROJ,DEV,SUPPORT
 
-# With search filters
-uvx mcp-atlassian \
-  --confluence-url=https://your.atlassian.net/wiki \
-  --confluence-username=email \
-  --confluence-token=token \
-  --confluence-spaces-filter=DEV,TEAM,DOC \
-  --jira-url=https://your.atlassian.net \
-  --jira-username=email \
-  --jira-token=token \
-  --jira-projects-filter=PROJ,DEV,SUPPORT
-```
-
-You can also set filters using environment variables:
-```bash
-export CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC
-export JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT
-```
+# You can also set filters using environment variables:
+# export CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC
+# export JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT
 
 These filters help narrow down search results to the most relevant spaces or projects, improving response quality and performance.
 
@@ -298,20 +290,26 @@ CONFLUENCE_URL=https://your-domain.atlassian.net/wiki  # Your Confluence cloud U
 CONFLUENCE_USERNAME=your.email@domain.com              # Your Atlassian account email
 CONFLUENCE_API_TOKEN=your_api_token                    # API token for Confluence
 
+# Optional Confluence filters
+# CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC                # Optional: Filter Confluence spaces
+
 # Confluence Server/Data Center (alternative to CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN)
 # CONFLUENCE_URL=https://confluence.your-company.com        # Your Confluence Server/Data Center URL
 # CONFLUENCE_PERSONAL_TOKEN=your_personal_access_token      # Personal Access Token for Confluence Server/Data Center
-# CONFLUENCE_SSL_VERIFY=true                                # Set to 'false' for self-signed certificates
+# CONFLUENCE_SSL_VERIFY=true                               # Set to 'false' for self-signed certificates
 
 # Jira Cloud
 JIRA_URL=https://your-domain.atlassian.net            # Your Jira cloud URL
 JIRA_USERNAME=your.email@domain.com                   # Your Atlassian account email
 JIRA_API_TOKEN=your_api_token                         # API token for Jira Cloud
 
+# Optional Jira filters
+# JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT               # Optional: Filter Jira projects
+
 # Jira Server/Data Center (alternative to JIRA_USERNAME and JIRA_API_TOKEN)
 # JIRA_URL=https://jira.your-company.com              # Your Jira Server/Data Center URL
 # JIRA_PERSONAL_TOKEN=your_personal_access_token      # Personal Access Token for Jira Server/Data Center
-# JIRA_SSL_VERIFY=true                                # Set to 'false' for self-signed certificates
+# JIRA_SSL_VERIFY=true                               # Set to 'false' for self-signed certificates
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The integration supports using either Confluence, Jira, or both services. You on
 - For Jira Cloud: Include `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN`
 - For Jira Server/Data Center: Include `JIRA_URL` and `JIRA_PERSONAL_TOKEN`
 - For SSE transport: Add `--transport sse` and `--port` arguments
+- To filter search results: Use `CONFLUENCE_SPACES_FILTER` and `JIRA_PROJECTS_FILTER` to narrow down results
 
 <details>
 <summary>View all configuration options</summary>
@@ -84,11 +85,13 @@ The integration supports using either Confluence, Jira, or both services. You on
 | Email | `CONFLUENCE_USERNAME` | `--confluence-username` | O | X |
 | API Token | `CONFLUENCE_API_TOKEN` | `--confluence-token` | O | X |
 | PAT | `CONFLUENCE_PERSONAL_TOKEN` | `--confluence-personal-token` | X | O |
+| Spaces Filter | `CONFLUENCE_SPACES_FILTER` | `--confluence-spaces-filter` | Optional | Optional |
 | **Jira** |
 | URL | `JIRA_URL` | `--jira-url` | O | O |
 | Email | `JIRA_USERNAME` | `--jira-username` | O | X |
 | API Token | `JIRA_API_TOKEN` | `--jira-token` | O | X |
 | PAT | `JIRA_PERSONAL_TOKEN` | `--jira-personal-token` | X | O |
+| Projects Filter | `JIRA_PROJECTS_FILTER` | `--jira-projects-filter` | Optional | Optional |
 | **Common** |
 | SSL Verify | `*_SSL_VERIFY` | `--[no-]*-ssl-verify` | X | Optional |
 | Transport | - | `--transport stdio\|sse` | Optional | Optional |
@@ -116,7 +119,26 @@ uvx mcp-atlassian \
   --jira-personal-token=token \
   --transport sse \
   --port 8000
+  
+# With search filters
+uvx mcp-atlassian \
+  --confluence-url=https://your.atlassian.net/wiki \
+  --confluence-username=email \
+  --confluence-token=token \
+  --confluence-spaces-filter=DEV,TEAM,DOC \
+  --jira-url=https://your.atlassian.net \
+  --jira-username=email \
+  --jira-token=token \
+  --jira-projects-filter=PROJ,DEV,SUPPORT
 ```
+
+You can also set filters using environment variables:
+```bash
+export CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC
+export JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT
+```
+
+These filters help narrow down search results to the most relevant spaces or projects, improving response quality and performance.
 
 ### 4. IDE Integration
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ uvx mcp-atlassian \
   --jira-personal-token=token \
   --transport sse \
   --port 8000
-  
+
 # With search filters
 uvx mcp-atlassian \
   --confluence-url=https://your.atlassian.net/wiki \

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -48,6 +48,10 @@ logger = logging.getLogger("mcp-atlassian")
     help="Verify SSL certificates for Confluence Server/Data Center (default: verify)",
 )
 @click.option(
+    "--confluence-spaces-filter",
+    help="Comma-separated list of Confluence space keys to filter search results",
+)
+@click.option(
     "--jira-url",
     help="Jira URL (e.g., https://your-domain.atlassian.net or https://jira.your-company.com)",
 )
@@ -62,6 +66,10 @@ logger = logging.getLogger("mcp-atlassian")
     default=True,
     help="Verify SSL certificates for Jira Server/Data Center (default: verify)",
 )
+@click.option(
+    "--jira-projects-filter",
+    help="Comma-separated list of Jira project keys to filter search results",
+)
 def main(
     verbose: bool,
     env_file: str | None,
@@ -72,11 +80,13 @@ def main(
     confluence_token: str | None,
     confluence_personal_token: str | None,
     confluence_ssl_verify: bool,
+    confluence_spaces_filter: str | None,
     jira_url: str | None,
     jira_username: str | None,
     jira_token: str | None,
     jira_personal_token: str | None,
     jira_ssl_verify: bool,
+    jira_projects_filter: str | None,
 ) -> None:
     """MCP Atlassian Server - Jira and Confluence functionality for MCP
 
@@ -120,8 +130,16 @@ def main(
     # Set SSL verification for Confluence Server/Data Center
     os.environ["CONFLUENCE_SSL_VERIFY"] = str(confluence_ssl_verify).lower()
 
+    # Set spaces filter for Confluence
+    if confluence_spaces_filter:
+        os.environ["CONFLUENCE_SPACES_FILTER"] = confluence_spaces_filter
+
     # Set SSL verification for Jira Server/Data Center
     os.environ["JIRA_SSL_VERIFY"] = str(jira_ssl_verify).lower()
+
+    # Set projects filter for Jira
+    if jira_projects_filter:
+        os.environ["JIRA_PROJECTS_FILTER"] = jira_projects_filter
 
     from . import server
 

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -15,6 +15,7 @@ class ConfluenceConfig:
     api_token: str | None = None  # API token used as password
     personal_token: str | None = None  # Personal access token (Server/DC)
     ssl_verify: bool = True  # Whether to verify SSL certificates
+    spaces_filter: str | None = None  # List of space keys to filter searches
 
     @property
     def is_cloud(self) -> bool:
@@ -71,6 +72,9 @@ class ConfluenceConfig:
         # SSL verification (for Server/DC)
         ssl_verify_env = os.getenv("CONFLUENCE_SSL_VERIFY", "true").lower()
         ssl_verify = ssl_verify_env not in ("false", "0", "no")
+        
+        # Get the spaces filter if provided
+        spaces_filter = os.getenv("CONFLUENCE_SPACES_FILTER")
 
         return cls(
             url=url,
@@ -79,4 +83,5 @@ class ConfluenceConfig:
             api_token=api_token,
             personal_token=personal_token,
             ssl_verify=ssl_verify,
+            spaces_filter=spaces_filter,
         )

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -72,7 +72,7 @@ class ConfluenceConfig:
         # SSL verification (for Server/DC)
         ssl_verify_env = os.getenv("CONFLUENCE_SSL_VERIFY", "true").lower()
         ssl_verify = ssl_verify_env not in ("false", "0", "no")
-        
+
         # Get the spaces filter if provided
         spaces_filter = os.getenv("CONFLUENCE_SPACES_FILTER")
 

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -13,18 +13,39 @@ logger = logging.getLogger("mcp-atlassian")
 class SearchMixin(ConfluenceClient):
     """Mixin for Confluence search operations."""
 
-    def search(self, cql: str, limit: int = 10) -> list[ConfluencePage]:
+    def search(self, cql: str, limit: int = 10, spaces_filter: str | None = None) -> list[ConfluencePage]:
         """
         Search content using Confluence Query Language (CQL).
 
         Args:
             cql: Confluence Query Language string
             limit: Maximum number of results to return
+            spaces_filter: Optional comma-separated list of space keys to filter by, overrides config
 
         Returns:
             List of ConfluencePage models containing search results
         """
         try:
+            # Use spaces_filter parameter if provided, otherwise fall back to config
+            filter_to_use = spaces_filter or self.config.spaces_filter
+            
+            # Apply spaces filter if present
+            if filter_to_use:
+                # Split spaces filter by commas and handle possible whitespace
+                spaces = [s.strip() for s in filter_to_use.split(",")]
+                
+                # Build the space filter query part
+                space_query = " OR ".join([f'space = "{space}"' for space in spaces])
+                
+                # Add the space filter to existing query with parentheses
+                if cql and space_query:
+                    if "space = " not in cql:  # Only add if not already filtering by space
+                        cql = f"({cql}) AND ({space_query})" 
+                else:
+                    cql = space_query
+                    
+                logger.info(f"Applied spaces filter to query: {cql}")
+                
             # Execute the CQL search query
             results = self.confluence.cql(cql=cql, limit=limit)
 

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -13,7 +13,9 @@ logger = logging.getLogger("mcp-atlassian")
 class SearchMixin(ConfluenceClient):
     """Mixin for Confluence search operations."""
 
-    def search(self, cql: str, limit: int = 10, spaces_filter: str | None = None) -> list[ConfluencePage]:
+    def search(
+        self, cql: str, limit: int = 10, spaces_filter: str | None = None
+    ) -> list[ConfluencePage]:
         """
         Search content using Confluence Query Language (CQL).
 
@@ -28,24 +30,26 @@ class SearchMixin(ConfluenceClient):
         try:
             # Use spaces_filter parameter if provided, otherwise fall back to config
             filter_to_use = spaces_filter or self.config.spaces_filter
-            
+
             # Apply spaces filter if present
             if filter_to_use:
                 # Split spaces filter by commas and handle possible whitespace
                 spaces = [s.strip() for s in filter_to_use.split(",")]
-                
+
                 # Build the space filter query part
                 space_query = " OR ".join([f'space = "{space}"' for space in spaces])
-                
+
                 # Add the space filter to existing query with parentheses
                 if cql and space_query:
-                    if "space = " not in cql:  # Only add if not already filtering by space
-                        cql = f"({cql}) AND ({space_query})" 
+                    if (
+                        "space = " not in cql
+                    ):  # Only add if not already filtering by space
+                        cql = f"({cql}) AND ({space_query})"
                 else:
                     cql = space_query
-                    
+
                 logger.info(f"Applied spaces filter to query: {cql}")
-                
+
             # Execute the CQL search query
             results = self.confluence.cql(cql=cql, limit=limit)
 

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -19,6 +19,7 @@ class JiraConfig:
     api_token: str | None = None  # API token (Cloud)
     personal_token: str | None = None  # Personal access token (Server/DC)
     ssl_verify: bool = True  # Whether to verify SSL certificates
+    projects_filter: str | None = None  # List of project keys to filter searches
 
     @property
     def is_cloud(self) -> bool:
@@ -83,6 +84,9 @@ class JiraConfig:
         # SSL verification (for Server/DC)
         ssl_verify_env = os.getenv("JIRA_SSL_VERIFY", "true").lower()
         ssl_verify = ssl_verify_env not in ("false", "0", "no")
+        
+        # Get the projects filter if provided
+        projects_filter = os.getenv("JIRA_PROJECTS_FILTER")
 
         return cls(
             url=url,
@@ -91,4 +95,5 @@ class JiraConfig:
             api_token=api_token,
             personal_token=personal_token,
             ssl_verify=ssl_verify,
+            projects_filter=projects_filter,
         )

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -84,7 +84,7 @@ class JiraConfig:
         # SSL verification (for Server/DC)
         ssl_verify_env = os.getenv("JIRA_SSL_VERIFY", "true").lower()
         ssl_verify = ssl_verify_env not in ("false", "0", "no")
-        
+
         # Get the projects filter if provided
         projects_filter = os.getenv("JIRA_PROJECTS_FILTER")
 

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -19,6 +19,7 @@ class SearchMixin(JiraClient):
         start: int = 0,
         limit: int = 50,
         expand: str | None = None,
+        projects_filter: str | None = None,
     ) -> list[JiraIssue]:
         """
         Search for issues using JQL (Jira Query Language).
@@ -29,6 +30,7 @@ class SearchMixin(JiraClient):
             start: Starting index
             limit: Maximum issues to return
             expand: Optional items to expand (comma-separated)
+            projects_filter: Optional comma-separated list of project keys to filter by, overrides config
 
         Returns:
             List of JiraIssue models representing the search results
@@ -37,6 +39,32 @@ class SearchMixin(JiraClient):
             Exception: If there is an error searching for issues
         """
         try:
+            # Use projects_filter parameter if provided, otherwise fall back to config
+            filter_to_use = projects_filter or self.config.projects_filter
+            
+            # Apply projects filter if present
+            if filter_to_use:
+                # Split projects filter by commas and handle possible whitespace
+                projects = [p.strip() for p in filter_to_use.split(",")]
+                
+                # Build the project filter query part
+                if len(projects) == 1:
+                    project_query = f'project = {projects[0]}'
+                else:
+                    quoted_projects = [f'"{p}"' for p in projects]
+                    projects_list = ", ".join(quoted_projects)
+                    project_query = f'project IN ({projects_list})'
+                
+                # Add the project filter to existing query
+                if jql and project_query:
+                    if "project = " not in jql and "project IN" not in jql:  
+                        # Only add if not already filtering by project
+                        jql = f"({jql}) AND {project_query}" 
+                else:
+                    jql = project_query
+                    
+                logger.info(f"Applied projects filter to query: {jql}")
+                
             response = self.jira.jql(
                 jql, fields=fields, start=start, limit=limit, expand=expand
             )

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -41,30 +41,30 @@ class SearchMixin(JiraClient):
         try:
             # Use projects_filter parameter if provided, otherwise fall back to config
             filter_to_use = projects_filter or self.config.projects_filter
-            
+
             # Apply projects filter if present
             if filter_to_use:
                 # Split projects filter by commas and handle possible whitespace
                 projects = [p.strip() for p in filter_to_use.split(",")]
-                
+
                 # Build the project filter query part
                 if len(projects) == 1:
-                    project_query = f'project = {projects[0]}'
+                    project_query = f"project = {projects[0]}"
                 else:
                     quoted_projects = [f'"{p}"' for p in projects]
                     projects_list = ", ".join(quoted_projects)
-                    project_query = f'project IN ({projects_list})'
-                
+                    project_query = f"project IN ({projects_list})"
+
                 # Add the project filter to existing query
                 if jql and project_query:
-                    if "project = " not in jql and "project IN" not in jql:  
+                    if "project = " not in jql and "project IN" not in jql:
                         # Only add if not already filtering by project
-                        jql = f"({jql}) AND {project_query}" 
+                        jql = f"({jql}) AND {project_query}"
                 else:
                     jql = project_query
-                    
+
                 logger.info(f"Applied projects filter to query: {jql}")
-                
+
             response = self.jira.jql(
                 jql, fields=fields, start=start, limit=limit, expand=expand
             )

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -883,7 +883,9 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 query = f'text ~ "{query}"'
                 logger.info(f"Converting simple search term to CQL: {query}")
 
-            pages = ctx.confluence.search(query, limit=limit, spaces_filter=spaces_filter)
+            pages = ctx.confluence.search(
+                query, limit=limit, spaces_filter=spaces_filter
+            )
 
             # Format results using the to_simplified_dict method
             search_results = [page.to_simplified_dict() for page in pages]
@@ -1134,7 +1136,9 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             limit = min(int(arguments.get("limit", 10)), 50)
             projects_filter = arguments.get("projects_filter")
 
-            issues = ctx.jira.search_issues(jql, fields=fields, limit=limit, projects_filter=projects_filter)
+            issues = ctx.jira.search_issues(
+                jql, fields=fields, limit=limit, projects_filter=projects_filter
+            )
 
             # Format results using the to_simplified_dict method
             search_results = [issue.to_simplified_dict() for issue in issues]

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -5,12 +5,24 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from mcp_atlassian.jira.projects import ProjectsMixin
+from mcp_atlassian.jira.config import JiraConfig
 
 
 @pytest.fixture
-def projects_mixin():
+def mock_config():
+    """Fixture to create a mock JiraConfig instance."""
+    config = MagicMock(spec=JiraConfig)
+    config.url = "https://test.atlassian.net"
+    config.username = "test@example.com"
+    config.api_token = "test-token"
+    config.auth_type = "token"
+    return config
+
+
+@pytest.fixture
+def projects_mixin(mock_config):
     """Fixture to create a ProjectsMixin instance for testing."""
-    mixin = ProjectsMixin()
+    mixin = ProjectsMixin(config=mock_config)
     mixin.jira = MagicMock()
     return mixin
 

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from mcp_atlassian.jira.projects import ProjectsMixin
 from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.jira.projects import ProjectsMixin
 
 
 @pytest.fixture

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -165,6 +165,106 @@ class TestSearchMixin:
         with pytest.raises(Exception, match="Error searching issues"):
             search_mixin.search_issues("project = TEST")
 
+    def test_search_issues_with_projects_filter(self, search_mixin):
+        """Test search with projects filter."""
+        # Setup mock response
+        mock_issues = {
+            "issues": [
+                {
+                    "id": "10001",
+                    "key": "TEST-123",
+                    "fields": {
+                        "summary": "Test issue",
+                        "issuetype": {"name": "Bug"},
+                        "status": {"name": "Open"},
+                    },
+                }
+            ],
+            "total": 1,
+            "startAt": 0,
+            "maxResults": 50,
+        }
+        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.config.url = "https://example.atlassian.net"
+
+        # Test with single project filter
+        result = search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
+        search_mixin.jira.jql.assert_called_with(
+            "(text ~ 'test') AND project = TEST",
+            fields="*all",
+            start=0,
+            limit=50,
+            expand=None,
+        )
+        assert len(result) == 1
+
+        # Test with multiple projects filter
+        result = search_mixin.search_issues("text ~ 'test'", projects_filter="TEST,DEV")
+        search_mixin.jira.jql.assert_called_with(
+            '(text ~ \'test\') AND project IN ("TEST", "DEV")',
+            fields="*all",
+            start=0,
+            limit=50,
+            expand=None,
+        )
+        assert len(result) == 1
+
+        # Test with filter when query already has project
+        result = search_mixin.search_issues("project = EXISTING", projects_filter="TEST")
+        search_mixin.jira.jql.assert_called_with(
+            "project = EXISTING",  # Should not add filter when project already exists
+            fields="*all",
+            start=0,
+            limit=50,
+            expand=None,
+        )
+        assert len(result) == 1
+
+    def test_search_issues_with_config_projects_filter(self, search_mixin):
+        """Test search using projects filter from config."""
+        # Setup mock response
+        mock_issues = {
+            "issues": [
+                {
+                    "id": "10001",
+                    "key": "TEST-123",
+                    "fields": {
+                        "summary": "Test issue",
+                        "issuetype": {"name": "Bug"},
+                        "status": {"name": "Open"},
+                    },
+                }
+            ],
+            "total": 1,
+            "startAt": 0,
+            "maxResults": 50,
+        }
+        search_mixin.jira.jql.return_value = mock_issues
+        search_mixin.config.url = "https://example.atlassian.net"
+        search_mixin.config.projects_filter = "TEST,DEV"
+
+        # Test with config filter
+        result = search_mixin.search_issues("text ~ 'test'")
+        search_mixin.jira.jql.assert_called_with(
+            '(text ~ \'test\') AND project IN ("TEST", "DEV")',
+            fields="*all",
+            start=0,
+            limit=50,
+            expand=None,
+        )
+        assert len(result) == 1
+
+        # Test that explicit filter overrides config filter
+        result = search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
+        search_mixin.jira.jql.assert_called_with(
+            "(text ~ 'test') AND project = OVERRIDE",
+            fields="*all",
+            start=0,
+            limit=50,
+            expand=None,
+        )
+        assert len(result) == 1
+
     def test_get_project_issues(self, search_mixin):
         """Test get_project_issues method."""
         # Mock the search_issues method

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -210,7 +210,9 @@ class TestSearchMixin:
         assert len(result) == 1
 
         # Test with filter when query already has project
-        result = search_mixin.search_issues("project = EXISTING", projects_filter="TEST")
+        result = search_mixin.search_issues(
+            "project = EXISTING", projects_filter="TEST"
+        )
         search_mixin.jira.jql.assert_called_with(
             "project = EXISTING",  # Should not add filter when project already exists
             fields="*all",


### PR DESCRIPTION
Add confluence-spaces and jira-projects filter arguments,
these filters help narrow down search results to the most relevant spaces or projects, improving response quality and performance.