### PR TITLE
Fix: reduce default logging level to ensure Cline VS Code compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,7 @@ JIRA_API_TOKEN=your_api_token
 # JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT              # Optional: Filter Jira projects
 
 # Debug options (CLI: -v, --verbose)
+# Default logging level is WARNING (minimal output)
+# Use MCP_VERBOSE=true or --verbose to set logging to INFO level
+# Use --verbose --verbose (or -vv) to set logging to DEBUG level
+# MCP_VERBOSE=true

--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ uvx mcp-atlassian \
 - `--port`: Port number for SSE transport (default: 8000)
 - `--[no-]confluence-ssl-verify`: Toggle SSL verification for Confluence Server/DC
 - `--[no-]jira-ssl-verify`: Toggle SSL verification for Jira Server/DC
-- `--verbose`: Increase logging verbosity (can be used multiple times)
-- `--read-only`: Run in read-only mode (disables all write operations)
 - `--confluence-spaces-filter`: Comma-separated list of space keys to filter Confluence search results (e.g., "DEV,TEAM,DOC")
 - `--jira-projects-filter`: Comma-separated list of project keys to filter Jira search results (e.g., "PROJ,DEV,SUPPORT")
+- `--read-only`: Run in read-only mode (disables all write operations)
+- `--verbose`: Increase logging verbosity (can be used multiple times, default is WARNING level)
+  - `-v` or `--verbose`: Set logging to INFO level
+  - `-vv` or `--verbose --verbose`: Set logging to DEBUG level
 
 > **Note:** All configuration options can also be set via environment variables. See the `.env.example` file in the repository for the full list of available environment variables.
 

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -10,7 +10,7 @@ from .utils.logging import setup_logging
 __version__ = "0.3.0"
 
 # Initialize logging with appropriate level
-logging_level = logging.INFO
+logging_level = logging.WARNING
 if os.getenv("MCP_VERBOSE", "").lower() in ("true", "1", "yes"):
     logging_level = logging.DEBUG
 
@@ -106,7 +106,7 @@ def main(
     Supports both Atlassian Cloud and Jira Server/Data Center deployments.
     """
     # Configure logging based on verbosity
-    logging_level = logging.INFO
+    logging_level = logging.WARNING
     if verbose == 1:
         logging_level = logging.INFO
     elif verbose >= 2:

--- a/src/mcp_atlassian/utils/logging.py
+++ b/src/mcp_atlassian/utils/logging.py
@@ -8,12 +8,12 @@ output stream based on their level.
 import logging
 
 
-def setup_logging(level: int = logging.INFO) -> logging.Logger:
+def setup_logging(level: int = logging.WARNING) -> logging.Logger:
     """
     Configure MCP-Atlassian logging with level-based stream routing.
 
     Args:
-        level: The minimum logging level to display
+        level: The minimum logging level to display (default: WARNING)
 
     Returns:
         The configured logger instance
@@ -32,8 +32,12 @@ def setup_logging(level: int = logging.INFO) -> logging.Logger:
     handler.setFormatter(formatter)
     root_logger.addHandler(handler)
 
-    # Configure the application logger
-    logger = logging.getLogger("mcp-atlassian")
-    logger.setLevel(level)
+    # Configure specific loggers
+    loggers = ["mcp-atlassian", "mcp.server", "mcp.server.lowlevel.server", "mcp-jira"]
 
-    return logger
+    for logger_name in loggers:
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(level)
+
+    # Return the application logger
+    return logging.getLogger("mcp-atlassian")

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -4,15 +4,15 @@ from mcp_atlassian.utils.logging import setup_logging
 
 
 def test_setup_logging_default_level():
-    """Test setup_logging with default INFO level"""
+    """Test setup_logging with default WARNING level"""
     logger = setup_logging()
 
-    # Check logger level is set to INFO
-    assert logger.level == logging.INFO
+    # Check logger level is set to WARNING
+    assert logger.level == logging.WARNING
 
     # Check root logger is configured
     root_logger = logging.getLogger()
-    assert root_logger.level == logging.INFO
+    assert root_logger.level == logging.WARNING
 
     # Verify handler and formatter
     assert len(root_logger.handlers) == 1


### PR DESCRIPTION
## Problem
The Cline VS Code extension was unable to connect to the mcp-atlassian server, while the same configuration worked correctly with Cursor IDE and Claude Desktop. Investigation revealed that Cline interprets all STDERR output (including INFO level logs) as errors, breaking the connection.

## Solution
This PR changes the default logging level from INFO to WARNING across all loggers:
- Sets default logging level to WARNING in both initialization paths
- Configures all relevant loggers (`mcp-atlassian`, `mcp.server`, `mcp.server.lowlevel.server`, `mcp-jira`) to use consistent levels
- Maintains the ability to increase verbosity with the `--verbose` flag (INFO level) or `-vv` flag (DEBUG level)
- Updates documentation to explain the logging levels and compatibility improvements

## Changes
- Modified `src/mcp_atlassian/__init__.py` to use WARNING as the default logging level
- Updated `src/mcp_atlassian/utils/logging.py` to properly configure all loggers
- Added explanatory comments to `.env.example` about logging levels
- Updated README with compatibility notes and improved documentation about logging flags

## Testing
- Verified connection with Cline VS Code extension now works properly
- Confirmed existing functionality with Claude Desktop and Cursor IDE remains intact
- Tested various verbosity settings to ensure logging control works as expected

## References
- Resolves #82
- Related to cline/cline#2333

As discussed in cline/cline#2333, the issue was caused by Cline's handling of STDERR output. This change prevents INFO messages from appearing on STDERR while maintaining compatibility with all clients.