### PR TITLE
Parse fixVersions field properly under "fields"

### DIFF
--- a/src/mcp_atlassian/models/jira.py
+++ b/src/mcp_atlassian/models/jira.py
@@ -470,6 +470,7 @@ class JiraIssue(ApiModel, TimestampMixin):
     url: str | None = None
     epic_key: str | None = None
     epic_name: str | None = None
+    fix_versions: list[str] = Field(default_factory=list)
     custom_fields: dict[str, Any] = Field(default_factory=dict)
     requested_fields: str | list[str] | None = None
 
@@ -674,6 +675,14 @@ class JiraIssue(ApiModel, TimestampMixin):
                 if isinstance(attachment, dict):
                     attachments.append(JiraAttachment.from_api_response(attachment))
 
+        # Extract fixVersions safely
+        fix_versions = []
+        fix_versions_data = fields.get("fixVersions", [])
+        if isinstance(fix_versions_data, list):
+            for version in fix_versions_data:
+                if isinstance(version, dict) and "name" in version:
+                    fix_versions.append(version.get("name"))
+
         # Construct URL if base_url is provided
         url = None
         base_url = kwargs.get("base_url")
@@ -745,6 +754,7 @@ class JiraIssue(ApiModel, TimestampMixin):
             url=url,
             epic_key=epic_key,
             epic_name=epic_name,
+            fix_versions=fix_versions,
             custom_fields=custom_fields,
             requested_fields=requested_fields,
         )
@@ -809,6 +819,7 @@ class JiraIssue(ApiModel, TimestampMixin):
                     "url": self.url,
                     "epic_key": self.epic_key,
                     "epic_name": self.epic_name,
+                    "fix_versions": self.fix_versions,
                 }
             )
 
@@ -855,6 +866,7 @@ class JiraIssue(ApiModel, TimestampMixin):
                 "url": lambda: self.url,
                 "epic_key": lambda: self.epic_key,
                 "epic_name": lambda: self.epic_name,
+                "fix_versions": lambda: self.fix_versions,
             }
 
             # Process each requested field


### PR DESCRIPTION
It seems this field could be parsed too, as it is not custom field.

@sooperset I was thinking https://github.com/sooperset/mcp-atlassian/pull/157 will resolve this problem that I had, but it seems it parses custom fields only, no? Correct me if I'm wrong.

Anyways. I've added this code to parse this missing field, but maybe it would be good if there would be some refactor so instead of fetching all the predefined fields one-by-one it could just save the whole API call and fetch it depending on which `field` under `fields` user requests? Then it'd avoid adding more fields one-by-one in the future.

LMK what you think @sooperset 