### PR TITLE
feat(search): use siteSearch as default with text search fallback

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -340,10 +340,12 @@ async def list_tools() -> list[Tool]:
                         "properties": {
                             "query": {
                                 "type": "string",
-                                "description": "Search query - can be either a simple text (e.g. 'project documentation') or a CQL query string. Examples of CQL:\n"
+                                "description": "Search query - can be either a simple text (e.g. 'project documentation') or a CQL query string. Simple queries use 'siteSearch' by default, to mimic the WebUI search, with an automatic fallback to 'text' search if not supported. Examples of CQL:\n"
                                 "- Basic search: 'type=page AND space=DEV'\n"
                                 "- Personal space search: 'space=\"~username\"' (note: personal space keys starting with ~ must be quoted)\n"
                                 "- Search by title: 'title~\"Meeting Notes\"'\n"
+                                "- Use siteSearch: 'siteSearch ~ \"important concept\"'\n"
+                                "- Use text search: 'text ~ \"important concept\"'\n"
                                 "- Recent content: 'created >= \"2023-01-01\"'\n"
                                 "- Content with specific label: 'label=documentation'\n"
                                 "- Recently modified content: 'lastModified > startOfMonth(\"-1M\")'\n"
@@ -1267,14 +1269,34 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 x in query
                 for x in ["=", "~", ">", "<", " AND ", " OR ", "currentUser()"]
             ):
-                # Convert simple search term to CQL text search
-                # This will search in all content (title, body, etc.)
-                query = f'text ~ "{query}"'
-                logger.info(f"Converting simple search term to CQL: {query}")
-
-            pages = ctx.confluence.search(
-                query, limit=limit, spaces_filter=spaces_filter
-            )
+                # Convert simple search term to CQL siteSearch (previously it was a 'text' search)
+                # This will use the same search mechanism as the WebUI and give much more relevant results
+                original_query = query  # Store the original query for fallback
+                try:
+                    # Try siteSearch first - it's available in newer versions and provides better results
+                    query = f'siteSearch ~ "{original_query}"'
+                    logger.info(
+                        f"Converting simple search term to CQL using siteSearch: {query}"
+                    )
+                    pages = ctx.confluence.search(
+                        query, limit=limit, spaces_filter=spaces_filter
+                    )
+                except Exception as e:
+                    # If siteSearch fails (possibly not supported in this Confluence version),
+                    # fall back to text search which is supported in all versions
+                    logger.warning(
+                        f"siteSearch failed, falling back to text search: {str(e)}"
+                    )
+                    query = f'text ~ "{original_query}"'
+                    logger.info(f"Falling back to text search with CQL: {query}")
+                    pages = ctx.confluence.search(
+                        query, limit=limit, spaces_filter=spaces_filter
+                    )
+            else:
+                # Using direct CQL query as provided
+                pages = ctx.confluence.search(
+                    query, limit=limit, spaces_filter=spaces_filter
+                )
 
             # Format results using the to_simplified_dict method
             search_results = [page.to_simplified_dict() for page in pages]


### PR DESCRIPTION
## Description
Enhances Confluence search functionality by using `siteSearch` instead of `text` search for simple queries. This change leverages the same search mechanisms as the Confluence WebUI, providing more relevant results by default. An automatic fallback to text search ensures compatibility with older Confluence Server/Data Center versions.

Without this, simple searches on Confluence rarely return the most relevant results, making it harder for an Agent to find what's needed.

## Changes
- Updated the search conversion to use `siteSearch ~ "query"` instead of `text ~ "query"` for simple terms.
- Added an automatic fallback mechanism to text search if siteSearch fails.
- Added unit tests for the updated search.
- Updated tool specs to reflect the new search behavior and fallback mechanism.

## Testing
[x] Unit tests added/updated
[x] Integration tests passed
[x] Manual checks performed: Verified simple search terms are properly converted to siteSearch queries and provide much higher quality results.

## Checklist
[x] Code follows project style guidelines (linting passes on the changes).
[x] Tests added/updated for changes.
[x] All tests pass locally.
[x] Documentation updated.