### PR TITLE
Fix handling of fixVersions when provided in additional_fields (#241)

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -694,6 +694,12 @@ class IssuesMixin(UsersMixin):
 
         # Process each kwarg
         for key, value in kwargs.items():
+            # Handle fixVersions specifically as it's a standard field often required
+            if key.lower() == "fixversions":
+                fields["fixVersions"] = value
+                logger.debug("Added fixVersions from additional_fields: %s", value)
+                continue  # Handled fixVersions
+
             # Explicitly handle components field
             if key.lower() == "components":
                 # Assuming the value is already in the correct format e.g., [{'name': 'Vortex'}] or [{'id': '11004'}]


### PR DESCRIPTION
## PR Content
### Problem
`fixVersions` passed via `additional_fields` isn't added to the Jira API request, breaking the workaround suggested in #212. The `_add_custom_fields` method skips standard field names not found in the `field_ids` mapping.

### Solution
Modified `_add_custom_fields` in `issues.py` to explicitly check for and handle `fixVersions`.

### Changes
- Added specific check for `fixVersions` in `_add_custom_fields`
- Added logging for confirmation
- Added unit tests to verify the fix

Fixes #241
