### PR TITLE
Fix: jira_search fields parameter to correctly filter response fields

### DIFF
--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -43,7 +43,7 @@ class SearchMixin(JiraClient):
 
             # Convert the response to a search result model
             search_result = JiraSearchResult.from_api_response(
-                response, base_url=self.config.url
+                response, base_url=self.config.url, requested_fields=fields
             )
 
             # Return the list of issues


### PR DESCRIPTION
## Changes
- Modified the `JiraIssue` model to store custom fields and track requested fields
- Updated the conversion pipeline to preserve field filtering throughout
- Enhanced the `to_simplified_dict` method to only return fields that were requested
- Added test to verify field filtering for both standard and custom fields
- Ensured backward compatibility with existing code

## Testing
Added a unit test that verifies field filtering works correctly, including for custom fields.

## Related Issues
Fixes #141