### PR TITLE
Implement possibility to download attachments from JIRA

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -20,6 +20,7 @@ from .search import SearchMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
 from .worklog import WorklogMixin
+from .attachments import AttachmentsMixin
 
 
 class JiraFetcher(
@@ -33,6 +34,7 @@ class JiraFetcher(
     SearchMixin,
     IssuesMixin,
     UsersMixin,
+    AttachmentsMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -48,6 +50,7 @@ class JiraFetcher(
     - SearchMixin: Search operations
     - IssuesMixin: Issue operations
     - UsersMixin: User operations
+    - AttachmentsMixin: Attachment download operations
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -3,9 +3,9 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
-from ..models.jira import JiraAttachment, JiraIssue
+from ..models.jira import JiraAttachment
 from .client import JiraClient
 
 # Configure logging
@@ -34,37 +34,39 @@ class AttachmentsMixin(JiraClient):
             # Convert to absolute path if relative
             if not os.path.isabs(target_path):
                 target_path = os.path.abspath(target_path)
-                
+
             logger.info(f"Downloading attachment from {url} to {target_path}")
-            
+
             # Create the directory if it doesn't exist
             os.makedirs(os.path.dirname(target_path), exist_ok=True)
-            
+
             # Use the Jira session to download the file
             response = self.jira._session.get(url, stream=True)
             response.raise_for_status()
-            
+
             # Write the file to disk
             with open(target_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=8192):
                     f.write(chunk)
-            
+
             # Verify the file was created
             if os.path.exists(target_path):
                 file_size = os.path.getsize(target_path)
-                logger.info(f"Successfully downloaded attachment to {target_path} (size: {file_size} bytes)")
+                logger.info(
+                    f"Successfully downloaded attachment to {target_path} (size: {file_size} bytes)"
+                )
                 return True
             else:
                 logger.error(f"File was not created at {target_path}")
                 return False
-            
+
         except Exception as e:
             logger.error(f"Error downloading attachment: {str(e)}")
             return False
 
     def download_issue_attachments(
         self, issue_key: str, target_dir: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Download all attachments for a Jira issue.
 
@@ -78,77 +80,79 @@ class AttachmentsMixin(JiraClient):
         # Convert to absolute path if relative
         if not os.path.isabs(target_dir):
             target_dir = os.path.abspath(target_dir)
-            
-        logger.info(f"Downloading attachments for {issue_key} to directory: {target_dir}")
-            
+
+        logger.info(
+            f"Downloading attachments for {issue_key} to directory: {target_dir}"
+        )
+
         # Create the target directory if it doesn't exist
         target_path = Path(target_dir)
         target_path.mkdir(parents=True, exist_ok=True)
-        
+
         # Get the issue with attachments
         logger.info(f"Fetching issue {issue_key} with attachments")
         issue_data = self.jira.issue(issue_key, fields="attachment")
-        
+
         if not issue_data or "fields" not in issue_data:
             logger.error(f"Could not retrieve issue {issue_key}")
             return {"success": False, "error": f"Could not retrieve issue {issue_key}"}
-        
+
         # Process attachments
         attachments = []
         results = []
-        
+
         # Extract attachments from the API response
         attachment_data = issue_data.get("fields", {}).get("attachment", [])
-        
+
         if not attachment_data:
             return {
                 "success": True,
                 "message": f"No attachments found for issue {issue_key}",
                 "downloaded": [],
-                "failed": []
+                "failed": [],
             }
-        
+
         # Create JiraAttachment objects for each attachment
         for attachment in attachment_data:
             if isinstance(attachment, dict):
                 attachments.append(JiraAttachment.from_api_response(attachment))
-        
+
         # Download each attachment
         downloaded = []
         failed = []
-        
+
         for attachment in attachments:
             if not attachment.url:
                 logger.warning(f"No URL for attachment {attachment.filename}")
-                failed.append({
-                    "filename": attachment.filename,
-                    "error": "No URL available"
-                })
+                failed.append(
+                    {"filename": attachment.filename, "error": "No URL available"}
+                )
                 continue
-                
+
             # Create a safe filename
             safe_filename = Path(attachment.filename).name
             file_path = target_path / safe_filename
-            
+
             # Download the attachment
             success = self.download_attachment(attachment.url, str(file_path))
-            
+
             if success:
-                downloaded.append({
-                    "filename": attachment.filename,
-                    "path": str(file_path),
-                    "size": attachment.size
-                })
+                downloaded.append(
+                    {
+                        "filename": attachment.filename,
+                        "path": str(file_path),
+                        "size": attachment.size,
+                    }
+                )
             else:
-                failed.append({
-                    "filename": attachment.filename,
-                    "error": "Download failed"
-                })
-        
+                failed.append(
+                    {"filename": attachment.filename, "error": "Download failed"}
+                )
+
         return {
             "success": True,
             "issue_key": issue_key,
             "total": len(attachments),
             "downloaded": downloaded,
-            "failed": failed
+            "failed": failed,
         }

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -1,0 +1,154 @@
+"""Attachment operations for Jira API."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..models.jira import JiraAttachment, JiraIssue
+from .client import JiraClient
+
+# Configure logging
+logger = logging.getLogger("mcp-jira")
+
+
+class AttachmentsMixin(JiraClient):
+    """Mixin for Jira attachment operations."""
+
+    def download_attachment(self, url: str, target_path: str) -> bool:
+        """
+        Download a Jira attachment to the specified path.
+
+        Args:
+            url: The URL of the attachment to download
+            target_path: The path where the attachment should be saved
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not url:
+            logger.error("No URL provided for attachment download")
+            return False
+
+        try:
+            # Convert to absolute path if relative
+            if not os.path.isabs(target_path):
+                target_path = os.path.abspath(target_path)
+                
+            logger.info(f"Downloading attachment from {url} to {target_path}")
+            
+            # Create the directory if it doesn't exist
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+            
+            # Use the Jira session to download the file
+            response = self.jira._session.get(url, stream=True)
+            response.raise_for_status()
+            
+            # Write the file to disk
+            with open(target_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            
+            # Verify the file was created
+            if os.path.exists(target_path):
+                file_size = os.path.getsize(target_path)
+                logger.info(f"Successfully downloaded attachment to {target_path} (size: {file_size} bytes)")
+                return True
+            else:
+                logger.error(f"File was not created at {target_path}")
+                return False
+            
+        except Exception as e:
+            logger.error(f"Error downloading attachment: {str(e)}")
+            return False
+
+    def download_issue_attachments(
+        self, issue_key: str, target_dir: str
+    ) -> Dict[str, Any]:
+        """
+        Download all attachments for a Jira issue.
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123')
+            target_dir: The directory where attachments should be saved
+
+        Returns:
+            A dictionary with download results
+        """
+        # Convert to absolute path if relative
+        if not os.path.isabs(target_dir):
+            target_dir = os.path.abspath(target_dir)
+            
+        logger.info(f"Downloading attachments for {issue_key} to directory: {target_dir}")
+            
+        # Create the target directory if it doesn't exist
+        target_path = Path(target_dir)
+        target_path.mkdir(parents=True, exist_ok=True)
+        
+        # Get the issue with attachments
+        logger.info(f"Fetching issue {issue_key} with attachments")
+        issue_data = self.jira.issue(issue_key, fields="attachment")
+        
+        if not issue_data or "fields" not in issue_data:
+            logger.error(f"Could not retrieve issue {issue_key}")
+            return {"success": False, "error": f"Could not retrieve issue {issue_key}"}
+        
+        # Process attachments
+        attachments = []
+        results = []
+        
+        # Extract attachments from the API response
+        attachment_data = issue_data.get("fields", {}).get("attachment", [])
+        
+        if not attachment_data:
+            return {
+                "success": True,
+                "message": f"No attachments found for issue {issue_key}",
+                "downloaded": [],
+                "failed": []
+            }
+        
+        # Create JiraAttachment objects for each attachment
+        for attachment in attachment_data:
+            if isinstance(attachment, dict):
+                attachments.append(JiraAttachment.from_api_response(attachment))
+        
+        # Download each attachment
+        downloaded = []
+        failed = []
+        
+        for attachment in attachments:
+            if not attachment.url:
+                logger.warning(f"No URL for attachment {attachment.filename}")
+                failed.append({
+                    "filename": attachment.filename,
+                    "error": "No URL available"
+                })
+                continue
+                
+            # Create a safe filename
+            safe_filename = Path(attachment.filename).name
+            file_path = target_path / safe_filename
+            
+            # Download the attachment
+            success = self.download_attachment(attachment.url, str(file_path))
+            
+            if success:
+                downloaded.append({
+                    "filename": attachment.filename,
+                    "path": str(file_path),
+                    "size": attachment.size
+                })
+            else:
+                failed.append({
+                    "filename": attachment.filename,
+                    "error": "Download failed"
+                })
+        
+        return {
+            "success": True,
+            "issue_key": issue_key,
+            "total": len(attachments),
+            "downloaded": downloaded,
+            "failed": failed
+        }

--- a/src/mcp_atlassian/models/jira.py
+++ b/src/mcp_atlassian/models/jira.py
@@ -366,6 +366,84 @@ class JiraComment(ApiModel, TimestampMixin):
         return result
 
 
+class JiraAttachment(ApiModel):
+    """
+    Model representing a Jira issue attachment.
+    
+    This model contains information about files attached to Jira issues,
+    including the filename, size, content type, and download URL.
+    """
+
+    id: str = JIRA_DEFAULT_ID
+    filename: str = EMPTY_STRING
+    size: int = 0
+    content_type: str | None = None
+    created: str = EMPTY_STRING
+    author: JiraUser | None = None
+    url: str | None = None
+    thumbnail_url: str | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraAttachment":
+        """
+        Create a JiraAttachment from a Jira API response.
+
+        Args:
+            data: The attachment data from the Jira API
+
+        Returns:
+            A JiraAttachment instance
+        """
+        if not data:
+            return cls()
+
+        # Handle non-dictionary data by returning a default instance
+        if not isinstance(data, dict):
+            logger.debug("Received non-dictionary data, returning default instance")
+            return cls()
+
+        # Ensure ID is a string
+        attachment_id = data.get("id", JIRA_DEFAULT_ID)
+        if attachment_id is not None:
+            attachment_id = str(attachment_id)
+
+        # Extract author information
+        author = None
+        if author_data := data.get("author"):
+            author = JiraUser.from_api_response(author_data)
+
+        return cls(
+            id=attachment_id,
+            filename=str(data.get("filename", EMPTY_STRING)),
+            size=int(data.get("size", 0)),
+            content_type=data.get("mimeType"),
+            created=data.get("created", EMPTY_STRING),
+            author=author,
+            url=data.get("content"),
+            thumbnail_url=data.get("thumbnail"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result = {
+            "filename": self.filename,
+            "size": self.size,
+            "created": self.created,
+            "url": self.url,
+        }
+
+        if self.content_type:
+            result["content_type"] = self.content_type
+            
+        if self.author:
+            result["author"] = self.author.display_name
+            
+        if self.thumbnail_url:
+            result["thumbnail_url"] = self.thumbnail_url
+
+        return result
+
+
 class JiraIssue(ApiModel, TimestampMixin):
     """
     Model representing a Jira issue.
@@ -388,6 +466,7 @@ class JiraIssue(ApiModel, TimestampMixin):
     labels: list[str] = Field(default_factory=list)
     components: list[str] = Field(default_factory=list)
     comments: list[JiraComment] = Field(default_factory=list)
+    attachments: list[JiraAttachment] = Field(default_factory=list)
     url: str | None = None
     epic_key: str | None = None
     epic_name: str | None = None
@@ -570,6 +649,14 @@ class JiraIssue(ApiModel, TimestampMixin):
             if isinstance(comments_list, list):
                 comments = [JiraComment.from_api_response(c) for c in comments_list]
 
+        # Process attachments
+        attachments = []
+        attachments_data = fields.get("attachment", [])
+        if isinstance(attachments_data, list):
+            for attachment in attachments_data:
+                if isinstance(attachment, dict):
+                    attachments.append(JiraAttachment.from_api_response(attachment))
+
         # Construct URL if base_url is provided
         url = None
         base_url = kwargs.get("base_url")
@@ -637,6 +724,7 @@ class JiraIssue(ApiModel, TimestampMixin):
             labels=labels,
             components=components,
             comments=comments,
+            attachments=attachments,
             url=url,
             epic_key=epic_key,
             epic_name=epic_name,
@@ -717,6 +805,9 @@ class JiraIssue(ApiModel, TimestampMixin):
             ],
             "comments": lambda: [
                 comment.to_simplified_dict() for comment in self.comments
+            ],
+            "attachments": lambda: [
+                attachment.to_simplified_dict() for attachment in self.attachments
             ],
             "url": lambda: self.url,
             "epic_key": lambda: self.epic_key,

--- a/src/mcp_atlassian/models/jira.py
+++ b/src/mcp_atlassian/models/jira.py
@@ -369,7 +369,7 @@ class JiraComment(ApiModel, TimestampMixin):
 class JiraAttachment(ApiModel):
     """
     Model representing a Jira issue attachment.
-    
+
     This model contains information about files attached to Jira issues,
     including the filename, size, content type, and download URL.
     """
@@ -434,10 +434,10 @@ class JiraAttachment(ApiModel):
 
         if self.content_type:
             result["content_type"] = self.content_type
-            
+
         if self.author:
             result["author"] = self.author.display_name
-            
+
         if self.thumbnail_url:
             result["thumbnail_url"] = self.thumbnail_url
 

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -669,6 +669,24 @@ async def list_tools() -> list[Tool]:
                         "required": ["issue_key"],
                     },
                 ),
+                Tool(
+                    name="jira_download_attachments",
+                    description="Download attachments from a Jira issue",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "issue_key": {
+                                "type": "string",
+                                "description": "Jira issue key (e.g., 'PROJ-123')",
+                            },
+                            "target_dir": {
+                                "type": "string",
+                                "description": "Directory where attachments should be saved",
+                            },
+                        },
+                        "required": ["issue_key", "target_dir"],
+                    },
+                ),
             ]
         )
 
@@ -1293,6 +1311,31 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             return [
                 TextContent(
                     type="text", text=json.dumps(result, indent=2, ensure_ascii=False)
+                )
+            ]
+
+        elif name == "jira_download_attachments" and ctx and ctx.jira:
+            if not ctx or not ctx.jira:
+                raise ValueError("Jira is not configured.")
+
+            issue_key = arguments.get("issue_key")
+            target_dir = arguments.get("target_dir")
+
+            if not issue_key:
+                raise ValueError("Missing required parameter: issue_key")
+            if not target_dir:
+                raise ValueError("Missing required parameter: target_dir")
+
+            # Download the attachments
+            result = ctx.jira.download_issue_attachments(
+                issue_key=issue_key, 
+                target_dir=target_dir
+            )
+
+            return [
+                TextContent(
+                    type="text", 
+                    text=json.dumps(result, indent=2, ensure_ascii=False)
                 )
             ]
 

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -1328,14 +1328,12 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
 
             # Download the attachments
             result = ctx.jira.download_issue_attachments(
-                issue_key=issue_key, 
-                target_dir=target_dir
+                issue_key=issue_key, target_dir=target_dir
             )
 
             return [
                 TextContent(
-                    type="text", 
-                    text=json.dumps(result, indent=2, ensure_ascii=False)
+                    type="text", text=json.dumps(result, indent=2, ensure_ascii=False)
                 )
             ]
 

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -1,0 +1,397 @@
+"""Tests for the Jira attachments module."""
+
+from unittest.mock import MagicMock, mock_open, patch
+
+from mcp_atlassian.jira.attachments import AttachmentsMixin
+from mcp_atlassian.jira.config import JiraConfig
+
+# BSTASZ: some simple test scenarios for AttachmentsMixin
+# downloading attachment & attachments with a success,
+# with relative path
+# fail with no URL
+# fail with HTTP error
+# errors testing for files - write error, file exists, etc.
+# fail with not found issue
+# fail with missing URLs
+# fail with attachments downloading errors
+
+
+class TestAttachmentsMixin:
+    """Tests for the AttachmentsMixin class."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        # Create a mock Jira client
+        with (
+            patch("mcp_atlassian.jira.client.Jira"),
+            patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+        ):
+            config = JiraConfig(
+                url="https://test.atlassian.net",
+                auth_type="basic",
+                username="test_username",
+                api_token="test_token",
+            )
+            self.client = AttachmentsMixin(config=config)
+            self.client.jira = MagicMock()
+            self.client.jira._session = MagicMock()
+
+    def test_download_attachment_success(self):
+        """Test successful attachment download."""
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"test content"]
+        mock_response.raise_for_status = MagicMock()
+        self.client.jira._session.get.return_value = mock_response
+
+        # Mock file operations
+        with (
+            patch("builtins.open", mock_open()) as mock_file,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.getsize") as mock_getsize,
+            patch("os.makedirs") as mock_makedirs,
+        ):
+            mock_exists.return_value = True
+            mock_getsize.return_value = 12  # Length of "test content"
+
+            # Call the method
+            result = self.client.download_attachment(
+                "https://test.url/attachment", "/tmp/test_file.txt"
+            )
+
+            # Assertions
+            assert result is True
+            self.client.jira._session.get.assert_called_once_with(
+                "https://test.url/attachment", stream=True
+            )
+            mock_file.assert_called_once_with("/tmp/test_file.txt", "wb")
+            mock_file().write.assert_called_once_with(b"test content")
+            mock_makedirs.assert_called_once()
+
+    def test_download_attachment_relative_path(self):
+        """Test attachment download with a relative path."""
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"test content"]
+        mock_response.raise_for_status = MagicMock()
+        self.client.jira._session.get.return_value = mock_response
+
+        # Mock file operations and os.path.abspath
+        with (
+            patch("builtins.open", mock_open()) as mock_file,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.getsize") as mock_getsize,
+            patch("os.makedirs") as mock_makedirs,
+            patch("os.path.abspath") as mock_abspath,
+            patch("os.path.isabs") as mock_isabs,
+        ):
+            mock_exists.return_value = True
+            mock_getsize.return_value = 12
+            mock_isabs.return_value = False
+            mock_abspath.return_value = "/absolute/path/test_file.txt"
+
+            # Call the method with a relative path
+            result = self.client.download_attachment(
+                "https://test.url/attachment", "test_file.txt"
+            )
+
+            # Assertions
+            assert result is True
+            mock_isabs.assert_called_once_with("test_file.txt")
+            mock_abspath.assert_called_once_with("test_file.txt")
+            mock_file.assert_called_once_with("/absolute/path/test_file.txt", "wb")
+
+    def test_download_attachment_no_url(self):
+        """Test attachment download with no URL."""
+        result = self.client.download_attachment("", "/tmp/test_file.txt")
+        assert result is False
+
+    def test_download_attachment_http_error(self):
+        """Test attachment download with an HTTP error."""
+        # Mock the response to raise an HTTP error
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("HTTP Error")
+        self.client.jira._session.get.return_value = mock_response
+
+        result = self.client.download_attachment(
+            "https://test.url/attachment", "/tmp/test_file.txt"
+        )
+        assert result is False
+
+    def test_download_attachment_file_write_error(self):
+        """Test attachment download with a file write error."""
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"test content"]
+        mock_response.raise_for_status = MagicMock()
+        self.client.jira._session.get.return_value = mock_response
+
+        # Mock file operations to raise an exception during write
+        with (
+            patch("builtins.open", mock_open()) as mock_file,
+            patch("os.makedirs") as mock_makedirs,
+        ):
+            mock_file().write.side_effect = OSError("Write error")
+
+            result = self.client.download_attachment(
+                "https://test.url/attachment", "/tmp/test_file.txt"
+            )
+            assert result is False
+
+    def test_download_attachment_file_not_created(self):
+        """Test attachment download when file is not created."""
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"test content"]
+        mock_response.raise_for_status = MagicMock()
+        self.client.jira._session.get.return_value = mock_response
+
+        # Mock file operations
+        with (
+            patch("builtins.open", mock_open()) as mock_file,
+            patch("os.path.exists") as mock_exists,
+            patch("os.makedirs") as mock_makedirs,
+        ):
+            mock_exists.return_value = False  # File doesn't exist after write
+
+            result = self.client.download_attachment(
+                "https://test.url/attachment", "/tmp/test_file.txt"
+            )
+            assert result is False
+
+    def test_download_issue_attachments_success(self):
+        """Test successful download of all issue attachments."""
+        # Mock the issue data
+        mock_issue = {
+            "fields": {
+                "attachment": [
+                    {
+                        "filename": "test1.txt",
+                        "content": "https://test.url/attachment1",
+                        "size": 100,
+                    },
+                    {
+                        "filename": "test2.txt",
+                        "content": "https://test.url/attachment2",
+                        "size": 200,
+                    },
+                ]
+            }
+        }
+        self.client.jira.issue.return_value = mock_issue
+
+        # Mock JiraAttachment.from_api_response
+        mock_attachment1 = MagicMock()
+        mock_attachment1.filename = "test1.txt"
+        mock_attachment1.url = "https://test.url/attachment1"
+        mock_attachment1.size = 100
+
+        mock_attachment2 = MagicMock()
+        mock_attachment2.filename = "test2.txt"
+        mock_attachment2.url = "https://test.url/attachment2"
+        mock_attachment2.size = 200
+
+        # Mock the download_attachment method
+        with (
+            patch.object(
+                self.client, "download_attachment", return_value=True
+            ) as mock_download,
+            patch("pathlib.Path.mkdir") as mock_mkdir,
+            patch(
+                "mcp_atlassian.models.jira.JiraAttachment.from_api_response",
+                side_effect=[mock_attachment1, mock_attachment2],
+            ),
+        ):
+            result = self.client.download_issue_attachments(
+                "TEST-123", "/tmp/attachments"
+            )
+
+            # Assertions
+            assert result["success"] is True
+            assert len(result["downloaded"]) == 2
+            assert len(result["failed"]) == 0
+            assert result["total"] == 2
+            assert result["issue_key"] == "TEST-123"
+            assert mock_download.call_count == 2
+            mock_mkdir.assert_called_once()
+
+    def test_download_issue_attachments_relative_path(self):
+        """Test download issue attachments with a relative path."""
+        # Mock the issue data
+        mock_issue = {
+            "fields": {
+                "attachment": [
+                    {
+                        "filename": "test1.txt",
+                        "content": "https://test.url/attachment1",
+                        "size": 100,
+                    }
+                ]
+            }
+        }
+        self.client.jira.issue.return_value = mock_issue
+
+        # Mock attachment
+        mock_attachment = MagicMock()
+        mock_attachment.filename = "test1.txt"
+        mock_attachment.url = "https://test.url/attachment1"
+        mock_attachment.size = 100
+
+        # Mock path operations
+        with (
+            patch.object(
+                self.client, "download_attachment", return_value=True
+            ) as mock_download,
+            patch("pathlib.Path.mkdir") as mock_mkdir,
+            patch(
+                "mcp_atlassian.models.jira.JiraAttachment.from_api_response",
+                return_value=mock_attachment,
+            ),
+            patch("os.path.isabs") as mock_isabs,
+            patch("os.path.abspath") as mock_abspath,
+        ):
+            mock_isabs.return_value = False
+            mock_abspath.return_value = "/absolute/path/attachments"
+
+            result = self.client.download_issue_attachments("TEST-123", "attachments")
+
+            # Assertions
+            assert result["success"] is True
+            mock_isabs.assert_called_once_with("attachments")
+            mock_abspath.assert_called_once_with("attachments")
+
+    def test_download_issue_attachments_no_attachments(self):
+        """Test download when issue has no attachments."""
+        # Mock the issue data with no attachments
+        mock_issue = {"fields": {"attachment": []}}
+        self.client.jira.issue.return_value = mock_issue
+
+        with patch("pathlib.Path.mkdir") as mock_mkdir:
+            result = self.client.download_issue_attachments(
+                "TEST-123", "/tmp/attachments"
+            )
+
+            # Assertions
+            assert result["success"] is True
+            assert "No attachments found" in result["message"]
+            assert len(result["downloaded"]) == 0
+            assert len(result["failed"]) == 0
+            mock_mkdir.assert_called_once()
+
+    def test_download_issue_attachments_issue_not_found(self):
+        """Test download when issue cannot be retrieved."""
+        self.client.jira.issue.return_value = None
+
+        result = self.client.download_issue_attachments("TEST-123", "/tmp/attachments")
+
+        # Assertions
+        assert result["success"] is False
+        assert "Could not retrieve issue" in result["error"]
+
+    def test_download_issue_attachments_no_fields(self):
+        """Test download when issue has no fields."""
+        # Mock the issue data with no fields
+        mock_issue = {}  # Missing 'fields' key
+        self.client.jira.issue.return_value = mock_issue
+
+        result = self.client.download_issue_attachments("TEST-123", "/tmp/attachments")
+
+        # Assertions
+        assert result["success"] is False
+        assert "Could not retrieve issue" in result["error"]
+
+    def test_download_issue_attachments_some_failures(self):
+        """Test download when some attachments fail to download."""
+        # Mock the issue data
+        mock_issue = {
+            "fields": {
+                "attachment": [
+                    {
+                        "filename": "test1.txt",
+                        "content": "https://test.url/attachment1",
+                        "size": 100,
+                    },
+                    {
+                        "filename": "test2.txt",
+                        "content": "https://test.url/attachment2",
+                        "size": 200,
+                    },
+                ]
+            }
+        }
+        self.client.jira.issue.return_value = mock_issue
+
+        # Mock attachments
+        mock_attachment1 = MagicMock()
+        mock_attachment1.filename = "test1.txt"
+        mock_attachment1.url = "https://test.url/attachment1"
+        mock_attachment1.size = 100
+
+        mock_attachment2 = MagicMock()
+        mock_attachment2.filename = "test2.txt"
+        mock_attachment2.url = "https://test.url/attachment2"
+        mock_attachment2.size = 200
+
+        # Mock the download_attachment method to succeed for first attachment and fail for second
+        with (
+            patch.object(
+                self.client, "download_attachment", side_effect=[True, False]
+            ) as mock_download,
+            patch("pathlib.Path.mkdir") as mock_mkdir,
+            patch(
+                "mcp_atlassian.models.jira.JiraAttachment.from_api_response",
+                side_effect=[mock_attachment1, mock_attachment2],
+            ),
+        ):
+            result = self.client.download_issue_attachments(
+                "TEST-123", "/tmp/attachments"
+            )
+
+            # Assertions
+            assert result["success"] is True
+            assert len(result["downloaded"]) == 1
+            assert len(result["failed"]) == 1
+            assert result["downloaded"][0]["filename"] == "test1.txt"
+            assert result["failed"][0]["filename"] == "test2.txt"
+            assert mock_download.call_count == 2
+
+    def test_download_issue_attachments_missing_url(self):
+        """Test download when an attachment has no URL."""
+        # Mock the issue data
+        mock_issue = {
+            "fields": {
+                "attachment": [
+                    {
+                        "filename": "test1.txt",
+                        "content": "https://test.url/attachment1",
+                        "size": 100,
+                    }
+                ]
+            }
+        }
+        self.client.jira.issue.return_value = mock_issue
+
+        # Mock attachment with no URL
+        mock_attachment = MagicMock()
+        mock_attachment.filename = "test1.txt"
+        mock_attachment.url = None  # No URL
+        mock_attachment.size = 100
+
+        # Mock path operations
+        with (
+            patch("pathlib.Path.mkdir") as mock_mkdir,
+            patch(
+                "mcp_atlassian.models.jira.JiraAttachment.from_api_response",
+                return_value=mock_attachment,
+            ),
+        ):
+            result = self.client.download_issue_attachments(
+                "TEST-123", "/tmp/attachments"
+            )
+
+            # Assertions
+            assert result["success"] is True
+            assert len(result["downloaded"]) == 0
+            assert len(result["failed"]) == 1
+            assert result["failed"][0]["filename"] == "test1.txt"
+            assert "No URL available" in result["failed"][0]["error"]


### PR DESCRIPTION
As the title says, this adds an additional tool, which is accessible by specifying `jira_download_attachments issueId directory`.
Maybe this approach is extendible for Confluence too, as someone already requested in [https://github.com/sooperset/mcp-atlassian/issues/152](url)

