### PR TITLE
Support on-prem servers

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -54,6 +54,7 @@ class PagesMixin(ConfluenceClient):
                 # Override content with our processed version
                 content_override=page_content,
                 content_format="storage" if not convert_to_markdown else "markdown",
+                is_cloud=self.config.is_cloud,
             )
         except HTTPError as http_err:
             if http_err.response is not None and http_err.response.status_code in [
@@ -178,6 +179,7 @@ class PagesMixin(ConfluenceClient):
                 # Override content with our processed version
                 content_override=page_content,
                 content_format="storage" if not convert_to_markdown else "markdown",
+                is_cloud=self.config.is_cloud,
             )
 
         except KeyError as e:
@@ -245,6 +247,7 @@ class PagesMixin(ConfluenceClient):
                 # Override content with our processed version
                 content_override=page_content,
                 content_format="storage" if not convert_to_markdown else "markdown",
+                is_cloud=self.config.is_cloud,
             )
 
             page_models.append(page_model)

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -66,8 +66,8 @@ class SearchMixin(ConfluenceClient):
 
             # Convert the response to a search result model
             search_result = ConfluenceSearchResult.from_api_response(
-                results, 
-                base_url=self.config.url, 
+                results,
+                base_url=self.config.url,
                 cql_query=cql,
                 is_cloud=self.config.is_cloud,
             )

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -66,7 +66,10 @@ class SearchMixin(ConfluenceClient):
 
             # Convert the response to a search result model
             search_result = ConfluenceSearchResult.from_api_response(
-                results, base_url=self.config.url, cql_query=cql
+                results, 
+                base_url=self.config.url, 
+                cql_query=cql,
+                is_cloud=self.config.is_cloud,
             )
 
             # Process result excerpts as content

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -195,7 +195,7 @@ class ConfluencePage(ApiModel, TimestampMixin):
         url = None
         if base_url := kwargs.get("base_url"):
             page_id = data.get("id")
-            
+
             # Use different URL format based on whether it's cloud or server
             is_cloud = kwargs.get("is_cloud", False)
             if is_cloud:

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -117,17 +117,32 @@ class ConfluencePage(ApiModel, TimestampMixin):
 
         Args:
             data: The page data from the Confluence API
-            **kwargs: Additional context parameters, including:
-                - base_url: Base URL for constructing the page URL
-                - include_body: Whether to include the page body (defaults to True)
-                - content_format: Content format to use (defaults to "view")
-                - content_override: Optional content to use instead of extracting from API response
+            **kwargs: Additional keyword arguments
+                base_url: Base URL for constructing page URLs
+                include_body: Whether to include body content
+                content_override: Override the content value
+                content_format: Override the content format
+                is_cloud: Whether this is a cloud instance (affects URL format)
 
         Returns:
             A ConfluencePage instance
         """
         if not data:
             return cls()
+
+        # Extract space information first to ensure it's available for URL construction
+        space_data = data.get("space", {})
+        if not space_data:
+            # Try to extract space info from _expandable if available
+            if expandable := data.get("_expandable", {}):
+                if space_path := expandable.get("space"):
+                    # Extract space key from REST API path
+                    if space_path.startswith("/rest/api/space/"):
+                        space_key = space_path.split("/rest/api/space/")[1]
+                        space_data = {"key": space_key, "name": f"Space {space_key}"}
+
+        # Create space model
+        space = ConfluenceSpace.from_api_response(space_data)
 
         # Extract content based on format or use override if provided
         content = EMPTY_STRING
@@ -141,11 +156,6 @@ class ConfluencePage(ApiModel, TimestampMixin):
             body = data.get("body", {})
             if content_format in body:
                 content = body.get(content_format, {}).get("value", EMPTY_STRING)
-
-        # Process space
-        space = None
-        if space_data := data.get("space"):
-            space = ConfluenceSpace.from_api_response(space_data)
 
         # Process author/creator
         author = None
@@ -184,8 +194,17 @@ class ConfluencePage(ApiModel, TimestampMixin):
         # Construct URL if base_url is provided
         url = None
         if base_url := kwargs.get("base_url"):
-            url = f"{base_url}/spaces/{data.get('space', {}).get('key')}/"
-            url += f"pages/{data.get('id')}"
+            page_id = data.get("id")
+            
+            # Use different URL format based on whether it's cloud or server
+            is_cloud = kwargs.get("is_cloud", False)
+            if is_cloud:
+                # Cloud format: {base_url}/spaces/{space_key}/pages/{page_id}
+                space_key = space.key if space and space.key else "unknown"
+                url = f"{base_url}/spaces/{space_key}/pages/{page_id}"
+            else:
+                # Server format: {base_url}/pages/viewpage.action?pageId={page_id}
+                url = f"{base_url}/pages/viewpage.action?pageId={page_id}"
 
         return cls(
             id=str(data.get("id", CONFLUENCE_DEFAULT_ID)),

--- a/src/mcp_atlassian/models/confluence/search.py
+++ b/src/mcp_atlassian/models/confluence/search.py
@@ -39,6 +39,7 @@ class ConfluenceSearchResult(ApiModel, TimestampMixin):
             data: The search result data from the Confluence API
             **kwargs: Additional context parameters, including:
                 - base_url: Base URL for constructing page URLs
+                - is_cloud: Whether this is a cloud instance (affects URL format)
 
         Returns:
             A ConfluenceSearchResult instance

--- a/tests/unit/models/test_confluence_models.py
+++ b/tests/unit/models/test_confluence_models.py
@@ -418,12 +418,12 @@ class TestConfluencePage:
         page_data = {
             "id": "123456",
             "title": "Test Page",
-            "_expandable": {
-                "space": "/rest/api/space/TEST"
-            }
+            "_expandable": {"space": "/rest/api/space/TEST"},
         }
 
-        page = ConfluencePage.from_api_response(page_data, base_url="https://confluence.example.com")
+        page = ConfluencePage.from_api_response(
+            page_data, base_url="https://confluence.example.com", is_cloud=True
+        )
 
         assert page.space is not None
         assert page.space.key == "TEST"
@@ -432,12 +432,11 @@ class TestConfluencePage:
 
     def test_from_api_response_with_missing_space(self):
         """Test creating a ConfluencePage with no space information."""
-        page_data = {
-            "id": "123456",
-            "title": "Test Page"
-        }
+        page_data = {"id": "123456", "title": "Test Page"}
 
-        page = ConfluencePage.from_api_response(page_data, base_url="https://confluence.example.com")
+        page = ConfluencePage.from_api_response(
+            page_data, base_url="https://confluence.example.com", is_cloud=True
+        )
 
         assert page.space is not None
         assert page.space.key == ""  # Default from ConfluenceSpace
@@ -448,10 +447,12 @@ class TestConfluencePage:
         page_data = {
             "id": "123456",
             "title": "Test Page",
-            "space": {}  # Empty space data
+            "space": {},  # Empty space data
         }
 
-        page = ConfluencePage.from_api_response(page_data, base_url="https://confluence.example.com")
+        page = ConfluencePage.from_api_response(
+            page_data, base_url="https://confluence.example.com", is_cloud=True
+        )
 
         assert page.space is not None
         assert page.space.key == ""  # Default from ConfluenceSpace
@@ -462,7 +463,7 @@ class TestConfluencePage:
         page_data = {
             "id": "123456",
             "title": "Test Page",
-            "space": {"key": "TEST", "name": "Test Space"}
+            "space": {"key": "TEST", "name": "Test Space"},
         }
 
         page = ConfluencePage.from_api_response(page_data)  # No base_url provided
@@ -476,13 +477,11 @@ class TestConfluencePage:
         page_data = {
             "id": "123456",
             "title": "Test Page",
-            "space": {"key": "TEST", "name": "Test Space"}
+            "space": {"key": "TEST", "name": "Test Space"},
         }
 
         page = ConfluencePage.from_api_response(
-            page_data, 
-            base_url="https://example.atlassian.net/wiki",
-            is_cloud=True
+            page_data, base_url="https://example.atlassian.net/wiki", is_cloud=True
         )
 
         assert page.url == "https://example.atlassian.net/wiki/spaces/TEST/pages/123456"
@@ -492,16 +491,17 @@ class TestConfluencePage:
         page_data = {
             "id": "123456",
             "title": "Test Page",
-            "space": {"key": "TEST", "name": "Test Space"}
+            "space": {"key": "TEST", "name": "Test Space"},
         }
 
         page = ConfluencePage.from_api_response(
-            page_data, 
-            base_url="https://wiki.corp.example.com",
-            is_cloud=False
+            page_data, base_url="https://wiki.corp.example.com", is_cloud=False
         )
 
-        assert page.url == "https://wiki.corp.example.com/pages/viewpage.action?pageId=123456"
+        assert (
+            page.url
+            == "https://wiki.corp.example.com/pages/viewpage.action?pageId=123456"
+        )
 
 
 class TestConfluenceSearchResult:

--- a/tests/unit/models/test_confluence_models.py
+++ b/tests/unit/models/test_confluence_models.py
@@ -413,6 +413,96 @@ class TestConfluencePage:
         # URL should be included
         assert "url" in simplified
 
+    def test_from_api_response_with_expandable_space(self):
+        """Test creating a ConfluencePage from data with space info in _expandable."""
+        page_data = {
+            "id": "123456",
+            "title": "Test Page",
+            "_expandable": {
+                "space": "/rest/api/space/TEST"
+            }
+        }
+
+        page = ConfluencePage.from_api_response(page_data, base_url="https://confluence.example.com")
+
+        assert page.space is not None
+        assert page.space.key == "TEST"
+        assert page.space.name == "Space TEST"
+        assert page.url == "https://confluence.example.com/spaces/TEST/pages/123456"
+
+    def test_from_api_response_with_missing_space(self):
+        """Test creating a ConfluencePage with no space information."""
+        page_data = {
+            "id": "123456",
+            "title": "Test Page"
+        }
+
+        page = ConfluencePage.from_api_response(page_data, base_url="https://confluence.example.com")
+
+        assert page.space is not None
+        assert page.space.key == ""  # Default from ConfluenceSpace
+        assert page.url == "https://confluence.example.com/spaces/unknown/pages/123456"
+
+    def test_from_api_response_with_empty_space_data(self):
+        """Test creating a ConfluencePage with empty space data."""
+        page_data = {
+            "id": "123456",
+            "title": "Test Page",
+            "space": {}  # Empty space data
+        }
+
+        page = ConfluencePage.from_api_response(page_data, base_url="https://confluence.example.com")
+
+        assert page.space is not None
+        assert page.space.key == ""  # Default from ConfluenceSpace
+        assert page.url == "https://confluence.example.com/spaces/unknown/pages/123456"
+
+    def test_from_api_response_url_construction_without_base_url(self):
+        """Test that URL is None when base_url is not provided."""
+        page_data = {
+            "id": "123456",
+            "title": "Test Page",
+            "space": {"key": "TEST", "name": "Test Space"}
+        }
+
+        page = ConfluencePage.from_api_response(page_data)  # No base_url provided
+
+        assert page.url is None
+        assert page.space is not None
+        assert page.space.key == "TEST"
+
+    def test_url_construction_cloud_format(self):
+        """Test URL construction in cloud format."""
+        page_data = {
+            "id": "123456",
+            "title": "Test Page",
+            "space": {"key": "TEST", "name": "Test Space"}
+        }
+
+        page = ConfluencePage.from_api_response(
+            page_data, 
+            base_url="https://example.atlassian.net/wiki",
+            is_cloud=True
+        )
+
+        assert page.url == "https://example.atlassian.net/wiki/spaces/TEST/pages/123456"
+
+    def test_url_construction_server_format(self):
+        """Test URL construction in server format."""
+        page_data = {
+            "id": "123456",
+            "title": "Test Page",
+            "space": {"key": "TEST", "name": "Test Space"}
+        }
+
+        page = ConfluencePage.from_api_response(
+            page_data, 
+            base_url="https://wiki.corp.example.com",
+            is_cloud=False
+        )
+
+        assert page.url == "https://wiki.corp.example.com/pages/viewpage.action?pageId=123456"
+
 
 class TestConfluenceSearchResult:
     """Tests for the ConfluenceSearchResult model."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

This adds support for on-prem Confluence servers. The current code didn't work with my company's installation without these changes.

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

## Changes

<!-- Briefly list the key changes made. -->

- Detects whether Confluence is cloud or server and adjusts URLs based on that.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [X] Unit tests added/updated
- [x] Integration tests passed
- [X] Manual checks performed: Testing with my company's Confluence server (did not test with Confluence Cloud as I do not have an instance available)

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
