### PR TITLE
Fix Jira Server/DC assignee issue by prioritizing user name over key

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -540,8 +540,9 @@ class IssuesMixin(UsersMixin):
             # Add assignee if provided
             if assignee:
                 try:
-                    account_id = self._get_account_id(assignee)
-                    self._add_assignee_to_fields(fields, account_id)
+                    # _get_account_id now returns the correct identifier (accountId for cloud, name for server)
+                    assignee_identifier = self._get_account_id(assignee)
+                    self._add_assignee_to_fields(fields, assignee_identifier)
                 except ValueError as e:
                     logger.warning(f"Could not assign issue: {str(e)}")
 
@@ -1287,8 +1288,9 @@ class IssuesMixin(UsersMixin):
                 # Add assignee if provided
                 if assignee:
                     try:
-                        account_id = self._get_account_id(assignee)
-                        self._add_assignee_to_fields(fields, account_id)
+                        # _get_account_id now returns the correct identifier (accountId for cloud, name for server)
+                        assignee_identifier = self._get_account_id(assignee)
+                        self._add_assignee_to_fields(fields, assignee_identifier)
                     except ValueError as e:
                         logger.warning(f"Could not assign issue: {str(e)}")
 

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -140,21 +140,25 @@ class UsersMixin(JiraClient):
                     or user.get("name", "").lower() == username.lower()
                     or user.get("emailAddress", "").lower() == username.lower()
                 ):
-                    # Jira Cloud uses accountId
-                    if "accountId" in user:
-                        return user["accountId"]
-                    # Jira Data Center/Server might use key
-                    elif "key" in user:
-                        logger.info(
-                            "Using 'key' instead of 'accountId' for Jira Data Center/Server"
-                        )
-                        return user["key"]
-                    # Last resort fallback to name
-                    elif "name" in user:
-                        logger.info(
-                            "Using 'name' instead of 'accountId' for Jira Data Center/Server"
-                        )
-                        return user["name"]
+                    # Prioritize based on Cloud vs Server/DC for assignee field compatibility
+                    if self.config.is_cloud:
+                        # Cloud requires accountId
+                        if "accountId" in user:
+                            return user["accountId"]
+                    else:
+                        # Server/DC requires 'name' for the assignee field { "name": ... }
+                        if "name" in user:
+                            logger.info(
+                                "Using 'name' for assignee field in Jira Data Center/Server"
+                            )
+                            return user["name"]
+                        # Fallback to key if name is somehow missing (less common)
+                        elif "key" in user:
+                            logger.info(
+                                "Using 'key' as fallback for assignee name in Jira Data Center/Server"
+                            )
+                            return user["key"]
+
             return None
         except Exception as e:
             logger.info(f"Error looking up user directly: {str(e)}")
@@ -195,21 +199,24 @@ class UsersMixin(JiraClient):
             if response.status_code == 200:
                 data = response.json()
                 for user in data.get("users", []):
-                    # Jira Cloud uses accountId
-                    if "accountId" in user:
-                        return user["accountId"]
-                    # Jira Data Center/Server might use key
-                    elif "key" in user:
-                        logger.info(
-                            "Using 'key' instead of 'accountId' for Jira Data Center/Server"
-                        )
-                        return user["key"]
-                    # Last resort fallback to name
-                    elif "name" in user:
-                        logger.info(
-                            "Using 'name' instead of 'accountId' for Jira Data Center/Server"
-                        )
-                        return user["name"]
+                    # Prioritize based on Cloud vs Server/DC for assignee field compatibility
+                    if self.config.is_cloud:
+                        # Cloud requires accountId
+                        if "accountId" in user:
+                            return user["accountId"]
+                    else:
+                        # Server/DC requires 'name' for the assignee field { "name": ... }
+                        if "name" in user:
+                            logger.info(
+                                "Using 'name' for assignee field in Jira Data Center/Server"
+                            )
+                            return user["name"]
+                        # Fallback to key if name is somehow missing (less common)
+                        elif "key" in user:
+                            logger.info(
+                                "Using 'key' as fallback for assignee name in Jira Data Center/Server"
+                            )
+                            return user["key"]
             return None
         except Exception as e:
             logger.info(f"Error looking up user by permissions: {str(e)}")


### PR DESCRIPTION
## Description

This PR fixes an issue where creating Jira issues with assignees in Server/Data Center environments fails. The root cause is that `_lookup_user_directly` prioritizes returning the user's `key`, but the Jira Server/DC API expects the user's `name` when setting the assignee via `{"name": ...}` during issue creation.

Fixes: #223

## Changes

- Modified `_lookup_user_directly` to prioritize returning user's `name` over `key` for Jira Server/DC environments
- Applied the same prioritization logic to `_lookup_user_by_permissions` for consistency
- Renamed variables in issue creation methods from `account_id` to `assignee_identifier` for clarity
- Added and updated unit tests to verify the correct behavior in all environments

## Testing

- [x] Unit tests added/updated
  - Added test for prioritizing name over key when both are present
  - Added test for fallback to key when name is missing
  - Updated existing tests to match new behavior
- [x] All tests pass locally
- [x] Manual checks performed: verified assignee field structure in debug logs

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed). 