### PR TITLE
Honor TRANSPORT and PORT environment variables with proper precedence (#291)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,9 @@
 # Transport Options
 # CLI: --transport [stdio|sse], --port PORT
 # Default: stdio transport
-# TRANSPORT=stdio
-# PORT=8000
+# Note: PORT is only used when TRANSPORT=sse
+# TRANSPORT=stdio        # Options: stdio, sse
+# PORT=8000              # Only used when TRANSPORT=sse
 
 # Read-only Mode (disables all write operations)
 # CLI: --read-only


### PR DESCRIPTION
### Description

This PR fixes an issue where the `TRANSPORT` and `PORT` environment variables were being ignored, requiring users to explicitly use command-line arguments to configure transport mode and port. The changes implement proper environment variable support with a clear precedence order and make sure PORT is only considered when relevant.

Fixes: #291

### Changes

- Added logic to check for `TRANSPORT` and `PORT` environment variables after loading dotenv
- Implemented proper precedence: command-line arguments override environment variables, which override defaults
- Added conditional handling to only use `PORT` when the final transport mode is `sse`
- Updated `.env.example` file to clarify usage of these variables and their relationship

### Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [ ] Manual checks performed

### Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated
