### PR TITLE
Add version-specific tags for container images on ghcr.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Version control
+.git
+.gitignore
+.github
+
+# Virtual environments
+.venv*
+venv*
+env*
+
+# Python bytecode/cache
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache
+.coverage
+.mypy_cache
+.ruff_cache
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# Environment variables and secrets
+.env*
+*.env
+*.key
+
+# Logs
+*.log
+
+# Docker related
+Dockerfile*
+docker-compose*
+.dockerignore
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Temporal and backup files
+*.tmp
+*.bak
+*.backup

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,10 +9,13 @@ on:
       - main     # Trigger on PRs targeting main branch
   workflow_dispatch: {} # Allow manual triggering from the Actions tab
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Define permissions required by the job to push to ghcr.io
     permissions:
       contents: read  # Needed for checkout
       packages: write # Needed to push packages to ghcr.io
@@ -20,27 +23,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      # Step to extract the version number from the Git tag
-      # Handles both tag pushes and manual dispatches differently
-      - name: Extract Version
-        id: get_version
-        run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
-            # For tag pushes (e.g., refs/tags/v1.2.3), remove 'v' prefix
-            echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-            echo "IS_RELEASE_TAG=true" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # For PRs, use PR number in the tag
-            echo "VERSION=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            echo "IS_RELEASE_TAG=false" >> $GITHUB_OUTPUT
-          else
-            # For manual dispatch or other events, use branch name or default
-            # Sanitize branch name for Docker tag compatibility
-            BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9_.-]/-/g')
-            echo "VERSION=${BRANCH_NAME}-manual" >> $GITHUB_OUTPUT
-            echo "IS_RELEASE_TAG=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -50,27 +32,46 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Extract metadata (tags, labels) for Docker
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Create 'main' tag on push to main branch
+            type=ref,event=branch,branch=main
+            # Create 'X.Y.Z', 'X.Y', 'X' tags on tag push (e.g., v1.2.3 -> 1.2.3, 1.2, 1)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # Only create 'latest' tag if it's a tag push AND it's a non-prerelease version tag (no '-')
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            # Create a tag for PRs (e.g., pr-123) - useful for testing PR builds
+            type=ref,event=pr
+            # For manual workflow runs, use branch name with 'manual' suffix
+            type=raw,value={{branch}}-manual,enable=${{ github.event_name == 'workflow_dispatch' }}
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
+        # Only login for pushes and manual runs, not for PRs
+        if: github.event_name != 'pull_request'
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }} # Use the GitHub actor running the action
-          password: ${{ secrets.GITHUB_TOKEN }} # Use the automatically generated token
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        id: docker_build # Added ID for potential metadata use
+        id: docker_build
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          # Allow pushing from PRs as well for testing
-          push: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/mcp-atlassian:latest
-            ghcr.io/${{ github.repository_owner }}/mcp-atlassian:${{ steps.get_version.outputs.VERSION }}
-          # Add labels to the image
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.created=${{ github.event.repository.created_at }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.get_version.outputs.VERSION }}
+          # Only push for non-PR events
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags and labels from metadata action
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Enable Docker layer caching
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,11 @@ jobs:
             echo "IS_RELEASE_TAG=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -57,6 +62,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           # Allow pushing from PRs as well for testing
           push: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
           tags: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,8 +57,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # Push only on tag pushes or manual triggers, not on PRs for security
-          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          # Allow pushing from PRs as well for testing
+          push: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/mcp-atlassian:latest
             ghcr.io/${{ github.repository_owner }}/mcp-atlassian:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tag pushes (e.g., v0.7.1)
+  workflow_dispatch: {} # Allow manual triggering from the Actions tab
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    # Define permissions required by the job to push to ghcr.io
+    permissions:
+      contents: read  # Needed for checkout
+      packages: write # Needed to push packages to ghcr.io
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Step to extract the version number from the Git tag
+      # Handles both tag pushes and manual dispatches differently
+      - name: Extract Version
+        id: get_version
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            # For tag pushes (e.g., refs/tags/v1.2.3), remove 'v' prefix
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "IS_RELEASE_TAG=true" >> $GITHUB_OUTPUT
+          else
+            # For manual dispatch or other events, use branch name or default
+            # Sanitize branch name for Docker tag compatibility
+            BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9_.-]/-/g')
+            echo "VERSION=${BRANCH_NAME}-manual" >> $GITHUB_OUTPUT
+            echo "IS_RELEASE_TAG=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }} # Use the GitHub actor running the action
+          password: ${{ secrets.GITHUB_TOKEN }} # Use the automatically generated token
+
+      - name: Build and push Docker image
+        id: docker_build # Added ID for potential metadata use
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          # Push only on tag pushes or manual triggers
+          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/mcp-atlassian:latest
+            ghcr.io/${{ github.repository_owner }}/mcp-atlassian:${{ steps.get_version.outputs.VERSION }}
+          # Add labels to the image
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.created=${{ github.event.repository.created_at }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*.*.*' # Trigger on version tag pushes (e.g., v0.7.1)
+  pull_request:
+    branches:
+      - main     # Trigger on PRs targeting main branch
   workflow_dispatch: {} # Allow manual triggering from the Actions tab
 
 jobs:
@@ -27,6 +30,10 @@ jobs:
             # For tag pushes (e.g., refs/tags/v1.2.3), remove 'v' prefix
             echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
             echo "IS_RELEASE_TAG=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # For PRs, use PR number in the tag
+            echo "VERSION=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "IS_RELEASE_TAG=false" >> $GITHUB_OUTPUT
           else
             # For manual dispatch or other events, use branch name or default
             # Sanitize branch name for Docker tag compatibility
@@ -50,7 +57,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # Push only on tag pushes or manual triggers
+          # Push only on tag pushes or manual triggers, not on PRs for security
           push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/mcp-atlassian:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,29 +10,38 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
-# Generate proper TOML lockfile first
-RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv lock
+# Copy only necessary files for dependency installation
+COPY pyproject.toml uv.lock ./
 
 # Install the project's dependencies using the lockfile
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
     uv sync --frozen --no-install-project --no-dev --no-editable
 
-# Then, add the rest of the project source code and install it
-ADD . /app
+# Copy the rest of the application code
+COPY . .
+
+# Install the project itself, skipping already installed dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --frozen --no-dev --no-editable --no-deps
 
 FROM python:3.10-slim
 
+# Create a non-root user
+RUN groupadd --system --gid 1001 app && \
+    useradd --system --uid 1001 --gid 1001 --no-create-home --shell /sbin/nologin app
+
 WORKDIR /app
 
+# Copy virtual environment from the build stage
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+# Copy application code
+COPY --from=uv --chown=app:app /app /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# Switch to non-root user
+USER app
 
 ENTRYPOINT ["mcp-atlassian"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . .
 
 # Install the project itself, skipping already installed dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable --no-deps
+    uv sync --frozen --no-dev --no-editable
 
 FROM python:3.10-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,38 +10,29 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
-# Copy only necessary files for dependency installation
-COPY pyproject.toml uv.lock ./
+# Generate proper TOML lockfile first
+RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv lock
 
 # Install the project's dependencies using the lockfile
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
     uv sync --frozen --no-install-project --no-dev --no-editable
 
-# Copy the rest of the application code
-COPY . .
-
-# Install the project itself, skipping already installed dependencies
+# Then, add the rest of the project source code and install it
+ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
     uv sync --frozen --no-dev --no-editable
 
 FROM python:3.10-slim
 
-# Create a non-root user
-RUN groupadd --system --gid 1001 app && \
-    useradd --system --uid 1001 --gid 1001 --no-create-home --shell /sbin/nologin app
-
 WORKDIR /app
 
-# Copy virtual environment from the build stage
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
-
-# Copy application code
-COPY --from=uv --chown=app:app /app /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
-
-# Switch to non-root user
-USER app
 
 ENTRYPOINT ["mcp-atlassian"]

--- a/README.md
+++ b/README.md
@@ -96,11 +96,8 @@ npx -y @smithery/cli install mcp-atlassian --client claude
 
 1. Pull the Docker image:
    ```bash
-   # Pull the latest version
+   # Pull the docker image
    docker pull ghcr.io/sooperset/mcp-atlassian:latest
-
-   # Or pull a specific version (recommended for stability)
-   docker pull ghcr.io/sooperset/mcp-atlassian:0.7.1
    ```
 
    Alternatively, you can build it locally:

--- a/README.md
+++ b/README.md
@@ -94,13 +94,19 @@ npx -y @smithery/cli install mcp-atlassian --client claude
 
 **Option 4: Using Docker**
 
-1. Clone the repository:
+1. Pull the Docker image:
+   ```bash
+   # Pull the latest version
+   docker pull ghcr.io/sooperset/mcp-atlassian:latest
+
+   # Or pull a specific version (recommended for stability)
+   docker pull ghcr.io/sooperset/mcp-atlassian:0.7.1
+   ```
+
+   Alternatively, you can build it locally:
    ```bash
    git clone https://github.com/sooperset/mcp-atlassian.git
    cd mcp-atlassian
-   ```
-2. Build the Docker image:
-   ```bash
    docker build -t mcp/atlassian .
    ```
 
@@ -267,7 +273,7 @@ If you've installed mcp-atlassian with pip, use this configuration instead:
 
 <details> <summary>Using Docker</summary>
 
-If you've built the Docker image, use this configuration:
+If you're using the Docker image, use this configuration:
 
 **Method 1: Using Environment Variables**
 
@@ -280,7 +286,7 @@ If you've built the Docker image, use this configuration:
         "run",
         "--rm",
         "-i",
-        "mcp/atlassian",
+        "ghcr.io/sooperset/mcp-atlassian:latest",
         "--confluence-url=https://your-company.atlassian.net/wiki",
         "--confluence-username=your.email@company.com",
         "--confluence-token=your_api_token",
@@ -302,7 +308,7 @@ Create a `.env` file based on the `.env.example` template in the repository and 
   "mcpServers": {
     "mcp-atlassian": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "--env-file", "/path/to/your/.env", "mcp/atlassian"]
+      "args": ["run", "--rm", "-i", "--env-file", "/path/to/your/.env", "ghcr.io/sooperset/mcp-atlassian:latest"]
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adds support for publishing Docker images to GitHub Container Registry (ghcr.io) with both latest and version-specific tags. It also adds a manual trigger option for the Docker publishing workflow, providing more flexibility for CI/CD processes.

Fixes: #243

## Changes

- Created `.github/workflows/docker-publish.yml` workflow file that:
  - Uses GitHub Container Registry (ghcr.io) for publishing images
  - Adds support for both version tags and latest tags
  - Includes triggers for both tag pushes (v*.*.*) and manual workflow dispatch
  - Extracts version information dynamically from Git tags or branch names
- Updated README.md with:
  - Documentation for pulling versioned images from ghcr.io
  - Updated Docker configuration examples for IDE integration
  - Recommendations for pinning to specific version tags

## Testing

- [x] Manual checks performed: 
  - Verified workflow file syntax for GitHub Actions
  - Ensured Docker image tagging logic correctly handles both tag pushes and manual triggers
  - Confirmed README Docker documentation is consistent and clear

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).