### PR TITLE
Fix jira_get_issue tool to include comments when requested with comment_limit

### DIFF
--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -576,7 +576,7 @@ class JiraIssue(ApiModel, TimestampMixin):
             result["updated"] = self.updated
 
         # Add comments if available and requested
-        if self.comments and should_include_field("comments"):
+        if self.comments and should_include_field("comment"):
             result["comments"] = [
                 comment.to_simplified_dict() for comment in self.comments
             ]

--- a/tests/test_real_api_validation.py
+++ b/tests/test_real_api_validation.py
@@ -1277,3 +1277,31 @@ class TestRealToolValidation:
             pytest.skip(
                 f"Epic {test_epic_key} has less than 2 issues, cannot test pagination."
             )
+
+    @pytest.mark.anyio
+    async def test_jira_get_issue_includes_comments(
+        self, use_real_jira_data: bool, test_issue_key: str
+    ) -> None:
+        """Test that jira_get_issue includes comments when comment_limit > 0."""
+        if not use_real_jira_data:
+            pytest.skip("Real Jira data testing is disabled")
+
+        # Call with comment_limit=10 and without specifying fields
+        # This should use default fields and include comments
+        result = await call_tool(
+            "jira_get_issue",
+            {"issue_key": test_issue_key, "comment_limit": 10},
+        )
+
+        assert isinstance(result, dict)
+        assert "comments" in result
+        assert isinstance(result["comments"], list)
+
+        # Test with fields="summary" explicitly - comments should not be present
+        result_without_comments = await call_tool(
+            "jira_get_issue",
+            {"issue_key": test_issue_key, "comment_limit": 10, "fields": "summary"},
+        )
+
+        assert isinstance(result_without_comments, dict)
+        assert "comments" not in result_without_comments


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

This PR fixes an issue with the `jira_get_issue` tool where comments were being fetched from the Jira API but filtered out of the final response even when explicitly requested with `comment_limit > 0`. The bug was due to a field name mismatch in the serialization logic.

Fixes: #275

## Changes

<!-- Briefly list the key changes made. -->

- Fixed `JiraIssue.to_simplified_dict()` to check for `"comment"` (singular) instead of `"comments"` (plural) to match the field name used in the `requested_fields` list
- Added integration test `test_jira_get_issue_includes_comments` to verify that comments are included when requested with `comment_limit > 0`

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `[Verified that comments appear in the jira_get_issue response when comment_limit>0 is specified]`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).