### PR TITLE
Add `get` tool for Jira agile sprint and board

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # MCP Atlassian
 
+![PyPI Version](https://img.shields.io/pypi/v/mcp-atlassian)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/mcp-atlassian)
+![PePy - Total Downloads](https://static.pepy.tech/personalized-badge/mcp-atlassian?period=total&units=international_system&left_color=grey&right_color=blue&left_text=Total%20Downloads)
+![License](https://img.shields.io/github/license/sooperset/mcp-atlassian)
+
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). This integration supports both Confluence & Jira Cloud and Server/Data Center deployments.
 
 ### Feature Demo

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -20,6 +20,7 @@ from .search import SearchMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
 from .worklog import WorklogMixin
+from .boards import BoardsMixin
 
 
 class JiraFetcher(
@@ -33,6 +34,7 @@ class JiraFetcher(
     SearchMixin,
     IssuesMixin,
     UsersMixin,
+    BoardsMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -48,6 +50,7 @@ class JiraFetcher(
     - SearchMixin: Search operations
     - IssuesMixin: Issue operations
     - UsersMixin: User operations
+    - BoardsMixin: Board operations
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -17,6 +17,7 @@ from .formatting import FormattingMixin
 from .issues import IssuesMixin
 from .projects import ProjectsMixin
 from .search import SearchMixin
+from .sprints import SprintsMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
 from .worklog import WorklogMixin
@@ -35,6 +36,7 @@ class JiraFetcher(
     IssuesMixin,
     UsersMixin,
     BoardsMixin,
+    SprintsMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -51,6 +53,7 @@ class JiraFetcher(
     - IssuesMixin: Issue operations
     - UsersMixin: User operations
     - BoardsMixin: Board operations
+    - SprintsMixin: Sprint operations
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.

--- a/src/mcp_atlassian/jira/boards.py
+++ b/src/mcp_atlassian/jira/boards.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import requests
 
+from ..models.jira import JiraBoard
 from .client import JiraClient
 
 logger = logging.getLogger("mcp-jira")
@@ -32,7 +33,7 @@ class BoardsMixin(JiraClient):
             limit: Maximum number of boards to return
 
         Returns:
-            List of JiraBoards model with board information
+            List of board information
 
         Raises:
             Exception: If there is an error retrieving the boards
@@ -45,10 +46,43 @@ class BoardsMixin(JiraClient):
                 start=start,
                 limit=limit,
             )
-            return boards if isinstance(boards, list) else []
+            return boards.get("values", []) if isinstance(boards, dict) else []
         except requests.HTTPError as e:
             logger.error(f"Error getting all agile boards: {str(e.response.content)}")
             return []
         except Exception as e:
             logger.error(f"Error getting all agile boards: {str(e)}")
             return []
+
+    def get_all_agile_boards_model(
+        self,
+        board_name: str | None = None,
+        project_key: str | None = None,
+        board_type: str | None = None,
+        start: int = 0,
+        limit: int = 50,
+    ) -> list[JiraBoard]:
+        """
+        Get boards as JiraBoards model from Jira by name, project key, or type.
+
+        Args:
+            board_name: The name of board, support fuzzy search
+            project_key: Project key (e.g., PROJECT-123)
+            board_type: Board type (e.g., scrum, kanban)
+            start: Start index
+            limit: Maximum number of boards to return
+
+        Returns:
+            List of JiraBoards model with board information
+
+        Raises:
+            Exception: If there is an error retrieving the boards
+        """
+        boards = self.get_all_agile_boards(
+            board_name=board_name,
+            project_key=project_key,
+            board_type=board_type,
+            start=start,
+            limit=limit,
+        )
+        return [JiraBoard.from_api_response(board) for board in boards]

--- a/src/mcp_atlassian/jira/boards.py
+++ b/src/mcp_atlassian/jira/boards.py
@@ -1,0 +1,54 @@
+"""Module for Jira boards operations."""
+
+import logging
+from typing import Any
+
+import requests
+
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class BoardsMixin(JiraClient):
+    """Mixin for Jira boards operations."""
+
+    def get_all_agile_boards(
+        self,
+        board_name: str | None = None,
+        project_key: str | None = None,
+        board_type: str | None = None,
+        start: int = 0,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """
+        Get boards from Jira by name, project key, or type.
+
+        Args:
+            board_name: The name of board, support fuzzy search
+            project_key: Project key (e.g., PROJECT-123)
+            board_type: Board type (e.g., scrum, kanban)
+            start: Start index
+            limit: Maximum number of boards to return
+
+        Returns:
+            List of JiraBoards model with board information
+
+        Raises:
+            Exception: If there is an error retrieving the boards
+        """
+        try:
+            boards = self.jira.get_all_agile_boards(
+                board_name=board_name,
+                project_key=project_key,
+                board_type=board_type,
+                start=start,
+                limit=limit,
+            )
+            return boards if isinstance(boards, list) else []
+        except requests.HTTPError as e:
+            logger.error(f"Error getting all agile boards: {str(e.response.content)}")
+            return []
+        except Exception as e:
+            logger.error(f"Error getting all agile boards: {str(e)}")
+            return []

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -2,6 +2,8 @@
 
 import logging
 
+import requests
+
 from ..models.jira import JiraIssue, JiraSearchResult
 from .client import JiraClient
 from .utils import parse_date_ymd
@@ -153,6 +155,58 @@ class SearchMixin(JiraClient):
         except Exception as e:
             logger.error(f"Error getting issues for epic {epic_key}: {str(e)}")
             raise Exception(f"Error getting epic issues: {str(e)}") from e
+
+    def get_board_issues(
+        self,
+        board_id: str,
+        jql: str,
+        fields: str = "*all",
+        start: int = 0,
+        limit: int = 50,
+        expand: str | None = None,
+    ) -> list[JiraIssue]:
+        """
+        Get all issues linked to a specific board.
+
+        Args:
+            board_id: The ID of the board
+            jql: JQL query string
+            fields: Fields to return (comma-separated string or "*all")
+            start: Starting index
+            limit: Maximum issues to return
+            expand: Optional items to expand (comma-separated)
+
+        Returns:
+            List of JiraIssue models representing the issues linked to the board
+
+        Raises:
+            Exception: If there is an error getting board issues
+        """
+        try:
+            response = self.jira.get_issues_for_board(
+                board_id=board_id,
+                jql=jql,
+                fields=fields,
+                start=start,
+                limit=limit,
+                expand=expand,
+            )
+
+            # Convert the response to a search result model
+            search_result = JiraSearchResult.from_api_response(
+                response, base_url=self.config.url, requested_fields=fields
+            )
+            return search_result.issues
+        except requests.HTTPError as e:
+            logger.error(
+                f"Error searching issues for board '{board_id}': {str(e.response.content)}"
+            )
+            raise Exception(
+                f"Error searching issues for board: {str(e.response.content)}"
+            ) from e
+        except Exception as e:
+            logger.error(f"Error searching issues for board with JQL '{jql}': {str(e)}")
+            raise Exception(f"Error searching issues for board: {str(e)}") from e
 
     def _parse_date(self, date_str: str) -> str:
         """

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -199,14 +199,61 @@ class SearchMixin(JiraClient):
             return search_result.issues
         except requests.HTTPError as e:
             logger.error(
-                f"Error searching issues for board '{board_id}': {str(e.response.content)}"
+                f"Error searching issues for board with JQL '{board_id}': {str(e.response.content)}"
             )
             raise Exception(
-                f"Error searching issues for board: {str(e.response.content)}"
+                f"Error searching issues for board with JQL: {str(e.response.content)}"
             ) from e
         except Exception as e:
             logger.error(f"Error searching issues for board with JQL '{jql}': {str(e)}")
-            raise Exception(f"Error searching issues for board: {str(e)}") from e
+            raise Exception(
+                f"Error searching issues for board with JQL {str(e)}"
+            ) from e
+
+    def get_sprint_issues(
+        self,
+        sprint_id: str,
+        fields: str = "*all",
+        start: int = 0,
+        limit: int = 50,
+    ) -> list[JiraIssue]:
+        """
+        Get all issues linked to a specific sprint.
+
+        Args:
+            sprint_id: The ID of the sprint
+            fields: Fields to return (comma-separated string or "*all")
+            start: Starting index
+            limit: Maximum issues to return
+
+        Returns:
+            List of JiraIssue models representing the issues linked to the sprint
+
+        Raises:
+            Exception: If there is an error getting board issues
+        """
+        try:
+            response = self.jira.get_sprint_issues(
+                sprint_id=sprint_id,
+                start=start,
+                limit=limit,
+            )
+
+            # Convert the response to a search result model
+            search_result = JiraSearchResult.from_api_response(
+                response, base_url=self.config.url, requested_fields=fields
+            )
+            return search_result.issues
+        except requests.HTTPError as e:
+            logger.error(
+                f"Error searching issues for sprint '{sprint_id}': {str(e.response.content)}"
+            )
+            raise Exception(
+                f"Error searching issues for sprint: {str(e.response.content)}"
+            ) from e
+        except Exception as e:
+            logger.error(f"Error searching issues for sprint: {sprint_id}': {str(e)}")
+            raise Exception(f"Error searching issues for sprint: {str(e)}") from e
 
     def _parse_date(self, date_str: str) -> str:
         """

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -1,0 +1,70 @@
+"""Module for Jira sprints operations."""
+
+import logging
+from typing import Any
+
+import requests
+
+from ..models.jira import JiraSprint
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class SprintsMixin(JiraClient):
+    """Mixin for Jira sprints operations."""
+
+    def get_all_sprints_from_board(
+        self, board_id: str, state: str = None, start: int = 0, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """
+        Get all sprints from a board.
+
+        Args:
+            board_id: Board ID
+            state: Sprint state (e.g., active, future, closed) if None, return all state sprints
+            start: Start index
+            limit: Maximum number of sprints to return
+
+        Returns:
+            List of sprints
+        """
+        try:
+            sprints = self.jira.get_all_sprints_from_board(
+                board_id=board_id,
+                state=state,
+                start=start,
+                limit=limit,
+            )
+            return sprints.get("values", []) if isinstance(sprints, dict) else []
+        except requests.HTTPError as e:
+            logger.error(
+                f"Error getting all sprints from board: {str(e.response.content)}"
+            )
+            return []
+        except Exception as e:
+            logger.error(f"Error getting all sprints from board: {str(e)}")
+            return []
+
+    def get_all_sprints_from_board_model(
+        self, board_id: str, state: str = None, start: int = 0, limit: int = 50
+    ) -> list[JiraSprint]:
+        """
+        Get all sprints as JiraSprint from a board.
+
+        Args:
+            board_id: Board ID
+            state: Sprint state (e.g., active, future, closed) if None, return all state sprints
+            start: Start index
+            limit: Maximum number of sprints to return
+
+        Returns:
+            List of JiraSprint
+        """
+        sprints = self.get_all_sprints_from_board(
+            board_id=board_id,
+            state=state,
+            start=start,
+            limit=limit,
+        )
+        return [JiraSprint.from_api_response(sprint) for sprint in sprints]

--- a/src/mcp_atlassian/models/jira.py
+++ b/src/mcp_atlassian/models/jira.py
@@ -1030,3 +1030,50 @@ class JiraSearchResult(ApiModel):
                 "Search found %d issues but no issue data was returned", self.total
             )
         return self
+
+
+class JiraBoard(ApiModel):
+    """
+    Model representing a Jira board.
+    """
+
+    id: str = JIRA_DEFAULT_ID
+    name: str = UNKNOWN
+    type: str = UNKNOWN
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraBoard":
+        """
+        Create a JiraTransition instance from an API response dictionary.
+
+        Args:
+            data: The API response data
+            **kwargs: Additional options
+
+        Returns:
+            A new JiraTransition instance
+        """
+        if not data:
+            return cls()
+
+        # Handle non-dictionary data by returning a default instance
+        if not isinstance(data, dict):
+            logger.debug("Received non-dictionary data, returning default instance")
+            return cls()
+
+        transition_data: dict[str, Any] = {}
+
+        # Ensure ID is a string (API sometimes returns integers)
+        transition_id = data.get("id", JIRA_DEFAULT_ID)
+        if transition_id is not None:
+            transition_id = str(transition_id)
+        transition_data["id"] = transition_id
+
+        transition_data["name"] = str(data.get("name", UNKNOWN))
+        transition_data["type"] = str(data.get("type", UNKNOWN))
+
+        return cls(
+            id=transition_id,
+            name=str(data.get("name", UNKNOWN)),
+            type=str(data.get("type", UNKNOWN)),
+        )

--- a/src/mcp_atlassian/models/jira.py
+++ b/src/mcp_atlassian/models/jira.py
@@ -1044,14 +1044,14 @@ class JiraBoard(ApiModel):
     @classmethod
     def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraBoard":
         """
-        Create a JiraTransition instance from an API response dictionary.
+        Create a JiraBoard instance from an API response dictionary.
 
         Args:
             data: The API response data
             **kwargs: Additional options
 
         Returns:
-            A new JiraTransition instance
+            A new JiraBoard instance
         """
         if not data:
             return cls()
@@ -1086,4 +1086,83 @@ class JiraBoard(ApiModel):
             "id": self.id,
             "name": self.name,
             "type": self.type,
+        }
+
+
+class JiraSprint(ApiModel):
+    """
+    Model representing a Jira sprint.
+    """
+
+    id: str = JIRA_DEFAULT_ID
+    state: str = UNKNOWN
+    name: str = UNKNOWN
+    start_date: str = EMPTY_STRING
+    end_date: str = EMPTY_STRING
+    activated_date: str = EMPTY_STRING
+    origin_board_id: str = JIRA_DEFAULT_ID
+    goal: str = EMPTY_STRING
+    synced: bool = False
+    auto_start_stop: bool = False
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraSprint":
+        """
+        Create a JiraSprint instance from an API response dictionary.
+
+        Args:
+            data: The API response data
+            **kwargs: Additional options
+
+        Returns:
+            A new JiraSprint instance
+        """
+        if not data:
+            return cls()
+
+        # Handle non-dictionary data by returning a default instance
+        if not isinstance(data, dict):
+            logger.debug("Received non-dictionary data, returning default instance")
+            return cls()
+
+        transition_data: dict[str, Any] = {}
+
+        # Ensure ID is a string (API sometimes returns integers)
+        transition_id = data.get("id", JIRA_DEFAULT_ID)
+        if transition_id is not None:
+            transition_id = str(transition_id)
+        transition_data["id"] = transition_id
+
+        transition_data["state"] = data.get("state", UNKNOWN)
+        transition_data["name"] = data.get("name", UNKNOWN)
+
+        transition_data["start_date"] = data.get("startDate", EMPTY_STRING)
+        transition_data["end_date"] = data.get("endDate", EMPTY_STRING)
+        transition_data["activatedDate"] = data.get("activatedDate", EMPTY_STRING)
+
+        transition_data["originBoardId"] = str(
+            data.get("originBoardId", JIRA_DEFAULT_ID)
+        )
+
+        transition_data["goal"] = data.get("goal", EMPTY_STRING)
+        transition_data["synced"] = data.get("synced", False)
+        transition_data["autoStartStop"] = data.get("autoStartStop", False)
+
+        return cls(**transition_data)
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """
+        Convert to a simplified dictionary representation.
+        """
+        return {
+            "id": self.id,
+            "state": self.state,
+            "name": self.name,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "activatedDate": self.activated_date,
+            "originBoardId": self.origin_board_id,
+            "goal": self.goal,
+            "synced": self.synced,
+            "autoStartStop": self.auto_start_stop,
         }

--- a/src/mcp_atlassian/models/jira.py
+++ b/src/mcp_atlassian/models/jira.py
@@ -1077,3 +1077,13 @@ class JiraBoard(ApiModel):
             name=str(data.get("name", UNKNOWN)),
             type=str(data.get("type", UNKNOWN)),
         )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """
+        Convert to a simplified dictionary representation.
+        """
+        return {
+            "id": self.id,
+            "name": self.name,
+            "type": self.type,
+        }

--- a/tests/unit/jira/test_boards.py
+++ b/tests/unit/jira/test_boards.py
@@ -1,0 +1,85 @@
+"""Tests for the Jira BoardMixin"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from mcp_atlassian.jira import JiraConfig
+from mcp_atlassian.jira.boards import BoardsMixin
+
+
+@pytest.fixture
+def mock_config():
+    """Fixture to create a mock JiraConfig instance."""
+    config = MagicMock(spec=JiraConfig)
+    config.url = "https://test.atlassian.net"
+    config.username = "test@example.com"
+    config.api_token = "test-token"
+    config.auth_type = "token"
+    return config
+
+
+@pytest.fixture
+def boards_mixin(mock_config):
+    """Fixture to create a ProjectsMixin instance for testing."""
+    mixin = BoardsMixin(config=mock_config)
+    mixin.jira = MagicMock()
+
+    return mixin
+
+
+@pytest.fixture
+def mock_boards():
+    """Fixture to return mock boards data."""
+    return [
+        {
+            "id": 1000,
+            "self": "https://test.atlassian.net/rest/agile/1.0/board/1000",
+            "name": " Board One",
+            "type": "scrum",
+        },
+        {
+            "id": 1001,
+            "self": "https://test.atlassian.net/rest/agile/1.0/board/1001",
+            "name": " Board Two",
+            "type": "kanban",
+        },
+    ]
+
+
+def test_get_all_agile_boards(boards_mixin, mock_boards):
+    """Test get_all_agile_boards method."""
+    boards_mixin.jira.get_all_agile_boards.return_value = mock_boards
+
+    result = boards_mixin.get_all_agile_boards()
+    assert result == mock_boards
+
+
+def test_get_all_agile_boards_exception(boards_mixin):
+    """Test get_all_agile_boards method with exception."""
+    boards_mixin.jira.get_all_agile_boards.side_effect = Exception("API Error")
+
+    result = boards_mixin.get_all_agile_boards()
+    assert result == []
+    boards_mixin.jira.get_all_agile_boards.assert_called_once()
+
+
+def test_get_all_agile_boards_http_error(boards_mixin):
+    """Test get_all_agile_boards method with HTTPError."""
+    boards_mixin.jira.get_all_agile_boards.side_effect = requests.HTTPError(
+        response=MagicMock(content="API Error content")
+    )
+
+    result = boards_mixin.get_all_agile_boards()
+    assert result == []
+    boards_mixin.jira.get_all_agile_boards.assert_called_once()
+
+
+def test_get_all_agile_boards_non_list_response(boards_mixin):
+    """Test get_all_agile_boards method with non-list response."""
+    boards_mixin.jira.get_all_agile_boards.return_value = "not a list"
+
+    result = boards_mixin.get_all_agile_boards()
+    assert result == []
+    boards_mixin.jira.get_all_agile_boards.assert_called_once()

--- a/tests/unit/jira/test_boards.py
+++ b/tests/unit/jira/test_boards.py
@@ -7,6 +7,7 @@ import requests
 
 from mcp_atlassian.jira import JiraConfig
 from mcp_atlassian.jira.boards import BoardsMixin
+from mcp_atlassian.models.jira import JiraBoard
 
 
 @pytest.fixture
@@ -32,20 +33,26 @@ def boards_mixin(mock_config):
 @pytest.fixture
 def mock_boards():
     """Fixture to return mock boards data."""
-    return [
-        {
-            "id": 1000,
-            "self": "https://test.atlassian.net/rest/agile/1.0/board/1000",
-            "name": " Board One",
-            "type": "scrum",
-        },
-        {
-            "id": 1001,
-            "self": "https://test.atlassian.net/rest/agile/1.0/board/1001",
-            "name": " Board Two",
-            "type": "kanban",
-        },
-    ]
+    return {
+        "maxResults": 2,
+        "startAt": 0,
+        "total": 2,
+        "isLast": True,
+        "values": [
+            {
+                "id": 1000,
+                "self": "https://test.atlassian.net/rest/agile/1.0/board/1000",
+                "name": " Board One",
+                "type": "scrum",
+            },
+            {
+                "id": 1001,
+                "self": "https://test.atlassian.net/rest/agile/1.0/board/1001",
+                "name": " Board Two",
+                "type": "kanban",
+            },
+        ],
+    }
 
 
 def test_get_all_agile_boards(boards_mixin, mock_boards):
@@ -53,7 +60,7 @@ def test_get_all_agile_boards(boards_mixin, mock_boards):
     boards_mixin.jira.get_all_agile_boards.return_value = mock_boards
 
     result = boards_mixin.get_all_agile_boards()
-    assert result == mock_boards
+    assert result == mock_boards["values"]
 
 
 def test_get_all_agile_boards_exception(boards_mixin):
@@ -76,10 +83,19 @@ def test_get_all_agile_boards_http_error(boards_mixin):
     boards_mixin.jira.get_all_agile_boards.assert_called_once()
 
 
-def test_get_all_agile_boards_non_list_response(boards_mixin):
+def test_get_all_agile_boards_non_dict_response(boards_mixin):
     """Test get_all_agile_boards method with non-list response."""
-    boards_mixin.jira.get_all_agile_boards.return_value = "not a list"
+    boards_mixin.jira.get_all_agile_boards.return_value = "not a dict"
 
     result = boards_mixin.get_all_agile_boards()
     assert result == []
     boards_mixin.jira.get_all_agile_boards.assert_called_once()
+
+
+def test_get_all_agile_boards_model(boards_mixin, mock_boards):
+    boards_mixin.jira.get_all_agile_boards.return_value = mock_boards
+
+    result = boards_mixin.get_all_agile_boards_model()
+    assert result == [
+        JiraBoard.from_api_response(value) for value in mock_boards["values"]
+    ]

--- a/tests/unit/jira/test_boards.py
+++ b/tests/unit/jira/test_boards.py
@@ -23,7 +23,7 @@ def mock_config():
 
 @pytest.fixture
 def boards_mixin(mock_config):
-    """Fixture to create a ProjectsMixin instance for testing."""
+    """Fixture to create a BoardsMixin instance for testing."""
     mixin = BoardsMixin(config=mock_config)
     mixin.jira = MagicMock()
 

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from mcp_atlassian.jira.search import SearchMixin
 from mcp_atlassian.models.jira import JiraIssue
@@ -469,3 +470,67 @@ class TestSearchMixin:
         assert simplified["summary"] == "Test issue with custom field"
         assert simplified["assignee"]["name"] == "Test User"
         assert simplified["customfield_10049"] == "Custom value"
+
+    def test_get_board_issues(self, search_mixin):
+        """Test get_project_issues method."""
+        mock_issues = {
+            "issues": [
+                {
+                    "id": "10001",
+                    "key": "TEST-123",
+                    "fields": {
+                        "summary": "Test issue",
+                        "issuetype": {"name": "Bug"},
+                        "status": {"name": "Open"},
+                        "description": "Issue description",
+                        "created": "2024-01-01T10:00:00.000+0000",
+                        "updated": "2024-01-01T11:00:00.000+0000",
+                        "priority": {"name": "High"},
+                    },
+                }
+            ],
+            "total": 1,
+            "startAt": 0,
+            "maxResults": 50,
+        }
+        search_mixin.jira.get_issues_for_board.return_value = mock_issues
+
+        # Call the method
+        result = search_mixin.get_board_issues("1000", jql="", limit=20)
+
+        # Verify results
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert all(isinstance(issue, JiraIssue) for issue in result)
+
+        # Check the first issue
+        issue = result[0]
+        assert issue.key == "TEST-123"
+        assert issue.summary == "Test issue"
+        assert issue.description == "Issue description"
+        assert issue.status is not None
+        assert issue.status.name == "Open"
+        assert issue.issue_type is not None
+        assert issue.issue_type.name == "Bug"
+        assert issue.priority is not None
+        assert issue.priority.name == "High"
+
+        # Remove backward compatibility checks
+        assert "Issue description" in issue.description
+        assert issue.key == "TEST-123"
+
+    def test_get_board_issues_exception(self, search_mixin):
+        search_mixin.jira.get_issues_for_board.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception) as e:
+            search_mixin.get_board_issues("1000", jql="", limit=20)
+        assert "API Error" in str(e.value)
+
+    def test_get_board_issues_http_error(self, search_mixin):
+        search_mixin.jira.get_issues_for_board.side_effect = requests.HTTPError(
+            response=MagicMock(content="API Error content")
+        )
+
+        with pytest.raises(Exception) as e:
+            search_mixin.get_board_issues("1000", jql="", limit=20)
+        assert "API Error content" in str(e.value)

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -534,3 +534,67 @@ class TestSearchMixin:
         with pytest.raises(Exception) as e:
             search_mixin.get_board_issues("1000", jql="", limit=20)
         assert "API Error content" in str(e.value)
+
+    def test_get_sprint_issues(self, search_mixin):
+        """Test get_sprint_issues method."""
+        mock_issues = {
+            "issues": [
+                {
+                    "id": "10001",
+                    "key": "TEST-123",
+                    "fields": {
+                        "summary": "Test issue",
+                        "issuetype": {"name": "Bug"},
+                        "status": {"name": "Open"},
+                        "description": "Issue description",
+                        "created": "2024-01-01T10:00:00.000+0000",
+                        "updated": "2024-01-01T11:00:00.000+0000",
+                        "priority": {"name": "High"},
+                    },
+                }
+            ],
+            "total": 1,
+            "startAt": 0,
+            "maxResults": 50,
+        }
+        search_mixin.jira.get_sprint_issues.return_value = mock_issues
+
+        # Call the method
+        result = search_mixin.get_sprint_issues("10001")
+
+        # Verify results
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert all(isinstance(issue, JiraIssue) for issue in result)
+
+        # Check the first issue
+        issue = result[0]
+        assert issue.key == "TEST-123"
+        assert issue.summary == "Test issue"
+        assert issue.description == "Issue description"
+        assert issue.status is not None
+        assert issue.status.name == "Open"
+        assert issue.issue_type is not None
+        assert issue.issue_type.name == "Bug"
+        assert issue.priority is not None
+        assert issue.priority.name == "High"
+
+        # Remove backward compatibility checks
+        assert "Issue description" in issue.description
+        assert issue.key == "TEST-123"
+
+    def test_get_sprint_issues_exception(self, search_mixin):
+        search_mixin.jira.get_sprint_issues.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception) as e:
+            search_mixin.get_sprint_issues("10001")
+        assert "API Error" in str(e.value)
+
+    def test_get_sprint_issues_http_error(self, search_mixin):
+        search_mixin.jira.get_sprint_issues.side_effect = requests.HTTPError(
+            response=MagicMock(content="API Error content")
+        )
+
+        with pytest.raises(Exception) as e:
+            search_mixin.get_sprint_issues("10001")
+        assert "API Error content" in str(e.value)

--- a/tests/unit/jira/test_sprints.py
+++ b/tests/unit/jira/test_sprints.py
@@ -1,0 +1,124 @@
+"""Tests for the Jira SprintMixin"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from mcp_atlassian.jira import JiraConfig
+from mcp_atlassian.jira.sprints import SprintsMixin
+from mcp_atlassian.models.jira import JiraSprint
+
+
+@pytest.fixture
+def mock_config():
+    """Fixture to create a mock JiraConfig instance."""
+    config = MagicMock(spec=JiraConfig)
+    config.url = "https://test.atlassian.net"
+    config.username = "test@example.com"
+    config.api_token = "test-token"
+    config.auth_type = "token"
+    return config
+
+
+@pytest.fixture
+def sprints_mixin(mock_config):
+    """Fixture to create a SprintsMixin instance for testing."""
+    mixin = SprintsMixin(config=mock_config)
+    mixin.jira = MagicMock()
+
+    return mixin
+
+
+@pytest.fixture
+def mock_sprints():
+    """Fixture to return mock boards data."""
+    return {
+        "maxResults": 50,
+        "startAt": 0,
+        "isLast": True,
+        "values": [
+            {
+                "id": 10000,
+                "self": "https://test.atlassian.net/rest/agile/1.0/sprint/10000",
+                "state": "closed",
+                "name": "Sprint 0",
+                "startDate": "2024-05-06T02:00:00.000Z",
+                "endDate": "2024-05-17T10:00:00.000Z",
+                "completeDate": "2024-05-20T05:17:24.302Z",
+                "activatedDate": "2024-05-07T01:22:45.128Z",
+                "originBoardId": 1000,
+                "goal": "",
+                "synced": False,
+                "autoStartStop": False,
+            },
+            {
+                "id": 10001,
+                "self": "https://test.atlassian.net/rest/agile/1.0/sprint/10001",
+                "state": "active",
+                "name": "Sprint 1",
+                "startDate": "2025-03-24T06:13:00.000Z",
+                "endDate": "2025-04-07T06:13:00.000Z",
+                "activatedDate": "2025-03-24T06:13:20.729Z",
+                "originBoardId": 1000,
+                "goal": "",
+                "synced": False,
+                "autoStartStop": False,
+            },
+            {
+                "id": 10002,
+                "self": "https://test.atlassian.net/rest/agile/1.0/sprint/10002",
+                "state": "future",
+                "name": "Sprint 2",
+                "originBoardId": 1000,
+                "synced": False,
+                "autoStartStop": False,
+            },
+        ],
+    }
+
+
+def test_get_all_sprints_from_board(sprints_mixin, mock_sprints):
+    """Test get_all_sprints_from_board method."""
+    sprints_mixin.jira.get_all_sprints_from_board.return_value = mock_sprints
+
+    result = sprints_mixin.get_all_sprints_from_board("1000")
+    assert result == mock_sprints["values"]
+
+
+def test_get_all_sprints_from_board_exception(sprints_mixin):
+    """Test get_all_sprints_from_board method with exception."""
+    sprints_mixin.jira.get_all_sprints_from_board.side_effect = Exception("API Error")
+
+    result = sprints_mixin.get_all_sprints_from_board("1000")
+    assert result == []
+    sprints_mixin.jira.get_all_sprints_from_board.assert_called_once()
+
+
+def test_get_all_sprints_from_board_http_error(sprints_mixin):
+    """Test get_all_sprints_from_board method with HTTPError."""
+    sprints_mixin.jira.get_all_sprints_from_board.side_effect = requests.HTTPError(
+        response=MagicMock(content="API Error content")
+    )
+
+    result = sprints_mixin.get_all_sprints_from_board("1000")
+    assert result == []
+    sprints_mixin.jira.get_all_sprints_from_board.assert_called_once()
+
+
+def test_get_all_sprints_from_board_non_dict_response(sprints_mixin):
+    """Test get_all_sprints_from_board method with non-list response."""
+    sprints_mixin.jira.get_all_sprints_from_board.return_value = "not a dict"
+
+    result = sprints_mixin.get_all_sprints_from_board("1000")
+    assert result == []
+    sprints_mixin.jira.get_all_sprints_from_board.assert_called_once()
+
+
+def test_get_all_sprints_from_board_model(sprints_mixin, mock_sprints):
+    sprints_mixin.jira.get_all_sprints_from_board.return_value = mock_sprints
+
+    result = sprints_mixin.get_all_sprints_from_board_model("1000")
+    assert result == [
+        JiraSprint.from_api_response(value) for value in mock_sprints["values"]
+    ]


### PR DESCRIPTION
This PR add JiraSprint class and register get board , get issue from board, get sprint from board, get issue from sprint. 
Total of 4 tools. 