### PR TITLE
Fix: Properly implement SSL verification bypass for self-signed certificates

### DIFF
--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -4,6 +4,8 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
+from ..utils import is_atlassian_cloud_url
+
 
 @dataclass
 class ConfluenceConfig:
@@ -18,8 +20,13 @@ class ConfluenceConfig:
 
     @property
     def is_cloud(self) -> bool:
-        """Check if this is a cloud instance."""
-        return "atlassian.net" in self.url
+        """Check if this is a cloud instance.
+
+        Returns:
+            True if this is a cloud instance (atlassian.net), False otherwise.
+            Localhost URLs are always considered non-cloud (Server/Data Center).
+        """
+        return is_atlassian_cloud_url(self.url)
 
     @property
     def verify_ssl(self) -> bool:
@@ -50,7 +57,8 @@ class ConfluenceConfig:
         api_token = os.getenv("CONFLUENCE_API_TOKEN")
         personal_token = os.getenv("CONFLUENCE_PERSONAL_TOKEN")
 
-        is_cloud = "atlassian.net" in url
+        # Use the shared utility function directly
+        is_cloud = is_atlassian_cloud_url(url)
 
         if is_cloud:
             if username and api_token:

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -4,6 +4,8 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
+from ..utils import is_atlassian_cloud_url
+
 
 @dataclass
 class JiraConfig:
@@ -26,8 +28,9 @@ class JiraConfig:
 
         Returns:
             True if this is a cloud instance (atlassian.net), False otherwise.
+            Localhost URLs are always considered non-cloud (Server/Data Center).
         """
-        return "atlassian.net" in self.url
+        return is_atlassian_cloud_url(self.url)
 
     @property
     def verify_ssl(self) -> bool:
@@ -58,7 +61,8 @@ class JiraConfig:
         api_token = os.getenv("JIRA_API_TOKEN")
         personal_token = os.getenv("JIRA_PERSONAL_TOKEN")
 
-        is_cloud = "atlassian.net" in url
+        # Use the shared utility function directly
+        is_cloud = is_atlassian_cloud_url(url)
 
         if is_cloud:
             if username and api_token:

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -12,6 +12,7 @@ from mcp.types import Resource, TextContent, Tool
 
 from .confluence import ConfluenceFetcher
 from .jira import JiraFetcher
+from .utils import is_atlassian_cloud_url
 
 # Configure logging
 logger = logging.getLogger("mcp-atlassian")
@@ -32,7 +33,8 @@ def get_available_services() -> dict[str, bool | None]:
     # or server/data center authentication (URL + personal token)
     confluence_url = os.getenv("CONFLUENCE_URL")
     if confluence_url:
-        is_cloud = "atlassian.net" in confluence_url
+        is_cloud = is_atlassian_cloud_url(confluence_url)
+
         if is_cloud:
             confluence_vars = all(
                 [
@@ -54,7 +56,8 @@ def get_available_services() -> dict[str, bool | None]:
     # or server/data center authentication (URL + personal token)
     jira_url = os.getenv("JIRA_URL")
     if jira_url:
-        is_cloud = "atlassian.net" in jira_url
+        is_cloud = is_atlassian_cloud_url(jira_url)
+
         if is_cloud:
             jira_vars = all(
                 [jira_url, os.getenv("JIRA_USERNAME"), os.getenv("JIRA_API_TOKEN")]

--- a/src/mcp_atlassian/utils.py
+++ b/src/mcp_atlassian/utils.py
@@ -1,24 +1,41 @@
 """Utility functions for the MCP Atlassian integration."""
 
 import logging
+import ssl
 from typing import Any
 from urllib.parse import urlparse
 
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
+from urllib3.poolmanager import PoolManager
 
 # Configure logging
 logger = logging.getLogger("mcp-atlassian")
+
+
+def is_atlassian_cloud_url(url: str) -> bool:
+    """Determine if a URL belongs to Atlassian Cloud or Server/Data Center.
+
+    Args:
+        url: The URL to check
+
+    Returns:
+        True if the URL is for an Atlassian Cloud instance, False for Server/Data Center
+    """
+    # Localhost and IP-based URLs are always Server/Data Center
+    if "localhost" in url or "127.0.0.1" in url:
+        return False
+
+    # The standard check for Atlassian cloud domains
+    return "atlassian.net" in url
 
 
 class SSLIgnoreAdapter(HTTPAdapter):
     """HTTP adapter that ignores SSL verification.
 
     A custom transport adapter that disables SSL certificate verification for specific domains.
-
-    The adapter overrides the cert_verify method to force verify=False, ensuring SSL verification
-    is bypassed regardless of the verify parameter passed to the request. This only affects
-    domains where the adapter is explicitly mounted.
+    This implementation ensures that both verify_mode is set to CERT_NONE and check_hostname
+    is disabled, which is required for properly ignoring SSL certificates.
 
     Example:
         session = requests.Session()
@@ -31,8 +48,38 @@ class SSLIgnoreAdapter(HTTPAdapter):
         man-in-the-middle attacks.
     """
 
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any
+    ) -> None:
+        """Initialize the connection pool manager with SSL verification disabled.
+
+        This method is called when the adapter is created, and it's the proper place to
+        disable SSL verification completely.
+
+        Args:
+            connections: Number of connections to save in the pool
+            maxsize: Maximum number of connections in the pool
+            block: Whether to block when the pool is full
+            pool_kwargs: Additional arguments for the pool manager
+        """
+        # Configure SSL context to disable verification completely
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+
+        self.poolmanager = PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=context,
+            **pool_kwargs,
+        )
+
     def cert_verify(self, conn: Any, url: str, verify: bool, cert: Any | None) -> None:
         """Override cert verification to disable SSL verification.
+
+        This method is still included for backward compatibility, but the main
+        SSL disabling happens in init_poolmanager.
 
         Args:
             conn: The connection

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,30 @@
+"""Configuration for integration tests."""
+
+import pytest
+
+
+def pytest_configure(config):
+    """Add integration marker."""
+    config.addinivalue_line(
+        "markers", "integration: mark test as requiring integration with real services"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip integration tests unless explicitly requested."""
+    if not config.getoption("--integration", default=False):
+        # Skip integration tests by default
+        skip_integration = pytest.mark.skip(reason="Need --integration option to run")
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_integration)
+
+
+def pytest_addoption(parser):
+    """Add integration option to pytest."""
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="run integration tests",
+    )

--- a/tests/integration/test_ssl_verification.py
+++ b/tests/integration/test_ssl_verification.py
@@ -1,0 +1,75 @@
+"""Integration tests for SSL verification functionality."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from requests.sessions import Session
+
+from mcp_atlassian.utils import SSLIgnoreAdapter, configure_ssl_verification
+
+
+@pytest.mark.integration
+def test_configure_ssl_verification_with_real_confluence_url():
+    """Test SSL verification configuration with real Confluence URL from environment."""
+    # Get the URL from the environment
+    url = os.getenv("CONFLUENCE_URL")
+    if not url:
+        pytest.skip("CONFLUENCE_URL not set in environment")
+
+    # Create a real session
+    session = Session()
+    original_adapters_count = len(session.adapters)
+
+    # Mock the SSL_VERIFY value to be False for this test
+    with patch.dict(os.environ, {"CONFLUENCE_SSL_VERIFY": "false"}):
+        # Configure SSL verification - explicitly pass ssl_verify=False
+        configure_ssl_verification(
+            service_name="Confluence",
+            url=url,
+            session=session,
+            ssl_verify=False,
+        )
+
+        # Extract domain from URL (remove protocol and path)
+        domain = url.split("://")[1].split("/")[0]
+
+        # Verify the adapters are mounted correctly
+        assert len(session.adapters) == original_adapters_count + 2
+        assert f"https://{domain}" in session.adapters
+        assert f"http://{domain}" in session.adapters
+        assert isinstance(session.adapters[f"https://{domain}"], SSLIgnoreAdapter)
+        assert isinstance(session.adapters[f"http://{domain}"], SSLIgnoreAdapter)
+
+
+@pytest.mark.integration
+def test_configure_ssl_verification_with_real_jira_url():
+    """Test SSL verification configuration with real Jira URL from environment."""
+    # Get the URL from the environment
+    url = os.getenv("JIRA_URL")
+    if not url:
+        pytest.skip("JIRA_URL not set in environment")
+
+    # Create a real session
+    session = Session()
+    original_adapters_count = len(session.adapters)
+
+    # Mock the SSL_VERIFY value to be False for this test
+    with patch.dict(os.environ, {"JIRA_SSL_VERIFY": "false"}):
+        # Configure SSL verification - explicitly pass ssl_verify=False
+        configure_ssl_verification(
+            service_name="Jira",
+            url=url,
+            session=session,
+            ssl_verify=False,
+        )
+
+        # Extract domain from URL (remove protocol and path)
+        domain = url.split("://")[1].split("/")[0]
+
+        # Verify the adapters are mounted correctly
+        assert len(session.adapters) == original_adapters_count + 2
+        assert f"https://{domain}" in session.adapters
+        assert f"http://{domain}" in session.adapters
+        assert isinstance(session.adapters[f"https://{domain}"], SSLIgnoreAdapter)
+        assert isinstance(session.adapters[f"http://{domain}"], SSLIgnoreAdapter)

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -75,27 +75,43 @@ def test_from_env_missing_server_auth():
 
 def test_is_cloud():
     """Test that is_cloud property returns correct value."""
-    # Cloud instance
+    # Arrange & Act - Cloud URL
     config = ConfluenceConfig(
-        url="https://test.atlassian.net/wiki",
+        url="https://example.atlassian.net/wiki",
         auth_type="basic",
-        username="user",
-        api_token="token",
+        username="test",
+        api_token="test",
     )
+
+    # Assert
     assert config.is_cloud is True
 
-    # Server instance with basic authentication
+    # Arrange & Act - Server URL
     config = ConfluenceConfig(
-        url="https://confluence.company.com",
-        auth_type="basic",
-        username="user",
-        api_token="token",
+        url="https://confluence.example.com",
+        auth_type="token",
+        personal_token="test",
     )
+
+    # Assert
     assert config.is_cloud is False
 
-    # Server instance with token
+    # Arrange & Act - Localhost URL (Data Center/Server)
     config = ConfluenceConfig(
-        url="https://confluence.company.com",
+        url="http://localhost:8090",
         auth_type="token",
-        personal_token="token",
+        personal_token="test",
     )
+
+    # Assert
+    assert config.is_cloud is False
+
+    # Arrange & Act - IP localhost URL (Data Center/Server)
+    config = ConfluenceConfig(
+        url="http://127.0.0.1:8090",
+        auth_type="token",
+        personal_token="test",
+    )
+
+    # Assert
+    assert config.is_cloud is False

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -97,19 +97,43 @@ def test_from_env_missing_server_auth():
 
 def test_is_cloud():
     """Test that is_cloud property returns correct value."""
-    # Cloud instance
+    # Arrange & Act - Cloud URL
     config = JiraConfig(
-        url="https://test.atlassian.net",
+        url="https://example.atlassian.net",
         auth_type="basic",
-        username="user",
-        api_token="token",
+        username="test",
+        api_token="test",
     )
+
+    # Assert
     assert config.is_cloud is True
 
-    # Server/Data Center instance
+    # Arrange & Act - Server URL
     config = JiraConfig(
         url="https://jira.example.com",
         auth_type="token",
-        personal_token="token",
+        personal_token="test",
     )
+
+    # Assert
+    assert config.is_cloud is False
+
+    # Arrange & Act - Localhost URL (Data Center/Server)
+    config = JiraConfig(
+        url="http://localhost:8080",
+        auth_type="token",
+        personal_token="test",
+    )
+
+    # Assert
+    assert config.is_cloud is False
+
+    # Arrange & Act - IP localhost URL (Data Center/Server)
+    config = JiraConfig(
+        url="http://127.0.0.1:8080",
+        auth_type="token",
+        personal_token="test",
+    )
+
+    # Assert
     assert config.is_cloud is False

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,10 +1,16 @@
 """Tests for the utilities module."""
 
+import ssl
 from unittest.mock import MagicMock, patch
 
 from requests.adapters import HTTPAdapter
+from requests.sessions import Session
 
-from mcp_atlassian.utils import SSLIgnoreAdapter, configure_ssl_verification
+from mcp_atlassian.utils import (
+    SSLIgnoreAdapter,
+    configure_ssl_verification,
+    is_atlassian_cloud_url,
+)
 
 
 def test_ssl_ignore_adapter_cert_verify():
@@ -26,6 +32,37 @@ def test_ssl_ignore_adapter_cert_verify():
         mock_super_cert_verify.assert_called_once_with(
             connection, url, verify=False, cert=cert
         )
+
+
+def test_ssl_ignore_adapter_init_poolmanager():
+    """Test that SSLIgnoreAdapter properly initializes the connection pool with SSL verification disabled."""
+    # Arrange
+    adapter = SSLIgnoreAdapter()
+
+    # Mock PoolManager
+    with patch("mcp_atlassian.utils.PoolManager") as mock_pool_manager:
+        # Mock ssl.create_default_context
+        with patch(
+            "mcp_atlassian.utils.ssl.create_default_context"
+        ) as mock_create_context:
+            mock_context = MagicMock()
+            mock_create_context.return_value = mock_context
+
+            # Act
+            adapter.init_poolmanager(5, 10, block=True)
+
+            # Assert
+            mock_create_context.assert_called_once()
+            assert mock_context.check_hostname is False
+            assert mock_context.verify_mode == ssl.CERT_NONE
+
+            # Verify PoolManager was called with our context
+            mock_pool_manager.assert_called_once()
+            _, kwargs = mock_pool_manager.call_args
+            assert kwargs["num_pools"] == 5
+            assert kwargs["maxsize"] == 10
+            assert kwargs["block"] is True
+            assert kwargs["ssl_context"] == mock_context
 
 
 def test_configure_ssl_verification_disabled():
@@ -66,3 +103,79 @@ def test_configure_ssl_verification_enabled():
         # Assert
         mock_adapter_class.assert_not_called()
         assert session.mount.call_count == 0
+
+
+def test_is_atlassian_cloud_url():
+    """Test the is_atlassian_cloud_url function correctly identifies cloud vs server URLs."""
+    # Test Cloud URLs
+    assert is_atlassian_cloud_url("https://example.atlassian.net") is True
+    assert is_atlassian_cloud_url("https://company.atlassian.net/wiki") is True
+
+    # Test Server/Data Center URLs
+    assert is_atlassian_cloud_url("https://jira.example.com") is False
+    assert is_atlassian_cloud_url("https://confluence.company.com") is False
+
+    # Test localhost URLs
+    assert is_atlassian_cloud_url("http://localhost:8080") is False
+    assert is_atlassian_cloud_url("http://localhost:8090/wiki") is False
+
+    # Test IP-based localhost URLs
+    assert is_atlassian_cloud_url("http://127.0.0.1:8080") is False
+    assert is_atlassian_cloud_url("https://127.0.0.1:8090") is False
+
+
+def test_configure_ssl_verification_enabled_with_real_session():
+    """Test SSL verification configuration when verification is enabled using a real Session."""
+    session = Session()
+    original_adapters_count = len(session.adapters)
+
+    # Configure with SSL verification enabled
+    configure_ssl_verification(
+        service_name="Test",
+        url="https://example.com",
+        session=session,
+        ssl_verify=True,
+    )
+
+    # No adapters should be added when SSL verification is enabled
+    assert len(session.adapters) == original_adapters_count
+
+
+def test_configure_ssl_verification_disabled_with_real_session():
+    """Test SSL verification configuration when verification is disabled using a real Session."""
+    session = Session()
+    original_adapters_count = len(session.adapters)
+
+    # Configure with SSL verification disabled
+    configure_ssl_verification(
+        service_name="Test",
+        url="https://example.com",
+        session=session,
+        ssl_verify=False,
+    )
+
+    # Should add custom adapters for http and https protocols
+    assert len(session.adapters) == original_adapters_count + 2
+    assert "https://example.com" in session.adapters
+    assert "http://example.com" in session.adapters
+    assert isinstance(session.adapters["https://example.com"], SSLIgnoreAdapter)
+    assert isinstance(session.adapters["http://example.com"], SSLIgnoreAdapter)
+
+
+def test_ssl_ignore_adapter():
+    """Test the SSLIgnoreAdapter overrides the cert_verify method."""
+    # Mock objects
+    adapter = SSLIgnoreAdapter()
+    conn = MagicMock()
+    url = "https://example.com"
+    cert = None
+
+    # Test with verify=True - the adapter should still bypass SSL verification
+    with patch.object(HTTPAdapter, "cert_verify") as mock_cert_verify:
+        adapter.cert_verify(conn, url, verify=True, cert=cert)
+        mock_cert_verify.assert_called_once_with(conn, url, verify=False, cert=cert)
+
+    # Test with verify=False - same behavior
+    with patch.object(HTTPAdapter, "cert_verify") as mock_cert_verify:
+        adapter.cert_verify(conn, url, verify=False, cert=cert)
+        mock_cert_verify.assert_called_once_with(conn, url, verify=False, cert=cert)


### PR DESCRIPTION
## Problem
When SSL verification was disabled (`ssl_verify=False`), connections to Atlassian Server/Data Center 
instances with self-signed certificates still failed with SSL verification errors. This was happening
because the `SSLIgnoreAdapter` wasn't properly configuring the SSL context.

## Root Cause
The original implementation only overrode the `cert_verify` method but didn't properly configure
the SSL context. This resulted in the error: 
`Cannot set verify_mode to CERT_NONE when check_hostname is enabled`

## Solution
- Properly implement the `init_poolmanager` method in `SSLIgnoreAdapter` to configure the SSL context
- Disable both hostname checking and certificate verification by setting:
  - `context.check_hostname = False`
  - `context.verify_mode = ssl.CERT_NONE`
- Keep the existing `cert_verify` override for backwards compatibility
- Add comprehensive unit tests to verify the fix

## Benefits
- Connections to Atlassian instances with self-signed certificates now work correctly
- SSL verification can be properly disabled via environment variables
- No more configuration errors with local development environments

## Testing
- Added unit tests for SSL context configuration
- Manually tested with self-signed certificates
- Verified backwards compatibility

This fix resolves issue #135 where Confluence with SSL verification disabled
wasn't working properly with self-signed certificates.