### PR TITLE
Feature/update parentid

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -520,6 +520,10 @@ async def list_tools() -> list[Tool]:
                                     "description": "Optional comment for this version",
                                     "default": "",
                                 },
+                                "parent_id": {
+                                    "type": "string",
+                                    "description": "Optional the new parent page ID",
+                                },
                             },
                             "required": ["page_id", "title", "content"],
                         },
@@ -1450,6 +1454,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             content = arguments.get("content")
             is_minor_edit = arguments.get("is_minor_edit", False)
             version_comment = arguments.get("version_comment", "")
+            parent_id = arguments.get("parent_id")
 
             if not page_id or not title or not content:
                 raise ValueError(
@@ -1464,6 +1469,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 is_minor_edit=is_minor_edit,
                 version_comment=version_comment,
                 is_markdown=True,
+                parent_id=parent_id,
             )
 
             # Format results

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -680,3 +680,49 @@ class TestPagesMixin:
                 version_comment="Updated test",
                 always_update=True,
             )
+
+    def test_update_page_with_parent_id(self, pages_mixin):
+        """Test updating a page and changing its parent."""
+        # Arrange
+        page_id = "987654321"
+        title = "Updated Page"
+        body = "<p>Updated content</p>"
+        parent_id = "123456789"
+        is_minor_edit = False
+        version_comment = "Parent changed"
+
+        # Mock get_page_content to return a document
+        mock_document = ConfluencePage(
+            id=page_id,
+            title=title,
+            content="Updated content",
+            space={"key": "PROJ", "name": "Project"},
+            version={"number": 2},
+        )
+        with patch.object(pages_mixin, "get_page_content", return_value=mock_document):
+            # Act
+            result = pages_mixin.update_page(
+                page_id=page_id,
+                title=title,
+                body=body,
+                is_minor_edit=is_minor_edit,
+                version_comment=version_comment,
+                is_markdown=False,
+                parent_id=parent_id,
+            )
+
+            # Assert
+            pages_mixin.confluence.update_page.assert_called_once_with(
+                page_id=page_id,
+                title=title,
+                body=body,
+                type="page",
+                representation="storage",
+                minor_edit=is_minor_edit,
+                version_comment=version_comment,
+                always_update=True,
+                parent_id=parent_id,
+            )
+            assert result.id == page_id
+            assert result.title == title
+            assert result.version.number == 2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
Adds support for updating the parent page (`parent_id`) of a Confluence page via the `update_page` method and the `confluence_update_page` tool. This allows users to move a page under a new parent programmatically.

Fixes: #279

## Changes

<!-- Briefly list the key changes made. -->

- Added optional `parent_id` parameter to `PagesMixin.update_page`
- Updated the `confluence_update_page` tool schema and handler to accept and forward `parent_id`
- Added/updated unit tests to cover updating a page’s parent
- Updated documentation and type hints as needed

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] All unit tests pass locally
- [x] Manual checks performed: Verified that updating a page’s parent via the tool and in the Confluence UI works as expected

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).