### PR TITLE
CI: Add pytest workflow (#87)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+# .github/workflows/tests.yml
+
+name: Run Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Run pytest on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Allow other Python versions to finish even if one fails
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"] # Based on requires-python >=3.10
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'uv' # Enable caching for uv managed by setup-python
+
+    - name: Install uv
+      run: pip install uv # Install uv using pip
+
+    - name: Install dependencies
+      run: uv sync --frozen --all-extras --dev # Use uv sync as specified in CONTRIBUTING.md
+
+    - name: Run tests with pytest
+      # Add -v for verbose output, helpful in CI
+      # Add basic coverage reporting to terminal logs
+      run: uv run pytest -v --cov=src/mcp_atlassian --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,4 +38,5 @@ jobs:
     - name: Run tests with pytest
       # Add -v for verbose output, helpful in CI
       # Add basic coverage reporting to terminal logs
-      run: uv run pytest -v --cov=src/mcp_atlassian --cov-report=term-missing
+      # Skip real API validation tests as they require credentials
+      run: uv run pytest -v -k "not test_real_api_validation" --cov=src/mcp_atlassian --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
     name: Run pytest on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # Allow other Python versions to finish even if one fails
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # Based on requires-python >=3.10
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout repository
@@ -25,13 +25,15 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'uv' # Enable caching for uv managed by setup-python
 
     - name: Install uv
-      run: pip install uv # Install uv using pip
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: "0.6.10"
+        cache: true
 
     - name: Install dependencies
-      run: uv sync --frozen --all-extras --dev # Use uv sync as specified in CONTRIBUTING.md
+      run: uv sync --frozen --all-extras --dev
 
     - name: Run tests with pytest
       # Add -v for verbose output, helpful in CI


### PR DESCRIPTION
Closes #87

This PR adds automated testing to our CI pipeline using `pytest`. Now, tests will run automatically on pushes and PRs to `main`, helping us catch regressions early.
