### PR TITLE
Feat: Add GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,122 @@
+name: "\U0001F41B Bug Report"
+description: Create a report to help us improve mcp-atlassian
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Please confirm the following before submitting the issue.
+      options:
+        - label: I have searched the [existing issues](https://github.com/sooperset/mcp-atlassian/issues) to make sure this bug has not already been reported.
+          required: true
+        - label: I have checked the [README](https://github.com/sooperset/mcp-atlassian/blob/main/README.md) for relevant information.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: "When I call the `jira_create_issue` tool with..., it fails with..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide detailed steps to reproduce the behavior.
+      placeholder: |
+        1. Start the server with command `...`
+        2. Send a `list_tools` request using `...`
+        3. Call the tool `xyz` with arguments `...`
+        4. See error `...`
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: "I expected the Jira issue to be created successfully and return its key."
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include full error messages, logs (from the server and the client if possible), or screenshots.
+      placeholder: "The server returned an error message: '...' / The tool call returned an empty list."
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: mcp-atlassian Version
+      description: Which version of `mcp-atlassian` are you using? (Check `pip show mcp-atlassian` or `pyproject.toml`)
+      placeholder: "e.g., 0.6.5"
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation Method
+      description: How did you install `mcp-atlassian`?
+      options:
+        - From PyPI (pip install mcp-atlassian / uv add mcp-atlassian)
+        - From source (git clone)
+        - Docker
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you using?
+      options:
+        - Windows
+        - macOS
+        - Linux (Specify distribution below if relevant)
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      description: What version of Python are you using? (`python --version`)
+      placeholder: "e.g., 3.11.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: atlassian-instance
+    attributes:
+      label: Atlassian Instance Type
+      description: Are you connecting to Atlassian Cloud or Server/Data Center?
+      multiple: true
+      options:
+        - Jira Cloud
+        - Jira Server / Data Center
+        - Confluence Cloud
+        - Confluence Server / Data Center
+    validations:
+      required: true
+  - type: input
+    id: client-app
+    attributes:
+      label: Client Application
+      description: What application/library are you using to interact with the MCP server? (This is important!)
+      placeholder: "e.g., Cursor, LangChain, custom script, Inspector Tool"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here (e.g., environment variables, network configuration like proxies, specific Jira/Confluence setup).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "\U0001F4AC Ask a Question or Discuss"
+    url: https://github.com/sooperset/mcp-atlassian/discussions # GitHub Discussions 링크 (활성화되어 있다면)
+    about: Please ask and answer questions here, or start a general discussion.
+  - name: "\U0001F4DA Read the Documentation"
+    url: https://github.com/sooperset/mcp-atlassian/blob/main/README.md
+    about: Check the README for setup and usage instructions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: "\U0001F680 Feature Request"
+description: Suggest an idea or enhancement for mcp-atlassian
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea! Please describe your proposal clearly.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: "e.g., I'm always frustrated when [...] because [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen. How should the feature work?
+      placeholder: "Add a new tool `confluence_move_page` that takes `page_id` and `target_parent_id` arguments..."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+      placeholder: "I considered modifying the `confluence_update_page` tool, but..."
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: How would this feature benefit users? Who is the target audience?
+      placeholder: "This would allow AI agents to automatically organize documentation..."
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or links about the feature request here.


### PR DESCRIPTION
## Description

This PR introduces GitHub issue templates (`bug_report.yml`, `feature_request.yml`, `config.yml`) to guide users in submitting clear and informative bug reports and feature requests.

## Motivation

Recently, there has been an increase in issues lacking sufficient detail or relevance. These templates aim to:
- Standardize the information required for different types of issues.
- Prompt users for essential details (version, environment, steps to reproduce, use case, etc.).
- Reduce incomplete or ambiguous submissions.
- Streamline the issue triage and resolution process for maintainers.

## Changes Included

- Added a structured YAML template for **Bug Reports** (`.github/ISSUE_TEMPLATE/bug_report.yml`).
- Added a structured YAML template for **Feature Requests** (`.github/ISSUE_TEMPLATE/feature_request.yml`).
- Added a configuration file (`.github/ISSUE_TEMPLATE/config.yml`) to:
    - Disable the creation of blank issues.
    - Provide contact links (e.g., for Discussions or README).

## Impact

Users creating new issues will now be presented with specific templates to choose from, improving the overall quality and actionability of submitted issues.
