### PR TITLE
Fix: Add conditional quoting for CQL identifiers

### DIFF
--- a/src/mcp_atlassian/confluence/constants.py
+++ b/src/mcp_atlassian/confluence/constants.py
@@ -1,0 +1,50 @@
+"""Constants specific to Confluence and CQL."""
+
+# Based on https://developer.atlassian.com/cloud/confluence/cql-functions/#reserved-words
+# List might need refinement based on actual parser behavior
+# Using lowercase for case-insensitive matching
+RESERVED_CQL_WORDS = {
+    "after",
+    "and",
+    "as",
+    "avg",
+    "before",
+    "begin",
+    "by",
+    "commit",
+    "contains",
+    "count",
+    "distinct",
+    "else",
+    "empty",
+    "end",
+    "explain",
+    "from",
+    "having",
+    "if",
+    "in",
+    "inner",
+    "insert",
+    "into",
+    "is",
+    "isnull",
+    "left",
+    "like",
+    "limit",
+    "max",
+    "min",
+    "not",
+    "null",
+    "or",
+    "order",
+    "outer",
+    "right",
+    "select",
+    "sum",
+    "then",
+    "was",
+    "where",
+    "update",
+}
+
+# Add other Confluence-specific constants here if needed in the future.

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -6,6 +6,7 @@ import requests
 
 from ..models.confluence import ConfluencePage, ConfluenceSearchResult
 from .client import ConfluenceClient
+from .utils import quote_cql_identifier_if_needed
 
 logger = logging.getLogger("mcp-atlassian")
 
@@ -36,8 +37,13 @@ class SearchMixin(ConfluenceClient):
                 # Split spaces filter by commas and handle possible whitespace
                 spaces = [s.strip() for s in filter_to_use.split(",")]
 
-                # Build the space filter query part
-                space_query = " OR ".join([f'space = "{space}"' for space in spaces])
+                # Build the space filter query part using proper quoting for each space key
+                space_query = " OR ".join(
+                    [
+                        f"space = {quote_cql_identifier_if_needed(space)}"
+                        for space in spaces
+                    ]
+                )
 
                 # Add the space filter to existing query with parentheses
                 if cql and space_query:

--- a/src/mcp_atlassian/confluence/utils.py
+++ b/src/mcp_atlassian/confluence/utils.py
@@ -1,0 +1,66 @@
+"""Utility functions specific to Confluence operations."""
+
+import logging
+
+from .constants import RESERVED_CQL_WORDS
+
+logger = logging.getLogger(__name__)
+
+
+def quote_cql_identifier_if_needed(identifier: str) -> str:
+    """
+    Quotes a Confluence identifier for safe use in CQL literals if required.
+
+    Handles:
+    - Personal space keys starting with '~'.
+    - Identifiers matching reserved CQL words (case-insensitive).
+    - Identifiers starting with a number.
+    - Escapes internal quotes ('"') and backslashes ('\\') within the identifier
+      *before* quoting.
+
+    Args:
+        identifier: The identifier string (e.g., space key).
+
+    Returns:
+        The identifier, correctly quoted and escaped if necessary,
+        otherwise the original identifier.
+    """
+    needs_quoting = False
+    identifier_lower = identifier.lower()
+
+    # Rule 1: Starts with ~ (Personal Space Key)
+    if identifier.startswith("~"):
+        needs_quoting = True
+        logger.debug(f"Identifier '{identifier}' needs quoting (starts with ~).")
+
+    # Rule 2: Is a reserved word (case-insensitive check)
+    elif identifier_lower in RESERVED_CQL_WORDS:
+        needs_quoting = True
+        logger.debug(f"Identifier '{identifier}' needs quoting (reserved word).")
+
+    # Rule 3: Starts with a number
+    elif identifier and identifier[0].isdigit():
+        needs_quoting = True
+        logger.debug(f"Identifier '{identifier}' needs quoting (starts with digit).")
+
+    # Rule 4: Contains internal quotes or backslashes (always needs quoting+escaping)
+    elif '"' in identifier or "\\" in identifier:
+        needs_quoting = True
+        logger.debug(
+            f"Identifier '{identifier}' needs quoting (contains quotes/backslashes)."
+        )
+
+    # Add more rules here if other characters prove problematic (e.g., spaces, hyphens)
+    # elif ' ' in identifier or '-' in identifier:
+    #    needs_quoting = True
+
+    if needs_quoting:
+        # Escape internal backslashes first, then double quotes
+        escaped_identifier = identifier.replace("\\", "\\\\").replace('"', '\\"')
+        quoted_escaped = f'"{escaped_identifier}"'
+        logger.debug(f"Quoted and escaped identifier: {quoted_escaped}")
+        return quoted_escaped
+    else:
+        # Return the original identifier if no quoting is needed
+        logger.debug(f"Identifier '{identifier}' does not need quoting.")
+        return identifier

--- a/tests/unit/confluence/test_utils.py
+++ b/tests/unit/confluence/test_utils.py
@@ -1,0 +1,57 @@
+"""Tests for the Confluence utility functions."""
+
+from mcp_atlassian.confluence.constants import RESERVED_CQL_WORDS
+from mcp_atlassian.confluence.utils import quote_cql_identifier_if_needed
+
+
+class TestCQLQuoting:
+    """Tests for CQL quoting utility functions."""
+
+    def test_quote_personal_space_key(self):
+        """Test quoting of personal space keys."""
+        # Personal space keys starting with ~ should be quoted
+        assert quote_cql_identifier_if_needed("~username") == '"~username"'
+        assert quote_cql_identifier_if_needed("~admin") == '"~admin"'
+        assert quote_cql_identifier_if_needed("~user.name") == '"~user.name"'
+
+    def test_quote_reserved_words(self):
+        """Test quoting of reserved CQL words."""
+        # Reserved words should be quoted (case-insensitive)
+        for word in list(RESERVED_CQL_WORDS)[:5]:  # Test a subset for brevity
+            assert quote_cql_identifier_if_needed(word) == f'"{word}"'
+            assert quote_cql_identifier_if_needed(word.upper()) == f'"{word.upper()}"'
+            assert (
+                quote_cql_identifier_if_needed(word.capitalize())
+                == f'"{word.capitalize()}"'
+            )
+
+    def test_quote_numeric_keys(self):
+        """Test quoting of keys starting with numbers."""
+        # Keys starting with numbers should be quoted
+        assert quote_cql_identifier_if_needed("123space") == '"123space"'
+        assert quote_cql_identifier_if_needed("42") == '"42"'
+        assert quote_cql_identifier_if_needed("1test") == '"1test"'
+
+    def test_quote_special_characters(self):
+        """Test quoting and escaping of identifiers with special characters."""
+        # Keys with quotes or backslashes should be quoted and escaped
+        assert quote_cql_identifier_if_needed('my"space') == '"my\\"space"'
+        assert quote_cql_identifier_if_needed("test\\space") == '"test\\\\space"'
+
+        # Test combined quotes and backslashes
+        input_str = 'quote"and\\slash'
+        result = quote_cql_identifier_if_needed(input_str)
+        assert result == '"quote\\"and\\\\slash"'
+
+        # Verify the result by checking individual characters
+        assert result[0] == '"'  # opening quote
+        assert result[-1] == '"'  # closing quote
+        assert "\\\\" in result  # escaped backslash
+        assert '\\"' in result  # escaped quote
+
+    def test_no_quote_regular_keys(self):
+        """Test that regular keys are not quoted."""
+        # Regular space keys should not be quoted
+        assert quote_cql_identifier_if_needed("DEV") == "DEV"
+        assert quote_cql_identifier_if_needed("MYSPACE") == "MYSPACE"
+        assert quote_cql_identifier_if_needed("documentation") == "documentation"


### PR DESCRIPTION
Introduces `quote_cql_identifier_if_needed` utility in
`confluence/utils.py` to correctly quote identifiers (like personal
space keys '~...', reserved words, numeric-start strings)
for safe use in CQL literal values, according to Confluence documentation.
Also handles escaping of internal quotes/backslashes.

Defines reserved CQL words in new `confluence/constants.py`.

Applies this utility in:
- `server.py` (`read_resource`) when constructing CQL queries for space URIs.
- `confluence/search.py` when processing the `spaces_filter`.

Updates tool description in `server.py` to mention quoting requirements.
Adds unit tests for the new utility and updates tests for search mixin.

Fixes #184