### PR TITLE
Fix: Jira search pagination parameter mismatch (#308)

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -227,7 +227,7 @@ async def search(
     )
 
     # Format results
-    search_results = [issue.to_simplified_dict() for issue in issues]
+    search_results = [issue.to_simplified_dict() for issue in issues.issues]
 
     return [
         TextContent(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -221,7 +221,7 @@ async def search(
     issues = fetcher.search_issues(
         jql=jql,
         fields=fields,
-        start_at=start_at,
+        start=start_at,
         limit=limit,
         projects_filter=projects_filter,
     )
@@ -269,7 +269,7 @@ async def get_project_issues(
     # Get project issues
     issues = fetcher.get_project_issues(
         project_key=project_key,
-        start_at=start_at,
+        start=start_at,
         limit=limit,
     )
 

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -63,12 +63,14 @@ def mock_jira_fetcher():
 
     # Configure search_issues to return fixture data
     def mock_search_issues(jql, **kwargs):
-        issues = []
+        mock_result = MagicMock()
+        mock_result.issues = []
         for issue_data in MOCK_JIRA_JQL_RESPONSE_SIMPLIFIED["issues"]:
             mock_issue = MagicMock()
             mock_issue.to_simplified_dict.return_value = issue_data
-            issues.append(mock_issue)
-        return issues
+            mock_result.issues.append(mock_issue)
+        # Return a JiraSearchResult-like object with an 'issues' attribute
+        return mock_result
 
     mock_fetcher.search_issues.side_effect = mock_search_issues
 
@@ -288,6 +290,50 @@ async def test_search(jira_client, mock_jira_fetcher):
         start=0,
         projects_filter=None,
     )
+
+
+@pytest.mark.anyio
+async def test_search_with_jira_search_result(jira_client, mock_jira_fetcher):
+    """Test the search tool specifically with a JiraSearchResult object.
+
+    This test validates that the search tool can correctly extract issues from
+    a JiraSearchResult object's 'issues' attribute, fixing the TypeError bug
+    where the code was attempting to call to_simplified_dict() on a tuple.
+    """
+    async with jira_client as client:
+        response = await client.call_tool(
+            "search",
+            {
+                "jql": "project = TEST AND issuetype = Bug",
+                "fields": "summary,status,issuetype",
+                "limit": 5,
+            },
+        )
+
+    # The response is a list of TextContent objects
+    assert isinstance(response, list)
+    assert len(response) > 0
+    text_content = response[0]
+    assert text_content.type == "text"
+
+    # Parse the JSON content
+    content = json.loads(text_content.text)
+    # The tool returns a JSON array of issues
+    assert isinstance(content, list)
+    assert len(content) >= 1
+    assert content[0]["key"] == "PROJ-123"  # Using the key from fixture data
+
+    # Verify the fetcher was called with the correct parameters
+    mock_jira_fetcher.search_issues.assert_called_once_with(
+        jql="project = TEST AND issuetype = Bug",
+        fields="summary,status,issuetype",
+        limit=5,
+        start=0,
+        projects_filter=None,
+    )
+
+    # Reset the mock for future tests
+    mock_jira_fetcher.search_issues.reset_mock()
 
 
 @pytest.mark.anyio

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -285,7 +285,7 @@ async def test_search(jira_client, mock_jira_fetcher):
         jql="project = TEST",
         fields="summary,status",
         limit=10,
-        start_at=0,
+        start=0,
         projects_filter=None,
     )
 


### PR DESCRIPTION
### Description

This PR fixes two issues with the Jira search tools:

1. **Parameter Mismatch**: The Jira search tools (`jira_search` and `jira_get_project_issues`) were failing with a parameter name mismatch because they passed an incorrect parameter name to the underlying methods. The tools use `start_at` as their parameter name for pagination, but the underlying methods expect `start`.

2. **Iteration Error**: When the `jira_search` tool is called, it fails with a `TypeError: 'tuple' object has no attribute 'to_simplified_dict'`. This happens because the code incorrectly iterates over the `JiraSearchResult` Pydantic model instead of its `issues` attribute, resulting in attempts to call `to_simplified_dict()` on tuple values.

Fixes: #308

### Changes

- Changed `start_at=start_at` to `start=start_at` in the `search` function when calling `fetcher.search_issues()`
- Changed `start_at=start_at` to `start=start_at` in the `get_project_issues` function when calling `fetcher.get_project_issues()`
- Fixed the `search` function to correctly iterate over `issues.issues` instead of `issues` to resolve the TypeError
- Updated the mock in tests to properly return a JiraSearchResult-like object with an issues attribute
- Added a new test case `test_search_with_jira_search_result` to specifically test the fix for the iteration error
- Updated unit tests to verify the correct parameter names are used

### Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: [Verified that the Jira search and get_project_issues tools properly paginate results when using the start_at parameter]
- [x] Added specific test for the JiraSearchResult iteration fix

### Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
