### PR TITLE
Feature/add get link types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Added `get_issue_link_types()` method to retrieve all available issue link types
+
 ## [0.8.3] - 2025-04-24
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ For Jira Server/DC, use:
 ||`jira_get_sprints_from_board`|
 ||`jira_get_sprint_issues`|
 ||`jira_update_sprint`|
+||`jira_get_issue_link_types`|
 ||`jira_create_issue_link`|
 ||`jira_remove_issue_link`|
 

--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -83,18 +83,19 @@ class LinksMixin(JiraClient):
             Dictionary with the created link information
 
         Raises:
+            ValueError: If required fields are missing
             MCPAtlassianAuthenticationError: If authentication fails with the Jira API (401/403)
             Exception: If there is an error creating the issue link
         """
-        try:
-            # Validate required fields
-            if not data.get("type"):
-                raise ValueError("Link type is required")
-            if not data.get("inwardIssue") or not data["inwardIssue"].get("key"):
-                raise ValueError("Inward issue key is required")
-            if not data.get("outwardIssue") or not data["outwardIssue"].get("key"):
-                raise ValueError("Outward issue key is required")
+        # Validate required fields
+        if not data.get("type"):
+            raise ValueError("Link type is required")
+        if not data.get("inwardIssue") or not data["inwardIssue"].get("key"):
+            raise ValueError("Inward issue key is required")
+        if not data.get("outwardIssue") or not data["outwardIssue"].get("key"):
+            raise ValueError("Outward issue key is required")
 
+        try:
             # Create the issue link
             self.jira.create_issue_link(data)
 
@@ -140,14 +141,15 @@ class LinksMixin(JiraClient):
             Dictionary with the result of the operation
 
         Raises:
+            ValueError: If link_id is empty
             MCPAtlassianAuthenticationError: If authentication fails with the Jira API (401/403)
             Exception: If there is an error removing the issue link
         """
-        try:
-            # Validate input
-            if not link_id:
-                raise ValueError("Link ID is required")
+        # Validate input
+        if not link_id:
+            raise ValueError("Link ID is required")
 
+        try:
             # Remove the issue link
             self.jira.remove_issue_link(link_id)
 

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -18,6 +18,7 @@ from .common import (
     JiraUser,
 )
 from .issue import JiraIssue
+from .link import JiraIssueLinkType
 from .project import JiraProject
 from .search import JiraSearchResult
 from .workflow import JiraTransition
@@ -42,4 +43,5 @@ __all__ = [
     "JiraSprint",
     "JiraIssue",
     "JiraSearchResult",
+    "JiraIssueLinkType",
 ]

--- a/src/mcp_atlassian/models/jira/link.py
+++ b/src/mcp_atlassian/models/jira/link.py
@@ -1,0 +1,71 @@
+"""
+Jira issue link type models.
+
+This module provides Pydantic models for Jira issue link types.
+"""
+
+import logging
+from typing import Any
+
+from ..base import ApiModel
+from ..constants import EMPTY_STRING, JIRA_DEFAULT_ID, UNKNOWN
+
+logger = logging.getLogger(__name__)
+
+
+class JiraIssueLinkType(ApiModel):
+    """
+    Model representing a Jira issue link type.
+    """
+
+    id: str = JIRA_DEFAULT_ID
+    name: str = UNKNOWN
+    inward: str = EMPTY_STRING
+    outward: str = EMPTY_STRING
+    self_url: str | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraIssueLinkType":
+        """
+        Create a JiraIssueLinkType from a Jira API response.
+
+        Args:
+            data: The issue link type data from the Jira API
+
+        Returns:
+            A JiraIssueLinkType instance
+        """
+        if not data:
+            return cls()
+
+        if not isinstance(data, dict):
+            logger.debug("Received non-dictionary data, returning default instance")
+            return cls()
+
+        link_type_id = data.get("id", JIRA_DEFAULT_ID)
+        if link_type_id is not None:
+            link_type_id = str(link_type_id)
+
+        return cls(
+            id=link_type_id,
+            name=str(data.get("name", UNKNOWN)),
+            inward=str(data.get("inward", EMPTY_STRING)),
+            outward=str(data.get("outward", EMPTY_STRING)),
+            self_url=data.get("self"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result = {
+            "id": self.id,
+            "name": self.name,
+            "inward": self.inward,
+            "outward": self.outward,
+        }
+
+        if self.self_url:
+            result["self"] = self.self_url
+
+        return result

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -1105,6 +1105,15 @@ async def list_tools() -> list[Tool]:
                         },
                     ),
                     Tool(
+                        name="jira_get_link_types",
+                        description="Get all available issue link types",
+                        inputSchema={
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                        },
+                    ),
+                    Tool(
                         name="jira_transition_issue",
                         description="Transition a Jira issue to a new status",
                         inputSchema={
@@ -2354,6 +2363,37 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                 ]
             except Exception as e:
                 error_msg = f"Error removing issue link: {str(e)}"
+                logger.error(error_msg)
+                return [
+                    TextContent(
+                        type="text",
+                        text=error_msg,
+                    )
+                ]
+
+        elif name == "jira_get_link_types" and ctx and ctx.jira:
+            if not ctx or not ctx.jira:
+                raise ValueError("Jira is not configured.")
+
+            try:
+                # Get all issue link types
+                link_types = ctx.jira.get_issue_link_types()
+
+                # Format the response
+                formatted_link_types = [
+                    link_type.to_simplified_dict() for link_type in link_types
+                ]
+
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            formatted_link_types, indent=2, ensure_ascii=False
+                        ),
+                    )
+                ]
+            except Exception as e:
+                error_msg = f"Error getting issue link types: {str(e)}"
                 logger.error(error_msg)
                 return [
                     TextContent(

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -2371,7 +2371,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
                     )
                 ]
 
-        elif name == "jira_get_link_types" and ctx and ctx.jira:
+        elif name == "jira_get_link_types":
             if not ctx or not ctx.jira:
                 raise ValueError("Jira is not configured.")
 

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -1,288 +1,115 @@
-"""Tests for the Jira Links mixin."""
-
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from requests.exceptions import HTTPError
 
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.jira.links import LinksMixin
 from mcp_atlassian.models.jira import JiraIssueLinkType
 
 
 class TestLinksMixin:
-    """Tests for the LinksMixin class."""
-
     @pytest.fixture
-    def links_mixin(self, jira_client):
-        """Create a LinksMixin instance with mocked dependencies."""
-        mixin = LinksMixin(config=jira_client.config)
-        mixin.jira = jira_client.jira
+    def links_mixin(self):
+        mixin = LinksMixin()
+        mixin.jira = MagicMock()
         return mixin
 
-    def test_create_issue_link_basic(self, links_mixin):
-        """Test basic functionality of create_issue_link."""
-        # Setup mock
-        links_mixin.jira.create_issue_link.return_value = {"id": "12345"}
-
-        # Test data
-        link_data = {
-            "type": {"name": "Duplicate"},
-            "inwardIssue": {"key": "HSP-1"},
-            "outwardIssue": {"key": "MKY-1"},
-            "comment": {
-                "body": "Linked related issue!",
-                "visibility": {"type": "group", "value": "jira-software-users"},
-            },
-        }
-
-        # Call the method
-        result = links_mixin.create_issue_link(link_data)
-
-        # Verify API calls
-        links_mixin.jira.create_issue_link.assert_called_once_with(link_data)
-
-        # Verify result structure
-        assert result["success"] is True
-        assert "message" in result
-        assert result["link_type"] == "Duplicate"
-        assert result["inward_issue"] == "HSP-1"
-        assert result["outward_issue"] == "MKY-1"
-
-    def test_create_issue_link_missing_type(self, links_mixin):
-        """Test create_issue_link with missing type."""
-        # Test data with missing type
-        link_data = {"inwardIssue": {"key": "HSP-1"}, "outwardIssue": {"key": "MKY-1"}}
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(
-            Exception, match="Error creating issue link: Link type is required"
-        ):
-            links_mixin.create_issue_link(link_data)
-
-    def test_create_issue_link_missing_inward_issue(self, links_mixin):
-        """Test create_issue_link with missing inward issue."""
-        # Test data with missing inward issue
-        link_data = {"type": {"name": "Duplicate"}, "outwardIssue": {"key": "MKY-1"}}
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(
-            Exception, match="Error creating issue link: Inward issue key is required"
-        ):
-            links_mixin.create_issue_link(link_data)
-
-    def test_create_issue_link_missing_outward_issue(self, links_mixin):
-        """Test create_issue_link with missing outward issue."""
-        # Test data with missing outward issue
-        link_data = {"type": {"name": "Duplicate"}, "inwardIssue": {"key": "HSP-1"}}
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(
-            Exception, match="Error creating issue link: Outward issue key is required"
-        ):
-            links_mixin.create_issue_link(link_data)
-
-    def test_create_issue_link_api_error(self, links_mixin):
-        """Test error handling when creating an issue link."""
-        # Test data
-        link_data = {
-            "type": {"name": "Duplicate"},
-            "inwardIssue": {"key": "HSP-1"},
-            "outwardIssue": {"key": "MKY-1"},
-        }
-
-        # Make the API call raise an exception
-        links_mixin.jira.create_issue_link.side_effect = Exception("API error")
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(Exception, match="Error creating issue link: API error"):
-            links_mixin.create_issue_link(link_data)
-
-    def test_create_issue_link_http_error(self, links_mixin):
-        """Test HTTP error handling when creating an issue link."""
-        # Test data
-        link_data = {
-            "type": {"name": "Duplicate"},
-            "inwardIssue": {"key": "HSP-1"},
-            "outwardIssue": {"key": "MKY-1"},
-        }
-
-        # Create a mock HTTP error with a 401 status code
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        http_error = HTTPError("Unauthorized")
-        http_error.response = mock_response
-
-        # Make the API call raise the HTTP error
-        links_mixin.jira.create_issue_link.side_effect = http_error
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(Exception, match="Authentication failed for Jira API"):
-            links_mixin.create_issue_link(link_data)
-
-    def test_remove_issue_link_basic(self, links_mixin):
-        """Test basic functionality of remove_issue_link."""
-        # Setup mock
-        links_mixin.jira.remove_issue_link.return_value = (
-            None  # This method typically returns None
-        )
-
-        # Call the method
-        result = links_mixin.remove_issue_link("12345")
-
-        # Verify API calls
-        links_mixin.jira.remove_issue_link.assert_called_once_with("12345")
-
-        # Verify result structure
-        assert result["success"] is True
-        assert "message" in result
-        assert result["link_id"] == "12345"
-
-    def test_remove_issue_link_missing_id(self, links_mixin):
-        """Test remove_issue_link with missing link ID."""
-        # Call the method with empty link_id and verify it raises the expected exception
-        with pytest.raises(
-            Exception, match="Error removing issue link: Link ID is required"
-        ):
-            links_mixin.remove_issue_link("")
-
-        # Call the method with None link_id and verify it raises the expected exception
-        with pytest.raises(
-            Exception, match="Error removing issue link: Link ID is required"
-        ):
-            links_mixin.remove_issue_link(None)
-
-    def test_remove_issue_link_api_error(self, links_mixin):
-        """Test error handling when removing an issue link."""
-        # Make the API call raise an exception
-        links_mixin.jira.remove_issue_link.side_effect = Exception("API error")
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(Exception, match="Error removing issue link: API error"):
-            links_mixin.remove_issue_link("12345")
-
-    def test_remove_issue_link_http_error(self, links_mixin):
-        """Test HTTP error handling when removing an issue link."""
-        # Create a mock HTTP error with a 401 status code
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        http_error = HTTPError("Unauthorized")
-        http_error.response = mock_response
-
-        # Make the API call raise the HTTP error
-        links_mixin.jira.remove_issue_link.side_effect = http_error
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(Exception, match="Authentication failed for Jira API"):
-            links_mixin.remove_issue_link("12345")
-
-    def test_get_issue_link_types_basic(self, links_mixin, monkeypatch):
-        """Test basic functionality of get_issue_link_types."""
-        # Setup mock response
+    def test_get_issue_link_types_success(self, links_mixin):
         mock_response = {
             "issueLinkTypes": [
                 {
-                    "id": "10000",
+                    "id": "1",
                     "name": "Blocks",
                     "inward": "is blocked by",
                     "outward": "blocks",
-                    "self": "https://example.atlassian.net/rest/api/3/issueLinkType/10000",
                 },
                 {
-                    "id": "10001",
-                    "name": "Duplicate",
-                    "inward": "is duplicated by",
-                    "outward": "duplicates",
-                    "self": "https://example.atlassian.net/rest/api/3/issueLinkType/10001",
+                    "id": "2",
+                    "name": "Relates",
+                    "inward": "relates to",
+                    "outward": "is related to",
                 },
             ]
         }
+        links_mixin.jira.get.return_value = mock_response
 
-        # Create a mock method to replace the internal _get_json method
-        def mock_get_json(endpoint):
-            if endpoint == "issueLinkType":
-                return mock_response
-            return {}
-
-        # Patch the internal method
-        monkeypatch.setattr(links_mixin.jira, "_get_json", mock_get_json)
-
-        # Call the method
-        result = links_mixin.get_issue_link_types()
-
-        # Verify result structure
-        assert len(result) == 2
-        assert isinstance(result[0], JiraIssueLinkType)
-        assert result[0].id == "10000"
-        assert result[0].name == "Blocks"
-        assert result[0].inward == "is blocked by"
-        assert result[0].outward == "blocks"
-        assert (
-            result[0].self_url
-            == "https://example.atlassian.net/rest/api/3/issueLinkType/10000"
-        )
-
-        assert isinstance(result[1], JiraIssueLinkType)
-        assert result[1].id == "10001"
-        assert result[1].name == "Duplicate"
-        assert result[1].inward == "is duplicated by"
-        assert result[1].outward == "duplicates"
-        assert (
-            result[1].self_url
-            == "https://example.atlassian.net/rest/api/3/issueLinkType/10001"
-        )
-
-    def test_get_issue_link_types_empty_response(self, links_mixin, monkeypatch):
-        """Test get_issue_link_types with empty response."""
-        # Setup mock with empty response
-        mock_response = {"issueLinkTypes": []}
-
-        # Create a mock method to replace the internal _get_json method
-        def mock_get_json(endpoint):
-            if endpoint == "issueLinkType":
-                return mock_response
-            return {}
-
-        # Patch the internal method
-        monkeypatch.setattr(links_mixin.jira, "_get_json", mock_get_json)
-
-        # Call the method
-        result = links_mixin.get_issue_link_types()
-
-        # Verify result is an empty list
-        assert isinstance(result, list)
-        assert len(result) == 0
-
-    def test_get_issue_link_types_http_error(self, links_mixin, monkeypatch):
-        """Test HTTP error handling when getting issue link types."""
-        # Create a mock HTTP error with a 401 status code
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        http_error = HTTPError("Unauthorized")
-        http_error.response = mock_response
-
-        # Create a mock method that raises an HTTP error
-        def mock_get_json_error(endpoint):
-            raise http_error
-
-        # Patch the internal method
-        monkeypatch.setattr(links_mixin.jira, "_get_json", mock_get_json_error)
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(Exception, match="Authentication failed for Jira API"):
-            links_mixin.get_issue_link_types()
-
-    def test_get_issue_link_types_api_error(self, links_mixin, monkeypatch):
-        """Test error handling when getting issue link types."""
-
-        # Create a mock method that raises a general exception
-        def mock_get_json_error(endpoint):
-            raise Exception("API error")
-
-        # Patch the internal method
-        monkeypatch.setattr(links_mixin.jira, "_get_json", mock_get_json_error)
-
-        # Call the method and verify it raises the expected exception
-        with pytest.raises(
-            Exception, match="Error getting issue link types: API error"
+        with patch.object(
+            JiraIssueLinkType, "from_api_response", side_effect=lambda x: x
         ):
+            result = links_mixin.get_issue_link_types()
+
+        assert len(result) == 2
+        assert result[0]["name"] == "Blocks"
+        assert result[1]["name"] == "Relates"
+
+    def test_get_issue_link_types_authentication_error(self, links_mixin):
+        links_mixin.jira.get.side_effect = HTTPError(
+            response=MagicMock(status_code=401)
+        )
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
             links_mixin.get_issue_link_types()
+
+    def test_get_issue_link_types_generic_error(self, links_mixin):
+        links_mixin.jira.get.side_effect = Exception("Unexpected error")
+
+        with pytest.raises(Exception, match="Unexpected error"):
+            links_mixin.get_issue_link_types()
+
+    def test_create_issue_link_success(self, links_mixin):
+        data = {
+            "type": {"name": "Relates"},
+            "inwardIssue": {"key": "ISSUE-1"},
+            "outwardIssue": {"key": "ISSUE-2"},
+        }
+
+        response = links_mixin.create_issue_link(data)
+
+        links_mixin.jira.create_issue_link.assert_called_once_with(data)
+        assert response["success"] is True
+        assert response["message"] == "Link created between ISSUE-1 and ISSUE-2"
+
+    def test_create_issue_link_missing_type(self, links_mixin):
+        data = {
+            "inwardIssue": {"key": "ISSUE-1"},
+            "outwardIssue": {"key": "ISSUE-2"},
+        }
+
+        with pytest.raises(ValueError, match="Link type is required"):
+            links_mixin.create_issue_link(data)
+
+    def test_create_issue_link_authentication_error(self, links_mixin):
+        data = {
+            "type": {"name": "Relates"},
+            "inwardIssue": {"key": "ISSUE-1"},
+            "outwardIssue": {"key": "ISSUE-2"},
+        }
+        links_mixin.jira.create_issue_link.side_effect = HTTPError(
+            response=MagicMock(status_code=403)
+        )
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            links_mixin.create_issue_link(data)
+
+    def test_remove_issue_link_success(self, links_mixin):
+        link_id = "12345"
+
+        response = links_mixin.remove_issue_link(link_id)
+
+        links_mixin.jira.remove_issue_link.assert_called_once_with(link_id)
+        assert response["success"] is True
+        assert response["message"] == f"Link with ID {link_id} has been removed"
+
+    def test_remove_issue_link_missing_id(self, links_mixin):
+        with pytest.raises(ValueError, match="Link ID is required"):
+            links_mixin.remove_issue_link("")
+
+    def test_remove_issue_link_authentication_error(self, links_mixin):
+        link_id = "12345"
+        links_mixin.jira.remove_issue_link.side_effect = HTTPError(
+            response=MagicMock(status_code=401)
+        )
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            links_mixin.remove_issue_link(link_id)

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -10,9 +10,9 @@ from mcp_atlassian.models.jira import JiraIssueLinkType
 
 class TestLinksMixin:
     @pytest.fixture
-    def links_mixin(self):
-        mixin = LinksMixin()
-        mixin.jira = MagicMock()
+    def links_mixin(self, mock_config, mock_atlassian_jira):
+        mixin = LinksMixin(config=mock_config)
+        mixin.jira = mock_atlassian_jira
         return mixin
 
     def test_get_issue_link_types_success(self, links_mixin):
@@ -68,7 +68,7 @@ class TestLinksMixin:
 
         links_mixin.jira.create_issue_link.assert_called_once_with(data)
         assert response["success"] is True
-        assert response["message"] == "Link created between ISSUE-1 and ISSUE-2"
+        assert response["message"] == ("Link created between ISSUE-1 and ISSUE-2")
 
     def test_create_issue_link_missing_type(self, links_mixin):
         data = {
@@ -99,7 +99,7 @@ class TestLinksMixin:
 
         links_mixin.jira.remove_issue_link.assert_called_once_with(link_id)
         assert response["success"] is True
-        assert response["message"] == f"Link with ID {link_id} has been removed"
+        assert response["message"] == (f"Link with ID {link_id} has been removed")
 
     def test_remove_issue_link_missing_id(self, links_mixin):
         with pytest.raises(ValueError, match="Link ID is required"):

--- a/tests/unit/models/test_jira_models.py
+++ b/tests/unit/models/test_jira_models.py
@@ -20,6 +20,7 @@ from src.mcp_atlassian.models.constants import (
 from src.mcp_atlassian.models.jira import (
     JiraComment,
     JiraIssue,
+    JiraIssueLinkType,
     JiraIssueType,
     JiraPriority,
     JiraProject,
@@ -1130,6 +1131,68 @@ class TestJiraTransition:
         assert simplified["to_status"]["name"] == "In Progress"
         assert "has_screen" not in simplified
         assert "is_global" not in simplified
+
+
+class TestJiraIssueLinkType:
+    """Tests for the JiraIssueLinkType model."""
+
+    def test_from_api_response_with_valid_data(self):
+        """Test creating a JiraIssueLinkType from valid API data."""
+        data = {
+            "id": "10001",
+            "name": "Blocks",
+            "inward": "is blocked by",
+            "outward": "blocks",
+            "self": "https://example.atlassian.net/rest/api/3/issueLinkType/10001",
+        }
+        link_type = JiraIssueLinkType.from_api_response(data)
+        assert link_type.id == "10001"
+        assert link_type.name == "Blocks"
+        assert link_type.inward == "is blocked by"
+        assert link_type.outward == "blocks"
+        assert (
+            link_type.self_url
+            == "https://example.atlassian.net/rest/api/3/issueLinkType/10001"
+        )
+
+    def test_from_api_response_with_empty_data(self):
+        """Test creating a JiraIssueLinkType from empty data."""
+        link_type = JiraIssueLinkType.from_api_response({})
+        assert link_type.id == JIRA_DEFAULT_ID
+        assert link_type.name == UNKNOWN
+        assert link_type.inward == EMPTY_STRING
+        assert link_type.outward == EMPTY_STRING
+        assert link_type.self_url is None
+
+    def test_from_api_response_with_none_data(self):
+        """Test creating a JiraIssueLinkType from None data."""
+        link_type = JiraIssueLinkType.from_api_response(None)
+        assert link_type.id == JIRA_DEFAULT_ID
+        assert link_type.name == UNKNOWN
+        assert link_type.inward == EMPTY_STRING
+        assert link_type.outward == EMPTY_STRING
+        assert link_type.self_url is None
+
+    def test_to_simplified_dict(self):
+        """Test converting JiraIssueLinkType to a simplified dictionary."""
+        link_type = JiraIssueLinkType(
+            id="10001",
+            name="Blocks",
+            inward="is blocked by",
+            outward="blocks",
+            self_url="https://example.atlassian.net/rest/api/3/issueLinkType/10001",
+        )
+        simplified = link_type.to_simplified_dict()
+        assert isinstance(simplified, dict)
+        assert simplified["id"] == "10001"
+        assert simplified["name"] == "Blocks"
+        assert simplified["inward"] == "is blocked by"
+        assert simplified["outward"] == "blocks"
+        assert "self" in simplified
+        assert (
+            simplified["self"]
+            == "https://example.atlassian.net/rest/api/3/issueLinkType/10001"
+        )
 
 
 class TestJiraWorklog:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

This PR adds Jira issue linking type lookup functionality to the MCP Atlassian server. It enables users to retrieve available issue link types, and refactors code to create links between issues, and remove existing links. 

## Changes

<!-- Briefly list the key changes made. -->

- Added `get_issue_link_types()` method to retrieve all available issue link types
- Refactored `create_issue_link(data)` method to create links between issues
- Refactored `remove_issue_link(link_id)` method to remove existing links
- Added corresponding MCP tool interfaces for these operations

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `Tested with real Jira instance to verify link creation and removal`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [] Documentation updated (if needed).