### PR TITLE
Fix SSLError when using no SSL verify option

### DIFF
--- a/src/mcp_atlassian/utils.py
+++ b/src/mcp_atlassian/utils.py
@@ -67,8 +67,11 @@ class SSLIgnoreAdapter(HTTPAdapter):
         context = ssl.create_default_context()
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
-        context.options |= ssl.OP_LEGACY_SERVER_CONNECT
-        
+
+        # OP_LEGACY_SERVER_CONNECT was removed in Python 3.12
+        if hasattr(ssl, "OP_LEGACY_SERVER_CONNECT"):
+            context.options |= ssl.OP_LEGACY_SERVER_CONNECT
+
         self.poolmanager = PoolManager(
             num_pools=connections,
             maxsize=maxsize,

--- a/src/mcp_atlassian/utils.py
+++ b/src/mcp_atlassian/utils.py
@@ -67,7 +67,8 @@ class SSLIgnoreAdapter(HTTPAdapter):
         context = ssl.create_default_context()
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
-
+        context.options |= ssl.OP_LEGACY_SERVER_CONNECT
+        
         self.poolmanager = PoolManager(
             num_pools=connections,
             maxsize=maxsize,


### PR DESCRIPTION
This PR resolves an issue #148 where users encountered an SSL error `([SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1028))` when using the `--no-confluence-ssl-verify` or `--no-jira-ssl-verify` flag.

If a separate option needs to be created, or if comments or documentation updates are required, please let me know.

Fixes #148 
