### PR TITLE
Fix Windsurf unable to parse input schema for jira_create_issue

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -956,10 +956,9 @@ async def list_tools() -> list[Tool]:
                                     "default": "",
                                 },
                                 "components": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": 'List of component names to assign (e.g., ["Frontend", "API"])',
-                                    "default": [],
+                                    "type": "string",
+                                    "description": "Comma-separated list of component names to assign (e.g., 'Frontend,API')",
+                                    "default": "",
                                 },
                                 "additional_fields": {
                                     "type": "string",
@@ -1846,6 +1845,13 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             description = arguments.get("description", "")
             assignee = arguments.get("assignee")
             components = arguments.get("components")
+
+            # Parse components from comma-separated string to list
+            if components and isinstance(components, str):
+                # Split by comma and strip whitespace, removing empty entries
+                components = [
+                    comp.strip() for comp in components.split(",") if comp.strip()
+                ]
 
             # Parse additional fields
             additional_fields = {}

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -733,7 +733,7 @@ async def test_call_tool_jira_create_issue_with_components(app_context):
                 "project_key": "TEST",
                 "summary": "Test Issue with Components",
                 "issue_type": "Bug",
-                "components": ["UI", "API"],
+                "components": "UI,API",
             },
         )
 


### PR DESCRIPTION
## Description
This PR addresses issue #211 where Windsurf clients are unable to parse the input schema for the `jira_create_issue` tool. The issue occurs because Windsurf has trouble parsing array-type parameters in the tool's input schema.

## Changes
- Changed the `components` parameter in the `jira_create_issue` tool from an array type to a string type
- Updated the parameter description to specify it accepts a comma-separated list
- Added preprocessing logic in `server.py` to convert the comma-separated string to a list before passing to the JiraFetcher
- Updated the unit test to use the new string format while maintaining the same assertion

## Why This Approach
This approach maintains the existing behavior for all clients while making the tool compatible with Windsurf. The string-to-list conversion happens at the API boundary in `server.py`, keeping the JiraFetcher implementation clean with its well-defined `list[str] | None` contract.

## Fixes
Closes #211