### PR TITLE
Correct jira_update_issue example for assignee format

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -944,7 +944,7 @@ async def list_tools() -> list[Tool]:
                                     "description": (
                                         "A valid JSON object of fields to update as a string. "
                                         'Example: \'{"summary": "New title", "description": "Updated description", '
-                                        '"priority": {"name": "High"}, "assignee": {"name": "john.doe"}}\''
+                                        '"priority": {"name": "High"}, "assignee": "john.doe"}\''
                                     ),
                                 },
                                 "additional_fields": {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->
This PR corrects the example JSON provided in the `jira_update_issue` tool description within `src/mcp_atlassian/server.py`. The previous example incorrectly showed the `assignee` value as a dictionary (`{"name": "..."}`). This was inconsistent with the implementation in `IssuesMixin.update_issue`, which expects a string identifier (username, email, or account ID) for the assignee.

This incorrect example caused runtime error, `AttributeError: 'dict' object has no attribute 'startswith'`, when the tool was used with the assignee provided as a dictionary. This fix resolves the inconsistency and prevents this error.

<!-- Link related issues: Fixes #<issue_number> -->

## Changes

<!-- Briefly list the key changes made. -->

- Corrected the `assignee` example format in the `jira_update_issue` tool description (`server.py`).

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Confirmed the fix works when using the `jira_update_issue` tool via Cursor MCP.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).