### PR TITLE
Feature/robust sse transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,7 @@ JIRA_API_TOKEN=your_api_token
 # JIRA_URL=https://jira.your-company.com
 # JIRA_PERSONAL_TOKEN=your_personal_access_token
 # JIRA_SSL_VERIFY=true                 # CLI: --[no-]jira-ssl-verify
+
+# TLS/SSL
+# SSL_KEY=/some/path/to/sitename.key
+# SSL_CRT=/some/path/to/sitename.crt


### PR DESCRIPTION
By no means am I expecting you to merge this PR. This is more so my contribution to the community. And it resolves my issue #205 . Where clients can pass url parameters to server side using the same command line arguments already established. 

This offers a clean and simple solution that allows others to host the SSE server with minimal work and respects the jira/confluence URL environment variables that would be given by the host.

To use, on the client side, set the url to 
http://SERVER:8000/sse?jira-personal-token=PERSONAL_TOKEN&confluence-personal-token=PERSONAL_TOKEN

works for both cloud and server
