### PR TITLE
fix: Added create_sprint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,5 +53,7 @@ repos:
             'beautifulsoup4',
             'httpx',
             'python-dotenv',
-            'markdownify'
+            'markdownify',
+            'python-dateutil',
+            'types-python-dateutil',
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- added `jira_create_sprint`
 
 ## [0.8.3] - 2025-04-24
 

--- a/README.md
+++ b/README.md
@@ -295,80 +295,70 @@ For Jira Server/DC, use:
 
 ### SSE Transport Configuration
 
-<details> <summary>Using SSE Instead of stdio</summary>
+For SSE transport, first start the server with its configuration provided via command-line arguments or server-side environment variables (e.g., from a `.env` file):
+```bash
+# Example starting the server with Cloud configuration
+uvx mcp-atlassian --transport sse --port 9000 \
+  --confluence-url https://your-company.atlassian.net/wiki \
+  --confluence-username your.email@company.com \
+  --confluence-token your_api_token \
+  --jira-url https://your-company.atlassian.net \
+  --jira-username your.email@company.com \
+  --jira-token your_api_token
+```
 
-1.  Start the server manually in a terminal:
-
-    ```bash
-    docker run --rm -p 9000:9000 \
-      --env-file /path/to/your/.env \
-      ghcr.io/sooperset/mcp-atlassian:latest \
-      --transport sse --port 9000 -vv
-    ```
-
-2.  Configure your IDE to connect to the running server via its URL:
-
-    ```json
-    {
-      "mcpServers": {
-        "mcp-atlassian-sse": {
-          "url": "http://localhost:9000/sse"
-        }
-      }
+Then configure *only the URL* in Cursor's `~/.cursor/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian-sse": {
+      "url": "http://localhost:9000/sse"
     }
-    ```
-</details>
+  }
+}
+```
 
-## Tools
+## Resources
 
-### Key Tools
+> **Note:** The MCP server filters resources to only show Confluence spaces and Jira projects that the user is actively interacting with, based on their contributions and assignments.
 
-#### Confluence Tools
+- `confluence://{space_key}`: Access Confluence spaces
+- `jira://{project_key}`: Access Jira projects
 
-- `confluence_search`: Search Confluence content using CQL
-- `confluence_get_page`: Get content of a specific page
-- `confluence_create_page`: Create a new page
-- `confluence_update_page`: Update an existing page
+## Available Tools
 
-#### Jira Tools
+| Tool | Description |
+|------|-------------|
+| `confluence_search` | Search Confluence content using CQL |
+| `confluence_get_page` | Get content of a specific Confluence page |
+| `confluence_get_page_children` | Get child pages of a specific Confluence page |
+| `confluence_get_page_ancestors` | Get parent pages of a specific Confluence page |
+| `confluence_get_comments` | Get comments for a specific Confluence page |
+| `confluence_create_page` | Create a new Confluence page |
+| `confluence_update_page` | Update an existing Confluence page |
+| `confluence_delete_page` | Delete an existing Confluence page |
+| `confluence_attach_content` | Attach content to a Confluence page |
+| `jira_get_issue` | Get details of a specific Jira issue |
+| `jira_search` | Search Jira issues using JQL |
+| `jira_get_project_issues` | Get all issues for a specific Jira project |
+| `jira_get_epic_issues` | Get all issues linked to a specific Epic |
+| `jira_create_issue` | Create a new issue in Jira |
+| `jira_update_issue` | Update an existing Jira issue |
+| `jira_delete_issue` | Delete an existing Jira issue |
+| `jira_get_transitions` | Get available status transitions for a Jira issue |
+| `jira_transition_issue` | Transition a Jira issue to a new status |
+| `jira_add_comment` | Add a comment to a Jira issue |
+| `jira_add_worklog` | Add a worklog entry to a Jira issue |
+| `jira_get_worklog` | Get worklog entries for a Jira issue |
+| `jira_download_attachments` | Download attachments from a Jira issue |
+| `jira_link_to_epic` | Link an issue to an Epic |
+| `jira_get_agile_boards` | Get Jira agile boards by name, project key, or type |
+| `jira_get_board_issues` | Get all issues linked to a specific board |
+| `jira_get_sprints_from_board` | Get Jira sprints from board by state |
+| `jira_create_sprint` | Create Jira sprint for a board |
+| `jira_get_sprint_issues` | Get Jira issues from sprint |
 
-- `jira_get_issue`: Get details of a specific issue
-- `jira_search`: Search issues using JQL
-- `jira_create_issue`: Create a new issue
-- `jira_update_issue`: Update an existing issue
-- `jira_transition_issue`: Transition an issue to a new status
-- `jira_add_comment`: Add a comment to an issue
-
-<details> <summary>View All Tools</summary>
-
-|Confluence Tools|Jira Tools|
-|---|---|
-|`confluence_search`|`jira_get_issue`|
-|`confluence_get_page`|`jira_search`|
-|`confluence_get_page_children`|`jira_get_project_issues`|
-|`confluence_get_page_ancestors`|`jira_get_epic_issues`|
-|`confluence_get_comments`|`jira_create_issue`|
-|`confluence_create_page`|`jira_batch_create_issues`|
-|`confluence_update_page`|`jira_update_issue`|
-|`confluence_delete_page`|`jira_delete_issue`|
-||`jira_get_transitions`|
-||`jira_transition_issue`|
-||`jira_add_comment`|
-||`jira_add_worklog`|
-||`jira_get_worklog`|
-||`jira_download_attachments`|
-||`jira_link_to_epic`|
-||`jira_get_agile_boards`|
-||`jira_get_board_issues`|
-||`jira_get_sprints_from_board`|
-||`jira_get_sprint_issues`|
-||`jira_update_sprint`|
-||`jira_create_issue_link`|
-||`jira_remove_issue_link`|
-
-</details>
-
-## Troubleshooting & Debugging
+## Development & Debugging
 
 ### Common Issues
 

--- a/README.md
+++ b/README.md
@@ -3,25 +3,16 @@
 ![PyPI Version](https://img.shields.io/pypi/v/mcp-atlassian)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/mcp-atlassian)
 ![PePy - Total Downloads](https://static.pepy.tech/personalized-badge/mcp-atlassian?period=total&units=international_system&left_color=grey&right_color=blue&left_text=Total%20Downloads)
-[![Run Tests](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml/badge.svg)](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml)
 ![License](https://img.shields.io/github/license/sooperset/mcp-atlassian)
+[![smithery badge](https://smithery.ai/badge/mcp-atlassian)](https://smithery.ai/server/mcp-atlassian)
 
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). This integration supports both Confluence & Jira Cloud and Server/Data Center deployments.
 
-## Example Usage
-
-Ask your AI assistant to:
-
-- **📝 Automatic Jira Updates** - "Update Jira from our meeting notes"
-- **🔍 AI-Powered Confluence Search** - "Find our OKR guide in Confluence and summarize it"
-- **🐛 Smart Jira Issue Filtering** - "Show me urgent bugs in PROJ project from last week"
-- **📄 Content Creation & Management** - "Create a tech design doc for XYZ feature"
-
 ### Feature Demo
+![Jira Demo](https://github.com/user-attachments/assets/61573853-c8a8-45c9-be76-575f2b651984)
 
-https://github.com/user-attachments/assets/35303504-14c6-4ae4-913b-7c25ea511c3e
-
-<details> <summary>Confluence Demo</summary>
+<details>
+<summary>Confluence Demo</summary>
 
 https://github.com/user-attachments/assets/7fe9c488-ad0c-4876-9b54-120b666bb785
 
@@ -29,76 +20,231 @@ https://github.com/user-attachments/assets/7fe9c488-ad0c-4876-9b54-120b666bb785
 
 ### Compatibility
 
-|Product|Deployment Type|Support Status|
-|---|---|---|
-|**Confluence**|Cloud|✅ Fully supported|
-|**Confluence**|Server/Data Center|✅ Supported (version 6.0+)|
-|**Jira**|Cloud|✅ Fully supported|
-|**Jira**|Server/Data Center|✅ Supported (version 8.14+)|
+| Product | Deployment Type | Support Status              |
+|---------|----------------|-----------------------------|
+| **Confluence** | Cloud | ✅ Fully supported           |
+| **Confluence** | Server/Data Center | ✅ Supported (version 6.0+)  |
+| **Jira** | Cloud | ✅ Fully supported           |
+| **Jira** | Server/Data Center | ✅ Supported (version 8.14+) |
 
-## Quick Start Guide
+## Setup Guide
 
 ### 1. Authentication Setup
 
 First, generate the necessary authentication tokens for Confluence & Jira:
 
 #### For Cloud
-
 1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
 2. Click **Create API token**, name it
 3. Copy the token immediately
 
 #### For Server/Data Center
-
 1. Go to your profile (avatar) → **Profile** → **Personal Access Tokens**
 2. Click **Create token**, name it, set expiry
 3. Copy the token immediately
 
 ### 2. Installation
 
-MCP Atlassian is distributed as a Docker image. This is the recommended way to run the server, especially for IDE integration. Ensure you have Docker installed.
+Choose one of these installation methods:
 
 ```bash
-# Pull Pre-built Image
-docker pull ghcr.io/sooperset/mcp-atlassian:latest
+# Using uv (recommended)
+brew install uv
+uvx mcp-atlassian
+
+# Using pip
+pip install mcp-atlassian
+
+# Using Docker
+git clone https://github.com/sooperset/mcp-atlassian.git
+cd mcp-atlassian
+docker build -t mcp/atlassian .
+
+# Using Smithery
+npx -y @smithery/cli install mcp-atlassian --client claude
 ```
+
+### 3. Configuration and Usage
+
+You can configure the MCP server using command line arguments. The server supports using either Confluence, Jira, or both services - include only the arguments needed for your use case.
+
+#### Required Arguments
+
+For Cloud:
+```bash
+uvx mcp-atlassian \
+  --confluence-url https://your-company.atlassian.net/wiki \
+  --confluence-username your.email@company.com \
+  --confluence-token your_api_token \
+  --jira-url https://your-company.atlassian.net \
+  --jira-username your.email@company.com \
+  --jira-token your_api_token
+```
+
+For Server/Data Center:
+```bash
+uvx mcp-atlassian \
+  --confluence-url https://confluence.your-company.com \
+  --confluence-personal-token your_token \
+  --jira-url https://jira.your-company.com \
+  --jira-personal-token your_token
+```
+
+> **Note:** You can configure just Confluence, just Jira, or both services. Simply include only the arguments for the service(s) you want to use. For example, to use only Confluence Cloud, you would only need `--confluence-url`, `--confluence-username`, and `--confluence-token`.
+
+#### Optional Arguments
+
+- `--transport`: Choose transport type (`stdio` [default] or `sse`)
+- `--port`: Port number for SSE transport (default: 8000)
+- `--[no-]confluence-ssl-verify`: Toggle SSL verification for Confluence Server/DC
+- `--[no-]jira-ssl-verify`: Toggle SSL verification for Jira Server/DC
+- `--confluence-spaces-filter`: Comma-separated list of space keys to filter Confluence search results (e.g., "DEV,TEAM,DOC")
+- `--jira-projects-filter`: Comma-separated list of project keys to filter Jira search results (e.g., "PROJ,DEV,SUPPORT")
+- `--read-only`: Run in read-only mode (disables all write operations)
+- `--verbose`: Increase logging verbosity (can be used multiple times, default is WARNING level)
+  - `-v` or `--verbose`: Set logging to INFO level
+  - `-vv` or `--verbose --verbose`: Set logging to DEBUG level
+
+> **Note:** All configuration options can also be set via environment variables. See the `.env.example` file in the repository for the full list of available environment variables.
 
 ## IDE Integration
 
-MCP Atlassian is designed to be used with AI assistants through IDE integration.
+### Claude Desktop Setup
 
-> [!TIP]
-> **To apply the configuration in Claude Desktop:**
->
-> **Method 1 (Recommended)**: Click hamburger menu (☰) > Settings > Developer > "Edit Config" button
->
-> **Method 2**: Locate and edit the configuration file directly:
-> - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-> - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-> - **Linux**: `~/.config/Claude/claude_desktop_config.json`
->
-> **For Cursor**: Open Settings → Features → MCP Servers → + Add new global MCP server
+Using uvx (recommended) - Cloud:
 
-### Configuration Methods
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": [
+        "mcp-atlassian",
+        "--confluence-url=https://your-company.atlassian.net/wiki",
+        "--confluence-username=your.email@company.com",
+        "--confluence-token=your_api_token",
+        "--jira-url=https://your-company.atlassian.net",
+        "--jira-username=your.email@company.com",
+        "--jira-token=your_api_token"
+      ]
+    }
+  }
+}
+```
 
-There are two main approaches to configure the Docker container:
+<details>
+<summary>Using uvx (recommended) - Server/Data Center </summary>
 
-1. **Passing Variables Directly** (shown in examples below)
-2. **Using an Environment File** with `--env-file` flag (shown in collapsible sections)
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": [
+        "mcp-atlassian",
+        "--confluence-url=https://confluence.your-company.com",
+        "--confluence-personal-token=your_token",
+        "--jira-url=https://jira.your-company.com",
+        "--jira-personal-token=your_token"
+      ]
+    }
+  }
+}
+```
+</details>
 
-> [!NOTE]
-> Common environment variables include:
->
-> - `CONFLUENCE_SPACES_FILTER`: Filter by space keys (e.g., "DEV,TEAM,DOC")
-> - `JIRA_PROJECTS_FILTER`: Filter by project keys (e.g., "PROJ,DEV,SUPPORT")
-> - `READ_ONLY_MODE`: Set to "true" to disable write operations
-> - `MCP_VERBOSE`: Set to "true" for more detailed logging
->
-> See the [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) file for all available options.
+<details>
+<summary>Using uvx - Confluence with Basic Auth (older servers)</summary>
 
-### Configuration Examples
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": [
+        "mcp-atlassian",
+        "--confluence-url=https://confluence.your-company.com",
+        "--confluence-username=your.email@company.com",
+        "--confluence-token=your_password"
+      ]
+    }
+  }
+}
+```
+</details>
 
-**Method 1 (Passing Variables Directly):**
+<details>
+<summary>Using uvx - Confluence only</summary>
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": [
+        "mcp-atlassian",
+        "--confluence-url=https://your-company.atlassian.net/wiki",
+        "--confluence-username=your.email@company.com",
+        "--confluence-token=your_api_token"
+      ]
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary>Using uvx - Jira only</summary>
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": [
+        "mcp-atlassian",
+        "--jira-url=https://your-company.atlassian.net",
+        "--jira-username=your.email@company.com",
+        "--jira-token=your_api_token"
+      ]
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary>Using pip</summary>
+
+> Note: Examples below use Cloud configuration. For Server/Data Center, use the corresponding arguments (--confluence-personal-token, --jira-personal-token) as shown in the Configuration section above.
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "mcp-atlassian",
+      "args": [
+        "--confluence-url=https://your-company.atlassian.net/wiki",
+        "--confluence-username=your.email@company.com",
+        "--confluence-token=your_api_token",
+        "--jira-url=https://your-company.atlassian.net",
+        "--jira-username=your.email@company.com",
+        "--jira-token=your_api_token"
+      ]
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary>Using docker</summary>
+
+> Note: Examples below use Cloud configuration. For Server/Data Center, use the corresponding arguments (--confluence-personal-token, --jira-personal-token) as shown in the Configuration section above.
+
+There are two ways to configure the Docker environment:
+
+1. Using cli arguments directly in the config:
 ```json
 {
   "mcpServers": {
@@ -106,32 +252,22 @@ There are two main approaches to configure the Docker container:
       "command": "docker",
       "args": [
         "run",
-        "-i",
         "--rm",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_USERNAME",
-        "-e", "CONFLUENCE_API_TOKEN",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_USERNAME",
-        "-e", "JIRA_API_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
-        "CONFLUENCE_USERNAME": "your.email@company.com",
-        "CONFLUENCE_API_TOKEN": "your_confluence_api_token",
-        "JIRA_URL": "https://your-company.atlassian.net",
-        "JIRA_USERNAME": "your.email@company.com",
-        "JIRA_API_TOKEN": "your_jira_api_token"
-      }
+        "-i",
+        "mcp/atlassian",
+        "--confluence-url=https://your-company.atlassian.net/wiki",
+        "--confluence-username=your.email@company.com",
+        "--confluence-token=your_api_token",
+        "--jira-url=https://your-company.atlassian.net",
+        "--jira-username=your.email@company.com",
+        "--jira-token=your_api_token"
+      ]
     }
   }
 }
 ```
 
-<details>
-<summary>Alternative: Using Environment File</summary>
-
+2. Using an environment file:
 ```json
 {
   "mcpServers": {
@@ -142,8 +278,8 @@ There are two main approaches to configure the Docker container:
         "--rm",
         "-i",
         "--env-file",
-        "/path/to/your/mcp-atlassian.env",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
+        "/path/to/your/.env",
+        "mcp/atlassian"
       ]
     }
   }
@@ -151,149 +287,60 @@ There are two main approaches to configure the Docker container:
 ```
 </details>
 
+### Cursor IDE Setup
+
+1. Open Cursor Settings
+2. Navigate to `Features` > `MCP Servers` (or directly to `MCP`)
+3. Click `+ Add new global MCP server`
+
+This will create or edit the `~/.cursor/mcp.json` file with your MCP server configuration.
+
+![Cursor MCP Configuration](https://github.com/user-attachments/assets/d0901421-7359-4f3f-8330-a82fc574a015)
+
+#### JSON Configuration for stdio Transport
+
+For Cloud:
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": [
+        "mcp-atlassian",
+        "--confluence-url=https://your-company.atlassian.net/wiki",
+        "--confluence-username=your.email@company.com",
+        "--confluence-token=your_api_token",
+        "--jira-url=https://your-company.atlassian.net",
+        "--jira-username=your.email@company.com",
+        "--jira-token=your_api_token"
+      ]
+    }
+  }
+}
+```
+
 <details>
 <summary>Server/Data Center Configuration</summary>
 
-For Server/Data Center deployments, use direct variable passing:
-
 ```json
 {
   "mcpServers": {
     "mcp-atlassian": {
-      "command": "docker",
+      "command": "uvx",
       "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_PERSONAL_TOKEN",
-        "-e", "CONFLUENCE_SSL_VERIFY",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_PERSONAL_TOKEN",
-        "-e", "JIRA_SSL_VERIFY",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "CONFLUENCE_URL": "https://confluence.your-company.com",
-        "CONFLUENCE_PERSONAL_TOKEN": "your_confluence_pat",
-        "CONFLUENCE_SSL_VERIFY": "false",
-        "JIRA_URL": "https://jira.your-company.com",
-        "JIRA_PERSONAL_TOKEN": "your_jira_pat",
-        "JIRA_SSL_VERIFY": "false"
-      }
+        "mcp-atlassian",
+        "--confluence-url=https://confluence.your-company.com",
+        "--confluence-personal-token=your_token",
+        "--jira-url=https://jira.your-company.com",
+        "--jira-personal-token=your_token"
+      ]
     }
   }
 }
 ```
-
-> [!NOTE]
-> Set `CONFLUENCE_SSL_VERIFY` and `JIRA_SSL_VERIFY` to "false" only if you have self-signed certificates.
-
 </details>
 
-<details> <summary>Single Service Configurations</summary>
-
-**For Confluence Cloud only:**
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_USERNAME",
-        "-e", "CONFLUENCE_API_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
-        "CONFLUENCE_USERNAME": "your.email@company.com",
-        "CONFLUENCE_API_TOKEN": "your_api_token"
-      }
-    }
-  }
-}
-```
-
-For Confluence Server/DC, use:
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_PERSONAL_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "CONFLUENCE_URL": "https://confluence.your-company.com",
-        "CONFLUENCE_PERSONAL_TOKEN": "your_personal_token"
-      }
-    }
-  }
-}
-```
-
-**For Jira Cloud only:**
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_USERNAME",
-        "-e", "JIRA_API_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "JIRA_URL": "https://your-company.atlassian.net",
-        "JIRA_USERNAME": "your.email@company.com",
-        "JIRA_API_TOKEN": "your_api_token"
-      }
-    }
-  }
-}
-```
-
-For Jira Server/DC, use:
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_PERSONAL_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "JIRA_URL": "https://jira.your-company.com",
-        "JIRA_PERSONAL_TOKEN": "your_personal_token"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-### SSE Transport Configuration
+#### SSE Transport Configuration
 
 For SSE transport, first start the server with its configuration provided via command-line arguments or server-side environment variables (e.g., from a `.env` file):
 ```bash
@@ -360,29 +407,43 @@ Then configure *only the URL* in Cursor's `~/.cursor/mcp.json`:
 
 ## Development & Debugging
 
-### Common Issues
+### Local Development Setup
 
-- **Authentication Failures**:
-    - For Cloud: Check your API tokens (not your account password)
-    - For Server/Data Center: Verify your personal access token is valid and not expired
-    - For older Confluence servers: Some older versions require basic authentication with `CONFLUENCE_USERNAME` and `CONFLUENCE_API_TOKEN` (where token is your password)
-- **SSL Certificate Issues**: If using Server/Data Center and encounter SSL errors, set `CONFLUENCE_SSL_VERIFY=false` or `JIRA_SSL_VERIFY=false`
-- **Permission Errors**: Ensure your Atlassian account has sufficient permissions to access the spaces/projects
+If you've cloned the repository and want to run a local version:
+
+For Cloud:
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uv",
+      "args": [
+        "--directory", "/path/to/your/mcp-atlassian",
+        "run", "mcp-atlassian",
+        "--confluence-url=https://your-domain.atlassian.net/wiki",
+        "--confluence-username=your.email@domain.com",
+        "--confluence-token=your_api_token",
+        "--jira-url=https://your-domain.atlassian.net",
+        "--jira-username=your.email@domain.com",
+        "--jira-token=your_api_token"
+      ]
+    }
+  }
+}
+```
 
 ### Debugging Tools
 
 ```bash
-# Using MCP Inspector for testing
+# Using MCP Inspector
+# For installed package
 npx @modelcontextprotocol/inspector uvx mcp-atlassian ...
 
 # For local development version
 npx @modelcontextprotocol/inspector uv --directory /path/to/your/mcp-atlassian run mcp-atlassian ...
 
 # View logs
-# macOS
 tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
-# Windows
-type %APPDATA%\Claude\logs\mcp*.log | more
 ```
 
 ## Security
@@ -390,15 +451,6 @@ type %APPDATA%\Claude\logs\mcp*.log | more
 - Never share API tokens
 - Keep .env files secure and private
 - See [SECURITY.md](SECURITY.md) for best practices
-
-## Contributing
-
-We welcome contributions to MCP Atlassian! If you'd like to contribute:
-
-1. Check out our [CONTRIBUTING.md](CONTRIBUTING.md) guide for detailed development setup instructions.
-2. Make changes and submit a pull request.
-
-We use pre-commit hooks for code quality and follow semantic versioning for releases.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,25 @@
 ![PyPI Version](https://img.shields.io/pypi/v/mcp-atlassian)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/mcp-atlassian)
 ![PePy - Total Downloads](https://static.pepy.tech/personalized-badge/mcp-atlassian?period=total&units=international_system&left_color=grey&right_color=blue&left_text=Total%20Downloads)
+[![Run Tests](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml/badge.svg)](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml)
 ![License](https://img.shields.io/github/license/sooperset/mcp-atlassian)
-[![smithery badge](https://smithery.ai/badge/mcp-atlassian)](https://smithery.ai/server/mcp-atlassian)
 
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). This integration supports both Confluence & Jira Cloud and Server/Data Center deployments.
 
-### Feature Demo
-![Jira Demo](https://github.com/user-attachments/assets/61573853-c8a8-45c9-be76-575f2b651984)
+## Example Usage
 
-<details>
-<summary>Confluence Demo</summary>
+Ask your AI assistant to:
+
+- **📝 Automatic Jira Updates** - "Update Jira from our meeting notes"
+- **🔍 AI-Powered Confluence Search** - "Find our OKR guide in Confluence and summarize it"
+- **🐛 Smart Jira Issue Filtering** - "Show me urgent bugs in PROJ project from last week"
+- **📄 Content Creation & Management** - "Create a tech design doc for XYZ feature"
+
+### Feature Demo
+
+https://github.com/user-attachments/assets/35303504-14c6-4ae4-913b-7c25ea511c3e
+
+<details> <summary>Confluence Demo</summary>
 
 https://github.com/user-attachments/assets/7fe9c488-ad0c-4876-9b54-120b666bb785
 
@@ -20,231 +29,76 @@ https://github.com/user-attachments/assets/7fe9c488-ad0c-4876-9b54-120b666bb785
 
 ### Compatibility
 
-| Product | Deployment Type | Support Status              |
-|---------|----------------|-----------------------------|
-| **Confluence** | Cloud | ✅ Fully supported           |
-| **Confluence** | Server/Data Center | ✅ Supported (version 6.0+)  |
-| **Jira** | Cloud | ✅ Fully supported           |
-| **Jira** | Server/Data Center | ✅ Supported (version 8.14+) |
+|Product|Deployment Type|Support Status|
+|---|---|---|
+|**Confluence**|Cloud|✅ Fully supported|
+|**Confluence**|Server/Data Center|✅ Supported (version 6.0+)|
+|**Jira**|Cloud|✅ Fully supported|
+|**Jira**|Server/Data Center|✅ Supported (version 8.14+)|
 
-## Setup Guide
+## Quick Start Guide
 
 ### 1. Authentication Setup
 
 First, generate the necessary authentication tokens for Confluence & Jira:
 
 #### For Cloud
+
 1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
 2. Click **Create API token**, name it
 3. Copy the token immediately
 
 #### For Server/Data Center
+
 1. Go to your profile (avatar) → **Profile** → **Personal Access Tokens**
 2. Click **Create token**, name it, set expiry
 3. Copy the token immediately
 
 ### 2. Installation
 
-Choose one of these installation methods:
+MCP Atlassian is distributed as a Docker image. This is the recommended way to run the server, especially for IDE integration. Ensure you have Docker installed.
 
 ```bash
-# Using uv (recommended)
-brew install uv
-uvx mcp-atlassian
-
-# Using pip
-pip install mcp-atlassian
-
-# Using Docker
-git clone https://github.com/sooperset/mcp-atlassian.git
-cd mcp-atlassian
-docker build -t mcp/atlassian .
-
-# Using Smithery
-npx -y @smithery/cli install mcp-atlassian --client claude
+# Pull Pre-built Image
+docker pull ghcr.io/sooperset/mcp-atlassian:latest
 ```
-
-### 3. Configuration and Usage
-
-You can configure the MCP server using command line arguments. The server supports using either Confluence, Jira, or both services - include only the arguments needed for your use case.
-
-#### Required Arguments
-
-For Cloud:
-```bash
-uvx mcp-atlassian \
-  --confluence-url https://your-company.atlassian.net/wiki \
-  --confluence-username your.email@company.com \
-  --confluence-token your_api_token \
-  --jira-url https://your-company.atlassian.net \
-  --jira-username your.email@company.com \
-  --jira-token your_api_token
-```
-
-For Server/Data Center:
-```bash
-uvx mcp-atlassian \
-  --confluence-url https://confluence.your-company.com \
-  --confluence-personal-token your_token \
-  --jira-url https://jira.your-company.com \
-  --jira-personal-token your_token
-```
-
-> **Note:** You can configure just Confluence, just Jira, or both services. Simply include only the arguments for the service(s) you want to use. For example, to use only Confluence Cloud, you would only need `--confluence-url`, `--confluence-username`, and `--confluence-token`.
-
-#### Optional Arguments
-
-- `--transport`: Choose transport type (`stdio` [default] or `sse`)
-- `--port`: Port number for SSE transport (default: 8000)
-- `--[no-]confluence-ssl-verify`: Toggle SSL verification for Confluence Server/DC
-- `--[no-]jira-ssl-verify`: Toggle SSL verification for Jira Server/DC
-- `--confluence-spaces-filter`: Comma-separated list of space keys to filter Confluence search results (e.g., "DEV,TEAM,DOC")
-- `--jira-projects-filter`: Comma-separated list of project keys to filter Jira search results (e.g., "PROJ,DEV,SUPPORT")
-- `--read-only`: Run in read-only mode (disables all write operations)
-- `--verbose`: Increase logging verbosity (can be used multiple times, default is WARNING level)
-  - `-v` or `--verbose`: Set logging to INFO level
-  - `-vv` or `--verbose --verbose`: Set logging to DEBUG level
-
-> **Note:** All configuration options can also be set via environment variables. See the `.env.example` file in the repository for the full list of available environment variables.
 
 ## IDE Integration
 
-### Claude Desktop Setup
+MCP Atlassian is designed to be used with AI assistants through IDE integration.
 
-Using uvx (recommended) - Cloud:
+> [!TIP]
+> **To apply the configuration in Claude Desktop:**
+>
+> **Method 1 (Recommended)**: Click hamburger menu (☰) > Settings > Developer > "Edit Config" button
+>
+> **Method 2**: Locate and edit the configuration file directly:
+> - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+> - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+> - **Linux**: `~/.config/Claude/claude_desktop_config.json`
+>
+> **For Cursor**: Open Settings → Features → MCP Servers → + Add new global MCP server
 
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": [
-        "mcp-atlassian",
-        "--confluence-url=https://your-company.atlassian.net/wiki",
-        "--confluence-username=your.email@company.com",
-        "--confluence-token=your_api_token",
-        "--jira-url=https://your-company.atlassian.net",
-        "--jira-username=your.email@company.com",
-        "--jira-token=your_api_token"
-      ]
-    }
-  }
-}
-```
+### Configuration Methods
 
-<details>
-<summary>Using uvx (recommended) - Server/Data Center </summary>
+There are two main approaches to configure the Docker container:
 
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": [
-        "mcp-atlassian",
-        "--confluence-url=https://confluence.your-company.com",
-        "--confluence-personal-token=your_token",
-        "--jira-url=https://jira.your-company.com",
-        "--jira-personal-token=your_token"
-      ]
-    }
-  }
-}
-```
-</details>
+1. **Passing Variables Directly** (shown in examples below)
+2. **Using an Environment File** with `--env-file` flag (shown in collapsible sections)
 
-<details>
-<summary>Using uvx - Confluence with Basic Auth (older servers)</summary>
+> [!NOTE]
+> Common environment variables include:
+>
+> - `CONFLUENCE_SPACES_FILTER`: Filter by space keys (e.g., "DEV,TEAM,DOC")
+> - `JIRA_PROJECTS_FILTER`: Filter by project keys (e.g., "PROJ,DEV,SUPPORT")
+> - `READ_ONLY_MODE`: Set to "true" to disable write operations
+> - `MCP_VERBOSE`: Set to "true" for more detailed logging
+>
+> See the [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) file for all available options.
 
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": [
-        "mcp-atlassian",
-        "--confluence-url=https://confluence.your-company.com",
-        "--confluence-username=your.email@company.com",
-        "--confluence-token=your_password"
-      ]
-    }
-  }
-}
-```
-</details>
+### Configuration Examples
 
-<details>
-<summary>Using uvx - Confluence only</summary>
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": [
-        "mcp-atlassian",
-        "--confluence-url=https://your-company.atlassian.net/wiki",
-        "--confluence-username=your.email@company.com",
-        "--confluence-token=your_api_token"
-      ]
-    }
-  }
-}
-```
-</details>
-
-<details>
-<summary>Using uvx - Jira only</summary>
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": [
-        "mcp-atlassian",
-        "--jira-url=https://your-company.atlassian.net",
-        "--jira-username=your.email@company.com",
-        "--jira-token=your_api_token"
-      ]
-    }
-  }
-}
-```
-</details>
-
-<details>
-<summary>Using pip</summary>
-
-> Note: Examples below use Cloud configuration. For Server/Data Center, use the corresponding arguments (--confluence-personal-token, --jira-personal-token) as shown in the Configuration section above.
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "mcp-atlassian",
-      "args": [
-        "--confluence-url=https://your-company.atlassian.net/wiki",
-        "--confluence-username=your.email@company.com",
-        "--confluence-token=your_api_token",
-        "--jira-url=https://your-company.atlassian.net",
-        "--jira-username=your.email@company.com",
-        "--jira-token=your_api_token"
-      ]
-    }
-  }
-}
-```
-</details>
-
-<details>
-<summary>Using docker</summary>
-
-> Note: Examples below use Cloud configuration. For Server/Data Center, use the corresponding arguments (--confluence-personal-token, --jira-personal-token) as shown in the Configuration section above.
-
-There are two ways to configure the Docker environment:
-
-1. Using cli arguments directly in the config:
+**Method 1 (Passing Variables Directly):**
 ```json
 {
   "mcpServers": {
@@ -252,22 +106,32 @@ There are two ways to configure the Docker environment:
       "command": "docker",
       "args": [
         "run",
-        "--rm",
         "-i",
-        "mcp/atlassian",
-        "--confluence-url=https://your-company.atlassian.net/wiki",
-        "--confluence-username=your.email@company.com",
-        "--confluence-token=your_api_token",
-        "--jira-url=https://your-company.atlassian.net",
-        "--jira-username=your.email@company.com",
-        "--jira-token=your_api_token"
-      ]
+        "--rm",
+        "-e", "CONFLUENCE_URL",
+        "-e", "CONFLUENCE_USERNAME",
+        "-e", "CONFLUENCE_API_TOKEN",
+        "-e", "JIRA_URL",
+        "-e", "JIRA_USERNAME",
+        "-e", "JIRA_API_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "CONFLUENCE_USERNAME": "your.email@company.com",
+        "CONFLUENCE_API_TOKEN": "your_confluence_api_token",
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_jira_api_token"
+      }
     }
   }
 }
 ```
 
-2. Using an environment file:
+<details>
+<summary>Alternative: Using Environment File</summary>
+
 ```json
 {
   "mcpServers": {
@@ -278,172 +142,258 @@ There are two ways to configure the Docker environment:
         "--rm",
         "-i",
         "--env-file",
-        "/path/to/your/.env",
-        "mcp/atlassian"
+        "/path/to/your/mcp-atlassian.env",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
       ]
     }
   }
 }
 ```
 </details>
-
-### Cursor IDE Setup
-
-1. Open Cursor Settings
-2. Navigate to `Features` > `MCP Servers` (or directly to `MCP`)
-3. Click `+ Add new global MCP server`
-
-This will create or edit the `~/.cursor/mcp.json` file with your MCP server configuration.
-
-![Cursor MCP Configuration](https://github.com/user-attachments/assets/d0901421-7359-4f3f-8330-a82fc574a015)
-
-#### JSON Configuration for stdio Transport
-
-For Cloud:
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "uvx",
-      "args": [
-        "mcp-atlassian",
-        "--confluence-url=https://your-company.atlassian.net/wiki",
-        "--confluence-username=your.email@company.com",
-        "--confluence-token=your_api_token",
-        "--jira-url=https://your-company.atlassian.net",
-        "--jira-username=your.email@company.com",
-        "--jira-token=your_api_token"
-      ]
-    }
-  }
-}
-```
 
 <details>
 <summary>Server/Data Center Configuration</summary>
 
+For Server/Data Center deployments, use direct variable passing:
+
 ```json
 {
   "mcpServers": {
     "mcp-atlassian": {
-      "command": "uvx",
+      "command": "docker",
       "args": [
-        "mcp-atlassian",
-        "--confluence-url=https://confluence.your-company.com",
-        "--confluence-personal-token=your_token",
-        "--jira-url=https://jira.your-company.com",
-        "--jira-personal-token=your_token"
-      ]
+        "run",
+        "--rm",
+        "-i",
+        "-e", "CONFLUENCE_URL",
+        "-e", "CONFLUENCE_PERSONAL_TOKEN",
+        "-e", "CONFLUENCE_SSL_VERIFY",
+        "-e", "JIRA_URL",
+        "-e", "JIRA_PERSONAL_TOKEN",
+        "-e", "JIRA_SSL_VERIFY",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "CONFLUENCE_URL": "https://confluence.your-company.com",
+        "CONFLUENCE_PERSONAL_TOKEN": "your_confluence_pat",
+        "CONFLUENCE_SSL_VERIFY": "false",
+        "JIRA_URL": "https://jira.your-company.com",
+        "JIRA_PERSONAL_TOKEN": "your_jira_pat",
+        "JIRA_SSL_VERIFY": "false"
+      }
     }
   }
 }
 ```
+
+> [!NOTE]
+> Set `CONFLUENCE_SSL_VERIFY` and `JIRA_SSL_VERIFY` to "false" only if you have self-signed certificates.
+
 </details>
 
-#### SSE Transport Configuration
+<details> <summary>Single Service Configurations</summary>
 
-For SSE transport, first start the server with its configuration provided via command-line arguments or server-side environment variables (e.g., from a `.env` file):
-```bash
-# Example starting the server with Cloud configuration
-uvx mcp-atlassian --transport sse --port 9000 \
-  --confluence-url https://your-company.atlassian.net/wiki \
-  --confluence-username your.email@company.com \
-  --confluence-token your_api_token \
-  --jira-url https://your-company.atlassian.net \
-  --jira-username your.email@company.com \
-  --jira-token your_api_token
-```
+**For Confluence Cloud only:**
 
-Then configure *only the URL* in Cursor's `~/.cursor/mcp.json`:
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian-sse": {
-      "url": "http://localhost:9000/sse"
-    }
-  }
-}
-```
-
-## Resources
-
-> **Note:** The MCP server filters resources to only show Confluence spaces and Jira projects that the user is actively interacting with, based on their contributions and assignments.
-
-- `confluence://{space_key}`: Access Confluence spaces
-- `jira://{project_key}`: Access Jira projects
-
-## Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `confluence_search` | Search Confluence content using CQL |
-| `confluence_get_page` | Get content of a specific Confluence page |
-| `confluence_get_page_children` | Get child pages of a specific Confluence page |
-| `confluence_get_page_ancestors` | Get parent pages of a specific Confluence page |
-| `confluence_get_comments` | Get comments for a specific Confluence page |
-| `confluence_create_page` | Create a new Confluence page |
-| `confluence_update_page` | Update an existing Confluence page |
-| `confluence_delete_page` | Delete an existing Confluence page |
-| `confluence_attach_content` | Attach content to a Confluence page |
-| `jira_get_issue` | Get details of a specific Jira issue |
-| `jira_search` | Search Jira issues using JQL |
-| `jira_get_project_issues` | Get all issues for a specific Jira project |
-| `jira_get_epic_issues` | Get all issues linked to a specific Epic |
-| `jira_create_issue` | Create a new issue in Jira |
-| `jira_update_issue` | Update an existing Jira issue |
-| `jira_delete_issue` | Delete an existing Jira issue |
-| `jira_get_transitions` | Get available status transitions for a Jira issue |
-| `jira_transition_issue` | Transition a Jira issue to a new status |
-| `jira_add_comment` | Add a comment to a Jira issue |
-| `jira_add_worklog` | Add a worklog entry to a Jira issue |
-| `jira_get_worklog` | Get worklog entries for a Jira issue |
-| `jira_download_attachments` | Download attachments from a Jira issue |
-| `jira_link_to_epic` | Link an issue to an Epic |
-| `jira_get_agile_boards` | Get Jira agile boards by name, project key, or type |
-| `jira_get_board_issues` | Get all issues linked to a specific board |
-| `jira_get_sprints_from_board` | Get Jira sprints from board by state |
-| `jira_create_sprint` | Create Jira sprint for a board |
-| `jira_get_sprint_issues` | Get Jira issues from sprint |
-
-## Development & Debugging
-
-### Local Development Setup
-
-If you've cloned the repository and want to run a local version:
-
-For Cloud:
 ```json
 {
   "mcpServers": {
     "mcp-atlassian": {
-      "command": "uv",
+      "command": "docker",
       "args": [
-        "--directory", "/path/to/your/mcp-atlassian",
-        "run", "mcp-atlassian",
-        "--confluence-url=https://your-domain.atlassian.net/wiki",
-        "--confluence-username=your.email@domain.com",
-        "--confluence-token=your_api_token",
-        "--jira-url=https://your-domain.atlassian.net",
-        "--jira-username=your.email@domain.com",
-        "--jira-token=your_api_token"
-      ]
+        "run",
+        "--rm",
+        "-i",
+        "-e", "CONFLUENCE_URL",
+        "-e", "CONFLUENCE_USERNAME",
+        "-e", "CONFLUENCE_API_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "CONFLUENCE_USERNAME": "your.email@company.com",
+        "CONFLUENCE_API_TOKEN": "your_api_token"
+      }
     }
   }
 }
 ```
+
+For Confluence Server/DC, use:
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e", "CONFLUENCE_URL",
+        "-e", "CONFLUENCE_PERSONAL_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "CONFLUENCE_URL": "https://confluence.your-company.com",
+        "CONFLUENCE_PERSONAL_TOKEN": "your_personal_token"
+      }
+    }
+  }
+}
+```
+
+**For Jira Cloud only:**
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e", "JIRA_URL",
+        "-e", "JIRA_USERNAME",
+        "-e", "JIRA_API_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+For Jira Server/DC, use:
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e", "JIRA_URL",
+        "-e", "JIRA_PERSONAL_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "JIRA_URL": "https://jira.your-company.com",
+        "JIRA_PERSONAL_TOKEN": "your_personal_token"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+### SSE Transport Configuration
+
+<details> <summary>Using SSE Instead of stdio</summary>
+
+1.  Start the server manually in a terminal:
+
+    ```bash
+    docker run --rm -p 9000:9000 \
+      --env-file /path/to/your/.env \
+      ghcr.io/sooperset/mcp-atlassian:latest \
+      --transport sse --port 9000 -vv
+    ```
+
+2.  Configure your IDE to connect to the running server via its URL:
+
+    ```json
+    {
+      "mcpServers": {
+        "mcp-atlassian-sse": {
+          "url": "http://localhost:9000/sse"
+        }
+      }
+    }
+    ```
+</details>
+
+## Tools
+
+### Key Tools
+
+#### Confluence Tools
+
+- `confluence_search`: Search Confluence content using CQL
+- `confluence_get_page`: Get content of a specific page
+- `confluence_create_page`: Create a new page
+- `confluence_update_page`: Update an existing page
+
+#### Jira Tools
+
+- `jira_get_issue`: Get details of a specific issue
+- `jira_search`: Search issues using JQL
+- `jira_create_issue`: Create a new issue
+- `jira_update_issue`: Update an existing issue
+- `jira_transition_issue`: Transition an issue to a new status
+- `jira_add_comment`: Add a comment to an issue
+
+<details> <summary>View All Tools</summary>
+
+|Confluence Tools|Jira Tools|
+|---|---|
+|`confluence_search`|`jira_get_issue`|
+|`confluence_get_page`|`jira_search`|
+|`confluence_get_page_children`|`jira_get_project_issues`|
+|`confluence_get_page_ancestors`|`jira_get_epic_issues`|
+|`confluence_get_comments`|`jira_create_issue`|
+|`confluence_create_page`|`jira_batch_create_issues`|
+|`confluence_update_page`|`jira_update_issue`|
+|`confluence_delete_page`|`jira_delete_issue`|
+||`jira_get_transitions`|
+||`jira_transition_issue`|
+||`jira_add_comment`|
+||`jira_add_worklog`|
+||`jira_get_worklog`|
+||`jira_download_attachments`|
+||`jira_link_to_epic`|
+||`jira_get_agile_boards`|
+||`jira_get_board_issues`|
+||`jira_get_sprints_from_board`|
+||`jira_get_sprint_issues`|
+||`jira_create_sprint`|
+||`jira_update_sprint`|
+||`jira_create_issue_link`|
+||`jira_remove_issue_link`|
+
+</details>
+
+## Troubleshooting & Debugging
+
+### Common Issues
+
+- **Authentication Failures**:
+    - For Cloud: Check your API tokens (not your account password)
+    - For Server/Data Center: Verify your personal access token is valid and not expired
+    - For older Confluence servers: Some older versions require basic authentication with `CONFLUENCE_USERNAME` and `CONFLUENCE_API_TOKEN` (where token is your password)
+- **SSL Certificate Issues**: If using Server/Data Center and encounter SSL errors, set `CONFLUENCE_SSL_VERIFY=false` or `JIRA_SSL_VERIFY=false`
+- **Permission Errors**: Ensure your Atlassian account has sufficient permissions to access the spaces/projects
 
 ### Debugging Tools
 
 ```bash
-# Using MCP Inspector
-# For installed package
+# Using MCP Inspector for testing
 npx @modelcontextprotocol/inspector uvx mcp-atlassian ...
 
 # For local development version
 npx @modelcontextprotocol/inspector uv --directory /path/to/your/mcp-atlassian run mcp-atlassian ...
 
 # View logs
+# macOS
 tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
+# Windows
+type %APPDATA%\Claude\logs\mcp*.log | more
 ```
 
 ## Security
@@ -451,6 +401,15 @@ tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 - Never share API tokens
 - Keep .env files secure and private
 - See [SECURITY.md](SECURITY.md) for best practices
+
+## Contributing
+
+We welcome contributions to MCP Atlassian! If you'd like to contribute:
+
+1. Check out our [CONTRIBUTING.md](CONTRIBUTING.md) guide for detailed development setup instructions.
+2. Make changes and submit a pull request.
+
+We use pre-commit hooks for code quality and follow semantic versioning for releases.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "uvicorn>=0.27.1",
     "starlette>=0.37.1",
     "thefuzz>=0.22.1",
+    "python-dateutil>=2.9.0.post0",
+    "types-python-dateutil>=2.9.0.20241206",
 ]
 [[project.authors]]
 name = "sooperset"

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -1,11 +1,13 @@
 """Module for Jira sprints operations."""
 
+import datetime
 import logging
 from typing import Any
 
 import requests
 
 from ..models.jira import JiraSprint
+from ..utils.dates import parse_iso8601_date
 from .client import JiraClient
 
 logger = logging.getLogger("mcp-jira")
@@ -90,6 +92,22 @@ class SprintsMixin(JiraClient):
         Returns:
             Created sprint details
         """
+
+        if not start_date:
+            raise ValueError("Start date is required.")
+
+        # validate start date format
+        parsed_start_date = parse_iso8601_date(start_date)
+
+        # validate start date is not in the past
+        if parsed_start_date < datetime.datetime.now(datetime.timezone.utc):
+            raise ValueError("Start date cannot be in the past.")
+
+        # validate end date format
+        if end_date:
+            parsed_end_date = parse_iso8601_date(end_date)
+            if parsed_start_date >= parsed_end_date:
+                raise ValueError("Start date must be before end date.")
 
         try:
             sprint = self.jira.create_sprint(

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -99,6 +99,7 @@ class SprintsMixin(JiraClient):
                 end_date=end_date,
                 goal=goal,
             )
+
             logger.info(f"Sprint created: {sprint}")
 
             return JiraSprint.from_api_response(sprint)

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -69,59 +69,6 @@ class SprintsMixin(JiraClient):
         )
         return [JiraSprint.from_api_response(sprint) for sprint in sprints]
 
-    def update_sprint(
-        self,
-        sprint_id: str,
-        sprint_name: str | None,
-        state: str | None,
-        start_date: str | None,
-        end_date: str | None,
-        goal: str | None,
-    ) -> JiraSprint | None:
-        """
-        Update a sprint.
-
-        Args:
-            sprint_id: Sprint ID
-            sprint_name: New name for the sprint (optional)
-            state: New state for the sprint (future|active|closed - optional)
-            start_date: New start date for the sprint (optional)
-            end_date: New end date for the sprint (optional)
-            goal: New goal for the sprint (optional)
-
-        Returns:
-            Updated sprint
-        """
-        data = {}
-        if sprint_name:
-            data["name"] = sprint_name
-        if state and state not in ["future", "active", "closed"]:
-            logger.warning("Invalid state. Valid states are: future, active, closed.")
-            return None
-        elif state:
-            data["state"] = state
-        if start_date:
-            data["startDate"] = start_date
-        if end_date:
-            data["endDate"] = end_date
-        if goal:
-            data["goal"] = goal
-        if not sprint_id:
-            logger.warning("Sprint ID is required.")
-            return None
-        try:
-            updated_sprint = self.jira.update_partially_sprint(
-                sprint_id=sprint_id,
-                data=data,
-            )
-            return JiraSprint.from_api_response(updated_sprint)
-        except requests.HTTPError as e:
-            logger.error(f"Error updating sprint: {str(e.response.content)}")
-            return None
-        except Exception as e:
-            logger.error(f"Error updating sprint: {str(e)}")
-            return None
-
     def create_sprint(
         self,
         board_id: str,

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -100,72 +100,10 @@ class SprintsMixin(JiraClient):
                 goal=goal,
             )
 
-            logger.error(f"SPRINTDAVE Sprint created: {sprint}")
-
             return JiraSprint.from_api_response(sprint)
         except requests.HTTPError as e:
             logger.error(f"Error creating sprint: {str(e.response.content)}")
-            return {}
+            raise
         except Exception as e:
             logger.error(f"Error creating sprint: {str(e)}")
-            return {}
-
-    # def update_sprint(
-    #     self,
-    #     sprint_id: str,
-    #     name: str | None = None,
-    #     start_date: str | None = None,
-    #     end_date: str | None = None,
-    #     goal: str | None = None,
-    #     state: str | None = None,
-    # ) -> dict[str, Any]:
-    #     """
-    #     Update an existing sprint.
-
-    #     Args:
-    #         sprint_id: Sprint ID
-    #         name: New sprint name
-    #         start_date: New start date in ISO format
-    #         end_date: New end date in ISO format
-    #         goal: New sprint goal
-    #         state: New sprint state (e.g., active, future, closed)
-
-    #     Returns:
-    #         Updated sprint details
-    #     """
-    #     if not sprint_id:
-    #         logger.error("Sprint ID is required.")
-    #         return {}
-    #     if not any([name, start_date, end_date, goal, state]):
-    #         logger.error("At least one field must be provided for update.")
-    #         return {}
-
-    #     data = {}
-    #     if name:
-    #         data["name"] = name
-    #     if start_date:
-    #         data["startDate"] = start_date
-    #     if end_date:
-    #         data["endDate"] = end_date
-    #     if goal:
-    #         data["goal"] = goal
-    #     if state:
-    #         data["state"] = state
-    #     if not data:
-    #         logger.error("No data provided for update.")
-    #         return {}
-
-    #     try:
-    #         sprint = self.jira.update_partially_sprint(
-    #             sprint_id=sprint_id,
-    #             data=data,
-    #         )
-    #         return sprint
-    #     except requests.HTTPError as e:
-    #         logger.error(
-    #             f"Error updating sprint: {str(e.response.content)}"
-    #         )
-    #         return {}
-    #     except Exception as e:
-    #         logger.error(f"Error updating sprint: {str(e)}")
-    #         return {}
+            raise

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -83,8 +83,8 @@ class SprintsMixin(JiraClient):
         Create a new sprint.
 
         Args:
-            sprint_name: Sprint name
             board_id: Board ID
+            sprint_name: Sprint name
             start_date: Start date in ISO format
             end_date: End date in ISO format
             goal: Sprint goal
@@ -99,6 +99,9 @@ class SprintsMixin(JiraClient):
         # validate start date format
         parsed_start_date = parse_iso8601_date(start_date)
 
+        if parsed_start_date is None:
+            raise ValueError("Start date is required.")
+
         # validate start date is not in the past
         if parsed_start_date < datetime.datetime.now(datetime.timezone.utc):
             raise ValueError("Start date cannot be in the past.")
@@ -106,7 +109,7 @@ class SprintsMixin(JiraClient):
         # validate end date format
         if end_date:
             parsed_end_date = parse_iso8601_date(end_date)
-            if parsed_start_date >= parsed_end_date:
+            if parsed_end_date is not None and parsed_start_date >= parsed_end_date:
                 raise ValueError("Start date must be before end date.")
 
         try:

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -71,6 +71,59 @@ class SprintsMixin(JiraClient):
         )
         return [JiraSprint.from_api_response(sprint) for sprint in sprints]
 
+    def update_sprint(
+        self,
+        sprint_id: str,
+        sprint_name: str | None,
+        state: str | None,
+        start_date: str | None,
+        end_date: str | None,
+        goal: str | None,
+    ) -> JiraSprint | None:
+        """
+        Update a sprint.
+
+        Args:
+            sprint_id: Sprint ID
+            sprint_name: New name for the sprint (optional)
+            state: New state for the sprint (future|active|closed - optional)
+            start_date: New start date for the sprint (optional)
+            end_date: New end date for the sprint (optional)
+            goal: New goal for the sprint (optional)
+
+        Returns:
+            Updated sprint
+        """
+        data = {}
+        if sprint_name:
+            data["name"] = sprint_name
+        if state and state not in ["future", "active", "closed"]:
+            logger.warning("Invalid state. Valid states are: future, active, closed.")
+            return None
+        elif state:
+            data["state"] = state
+        if start_date:
+            data["startDate"] = start_date
+        if end_date:
+            data["endDate"] = end_date
+        if goal:
+            data["goal"] = goal
+        if not sprint_id:
+            logger.warning("Sprint ID is required.")
+            return None
+        try:
+            updated_sprint = self.jira.update_partially_sprint(
+                sprint_id=sprint_id,
+                data=data,
+            )
+            return JiraSprint.from_api_response(updated_sprint)
+        except requests.HTTPError as e:
+            logger.error(f"Error updating sprint: {str(e.response.content)}")
+            return None
+        except Exception as e:
+            logger.error(f"Error updating sprint: {str(e)}")
+            return None
+
     def create_sprint(
         self,
         board_id: str,

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -99,6 +99,7 @@ class SprintsMixin(JiraClient):
                 end_date=end_date,
                 goal=goal,
             )
+            logger.info(f"Sprint created: {sprint}")
 
             return JiraSprint.from_api_response(sprint)
         except requests.HTTPError as e:

--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -121,3 +121,104 @@ class SprintsMixin(JiraClient):
         except Exception as e:
             logger.error(f"Error updating sprint: {str(e)}")
             return None
+
+    def create_sprint(
+        self,
+        board_id: str,
+        sprint_name: str,
+        start_date: str,
+        end_date: str,
+        goal: str = None,
+    ) -> JiraSprint:
+        """
+        Create a new sprint.
+
+        Args:
+            sprint_name: Sprint name
+            board_id: Board ID
+            start_date: Start date in ISO format
+            end_date: End date in ISO format
+            goal: Sprint goal
+
+        Returns:
+            Created sprint details
+        """
+
+        try:
+            sprint = self.jira.create_sprint(
+                name=sprint_name,
+                board_id=board_id,
+                start_date=start_date,
+                end_date=end_date,
+                goal=goal,
+            )
+
+            logger.error(f"SPRINTDAVE Sprint created: {sprint}")
+
+            return JiraSprint.from_api_response(sprint)
+        except requests.HTTPError as e:
+            logger.error(f"Error creating sprint: {str(e.response.content)}")
+            return {}
+        except Exception as e:
+            logger.error(f"Error creating sprint: {str(e)}")
+            return {}
+
+    # def update_sprint(
+    #     self,
+    #     sprint_id: str,
+    #     name: str | None = None,
+    #     start_date: str | None = None,
+    #     end_date: str | None = None,
+    #     goal: str | None = None,
+    #     state: str | None = None,
+    # ) -> dict[str, Any]:
+    #     """
+    #     Update an existing sprint.
+
+    #     Args:
+    #         sprint_id: Sprint ID
+    #         name: New sprint name
+    #         start_date: New start date in ISO format
+    #         end_date: New end date in ISO format
+    #         goal: New sprint goal
+    #         state: New sprint state (e.g., active, future, closed)
+
+    #     Returns:
+    #         Updated sprint details
+    #     """
+    #     if not sprint_id:
+    #         logger.error("Sprint ID is required.")
+    #         return {}
+    #     if not any([name, start_date, end_date, goal, state]):
+    #         logger.error("At least one field must be provided for update.")
+    #         return {}
+
+    #     data = {}
+    #     if name:
+    #         data["name"] = name
+    #     if start_date:
+    #         data["startDate"] = start_date
+    #     if end_date:
+    #         data["endDate"] = end_date
+    #     if goal:
+    #         data["goal"] = goal
+    #     if state:
+    #         data["state"] = state
+    #     if not data:
+    #         logger.error("No data provided for update.")
+    #         return {}
+
+    #     try:
+    #         sprint = self.jira.update_partially_sprint(
+    #             sprint_id=sprint_id,
+    #             data=data,
+    #         )
+    #         return sprint
+    #     except requests.HTTPError as e:
+    #         logger.error(
+    #             f"Error updating sprint: {str(e.response.content)}"
+    #         )
+    #         return {}
+    #     except Exception as e:
+    #         logger.error(f"Error updating sprint: {str(e)}")
+    #         return {}

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -765,6 +765,36 @@ async def list_tools() -> list[Tool]:
                     },
                 ),
                 Tool(
+                    name="jira_create_sprint",
+                    description="Create Jira sprint for a board",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "board_id": {
+                                "type": "string",
+                                "description": "The id of board (e.g., '1000')",
+                            },
+                            "sprint_name": {
+                                "type": "string",
+                                "description": "Name of the sprint (e.g., 'Sprint 1')",
+                            },
+                            "start_date": {
+                                "type": "string",
+                                "description": "Start time for sprint (ISO 8601 format)",
+                            },
+                            "end_date": {
+                                "type": "string",
+                                "description": "End time for sprint (ISO 8601 format)",
+                            },
+                            "goal": {
+                                "type": "string",
+                                "description": "Goal of the sprint",
+                            }
+                        },
+                        "required": ["board_id ", "sprint_name", "start_date", "end_date"],
+                    },
+                ),
+                Tool(
                     name="jira_get_sprint_issues",
                     description="Get jira issues from sprint",
                     inputSchema={
@@ -1782,6 +1812,26 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                         indent=2,
                         ensure_ascii=False,
                     ),
+                )
+            ]
+        
+        elif name == "jira_create_sprint" and ctx and ctx.jira:
+            if not ctx or not ctx.jira:
+                raise ValueError("Jira is not configured.")
+
+            board_id = arguments.get("board_id")
+            sprint_name = arguments.get("sprint_name")
+            goal = arguments.get("goal")
+            start_date = arguments.get("start_date")
+            end_date = arguments.get("end_date")
+
+            sprint = ctx.jira.create_sprint(
+                board_id=board_id, sprint_name=sprint_name, goal=goal, start_date=start_date, end_date=end_date
+            )
+            
+            return [
+                TextContent(
+                    type="text", text=json.dumps(sprint.to_simplified_dict(), indent=2, ensure_ascii=False)
                 )
             ]
 

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -792,7 +792,7 @@ async def list_tools() -> list[Tool]:
                             },
                         },
                         "required": [
-                            "board_id ",
+                            "board_id",
                             "sprint_name",
                             "start_date",
                             "end_date",
@@ -1512,7 +1512,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 ]
 
         # Jira operations
-        elif name == "jira_get_issue" and ctx and ctx.jira:
+        elif name == "jira_get_issue":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1543,7 +1543,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_search" and ctx and ctx.jira:
+        elif name == "jira_search":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1628,7 +1628,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_get_epic_issues" and ctx and ctx.jira:
+        elif name == "jira_get_epic_issues":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1659,7 +1659,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_get_transitions" and ctx and ctx.jira:
+        elif name == "jira_get_transitions":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1688,7 +1688,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_get_worklog" and ctx and ctx.jira:
+        elif name == "jira_get_worklog":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1705,7 +1705,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_download_attachments" and ctx and ctx.jira:
+        elif name == "jira_download_attachments":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1728,7 +1728,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_get_agile_boards" and ctx and ctx.jira:
+        elif name == "jira_get_agile_boards":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1757,7 +1757,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_get_board_issues" and ctx and ctx.jira:
+        elif name == "jira_get_board_issues":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1796,7 +1796,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_get_sprints_from_board" and ctx and ctx.jira:
+        elif name == "jira_get_sprints_from_board":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 
@@ -1820,7 +1820,9 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_create_sprint" and ctx and ctx.jira:
+        elif name == "jira_create_sprint":
+            if not ctx or not ctx.jira:
+                raise ValueError("Jira is not configured.")
 
             board_id = arguments.get("board_id")
             sprint_name = arguments.get("sprint_name")
@@ -1845,7 +1847,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 )
             ]
 
-        elif name == "jira_get_sprint_issues" and ctx and ctx.jira:
+        elif name == "jira_get_sprint_issues":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -1821,8 +1821,6 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             ]
 
         elif name == "jira_create_sprint" and ctx and ctx.jira:
-            if not ctx or not ctx.jira:
-                raise ValueError("Jira is not configured.")
 
             board_id = arguments.get("board_id")
             sprint_name = arguments.get("sprint_name")

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -789,9 +789,14 @@ async def list_tools() -> list[Tool]:
                             "goal": {
                                 "type": "string",
                                 "description": "Goal of the sprint",
-                            }
+                            },
                         },
-                        "required": ["board_id ", "sprint_name", "start_date", "end_date"],
+                        "required": [
+                            "board_id ",
+                            "sprint_name",
+                            "start_date",
+                            "end_date",
+                        ],
                     },
                 ),
                 Tool(
@@ -1814,7 +1819,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                     ),
                 )
             ]
-        
+
         elif name == "jira_create_sprint" and ctx and ctx.jira:
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
@@ -1826,12 +1831,19 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             end_date = arguments.get("end_date")
 
             sprint = ctx.jira.create_sprint(
-                board_id=board_id, sprint_name=sprint_name, goal=goal, start_date=start_date, end_date=end_date
+                board_id=board_id,
+                sprint_name=sprint_name,
+                goal=goal,
+                start_date=start_date,
+                end_date=end_date,
             )
-            
+
             return [
                 TextContent(
-                    type="text", text=json.dumps(sprint.to_simplified_dict(), indent=2, ensure_ascii=False)
+                    type="text",
+                    text=json.dumps(
+                        sprint.to_simplified_dict(), indent=2, ensure_ascii=False
+                    ),
                 )
             ]
 

--- a/src/mcp_atlassian/utils/__init__.py
+++ b/src/mcp_atlassian/utils/__init__.py
@@ -5,6 +5,7 @@ This package provides various utility functions used throughout the codebase.
 
 # Re-export from ssl module
 # Re-export from io module
+from .dates import parse_iso8601_date
 from .io import is_read_only_mode
 
 # Export new logging utilities
@@ -21,4 +22,5 @@ __all__ = [
     "is_atlassian_cloud_url",
     "is_read_only_mode",
     "setup_logging",
+    "parse_iso8601_date",
 ]

--- a/src/mcp_atlassian/utils/dates.py
+++ b/src/mcp_atlassian/utils/dates.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from dateutil.parser import isoparse
+
+
+def parse_iso8601_date(date_string: str) -> datetime | None:
+    """
+    Validates of string is in ISO 8601 date format YYYY-MM-DDThh:mm:ss.sssZ
+
+    Args:
+        date_string (str): The string to validate.
+
+    Returns:
+        bool: date if the string is a valid ISO 8601 date/time, otherwise raises ValueError.
+    """
+    try:
+        return isoparse(date_string)
+    except ValueError as err:
+        raise ValueError(
+            "Incorrect data format, should be YYYY-MM-DDThh:mm:ss.sssZ"
+        ) from err

--- a/tests/unit/jira/test_sprints.py
+++ b/tests/unit/jira/test_sprints.py
@@ -48,7 +48,7 @@ def mock_sprints():
                 "completeDate": "2024-05-20T05:17:24.302Z",
                 "activatedDate": "2024-05-07T01:22:45.128Z",
                 "originBoardId": 1000,
-                "goal": "",
+                "goal": "your goal",
                 "synced": False,
                 "autoStartStop": False,
             },
@@ -122,6 +122,20 @@ def test_get_all_sprints_from_board_model(sprints_mixin, mock_sprints):
     assert result == [
         JiraSprint.from_api_response(value) for value in mock_sprints["values"]
     ]
+
+
+def test_create_sprint(sprints_mixin, mock_sprints):
+    """Test create_sprint method."""
+    sprints_mixin.jira.create_sprint.return_value = mock_sprints["values"][1]
+
+    result = sprints_mixin.create_sprint(
+        sprint_name="Sprint 1",
+        board_id="10001",
+        start_date="2025-05-01T00:00:00.000Z",
+        end_date="2025-05-15T00:00:00.000Z",
+        goal="Your goal",
+    )
+    assert result == JiraSprint.from_api_response(mock_sprints["values"][1])
 
 
 def test_update_sprint_success(sprints_mixin, mock_sprints):

--- a/tests/unit/jira/test_sprints.py
+++ b/tests/unit/jira/test_sprints.py
@@ -48,7 +48,7 @@ def mock_sprints():
                 "completeDate": "2024-05-20T05:17:24.302Z",
                 "activatedDate": "2024-05-07T01:22:45.128Z",
                 "originBoardId": 1000,
-                "goal": "your goal",
+                "goal": "",
                 "synced": False,
                 "autoStartStop": False,
             },

--- a/tests/unit/jira/test_sprints.py
+++ b/tests/unit/jira/test_sprints.py
@@ -43,8 +43,8 @@ def mock_sprints():
                 "self": "https://test.atlassian.net/rest/agile/1.0/sprint/10000",
                 "state": "closed",
                 "name": "Sprint 0",
-                "startDate": "2024-05-06T02:00:00.000Z",
-                "endDate": "2024-05-17T10:00:00.000Z",
+                "startDate": "2099-05-06T02:00:00.000Z",
+                "endDate": "2100-05-17T10:00:00.000Z",
                 "completeDate": "2024-05-20T05:17:24.302Z",
                 "activatedDate": "2024-05-07T01:22:45.128Z",
                 "originBoardId": 1000,
@@ -57,8 +57,8 @@ def mock_sprints():
                 "self": "https://test.atlassian.net/rest/agile/1.0/sprint/10001",
                 "state": "active",
                 "name": "Sprint 1",
-                "startDate": "2025-03-24T06:13:00.000Z",
-                "endDate": "2025-04-07T06:13:00.000Z",
+                "startDate": "2099-03-24T06:13:00.000Z",
+                "endDate": "2100-04-07T06:13:00.000Z",
                 "activatedDate": "2025-03-24T06:13:20.729Z",
                 "originBoardId": 1000,
                 "goal": "",
@@ -131,11 +131,121 @@ def test_create_sprint(sprints_mixin, mock_sprints):
     result = sprints_mixin.create_sprint(
         sprint_name="Sprint 1",
         board_id="10001",
-        start_date="2025-05-01T00:00:00.000Z",
-        end_date="2025-05-15T00:00:00.000Z",
+        start_date="2099-05-01T00:00:00.000Z",
+        end_date="2100-05-01T00:00:00.000Z",
         goal="Your goal",
     )
     assert result == JiraSprint.from_api_response(mock_sprints["values"][1])
+
+
+def test_create_sprint_http_exception(sprints_mixin, mock_sprints):
+    """Test create_sprint method."""
+    sprints_mixin.jira.create_sprint.side_effect = requests.HTTPError(
+        response=MagicMock(content="API Error content")
+    )
+
+    with pytest.raises(requests.HTTPError):
+        sprints_mixin.create_sprint(
+            sprint_name="Sprint 1",
+            board_id="10001",
+            start_date="2099-05-01T00:00:00.000Z",
+            end_date="2100-05-15T00:00:00.000Z",
+            goal="Your goal",
+        )
+
+
+def test_create_sprint_exception(sprints_mixin, mock_sprints):
+    """Test create_sprint method throws general Exception."""
+    sprints_mixin.jira.create_sprint.side_effect = Exception
+
+    with pytest.raises(Exception):
+        sprints_mixin.create_sprint(
+            sprint_name="Sprint 1",
+            board_id="10001",
+            start_date="2099-05-01T00:00:00.000Z",
+            end_date="2100-05-15T00:00:00.000Z",
+            goal="Your goal",
+        )
+
+
+def test_create_sprint_test_missing_startdate(sprints_mixin, mock_sprints):
+    """Test create_sprint method."""
+    sprints_mixin.jira.create_sprint.return_value = mock_sprints["values"][1]
+
+    with pytest.raises(ValueError) as excinfo:
+        sprints_mixin.create_sprint(
+            sprint_name="Sprint 1",
+            board_id="10001",
+            start_date="",
+            end_date="2100-05-15T00:00:00.000Z",
+            goal="Your goal",
+        )
+    assert str(excinfo.value) == "Start date is required."
+
+
+def test_create_sprint_test_invalid_startdate(sprints_mixin, mock_sprints):
+    """Test create_sprint method."""
+    sprints_mixin.jira.create_sprint.return_value = mock_sprints["values"][1]
+
+    with pytest.raises(ValueError) as excinfo:
+        sprints_mixin.create_sprint(
+            sprint_name="Sprint 1",
+            board_id="10001",
+            start_date="IAMNOTADATE!",
+            end_date="2100-05-15T00:00:00.000Z",
+            goal="Your goal",
+        )
+    assert (
+        str(excinfo.value)
+        == "Incorrect data format, should be YYYY-MM-DDThh:mm:ss.sssZ"
+    )
+
+
+def test_create_sprint_test_no_enddate(sprints_mixin, mock_sprints):
+    """Test create_sprint method."""
+    sprints_mixin.jira.create_sprint.return_value = mock_sprints["values"][1]
+
+    result = sprints_mixin.create_sprint(
+        sprint_name="Sprint 1",
+        board_id="10001",
+        start_date="2099-05-15T00:00:00.000Z",
+        end_date=None,
+        goal="Your goal",
+    )
+    assert result == JiraSprint.from_api_response(mock_sprints["values"][1])
+
+
+def test_create_sprint_test_invalid_enddate(sprints_mixin, mock_sprints):
+    """Test create_sprint method."""
+    sprints_mixin.jira.create_sprint.return_value = mock_sprints["values"][1]
+
+    with pytest.raises(ValueError) as excinfo:
+        sprints_mixin.create_sprint(
+            sprint_name="Sprint 1",
+            board_id="10001",
+            start_date="2099-05-15T00:00:00.000Z",
+            end_date="IAMNOTADATE!",
+            goal="Your goal",
+        )
+    assert (
+        str(excinfo.value)
+        == "Incorrect data format, should be YYYY-MM-DDThh:mm:ss.sssZ"
+    )
+
+
+def test_create_sprint_test_startdate_after_enddate(sprints_mixin, mock_sprints):
+    """Test create_sprint method."""
+    sprints_mixin.jira.create_sprint.return_value = mock_sprints["values"][1]
+
+    with pytest.raises(ValueError) as excinfo:
+        sprints_mixin.create_sprint(
+            sprint_name="Sprint 1",
+            board_id="10001",
+            start_date="2100-05-15T00:00:00.000Z",
+            end_date="2099-05-15T00:00:00.000Z",
+            goal="Your goal",
+        )
+    assert str(excinfo.value) == "Start date must be before end date."
 
 
 def test_update_sprint_success(sprints_mixin, mock_sprints):

--- a/uv.lock
+++ b/uv.lock
@@ -589,10 +589,12 @@ dependencies = [
     { name = "markdownify" },
     { name = "mcp" },
     { name = "pydantic" },
+    { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "starlette" },
     { name = "thefuzz" },
     { name = "trio" },
+    { name = "types-python-dateutil" },
     { name = "uvicorn" },
 ]
 
@@ -619,10 +621,12 @@ requires-dist = [
     { name = "markdownify", specifier = ">=0.11.6" },
     { name = "mcp", specifier = ">=1.3.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "starlette", specifier = ">=0.37.1" },
     { name = "thefuzz", specifier = ">=0.22.1" },
     { name = "trio", specifier = ">=0.29.0" },
+    { name = "types-python-dateutil", specifier = ">=2.9.0.20241206" },
     { name = "uvicorn", specifier = ">=0.27.1" },
 ]
 
@@ -937,6 +941,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
 ]
 
 [[package]]
@@ -1324,6 +1340,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/3c/874ac6ce93f4e6bd0283a5df2c8065f4e623c6c3bc0b2fb98c098313cb73/types_markdown-3.7.0.20241204.tar.gz", hash = "sha256:ecca2b25cd23163fd28ed5ba34d183d731da03e8a5ed3a20b60daded304c5410", size = 17820 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/26/3c9730e845cfd0d587e0dfa9c1975f02f9f49407afbf30800094bdac0286/types_Markdown-3.7.0.20241204-py3-none-any.whl", hash = "sha256:f96146c367ea9c82bfe9903559d72706555cc2a1a3474c58ebba03b418ab18da", size = 23572 },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20241206"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/60/47d92293d9bc521cd2301e423a358abfac0ad409b3a1606d8fbae1321961/types_python_dateutil-2.9.0.20241206.tar.gz", hash = "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb", size = 13802 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/b3/ca41df24db5eb99b00d97f89d7674a90cb6b3134c52fb8121b6d8d30f15c/types_python_dateutil-2.9.0.20241206-py3-none-any.whl", hash = "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53", size = 14384 },
 ]
 
 [[package]]


### PR DESCRIPTION
***definitely feel free to rip me up for not following standards here, python definitely isn't my usual forte***

### Description
Adding new jira_create_sprint functionality

### Changes
- Added create_sprint function to sprints.py
- Added new tool jira_create_sprint
- Mapped jira_create_sprint tool call to sprints.create_sprint

### Other notes
I made a conscious choice to to name the date arguments (start_date, end_date), to keep them distinctly namespaced from the pagination arguments startAt/endAt. Happy to move them to camel cased if thats the preference. 
I plan to add in all the sprint updating functionality after this PR merges. I tested it out using claude3.5 and it worked great! 
One other thing that was neat, was in the Tool definition, for start/end_date, if the description has the format "(ISO 8601 format)", claude will reformat the date appropriately, which is cool.