### PR TITLE
Fix: Correct command invocation in README (#179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,3 @@ CLAUDE.md
 
 # cursor
 .cursor*
-
-# repomix
-.repomixignore
-repomix.config.json

--- a/README.md
+++ b/README.md
@@ -222,10 +222,8 @@ Using uvx (recommended) - Cloud:
 {
   "mcpServers": {
     "mcp-atlassian": {
-      "command": "python",
+      "command": "mcp-atlassian",
       "args": [
-        "-m",
-        "mcp-atlassian",
         "--confluence-url=https://your-company.atlassian.net/wiki",
         "--confluence-username=your.email@company.com",
         "--confluence-token=your_api_token",


### PR DESCRIPTION
This PR updates the `README.md` to use the correct `mcp-atlassian` command for running the application.

The previous instructions using `python -m mcp_atlassian` were incorrect and caused errors because the package isn't designed to be executed that way. The correct method is to use the script entry point defined in `pyproject.toml`, which is made available as the `mcp-atlassian` command after installation.

All relevant examples in the README have been updated.

Fixes #179