### PR TITLE
feat: add support for getting and adding labels for Confluence pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ For Jira Server/DC, use:
 |`confluence_create_page`|`jira_batch_create_issues`|
 |`confluence_update_page`|`jira_update_issue`|
 |`confluence_delete_page`|`jira_delete_issue`|
-||`jira_get_transitions`|
-||`jira_transition_issue`|
+|`confluence_get_labels`|`jira_get_transitions`|
+|`confluence_add_label`|`jira_transition_issue`|
 ||`jira_add_comment`|
 ||`jira_add_worklog`|
 ||`jira_get_worklog`|

--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -6,12 +6,15 @@ This module provides access to Confluence content through the Model Context Prot
 from .client import ConfluenceClient
 from .comments import CommentsMixin
 from .config import ConfluenceConfig
+from .labels import LabelsMixin
 from .pages import PagesMixin
 from .search import SearchMixin
 from .spaces import SpacesMixin
 
 
-class ConfluenceFetcher(SearchMixin, SpacesMixin, PagesMixin, CommentsMixin):
+class ConfluenceFetcher(
+    SearchMixin, SpacesMixin, PagesMixin, CommentsMixin, LabelsMixin
+):
     """Main entry point for Confluence operations, providing backward compatibility.
 
     This class combines functionality from various mixins to maintain the same

--- a/src/mcp_atlassian/confluence/labels.py
+++ b/src/mcp_atlassian/confluence/labels.py
@@ -1,0 +1,87 @@
+"""Module for Confluence label operations."""
+
+import logging
+
+import requests
+
+from ..models.confluence import ConfluenceLabel
+from .client import ConfluenceClient
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+class LabelsMixin(ConfluenceClient):
+    """Mixin for Confluence label operations."""
+
+    def get_page_labels(self, page_id: str) -> list[ConfluenceLabel]:
+        """
+        Get all labels for a specific page.
+
+        Args:
+            page_id: The ID of the page to get labels from
+
+        Returns:
+            List of ConfluenceLabel models containing label content and metadata
+        """
+        try:
+            # Get page info to extract space details
+            page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
+            space_key = page.get("space", {}).get("key", "")
+
+            # Get labels with expanded content
+            labels_response = self.confluence.get_page_labels(page_id=page_id)
+
+            # Process each label
+            label_models = []
+            for label_data in labels_response.get("results", []):
+                # Create the model with the processed content
+                label_model = ConfluenceLabel.from_api_response(
+                    label_data,
+                    base_url=self.config.url,
+                )
+
+                label_models.append(label_model)
+
+            return label_models
+
+        except requests.RequestException as e:
+            logger.error(f"Network error when fetching labels: {str(e)}")
+            return []
+        except (ValueError, TypeError) as e:
+            logger.error(f"Error processing label data: {str(e)}")
+            return []
+        except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging
+            logger.error(f"Unexpected error fetching labels: {str(e)}")
+            logger.debug("Full exception details for labels:", exc_info=True)
+            return []
+
+    def add_page_label(self, page_id: str, name: str) -> list[ConfluenceLabel]:
+        """
+        Add a label to a Confluence page.
+
+        Args:
+            page_id: The ID of the page to update
+            name: The name of the label
+
+        Returns:
+            Label model containing the updated list of labels
+
+        Raises:
+            Exception: If there is an error adding the label
+        """
+        try:
+            logger.debug(f"Adding label with name '{name}' to page {page_id}")
+
+            update_kwargs = {
+                "page_id": page_id,
+                "label": name,
+            }
+            response = self.confluence.set_page_label(**update_kwargs)
+
+            # After update, refresh the page data
+            return self.get_page_labels(page_id)
+        except Exception as e:
+            logger.error(f"Error adding label '{name}' to page {page_id}: {str(e)}")
+            raise Exception(
+                f"Failed to add label '{name}' to page {page_id}: {str(e)}"
+            ) from e

--- a/src/mcp_atlassian/confluence/labels.py
+++ b/src/mcp_atlassian/confluence/labels.py
@@ -24,10 +24,6 @@ class LabelsMixin(ConfluenceClient):
             List of ConfluenceLabel models containing label content and metadata
         """
         try:
-            # Get page info to extract space details
-            page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
-            space_key = page.get("space", {}).get("key", "")
-
             # Get labels with expanded content
             labels_response = self.confluence.get_page_labels(page_id=page_id)
 

--- a/src/mcp_atlassian/models/__init__.py
+++ b/src/mcp_atlassian/models/__init__.py
@@ -13,6 +13,7 @@ from .base import ApiModel, TimestampMixin
 from .confluence import (
     ConfluenceAttachment,
     ConfluenceComment,
+    ConfluenceLabel,
     ConfluencePage,
     ConfluenceSearchResult,
     ConfluenceSpace,
@@ -99,6 +100,7 @@ __all__ = [
     "ConfluenceSpace",
     "ConfluencePage",
     "ConfluenceComment",
+    "ConfluenceLabel",
     "ConfluenceVersion",
     "ConfluenceSearchResult",
     "ConfluenceAttachment",

--- a/src/mcp_atlassian/models/confluence/__init__.py
+++ b/src/mcp_atlassian/models/confluence/__init__.py
@@ -14,6 +14,7 @@ Key models:
 
 from .comment import ConfluenceComment
 from .common import ConfluenceAttachment, ConfluenceUser
+from .label import ConfluenceLabel
 from .page import ConfluencePage, ConfluenceVersion
 from .search import ConfluenceSearchResult
 from .space import ConfluenceSpace
@@ -24,6 +25,7 @@ __all__ = [
     "ConfluenceSpace",
     "ConfluenceVersion",
     "ConfluenceComment",
+    "ConfluenceLabel",
     "ConfluencePage",
     "ConfluenceSearchResult",
 ]

--- a/src/mcp_atlassian/models/confluence/label.py
+++ b/src/mcp_atlassian/models/confluence/label.py
@@ -1,0 +1,62 @@
+"""
+Confluence label models.
+This module provides Pydantic models for Confluence page labels.
+"""
+
+import logging
+from typing import Any
+
+from ..base import ApiModel, TimestampMixin
+from ..constants import (
+    CONFLUENCE_DEFAULT_ID,
+    EMPTY_STRING,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ConfluenceLabel(ApiModel, TimestampMixin):
+    """
+    Model representing a Confluence label.
+    """
+
+    id: str = CONFLUENCE_DEFAULT_ID
+    name: str | None = None
+    prefix: str = EMPTY_STRING
+    label: str = EMPTY_STRING
+    type: str = "label"
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "ConfluenceLabel":
+        """
+        Create a ConfluenceLabel from a Confluence API response.
+
+        Args:
+            data: The label data from the Confluence API
+
+        Returns:
+            A ConfluenceLabel instance
+        """
+        if not data:
+            return cls()
+
+        return cls(
+            id=str(data.get("id", CONFLUENCE_DEFAULT_ID)),
+            name=data.get("name", EMPTY_STRING),
+            prefix=data.get("prefix", EMPTY_STRING),
+            label=data.get("label", EMPTY_STRING),
+            type=data.get("type", "label"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result = {
+            "id": self.id,
+            "name": self.name,
+            "prefix": self.prefix,
+            "label": self.label,
+        }
+
+        return result

--- a/src/mcp_atlassian/models/confluence/label.py
+++ b/src/mcp_atlassian/models/confluence/label.py
@@ -21,7 +21,7 @@ class ConfluenceLabel(ApiModel):
     """
 
     id: str = CONFLUENCE_DEFAULT_ID
-    name: str | None = None
+    name: str = EMPTY_STRING
     prefix: str = "global"
     label: str = EMPTY_STRING
     type: str = "label"
@@ -45,7 +45,7 @@ class ConfluenceLabel(ApiModel):
         return cls(
             id=str(data.get("id", CONFLUENCE_DEFAULT_ID)),
             name=data.get("name", EMPTY_STRING),
-            prefix=data.get("prefix", EMPTY_STRING),
+            prefix=data.get("prefix", "global"),
             label=data.get("label", EMPTY_STRING),
             type=data.get("type", "label"),
         )

--- a/src/mcp_atlassian/models/confluence/label.py
+++ b/src/mcp_atlassian/models/confluence/label.py
@@ -6,7 +6,7 @@ This module provides Pydantic models for Confluence page labels.
 import logging
 from typing import Any
 
-from ..base import ApiModel, TimestampMixin
+from ..base import ApiModel
 from ..constants import (
     CONFLUENCE_DEFAULT_ID,
     EMPTY_STRING,
@@ -15,7 +15,7 @@ from ..constants import (
 logger = logging.getLogger(__name__)
 
 
-class ConfluenceLabel(ApiModel, TimestampMixin):
+class ConfluenceLabel(ApiModel):
     """
     Model representing a Confluence label.
     """

--- a/src/mcp_atlassian/models/confluence/label.py
+++ b/src/mcp_atlassian/models/confluence/label.py
@@ -22,7 +22,7 @@ class ConfluenceLabel(ApiModel):
 
     id: str = CONFLUENCE_DEFAULT_ID
     name: str | None = None
-    prefix: str = EMPTY_STRING
+    prefix: str = "global"
     label: str = EMPTY_STRING
     type: str = "label"
 

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -1204,13 +1204,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             }
 
         def format_label(label: Any) -> dict[str, Any]:
-            if hasattr(label, "to_simplified_dict"):
-                # Cast the return value to dict[str, Any] to satisfy the type checker
-                return cast(dict[str, Any], label.to_simplified_dict())
-            return {
-                "name": label.get("name", {}),
-                "prefix": comment.get("prefix"),
-            }
+            return cast(dict[str, Any], label.to_simplified_dict())
 
         # Confluence operations
         if name == "confluence_search" and ctx and ctx.confluence:

--- a/tests/fixtures/confluence_mocks.py
+++ b/tests/fixtures/confluence_mocks.py
@@ -282,6 +282,35 @@ MOCK_COMMENTS_RESPONSE = {
         }
     ]
 }
+
+MOCK_LABELS_RESPONSE = {
+    "results": [
+        {
+            "id": "456789123",
+            "prefix": "global",
+            "name": "meeting-notes",
+            "label": "meeting-notes",
+        },
+        {
+            "id": "456789124",
+            "prefix": "my",
+            "name": "important",
+        },
+        {
+            "id": "456789125",
+            "name": "test",
+        },
+    ],
+    "start": 0,
+    "limit": 200,
+    "size": 2,
+    "_links": {
+        "self": "https://company.atlassian.net/wiki/rest/api/content/456789123",
+        "base": "https://company.atlassian.net",
+        "context": "",
+    },
+}
+
 MOCK_SPACES_RESPONSE = {
     "results": [
         {

--- a/tests/fixtures/confluence_mocks.py
+++ b/tests/fixtures/confluence_mocks.py
@@ -303,7 +303,7 @@ MOCK_LABELS_RESPONSE = {
     ],
     "start": 0,
     "limit": 200,
-    "size": 2,
+    "size": 3,
     "_links": {
         "self": "https://company.atlassian.net/wiki/rest/api/content/456789123",
         "base": "https://company.atlassian.net",

--- a/tests/test_real_api_validation.py
+++ b/tests/test_real_api_validation.py
@@ -29,6 +29,7 @@ from mcp.types import TextContent
 from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.comments import CommentsMixin as ConfluenceCommentsMixin
 from mcp_atlassian.confluence.config import ConfluenceConfig
+from mcp_atlassian.confluence.labels import LabelsMixin as ConfluenceLabelsMixin
 from mcp_atlassian.confluence.pages import PagesMixin
 from mcp_atlassian.confluence.search import SearchMixin as ConfluenceSearchMixin
 from mcp_atlassian.jira import JiraFetcher
@@ -36,7 +37,11 @@ from mcp_atlassian.jira.comments import CommentsMixin as JiraCommentsMixin
 from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.jira.issues import IssuesMixin
 from mcp_atlassian.jira.search import SearchMixin as JiraSearchMixin
-from mcp_atlassian.models.confluence import ConfluenceComment, ConfluencePage
+from mcp_atlassian.models.confluence import (
+    ConfluenceComment,
+    ConfluenceLabel,
+    ConfluencePage,
+)
 from mcp_atlassian.models.jira import JiraIssue
 from mcp_atlassian.server import call_tool
 
@@ -360,6 +365,28 @@ class TestRealConfluenceValidation:
             assert isinstance(comment, ConfluenceComment)
             assert comment.id is not None
             assert comment.body is not None
+
+    def test_get_page_labels(self, use_real_confluence_data, test_page_id):
+        """Test that page labels are properly converted to ConfluenceLabel models."""
+        if not use_real_confluence_data:
+            pytest.skip("Real Confluence data testing is disabled")
+
+        # Initialize the Confluence labels client
+        config = ConfluenceConfig.from_env()
+        labels_client = ConfluenceLabelsMixin(config=config)
+
+        # Get labels using the labels mixin
+        labels = labels_client.get_page_labels(test_page_id)
+
+        # If there are no labels, skip the test
+        if len(labels) == 0:
+            pytest.skip("Test page has no labels")
+
+        # Verify labels are ConfluenceLabel instances
+        for label in labels:
+            assert isinstance(label, ConfluenceLabel)
+            assert label.id is not None
+            assert label.name is not None
 
     def test_search_content(self, use_real_confluence_data):
         """Test that search returns ConfluencePage models."""
@@ -885,6 +912,40 @@ async def test_confluence_update_page(
 
         print("TextContent validation succeeded - 'type' field is properly required")
 
+    finally:
+        # Clean up resources even if the test fails
+        cleanup_resources()
+
+
+@pytest.mark.anyio
+async def test_confluence_add_page_label(
+    confluence_client: ConfluenceFetcher,
+    resource_tracker: ResourceTracker,
+    test_space_key: str,
+    cleanup_resources: Callable[[], None],
+) -> None:
+    """Test adding a label to a page in Confluence"""
+    # Create a test page first
+    test_id = str(uuid.uuid4())[:8]
+    title = f"Update Test Page {test_id}"
+    content = f"<p>Initial content {test_id}</p>"
+
+    try:
+        # Create the page using our module's API
+        page = confluence_client.create_page(
+            space_key=test_space_key, title=title, body=content
+        )
+
+        # Track the page for cleanup
+        page_id = page.id
+        resource_tracker.add_confluence_page(page_id)
+
+        # Test adding a label
+        name = "test"
+        updated_labels = confluence_client.add_page_label(page_id=page_id, name=name)
+
+        # Verify that a label has been added
+        assert updated_labels is not None
     finally:
         # Clean up resources even if the test fails
         cleanup_resources()

--- a/tests/unit/confluence/conftest.py
+++ b/tests/unit/confluence/conftest.py
@@ -12,6 +12,7 @@ sys.path.append(str(Path(__file__).parent.parent.parent))
 from fixtures.confluence_mocks import (
     MOCK_COMMENTS_RESPONSE,
     MOCK_CQL_SEARCH_RESPONSE,
+    MOCK_LABELS_RESPONSE,
     MOCK_PAGE_RESPONSE,
     MOCK_PAGES_FROM_SPACE_RESPONSE,
     MOCK_SPACES_RESPONSE,
@@ -60,6 +61,7 @@ def mock_atlassian_confluence():
             MOCK_PAGES_FROM_SPACE_RESPONSE
         )
         confluence_instance.get_page_comments.return_value = MOCK_COMMENTS_RESPONSE
+        confluence_instance.get_page_labels.return_value = MOCK_LABELS_RESPONSE
         confluence_instance.cql.return_value = MOCK_CQL_SEARCH_RESPONSE
 
         # Mock create_page to return a page with the given title

--- a/tests/unit/confluence/test_labels.py
+++ b/tests/unit/confluence/test_labels.py
@@ -54,36 +54,27 @@ class TestLabelsMixin:
             "API error"
         )
 
-        # Act
-        result = labels_mixin.get_page_labels("987654321")
-
-        # Assert
-        assert isinstance(result, list)
-        assert len(result) == 0  # Empty list on error
+        # Act/Assert
+        with pytest.raises(Exception, match="Failed fetching labels"):
+            labels_mixin.get_page_labels("987654321")
 
     def test_get_page_labels_key_error(self, labels_mixin):
         """Test handling of missing keys in API response."""
         # Mock the response to be missing expected keys
         labels_mixin.confluence.get_page_labels.return_value = {"invalid": "data"}
 
-        # Act
-        result = labels_mixin.get_page_labels("987654321")
-
-        # Assert
-        assert isinstance(result, list)
-        assert len(result) == 0  # Empty list on error
+        # Act/Assert
+        with pytest.raises(Exception, match="Failed fetching labels"):
+            labels_mixin.get_page_labels("987654321")
 
     def test_get_page_labels_value_error(self, labels_mixin):
         """Test handling of unexpected data types."""
         # Cause a value error by returning a string where a dict is expected
         labels_mixin.confluence.get_page_labels.return_value = "invalid"
 
-        # Act
-        result = labels_mixin.get_page_labels("987654321")
-
-        # Assert
-        assert isinstance(result, list)
-        assert len(result) == 0  # Empty list on error
+        # Act/Assert
+        with pytest.raises(Exception, match="Failed fetching labels"):
+            labels_mixin.get_page_labels("987654321")
 
     def test_get_page_labels_with_empty_results(self, labels_mixin):
         """Test handling of empty results."""

--- a/tests/unit/confluence/test_labels.py
+++ b/tests/unit/confluence/test_labels.py
@@ -9,7 +9,7 @@ from mcp_atlassian.confluence.labels import LabelsMixin
 from mcp_atlassian.models.confluence import ConfluenceLabel
 
 
-class TestLabelssMixin:
+class TestLabelsMixin:
     """Tests for the LabelsMixin class."""
 
     @pytest.fixture
@@ -31,26 +31,6 @@ class TestLabelssMixin:
         """Test get_page_labels with success response."""
         # Setup
         page_id = "12345"
-        # Configure the mock to return a successful response
-        labels_mixin.confluence.get_page_labels.return_value = {
-            "results": [
-                {
-                    "id": "456789123",
-                    "prefix": "global",
-                    "name": "meeting-notes",
-                    "label": "meeting-notes",
-                },
-                {
-                    "id": "456789124",
-                    "prefix": "my",
-                    "name": "important",
-                },
-                {
-                    "id": "456789125",
-                    "name": "test",
-                },
-            ]
-        }
 
         # Call the method
         result = labels_mixin.get_page_labels(page_id)
@@ -58,7 +38,14 @@ class TestLabelssMixin:
         # Verify
         labels_mixin.confluence.get_page_labels.assert_called_once_with(page_id=page_id)
         assert len(result) == 3
-        # assert result[0].body == "Processed Markdown"
+        assert result[0].id == "456789123"
+        assert result[0].prefix == "global"
+        assert result[0].label == "meeting-notes"
+        assert result[1].id == "456789124"
+        assert result[1].prefix == "my"
+        assert result[1].name == "important"
+        assert result[2].id == "456789125"
+        assert result[2].name == "test"
 
     def test_get_page_labels_api_error(self, labels_mixin):
         """Test handling of API errors."""
@@ -89,7 +76,7 @@ class TestLabelssMixin:
     def test_get_page_labels_value_error(self, labels_mixin):
         """Test handling of unexpected data types."""
         # Cause a value error by returning a string where a dict is expected
-        labels_mixin.confluence.get_page_by_id.return_value = "invalid"
+        labels_mixin.confluence.get_page_labels.return_value = "invalid"
 
         # Act
         result = labels_mixin.get_page_labels("987654321")

--- a/tests/unit/confluence/test_labels.py
+++ b/tests/unit/confluence/test_labels.py
@@ -1,0 +1,151 @@
+"""Unit tests for the LabelsMixin class."""
+
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from mcp_atlassian.confluence.labels import LabelsMixin
+from mcp_atlassian.models.confluence import ConfluenceLabel
+
+
+class TestLabelssMixin:
+    """Tests for the LabelsMixin class."""
+
+    @pytest.fixture
+    def labels_mixin(self, confluence_client):
+        """Create a LabelsMixin instance for testing."""
+        # LabelsMixin inherits from ConfluenceClient, so we need to create it properly
+        with patch(
+            "mcp_atlassian.confluence.labels.ConfluenceClient.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            mixin = LabelsMixin()
+            # Copy the necessary attributes from our mocked client
+            mixin.confluence = confluence_client.confluence
+            mixin.config = confluence_client.config
+            mixin.preprocessor = confluence_client.preprocessor
+            return mixin
+
+    def test_get_page_labels_success(self, labels_mixin):
+        """Test get_page_labels with success response."""
+        # Setup
+        page_id = "12345"
+        # Configure the mock to return a successful response
+        labels_mixin.confluence.get_page_labels.return_value = {
+            "results": [
+                {
+                    "id": "456789123",
+                    "prefix": "global",
+                    "name": "meeting-notes",
+                    "label": "meeting-notes",
+                },
+                {
+                    "id": "456789124",
+                    "prefix": "my",
+                    "name": "important",
+                },
+                {
+                    "id": "456789125",
+                    "name": "test",
+                },
+            ]
+        }
+
+        # Call the method
+        result = labels_mixin.get_page_labels(page_id)
+
+        # Verify
+        labels_mixin.confluence.get_page_labels.assert_called_once_with(page_id=page_id)
+        assert len(result) == 3
+        # assert result[0].body == "Processed Markdown"
+
+    def test_get_page_labels_api_error(self, labels_mixin):
+        """Test handling of API errors."""
+        # Mock the API to raise an exception
+        labels_mixin.confluence.get_page_labels.side_effect = requests.RequestException(
+            "API error"
+        )
+
+        # Act
+        result = labels_mixin.get_page_labels("987654321")
+
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 0  # Empty list on error
+
+    def test_get_page_labels_key_error(self, labels_mixin):
+        """Test handling of missing keys in API response."""
+        # Mock the response to be missing expected keys
+        labels_mixin.confluence.get_page_labels.return_value = {"invalid": "data"}
+
+        # Act
+        result = labels_mixin.get_page_labels("987654321")
+
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 0  # Empty list on error
+
+    def test_get_page_labels_value_error(self, labels_mixin):
+        """Test handling of unexpected data types."""
+        # Cause a value error by returning a string where a dict is expected
+        labels_mixin.confluence.get_page_by_id.return_value = "invalid"
+
+        # Act
+        result = labels_mixin.get_page_labels("987654321")
+
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 0  # Empty list on error
+
+    def test_get_page_labels_with_empty_results(self, labels_mixin):
+        """Test handling of empty results."""
+        # Mock empty results
+        labels_mixin.confluence.get_page_labels.return_value = {"results": []}
+
+        # Act
+        result = labels_mixin.get_page_labels("987654321")
+
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 0  # Empty list with no labels
+
+    def test_add_page_label_success(self, labels_mixin):
+        """Test adding a label"""
+        # Arrange
+        page_id = "987654321"
+        name = "test-label"
+        prefix = "global"
+
+        # Mock add_page_label to return a list of ConfluenceLabels
+        with patch.object(
+            labels_mixin,
+            "get_page_labels",
+            return_value=ConfluenceLabel(
+                id="123456789",
+                name=name,
+                prefix=prefix,
+            ),
+        ):
+            # Act
+            result = labels_mixin.add_page_label(page_id, name)
+
+            # Assert
+            labels_mixin.confluence.set_page_label.assert_called_once_with(
+                page_id=page_id, label=name
+            )
+
+            # Verify result is a ConfluenceLabel
+            assert isinstance(result, ConfluenceLabel)
+            assert result.id == "123456789"
+            assert result.name == name
+            assert result.prefix == prefix
+
+    def test_add_page_label_error(self, labels_mixin):
+        """Test error handling when adding a label."""
+        # Arrange
+        labels_mixin.confluence.set_page_label.side_effect = Exception("API Error")
+
+        # Act/Assert
+        with pytest.raises(Exception, match="Failed to add label"):
+            labels_mixin.add_page_label("987654321", "test")

--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from tests.fixtures.confluence_mocks import (
     MOCK_COMMENTS_RESPONSE,
     MOCK_CQL_SEARCH_RESPONSE,
+    MOCK_LABELS_RESPONSE,
     MOCK_PAGE_RESPONSE,
 )
 
@@ -55,6 +56,12 @@ def confluence_page_data() -> dict[str, Any]:
 def confluence_comments_data() -> dict[str, Any]:
     """Return mock Confluence comments data."""
     return MOCK_COMMENTS_RESPONSE
+
+
+@pytest.fixture
+def confluence_labels_data() -> dict[str, Any]:
+    """Return mock Confluence labels data."""
+    return MOCK_LABELS_RESPONSE
 
 
 # Conditional fixtures for accessing real data if the user wants to use it

--- a/tests/unit/models/test_confluence_models.py
+++ b/tests/unit/models/test_confluence_models.py
@@ -17,6 +17,7 @@ from src.mcp_atlassian.models import (
     ConfluenceUser,
     ConfluenceVersion,
 )
+from src.mcp_atlassian.models.constants import EMPTY_STRING
 
 # Optional: Import real API client for optional real-data testing
 try:
@@ -338,9 +339,9 @@ class TestConfluenceLabel:
 
         # Should use default values
         assert label.id == "0"
-        assert label.name is None
+        assert label.name == EMPTY_STRING
         assert label.prefix == "global"
-        assert label.label == ""
+        assert label.label == EMPTY_STRING
         assert label.type == "label"
 
     def test_to_simplified_dict(self):

--- a/tests/unit/models/test_confluence_models.py
+++ b/tests/unit/models/test_confluence_models.py
@@ -339,7 +339,7 @@ class TestConfluenceLabel:
         # Should use default values
         assert label.id == "0"
         assert label.name is None
-        assert label.prefix == ""
+        assert label.prefix == "global"
         assert label.label == ""
         assert label.type == "label"
 

--- a/tests/unit/models/test_confluence_models.py
+++ b/tests/unit/models/test_confluence_models.py
@@ -10,6 +10,7 @@ import pytest
 from src.mcp_atlassian.models import (
     ConfluenceAttachment,
     ConfluenceComment,
+    ConfluenceLabel,
     ConfluencePage,
     ConfluenceSearchResult,
     ConfluenceSpace,
@@ -314,6 +315,51 @@ class TestConfluenceComment:
         assert simplified["created"] == "2024-01-01 10:00:00"  # Formatted timestamp
         assert simplified["updated"] == "2024-01-01 10:00:00"  # Formatted timestamp
         assert simplified["author"] == "Comment Author"
+
+
+class TestConfluenceLabel:
+    """Tests for the ConfluenceLabel model."""
+
+    def test_from_api_response_with_valid_data(self, confluence_labels_data):
+        """Test creating a ConfluenceLabel from valid API data."""
+        label_data = confluence_labels_data["results"][0]
+
+        label = ConfluenceLabel.from_api_response(label_data)
+
+        assert label.id == "456789123"
+        assert label.name == "meeting-notes"
+        assert label.prefix == "global"
+        assert label.label == "meeting-notes"
+        assert label.type == "label"
+
+    def test_from_api_response_with_empty_data(self):
+        """Test creating a ConfluenceLabel from empty data."""
+        label = ConfluenceLabel.from_api_response({})
+
+        # Should use default values
+        assert label.id == "0"
+        assert label.name is None
+        assert label.prefix == ""
+        assert label.label == ""
+        assert label.type == "label"
+
+    def test_to_simplified_dict(self):
+        """Test converting ConfluenceLabel to a simplified dictionary."""
+        label = ConfluenceLabel(
+            id="456789123",
+            name="test",
+            prefix="my",
+            label="test",
+            type="label",
+        )
+
+        simplified = label.to_simplified_dict()
+
+        assert isinstance(simplified, dict)
+        assert simplified["id"] == "456789123"
+        assert simplified["name"] == "test"
+        assert simplified["prefix"] == "my"
+        assert simplified["label"] == "test"
 
 
 class TestConfluencePage:


### PR DESCRIPTION
## Description

This PR adds support for labels on Confluence pages:
- get all labels on a page
- add a label to a page

Note: I am not very experienced in Python programming. Please excuse any mistakes 🙈

## Changes

- Add `ConfluenceLabel` with the properties as defined in [Atlassian REST API Spec](https://developer.atlassian.com/server/confluence/rest/v900/api-group-content-labels/#api-rest-api-content-id-label-get-response):
  - id (string): unique id of this label
  - name (string): the actual name of the label
  - prefix (string): prefix (default: global)
  - label (string): I could not find a clear definition. It is mentioned in the spec. My Confluence server always returns an empty string.
- Add 2 new Tools `confluence_get_labels` and `confluence_add_label`
- Add unit and real API tests

## Testing

- [✔️] Unit tests added/updated
- [✔️] Integration tests passed
- [✔️] Manual checks performed: Added it to the vscode extension Cline as MCP server and successfully used prompts like _'Which labels are set on the page with "Test" in the title?'_ and _'Add the label "test" to all subpages of the page 12345'_

## Checklist

- [✔️] Code follows project style guidelines (linting passes).
- [✔️] Tests added/updated for changes.
- [✔️] All tests pass locally.
- [✔️ ] Documentation updated (if needed).
