### PR TITLE
feat: Add enabled tools flag and environment variable to filter avail…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ There are two main approaches to configure the Docker container:
 > - `JIRA_PROJECTS_FILTER`: Filter by project keys (e.g., "PROJ,DEV,SUPPORT")
 > - `READ_ONLY_MODE`: Set to "true" to disable write operations
 > - `MCP_VERBOSE`: Set to "true" for more detailed logging
+> - `ENABLED_TOOLS`: Comma-separated list of tool names to enable (e.g., "confluence_search,jira_get_issue")
 >
 > See the [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) file for all available options.
 
@@ -372,6 +373,22 @@ For Jira Server/DC, use:
 ||`jira_remove_issue_link`|
 
 </details>
+
+### Tool Filtering and Access Control
+
+The server provides two ways to control tool access:
+
+1. **Tool Filtering**: Use `--enabled-tools` flag or `ENABLED_TOOLS` environment variable to specify which tools should be available:
+
+   ```bash
+   # Via environment variable
+   ENABLED_TOOLS="confluence_search,jira_get_issue,jira_search"
+
+   # Or via command line flag
+   docker run ... --enabled-tools "confluence_search,jira_get_issue,jira_search" ...
+   ```
+
+2. **Read/Write Control**: Tools are categorized as read or write operations. When `READ_ONLY_MODE` is enabled, only read operations are available regardless of `ENABLED_TOOLS` setting.
 
 ## Troubleshooting & Debugging
 

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -82,6 +82,10 @@ logger = setup_logging(logging_level)
     is_flag=True,
     help="Run in read-only mode (disables all write operations)",
 )
+@click.option(
+    "--enabled-tools",
+    help="Comma-separated list of tools to enable (enables all if not specified)",
+)
 def main(
     verbose: bool,
     env_file: str | None,
@@ -100,6 +104,7 @@ def main(
     jira_ssl_verify: bool,
     jira_projects_filter: str | None,
     read_only: bool = False,
+    enabled_tools: str | None = None,
 ) -> None:
     """MCP Atlassian Server - Jira and Confluence functionality for MCP
 
@@ -156,6 +161,14 @@ def main(
             logger.debug(
                 f"Using port '{final_port}' from command line argument for SSE transport."
             )
+
+    # Handle enabled tools from CLI or environment
+    if enabled_tools:
+        os.environ["ENABLED_TOOLS"] = enabled_tools
+    elif os.getenv("ENABLED_TOOLS"):
+        logger.debug("Using enabled tools from environment variable")
+    else:
+        logger.debug("No tool filtering specified, all tools will be enabled")
 
     # Set environment variables from command line arguments if provided
     if confluence_url:

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -21,12 +21,29 @@ from .utils.urls import is_atlassian_cloud_url
 logger = logging.getLogger("mcp-atlassian")
 
 
+def get_enabled_tools() -> list[str] | None:
+    """Get the list of enabled tools from environment variable."""
+    enabled_tools_str = os.getenv("ENABLED_TOOLS")
+    if enabled_tools_str:
+        # Split by commas and strip whitespace
+        return [tool.strip() for tool in enabled_tools_str.split(",")]
+    return None
+
+
+def should_include_tool(tool_name: str, enabled_tools: list[str] | None) -> bool:
+    """Check if a tool should be included based on the enabled tools list."""
+    if enabled_tools is None:
+        return True
+    return tool_name in enabled_tools
+
+
 @dataclass
 class AppContext:
     """Application context for MCP Atlassian."""
 
     confluence: ConfluenceFetcher | None = None
     jira: JiraFetcher | None = None
+    enabled_tools: list[str] | None = None
 
 
 def get_available_services() -> dict[str, bool | None]:
@@ -184,8 +201,13 @@ async def server_lifespan(server: Server) -> AsyncIterator[AppContext]:
             except Exception as e:
                 logger.error(f"Failed to initialize Jira client: {e}", exc_info=True)
 
+        # Get the list of enabled tools
+        enabled_tools = get_enabled_tools()
+        if enabled_tools:
+            logger.debug(f"Filtering tools to: {', '.join(enabled_tools)}")
+
         # Provide context to the application
-        yield AppContext(confluence=confluence, jira=jira)
+        yield AppContext(confluence=confluence, jira=jira, enabled_tools=enabled_tools)
     finally:
         # Cleanup resources if needed
         pass
@@ -207,1052 +229,1064 @@ async def list_tools() -> list[Tool]:
     # Add Confluence tools if Confluence is configured
     if ctx and ctx.confluence:
         # Always add read operations
-        tools.extend(
-            [
-                Tool(
-                    name="confluence_search",
-                    description="Search Confluence content using simple terms or CQL",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "query": {
-                                "type": "string",
-                                "description": "Search query - can be either a simple text (e.g. 'project documentation') or a CQL query string. Simple queries use 'siteSearch' by default, to mimic the WebUI search, with an automatic fallback to 'text' search if not supported. Examples of CQL:\n"
-                                "- Basic search: 'type=page AND space=DEV'\n"
-                                "- Personal space search: 'space=\"~username\"' (note: personal space keys starting with ~ must be quoted)\n"
-                                "- Search by title: 'title~\"Meeting Notes\"'\n"
-                                "- Use siteSearch: 'siteSearch ~ \"important concept\"'\n"
-                                "- Use text search: 'text ~ \"important concept\"'\n"
-                                "- Recent content: 'created >= \"2023-01-01\"'\n"
-                                "- Content with specific label: 'label=documentation'\n"
-                                "- Recently modified content: 'lastModified > startOfMonth(\"-1M\")'\n"
-                                "- Content modified this year: 'creator = currentUser() AND lastModified > startOfYear()'\n"
-                                "- Content you contributed to recently: 'contributor = currentUser() AND lastModified > startOfWeek()'\n"
-                                "- Content watched by user: 'watcher = \"user@domain.com\" AND type = page'\n"
-                                '- Exact phrase in content: \'text ~ "\\"Urgent Review Required\\"" AND label = "pending-approval"\'\n'
-                                '- Title wildcards: \'title ~ "Minutes*" AND (space = "HR" OR space = "Marketing")\'\n'
-                                'Note: Special identifiers need proper quoting in CQL: personal space keys (e.g., "~username"), reserved words, numeric IDs, and identifiers with special characters.',
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
-                            },
-                            "spaces_filter": {
-                                "type": "string",
-                                "description": "Comma-separated list of space keys to filter results by. Overrides the environment variable CONFLUENCE_SPACES_FILTER if provided.",
-                            },
+        confluence_read_tools = [
+            Tool(
+                name="confluence_search",
+                description="Search Confluence content using simple terms or CQL",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query - can be either a simple text (e.g. 'project documentation') or a CQL query string. Simple queries use 'siteSearch' by default, to mimic the WebUI search, with an automatic fallback to 'text' search if not supported. Examples of CQL:\n"
+                            "- Basic search: 'type=page AND space=DEV'\n"
+                            "- Personal space search: 'space=\"~username\"' (note: personal space keys starting with ~ must be quoted)\n"
+                            "- Search by title: 'title~\"Meeting Notes\"'\n"
+                            "- Use siteSearch: 'siteSearch ~ \"important concept\"'\n"
+                            "- Use text search: 'text ~ \"important concept\"'\n"
+                            "- Recent content: 'created >= \"2023-01-01\"'\n"
+                            "- Content with specific label: 'label=documentation'\n"
+                            "- Recently modified content: 'lastModified > startOfMonth(\"-1M\")'\n"
+                            "- Content modified this year: 'creator = currentUser() AND lastModified > startOfYear()'\n"
+                            "- Content you contributed to recently: 'contributor = currentUser() AND lastModified > startOfWeek()'\n"
+                            "- Content watched by user: 'watcher = \"user@domain.com\" AND type = page'\n"
+                            '- Exact phrase in content: \'text ~ "\\"Urgent Review Required\\"" AND label = "pending-approval"\'\n'
+                            '- Title wildcards: \'title ~ "Minutes*" AND (space = "HR" OR space = "Marketing")\'\n'
+                            'Note: Special identifiers need proper quoting in CQL: personal space keys (e.g., "~username"), reserved words, numeric IDs, and identifiers with special characters.',
                         },
-                        "required": ["query"],
-                    },
-                ),
-                Tool(
-                    name="confluence_get_page",
-                    description="Get content of a specific Confluence page by ID",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "page_id": {
-                                "type": "string",
-                                "description": "Confluence page ID (numeric ID, can be found in the page URL). "
-                                "For example, in the URL 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', "
-                                "the page ID is '123456789'",
-                            },
-                            "include_metadata": {
-                                "type": "boolean",
-                                "description": "Whether to include page metadata such as creation date, last update, version, and labels",
-                                "default": True,
-                            },
-                            "convert_to_markdown": {
-                                "type": "boolean",
-                                "description": "Whether to convert page to markdown (true) or keep it in raw HTML format (false). Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: using HTML significantly increases token usage in AI responses.",
-                                "default": True,
-                            },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
                         },
-                        "required": ["page_id"],
-                    },
-                ),
-                Tool(
-                    name="confluence_get_page_children",
-                    description="Get child pages of a specific Confluence page",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "parent_id": {
-                                "type": "string",
-                                "description": "The ID of the parent page whose children you want to retrieve",
-                            },
-                            "expand": {
-                                "type": "string",
-                                "description": "Fields to expand in the response (e.g., 'version', 'body.storage')",
-                                "default": "version",
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of child pages to return (1-50)",
-                                "default": 25,
-                                "minimum": 1,
-                                "maximum": 50,
-                            },
-                            "include_content": {
-                                "type": "boolean",
-                                "description": "Whether to include the page content in the response",
-                                "default": False,
-                            },
+                        "spaces_filter": {
+                            "type": "string",
+                            "description": "Comma-separated list of space keys to filter results by. Overrides the environment variable CONFLUENCE_SPACES_FILTER if provided.",
                         },
-                        "required": ["parent_id"],
                     },
-                ),
-                Tool(
-                    name="confluence_get_page_ancestors",
-                    description="Get ancestor (parent) pages of a specific Confluence page",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "page_id": {
-                                "type": "string",
-                                "description": "The ID of the page whose ancestors you want to retrieve",
-                            },
+                    "required": ["query"],
+                },
+            ),
+            Tool(
+                name="confluence_get_page",
+                description="Get content of a specific Confluence page by ID",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "Confluence page ID (numeric ID, can be found in the page URL). "
+                            "For example, in the URL 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', "
+                            "the page ID is '123456789'",
                         },
-                        "required": ["page_id"],
-                    },
-                ),
-                Tool(
-                    name="confluence_get_comments",
-                    description="Get comments for a specific Confluence page",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "page_id": {
-                                "type": "string",
-                                "description": "Confluence page ID (numeric ID, can be parsed from URL, "
-                                "e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' "
-                                "-> '123456789')",
-                            }
+                        "include_metadata": {
+                            "type": "boolean",
+                            "description": "Whether to include page metadata such as creation date, last update, version, and labels",
+                            "default": True,
                         },
-                        "required": ["page_id"],
-                    },
-                ),
-                Tool(
-                    name="confluence_get_labels",
-                    description="Get labels for a specific Confluence page",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "page_id": {
-                                "type": "string",
-                                "description": "Confluence page ID (numeric ID, can be parsed from URL, "
-                                "e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' "
-                                "-> '123456789')",
-                            }
+                        "convert_to_markdown": {
+                            "type": "boolean",
+                            "description": "Whether to convert page to markdown (true) or keep it in raw HTML format (false). Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: using HTML significantly increases token usage in AI responses.",
+                            "default": True,
                         },
-                        "required": ["page_id"],
                     },
-                ),
-            ]
-        )
+                    "required": ["page_id"],
+                },
+            ),
+            Tool(
+                name="confluence_get_page_children",
+                description="Get child pages of a specific Confluence page",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "parent_id": {
+                            "type": "string",
+                            "description": "The ID of the parent page whose children you want to retrieve",
+                        },
+                        "expand": {
+                            "type": "string",
+                            "description": "Fields to expand in the response (e.g., 'version', 'body.storage')",
+                            "default": "version",
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of child pages to return (1-50)",
+                            "default": 25,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                        "include_content": {
+                            "type": "boolean",
+                            "description": "Whether to include the page content in the response",
+                            "default": False,
+                        },
+                    },
+                    "required": ["parent_id"],
+                },
+            ),
+            Tool(
+                name="confluence_get_page_ancestors",
+                description="Get ancestor (parent) pages of a specific Confluence page",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "The ID of the page whose ancestors you want to retrieve",
+                        },
+                    },
+                    "required": ["page_id"],
+                },
+            ),
+            Tool(
+                name="confluence_get_comments",
+                description="Get comments for a specific Confluence page",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "Confluence page ID (numeric ID, can be parsed from URL, "
+                            "e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' "
+                            "-> '123456789')",
+                        }
+                    },
+                    "required": ["page_id"],
+                },
+            ),
+            Tool(
+                name="confluence_get_labels",
+                description="Get labels for a specific Confluence page",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "page_id": {
+                            "type": "string",
+                            "description": "Confluence page ID (numeric ID, can be parsed from URL, "
+                            "e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' "
+                            "-> '123456789')",
+                        }
+                    },
+                    "required": ["page_id"],
+                },
+            ),
+        ]
+
+        # Filter and add read-only tools
+        for tool in confluence_read_tools:
+            if should_include_tool(tool.name, ctx.enabled_tools):
+                tools.append(tool)
 
         # Only add write operations if not in read-only mode
         if not read_only:
-            tools.extend(
-                [
-                    Tool(
-                        name="confluence_create_page",
-                        description="Create a new Confluence page",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "space_key": {
-                                    "type": "string",
-                                    "description": "The key of the space to create the page in "
-                                    "(usually a short uppercase code like 'DEV', 'TEAM', or 'DOC')",
-                                },
-                                "title": {
-                                    "type": "string",
-                                    "description": "The title of the page",
-                                },
-                                "content": {
-                                    "type": "string",
-                                    "description": "The content of the page in Markdown format. "
-                                    "Supports headings, lists, tables, code blocks, and other "
-                                    "Markdown syntax",
-                                },
-                                "parent_id": {
-                                    "type": "string",
-                                    "description": "Optional parent page ID. If provided, this page "
-                                    "will be created as a child of the specified page",
-                                },
+            confluence_write_tools = [
+                Tool(
+                    name="confluence_create_page",
+                    description="Create a new Confluence page",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "space_key": {
+                                "type": "string",
+                                "description": "The key of the space to create the page in "
+                                "(usually a short uppercase code like 'DEV', 'TEAM', or 'DOC')",
                             },
-                            "required": ["space_key", "title", "content"],
-                        },
-                    ),
-                    Tool(
-                        name="confluence_update_page",
-                        description="Update an existing Confluence page",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "page_id": {
-                                    "type": "string",
-                                    "description": "The ID of the page to update",
-                                },
-                                "title": {
-                                    "type": "string",
-                                    "description": "The new title of the page",
-                                },
-                                "content": {
-                                    "type": "string",
-                                    "description": "The new content of the page in Markdown format",
-                                },
-                                "is_minor_edit": {
-                                    "type": "boolean",
-                                    "description": "Whether this is a minor edit",
-                                    "default": False,
-                                },
-                                "version_comment": {
-                                    "type": "string",
-                                    "description": "Optional comment for this version",
-                                    "default": "",
-                                },
-                                "parent_id": {
-                                    "type": "string",
-                                    "description": "Optional the new parent page ID",
-                                },
+                            "title": {
+                                "type": "string",
+                                "description": "The title of the page",
                             },
-                            "required": ["page_id", "title", "content"],
-                        },
-                    ),
-                    Tool(
-                        name="confluence_delete_page",
-                        description="Delete an existing Confluence page",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "page_id": {
-                                    "type": "string",
-                                    "description": "The ID of the page to delete",
-                                },
+                            "content": {
+                                "type": "string",
+                                "description": "The content of the page in Markdown format. "
+                                "Supports headings, lists, tables, code blocks, and other "
+                                "Markdown syntax",
                             },
-                            "required": ["page_id"],
-                        },
-                    ),
-                    Tool(
-                        name="confluence_add_label",
-                        description="Add label to an existing Confluence page",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "page_id": {
-                                    "type": "string",
-                                    "description": "The ID of the page to update",
-                                },
-                                "name": {
-                                    "type": "string",
-                                    "description": "The name of the label",
-                                },
+                            "parent_id": {
+                                "type": "string",
+                                "description": "Optional parent page ID. If provided, this page "
+                                "will be created as a child of the specified page",
                             },
-                            "required": ["page_id", "name"],
                         },
-                    ),
-                ]
-            )
+                        "required": ["space_key", "title", "content"],
+                    },
+                ),
+                Tool(
+                    name="confluence_update_page",
+                    description="Update an existing Confluence page",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "page_id": {
+                                "type": "string",
+                                "description": "The ID of the page to update",
+                            },
+                            "title": {
+                                "type": "string",
+                                "description": "The new title of the page",
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": "The new content of the page in Markdown format",
+                            },
+                            "is_minor_edit": {
+                                "type": "boolean",
+                                "description": "Whether this is a minor edit",
+                                "default": False,
+                            },
+                            "version_comment": {
+                                "type": "string",
+                                "description": "Optional comment for this version",
+                                "default": "",
+                            },
+                            "parent_id": {
+                                "type": "string",
+                                "description": "Optional the new parent page ID",
+                            },
+                        },
+                        "required": ["page_id", "title", "content"],
+                    },
+                ),
+                Tool(
+                    name="confluence_delete_page",
+                    description="Delete an existing Confluence page",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "page_id": {
+                                "type": "string",
+                                "description": "The ID of the page to delete",
+                            },
+                        },
+                        "required": ["page_id"],
+                    },
+                ),
+                Tool(
+                    name="confluence_add_label",
+                    description="Add label to an existing Confluence page",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "page_id": {
+                                "type": "string",
+                                "description": "The ID of the page to update",
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the label",
+                            },
+                        },
+                        "required": ["page_id", "name"],
+                    },
+                ),
+            ]
+
+            # Filter and add write tools
+            for tool in confluence_write_tools:
+                if should_include_tool(tool.name, ctx.enabled_tools):
+                    tools.append(tool)
 
     # Add Jira tools if Jira is configured
     if ctx and ctx.jira:
         # Always add read operations
-        tools.extend(
-            [
+        jira_read_tools = [
+            Tool(
+                name="jira_get_issue",
+                description="Get details of a specific Jira issue including its Epic links and relationship information",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "issue_key": {
+                            "type": "string",
+                            "description": "Jira issue key (e.g., 'PROJ-123')",
+                        },
+                        "fields": {
+                            "type": "string",
+                            "description": "Fields to return. Can be a comma-separated list (e.g., 'summary,status,customfield_10010'), '*all' for all fields (including custom fields), or omitted for essential fields only",
+                            "default": "summary,description,status,assignee,reporter,labels,priority,created,updated,issuetype",
+                        },
+                        "expand": {
+                            "type": "string",
+                            "description": (
+                                "Optional fields to expand. Examples: 'renderedFields' "
+                                "(for rendered content), 'transitions' (for available "
+                                "status transitions), 'changelog' (for history)"
+                            ),
+                            "default": None,
+                        },
+                        "comment_limit": {
+                            "type": "integer",
+                            "description": (
+                                "Maximum number of comments to include "
+                                "(0 or null for no comments)"
+                            ),
+                            "minimum": 0,
+                            "maximum": 100,
+                            "default": 10,
+                        },
+                        "properties": {
+                            "type": "string",
+                            "description": "A comma-separated list of issue properties to return",
+                            "default": None,
+                        },
+                        "update_history": {
+                            "type": "boolean",
+                            "description": "Whether to update the issue view history for the requesting user",
+                            "default": True,
+                        },
+                    },
+                    "required": ["issue_key"],
+                },
+            ),
+            Tool(
+                name="jira_search",
+                description="Search Jira issues using JQL (Jira Query Language)",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "jql": {
+                            "type": "string",
+                            "description": "JQL query string (Jira Query Language). Examples:\n"
+                            '- Find Epics: "issuetype = Epic AND project = PROJ"\n'
+                            '- Find issues in Epic: "parent = PROJ-123"\n'
+                            "- Find by status: \"status = 'In Progress' AND project = PROJ\"\n"
+                            '- Find by assignee: "assignee = currentUser()"\n'
+                            '- Find recently updated: "updated >= -7d AND project = PROJ"\n'
+                            '- Find by label: "labels = frontend AND project = PROJ"\n'
+                            '- Find by priority: "priority = High AND project = PROJ"',
+                        },
+                        "fields": {
+                            "type": "string",
+                            "description": (
+                                "Comma-separated fields to return in the results. "
+                                "Use '*all' for all fields, or specify individual "
+                                "fields like 'summary,status,assignee,priority'"
+                            ),
+                            "default": "summary,description,status,assignee,reporter,labels,priority,created,updated,issuetype",
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                        "startAt": {
+                            "type": "number",
+                            "description": "Starting index for pagination (0-based)",
+                            "default": 0,
+                            "minimum": 0,
+                        },
+                        "projects_filter": {
+                            "type": "string",
+                            "description": "Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided.",
+                        },
+                    },
+                    "required": ["jql"],
+                },
+            ),
+            Tool(
+                name="jira_search_fields",
+                description="Search Jira fields by keyword with fuzzy match",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "keyword": {
+                            "type": "string",
+                            "description": "Keyword for fuzzy search. If left empty, lists the first 'limit' available fields in their default order.",
+                            "default": "",
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results",
+                            "default": 10,
+                            "minimum": 1,
+                        },
+                        "refresh": {
+                            "type": "boolean",
+                            "description": "Whether to force refresh the field list",
+                            "default": False,
+                        },
+                    },
+                    "required": [],
+                },
+            ),
+            Tool(
+                name="jira_get_project_issues",
+                description="Get all issues for a specific Jira project",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "project_key": {
+                            "type": "string",
+                            "description": "The project key",
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                        "startAt": {
+                            "type": "number",
+                            "description": "Starting index for pagination (0-based)",
+                            "default": 0,
+                            "minimum": 0,
+                        },
+                    },
+                    "required": ["project_key"],
+                },
+            ),
+            Tool(
+                name="jira_get_epic_issues",
+                description="Get all issues linked to a specific epic",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "epic_key": {
+                            "type": "string",
+                            "description": "The key of the epic (e.g., 'PROJ-123')",
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of issues to return (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                        "startAt": {
+                            "type": "number",
+                            "description": "Starting index for pagination (0-based)",
+                            "default": 0,
+                            "minimum": 0,
+                        },
+                    },
+                    "required": ["epic_key"],
+                },
+            ),
+            Tool(
+                name="jira_get_transitions",
+                description="Get available status transitions for a Jira issue",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "issue_key": {
+                            "type": "string",
+                            "description": "Jira issue key (e.g., 'PROJ-123')",
+                        },
+                    },
+                    "required": ["issue_key"],
+                },
+            ),
+            Tool(
+                name="jira_get_worklog",
+                description="Get worklog entries for a Jira issue",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "issue_key": {
+                            "type": "string",
+                            "description": "Jira issue key (e.g., 'PROJ-123')",
+                        },
+                    },
+                    "required": ["issue_key"],
+                },
+            ),
+            Tool(
+                name="jira_download_attachments",
+                description="Download attachments from a Jira issue",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "issue_key": {
+                            "type": "string",
+                            "description": "Jira issue key (e.g., 'PROJ-123')",
+                        },
+                        "target_dir": {
+                            "type": "string",
+                            "description": "Directory where attachments should be saved",
+                        },
+                    },
+                    "required": ["issue_key", "target_dir"],
+                },
+            ),
+            Tool(
+                name="jira_get_agile_boards",
+                description="Get jira agile boards by name, project key, or type",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "board_name": {
+                            "type": "string",
+                            "description": "The name of board, support fuzzy search",
+                        },
+                        "project_key": {
+                            "type": "string",
+                            "description": "Jira project key (e.g., 'PROJ-123')",
+                        },
+                        "board_type": {
+                            "type": "string",
+                            "description": "The type of jira board (e.g., 'scrum', 'kanban')",
+                        },
+                        "startAt": {
+                            "type": "number",
+                            "description": "Starting index for pagination (0-based)",
+                            "default": 0,
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="jira_get_board_issues",
+                description="Get all issues linked to a specific board",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "board_id": {
+                            "type": "string",
+                            "description": "The id of the board (e.g., '1001')",
+                        },
+                        "jql": {
+                            "type": "string",
+                            "description": "JQL query string (Jira Query Language). Examples:\n"
+                            '- Find Epics: "issuetype = Epic AND project = PROJ"\n'
+                            '- Find issues in Epic: "parent = PROJ-123"\n'
+                            "- Find by status: \"status = 'In Progress' AND project = PROJ\"\n"
+                            '- Find by assignee: "assignee = currentUser()"\n'
+                            '- Find recently updated: "updated >= -7d AND project = PROJ"\n'
+                            '- Find by label: "labels = frontend AND project = PROJ"\n'
+                            '- Find by priority: "priority = High AND project = PROJ"',
+                        },
+                        "fields": {
+                            "type": "string",
+                            "description": (
+                                "Comma-separated fields to return in the results. "
+                                "Use '*all' for all fields, or specify individual "
+                                "fields like 'summary,status,assignee,priority'"
+                            ),
+                            "default": "*all",
+                        },
+                        "startAt": {
+                            "type": "number",
+                            "description": "Starting index for pagination (0-based)",
+                            "default": 0,
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                        "expand": {
+                            "type": "string",
+                            "description": "Fields to expand in the response (e.g., 'version', 'body.storage')",
+                            "default": "version",
+                        },
+                    },
+                    "required": ["board_id", "jql"],
+                },
+            ),
+            Tool(
+                name="jira_get_sprints_from_board",
+                description="Get jira sprints from board by state",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "board_id": {
+                            "type": "string",
+                            "description": "The id of board (e.g., '1000')",
+                        },
+                        "state": {
+                            "type": "string",
+                            "description": "Sprint state (e.g., 'active', 'future', 'closed')",
+                        },
+                        "startAt": {
+                            "type": "number",
+                            "description": "Starting index for pagination (0-based)",
+                            "default": 0,
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="jira_create_sprint",
+                description="Create Jira sprint for a board",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "board_id": {
+                            "type": "string",
+                            "description": "The id of board (e.g., '1000')",
+                        },
+                        "sprint_name": {
+                            "type": "string",
+                            "description": "Name of the sprint (e.g., 'Sprint 1')",
+                        },
+                        "start_date": {
+                            "type": "string",
+                            "description": "Start time for sprint (ISO 8601 format)",
+                        },
+                        "end_date": {
+                            "type": "string",
+                            "description": "End time for sprint (ISO 8601 format)",
+                        },
+                        "goal": {
+                            "type": "string",
+                            "description": "Goal of the sprint",
+                        },
+                    },
+                    "required": [
+                        "board_id",
+                        "sprint_name",
+                        "start_date",
+                        "end_date",
+                    ],
+                },
+            ),
+            Tool(
+                name="jira_get_sprint_issues",
+                description="Get jira issues from sprint",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "sprint_id": {
+                            "type": "string",
+                            "description": "The id of sprint (e.g., '10001')",
+                        },
+                        "fields": {
+                            "type": "string",
+                            "description": (
+                                "Comma-separated fields to return in the results. "
+                                "Use '*all' for all fields, or specify individual "
+                                "fields like 'summary,status,assignee,priority'"
+                            ),
+                            "default": "*all",
+                        },
+                        "startAt": {
+                            "type": "number",
+                            "description": "Starting index for pagination (0-based)",
+                            "default": 0,
+                        },
+                        "limit": {
+                            "type": "number",
+                            "description": "Maximum number of results (1-50)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 50,
+                        },
+                    },
+                    "required": ["sprint_id"],
+                },
+            ),
+            Tool(
+                name="jira_update_sprint",
+                description="Update jira sprint",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "sprint_id": {
+                            "type": "string",
+                            "description": "The id of sprint (e.g., '10001')",
+                        },
+                        "sprint_name": {
+                            "type": "string",
+                            "description": "Optional: New name for the sprint",
+                        },
+                        "state": {
+                            "type": "string",
+                            "description": "Optional: New state for the sprint (future|active|closed)",
+                        },
+                        "start_date": {
+                            "type": "string",
+                            "description": "Optional: New start date for the sprint",
+                        },
+                        "end_date": {
+                            "type": "string",
+                            "description": "Optional: New end date for the sprint",
+                        },
+                        "goal": {
+                            "type": "string",
+                            "description": "Optional: New goal for the sprint",
+                        },
+                    },
+                    "required": ["sprint_id"],
+                },
+            ),
+        ]
+
+        # Filter and add read-only tools
+        for tool in jira_read_tools:
+            if should_include_tool(tool.name, ctx.enabled_tools):
+                tools.append(tool)
+
+        # Only add write operations if not in read-only mode
+        if not read_only:
+            jira_write_tools = [
                 Tool(
-                    name="jira_get_issue",
-                    description="Get details of a specific Jira issue including its Epic links and relationship information",
+                    name="jira_create_issue",
+                    description="Create a new Jira issue with optional Epic link or parent for subtasks",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "issue_key": {
-                                "type": "string",
-                                "description": "Jira issue key (e.g., 'PROJ-123')",
-                            },
-                            "fields": {
-                                "type": "string",
-                                "description": "Fields to return. Can be a comma-separated list (e.g., 'summary,status,customfield_10010'), '*all' for all fields (including custom fields), or omitted for essential fields only",
-                                "default": "summary,description,status,assignee,reporter,labels,priority,created,updated,issuetype",
-                            },
-                            "expand": {
+                            "project_key": {
                                 "type": "string",
                                 "description": (
-                                    "Optional fields to expand. Examples: 'renderedFields' "
-                                    "(for rendered content), 'transitions' (for available "
-                                    "status transitions), 'changelog' (for history)"
+                                    "The JIRA project key (e.g. 'PROJ', 'DEV', 'SUPPORT'). "
+                                    "This is the prefix of issue keys in your project. "
+                                    "Never assume what it might be, always ask the user."
                                 ),
+                            },
+                            "summary": {
+                                "type": "string",
+                                "description": "Summary/title of the issue",
+                            },
+                            "issue_type": {
+                                "type": "string",
+                                "description": (
+                                    "Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). "
+                                    "The available types depend on your project configuration. "
+                                    "For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields."
+                                ),
+                            },
+                            "assignee": {
+                                "type": "string",
+                                "description": "Assignee of the ticket (accountID, full name or e-mail)",
                                 "default": None,
                             },
-                            "comment_limit": {
-                                "type": "integer",
-                                "description": (
-                                    "Maximum number of comments to include "
-                                    "(0 or null for no comments)"
-                                ),
-                                "minimum": 0,
-                                "maximum": 100,
-                                "default": 10,
-                            },
-                            "properties": {
+                            "description": {
                                 "type": "string",
-                                "description": "A comma-separated list of issue properties to return",
-                                "default": None,
-                            },
-                            "update_history": {
-                                "type": "boolean",
-                                "description": "Whether to update the issue view history for the requesting user",
-                                "default": True,
-                            },
-                        },
-                        "required": ["issue_key"],
-                    },
-                ),
-                Tool(
-                    name="jira_search",
-                    description="Search Jira issues using JQL (Jira Query Language)",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "jql": {
-                                "type": "string",
-                                "description": "JQL query string (Jira Query Language). Examples:\n"
-                                '- Find Epics: "issuetype = Epic AND project = PROJ"\n'
-                                '- Find issues in Epic: "parent = PROJ-123"\n'
-                                "- Find by status: \"status = 'In Progress' AND project = PROJ\"\n"
-                                '- Find by assignee: "assignee = currentUser()"\n'
-                                '- Find recently updated: "updated >= -7d AND project = PROJ"\n'
-                                '- Find by label: "labels = frontend AND project = PROJ"\n'
-                                '- Find by priority: "priority = High AND project = PROJ"',
-                            },
-                            "fields": {
-                                "type": "string",
-                                "description": (
-                                    "Comma-separated fields to return in the results. "
-                                    "Use '*all' for all fields, or specify individual "
-                                    "fields like 'summary,status,assignee,priority'"
-                                ),
-                                "default": "summary,description,status,assignee,reporter,labels,priority,created,updated,issuetype",
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
-                            },
-                            "startAt": {
-                                "type": "number",
-                                "description": "Starting index for pagination (0-based)",
-                                "default": 0,
-                                "minimum": 0,
-                            },
-                            "projects_filter": {
-                                "type": "string",
-                                "description": "Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided.",
-                            },
-                        },
-                        "required": ["jql"],
-                    },
-                ),
-                Tool(
-                    name="jira_search_fields",
-                    description="Search Jira fields by keyword with fuzzy match",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "keyword": {
-                                "type": "string",
-                                "description": "Keyword for fuzzy search. If left empty, lists the first 'limit' available fields in their default order.",
+                                "description": "Issue description",
                                 "default": "",
                             },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results",
-                                "default": 10,
-                                "minimum": 1,
+                            "components": {
+                                "type": "string",
+                                "description": "Comma-separated list of component names to assign (e.g., 'Frontend,API')",
+                                "default": "",
                             },
-                            "refresh": {
+                            "additional_fields": {
+                                "type": "string",
+                                "description": (
+                                    "Optional JSON string of additional fields to set. "
+                                    "Examples:\n"
+                                    '- Set priority: {"priority": {"name": "High"}}\n'
+                                    '- Add labels: {"labels": ["frontend", "urgent"]}\n'
+                                    '- Link to parent (for any issue type): {"parent": "PROJ-123"}\n'
+                                    '- Set Fix Version/s: {"fixVersions": [{"id": "10020"}]}\n'
+                                    '- Custom fields: {"customfield_10010": "value"}'
+                                ),
+                                "default": "{}",
+                            },
+                        },
+                        "required": ["project_key", "summary", "issue_type"],
+                    },
+                ),
+                Tool(
+                    name="jira_batch_create_issues",
+                    description="Create multiple Jira issues in a batch",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "issues": {
+                                "type": "string",
+                                "description": (
+                                    "JSON array of issue objects. Each object should contain:\n"
+                                    "- project_key (required): The project key (e.g., 'PROJ')\n"
+                                    "- summary (required): Issue summary/title\n"
+                                    "- issue_type (required): Type of issue (e.g., 'Task', 'Bug')\n"
+                                    "- description (optional): Issue description\n"
+                                    "- assignee (optional): Assignee username or email\n"
+                                    "- components (optional): Array of component names\n"
+                                    "Example: [\n"
+                                    '  {"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"},\n'
+                                    '  {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}\n'
+                                    "]"
+                                ),
+                            },
+                            "validate_only": {
                                 "type": "boolean",
-                                "description": "Whether to force refresh the field list",
+                                "description": "If true, only validates the issues without creating them",
                                 "default": False,
                             },
                         },
-                        "required": [],
+                        "required": ["issues"],
                     },
                 ),
                 Tool(
-                    name="jira_get_project_issues",
-                    description="Get all issues for a specific Jira project",
+                    name="jira_batch_get_changelogs",
+                    description="Get changelogs for multiple Jira issues (Cloud only)",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "project_key": {
-                                "type": "string",
-                                "description": "The project key",
+                            "issue_ids_or_keys": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "List of Jira issue IDs or keys, e.g. ['PROJ-123', 'PROJ-124']",
+                            },
+                            "fields": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Filter the changelogs by fields, e.g. ['status', 'assignee']. Default to [] for all fields.",
+                                "default": [],
                             },
                             "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
-                            },
-                            "startAt": {
-                                "type": "number",
-                                "description": "Starting index for pagination (0-based)",
-                                "default": 0,
-                                "minimum": 0,
+                                "type": "integer",
+                                "description": (
+                                    "Maximum number of changelogs to return in result for each issue. "
+                                    "Default to -1 for all changelogs. "
+                                    "Notice that it only limits the results in the response, "
+                                    "the function will still fetch all the data."
+                                ),
+                                "default": -1,
                             },
                         },
-                        "required": ["project_key"],
+                        "required": ["issue_ids_or_keys"],
                     },
                 ),
                 Tool(
-                    name="jira_get_epic_issues",
-                    description="Get all issues linked to a specific epic",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "epic_key": {
-                                "type": "string",
-                                "description": "The key of the epic (e.g., 'PROJ-123')",
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of issues to return (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
-                            },
-                            "startAt": {
-                                "type": "number",
-                                "description": "Starting index for pagination (0-based)",
-                                "default": 0,
-                                "minimum": 0,
-                            },
-                        },
-                        "required": ["epic_key"],
-                    },
-                ),
-                Tool(
-                    name="jira_get_transitions",
-                    description="Get available status transitions for a Jira issue",
+                    name="jira_update_issue",
+                    description="Update an existing Jira issue including changing status, adding Epic links, updating fields, etc.",
                     inputSchema={
                         "type": "object",
                         "properties": {
                             "issue_key": {
                                 "type": "string",
                                 "description": "Jira issue key (e.g., 'PROJ-123')",
-                            },
-                        },
-                        "required": ["issue_key"],
-                    },
-                ),
-                Tool(
-                    name="jira_get_worklog",
-                    description="Get worklog entries for a Jira issue",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "issue_key": {
-                                "type": "string",
-                                "description": "Jira issue key (e.g., 'PROJ-123')",
-                            },
-                        },
-                        "required": ["issue_key"],
-                    },
-                ),
-                Tool(
-                    name="jira_download_attachments",
-                    description="Download attachments from a Jira issue",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "issue_key": {
-                                "type": "string",
-                                "description": "Jira issue key (e.g., 'PROJ-123')",
-                            },
-                            "target_dir": {
-                                "type": "string",
-                                "description": "Directory where attachments should be saved",
-                            },
-                        },
-                        "required": ["issue_key", "target_dir"],
-                    },
-                ),
-                Tool(
-                    name="jira_get_agile_boards",
-                    description="Get jira agile boards by name, project key, or type",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "board_name": {
-                                "type": "string",
-                                "description": "The name of board, support fuzzy search",
-                            },
-                            "project_key": {
-                                "type": "string",
-                                "description": "Jira project key (e.g., 'PROJ-123')",
-                            },
-                            "board_type": {
-                                "type": "string",
-                                "description": "The type of jira board (e.g., 'scrum', 'kanban')",
-                            },
-                            "startAt": {
-                                "type": "number",
-                                "description": "Starting index for pagination (0-based)",
-                                "default": 0,
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
-                            },
-                        },
-                    },
-                ),
-                Tool(
-                    name="jira_get_board_issues",
-                    description="Get all issues linked to a specific board",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "board_id": {
-                                "type": "string",
-                                "description": "The id of the board (e.g., '1001')",
-                            },
-                            "jql": {
-                                "type": "string",
-                                "description": "JQL query string (Jira Query Language). Examples:\n"
-                                '- Find Epics: "issuetype = Epic AND project = PROJ"\n'
-                                '- Find issues in Epic: "parent = PROJ-123"\n'
-                                "- Find by status: \"status = 'In Progress' AND project = PROJ\"\n"
-                                '- Find by assignee: "assignee = currentUser()"\n'
-                                '- Find recently updated: "updated >= -7d AND project = PROJ"\n'
-                                '- Find by label: "labels = frontend AND project = PROJ"\n'
-                                '- Find by priority: "priority = High AND project = PROJ"',
                             },
                             "fields": {
                                 "type": "string",
                                 "description": (
-                                    "Comma-separated fields to return in the results. "
-                                    "Use '*all' for all fields, or specify individual "
-                                    "fields like 'summary,status,assignee,priority'"
+                                    "A valid JSON object of fields to update as a string. "
+                                    'Example: \'{"summary": "New title", "description": "Updated description", '
+                                    '"priority": {"name": "High"}, "assignee": "john.doe"}\''
                                 ),
-                                "default": "*all",
                             },
-                            "startAt": {
-                                "type": "number",
-                                "description": "Starting index for pagination (0-based)",
-                                "default": 0,
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
-                            },
-                            "expand": {
+                            "additional_fields": {
                                 "type": "string",
-                                "description": "Fields to expand in the response (e.g., 'version', 'body.storage')",
-                                "default": "version",
+                                "description": "Optional JSON string of additional fields to update. Use this for custom fields or more complex updates.",
+                                "default": "{}",
+                            },
+                            "attachments": {
+                                "type": "string",
+                                "description": "Optional JSON string or comma-separated list of file paths to attach to the issue. "
+                                'Example: "/path/to/file1.txt,/path/to/file2.txt" or "["/path/to/file1.txt","/path/to/file2.txt"]"',
                             },
                         },
-                        "required": ["board_id", "jql"],
+                        "required": ["issue_key", "fields"],
                     },
                 ),
                 Tool(
-                    name="jira_get_sprints_from_board",
-                    description="Get jira sprints from board by state",
+                    name="jira_delete_issue",
+                    description="Delete an existing Jira issue",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "board_id": {
+                            "issue_key": {
                                 "type": "string",
-                                "description": "The id of board (e.g., '1000')",
-                            },
-                            "state": {
-                                "type": "string",
-                                "description": "Sprint state (e.g., 'active', 'future', 'closed')",
-                            },
-                            "startAt": {
-                                "type": "number",
-                                "description": "Starting index for pagination (0-based)",
-                                "default": 0,
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
+                                "description": "Jira issue key (e.g. PROJ-123)",
                             },
                         },
+                        "required": ["issue_key"],
                     },
                 ),
                 Tool(
-                    name="jira_create_sprint",
-                    description="Create Jira sprint for a board",
+                    name="jira_add_comment",
+                    description="Add a comment to a Jira issue",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "board_id": {
+                            "issue_key": {
                                 "type": "string",
-                                "description": "The id of board (e.g., '1000')",
+                                "description": "Jira issue key (e.g., 'PROJ-123')",
                             },
-                            "sprint_name": {
+                            "comment": {
                                 "type": "string",
-                                "description": "Name of the sprint (e.g., 'Sprint 1')",
+                                "description": "Comment text in Markdown format",
                             },
-                            "start_date": {
+                        },
+                        "required": ["issue_key", "comment"],
+                    },
+                ),
+                Tool(
+                    name="jira_add_worklog",
+                    description="Add a worklog entry to a Jira issue",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "issue_key": {
                                 "type": "string",
-                                "description": "Start time for sprint (ISO 8601 format)",
+                                "description": "Jira issue key (e.g., 'PROJ-123')",
                             },
-                            "end_date": {
+                            "time_spent": {
                                 "type": "string",
-                                "description": "End time for sprint (ISO 8601 format)",
+                                "description": (
+                                    "Time spent in Jira format. Examples: "
+                                    "'1h 30m' (1 hour and 30 minutes), "
+                                    "'1d' (1 day), '30m' (30 minutes), "
+                                    "'4h' (4 hours)"
+                                ),
                             },
-                            "goal": {
+                            "comment": {
                                 "type": "string",
-                                "description": "Goal of the sprint",
+                                "description": "Optional comment for the worklog in Markdown format",
+                            },
+                            "started": {
+                                "type": "string",
+                                "description": (
+                                    "Optional start time in ISO format. "
+                                    "If not provided, the current time will be used. "
+                                    "Example: '2023-08-01T12:00:00.000+0000'"
+                                ),
+                            },
+                        },
+                        "required": ["issue_key", "time_spent"],
+                    },
+                ),
+                Tool(
+                    name="jira_link_to_epic",
+                    description="Link an existing issue to an epic",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "issue_key": {
+                                "type": "string",
+                                "description": "The key of the issue to link (e.g., 'PROJ-123')",
+                            },
+                            "epic_key": {
+                                "type": "string",
+                                "description": "The key of the epic to link to (e.g., 'PROJ-456')",
+                            },
+                        },
+                        "required": ["issue_key", "epic_key"],
+                    },
+                ),
+                Tool(
+                    name="jira_create_issue_link",
+                    description="Create a link between two Jira issues",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "link_type": {
+                                "type": "string",
+                                "description": "The type of link to create (e.g., 'Duplicate', 'Blocks', 'Relates to')",
+                            },
+                            "inward_issue_key": {
+                                "type": "string",
+                                "description": "The key of the inward issue (e.g., 'PROJ-123')",
+                            },
+                            "outward_issue_key": {
+                                "type": "string",
+                                "description": "The key of the outward issue (e.g., 'PROJ-456')",
+                            },
+                            "comment": {
+                                "type": "string",
+                                "description": "Optional comment to add to the link",
+                            },
+                            "comment_visibility": {
+                                "type": "object",
+                                "description": "Optional visibility settings for the comment",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "description": "Type of visibility restriction (e.g., 'group')",
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "Value for the visibility restriction (e.g., 'jira-software-users')",
+                                    },
+                                },
                             },
                         },
                         "required": [
-                            "board_id",
-                            "sprint_name",
-                            "start_date",
-                            "end_date",
+                            "link_type",
+                            "inward_issue_key",
+                            "outward_issue_key",
                         ],
                     },
                 ),
                 Tool(
-                    name="jira_get_sprint_issues",
-                    description="Get jira issues from sprint",
+                    name="jira_remove_issue_link",
+                    description="Remove a link between two Jira issues",
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "sprint_id": {
+                            "link_id": {
                                 "type": "string",
-                                "description": "The id of sprint (e.g., '10001')",
+                                "description": "The ID of the link to remove",
+                            },
+                        },
+                        "required": ["link_id"],
+                    },
+                ),
+                Tool(
+                    name="jira_get_link_types",
+                    description="Get all available issue link types",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                ),
+                Tool(
+                    name="jira_transition_issue",
+                    description="Transition a Jira issue to a new status",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "issue_key": {
+                                "type": "string",
+                                "description": "Jira issue key (e.g., 'PROJ-123')",
+                            },
+                            "transition_id": {
+                                "type": "string",
+                                "description": (
+                                    "ID of the transition to perform. Use the jira_get_transitions tool first "
+                                    "to get the available transition IDs for the issue. "
+                                    "Example values: '11', '21', '31'"
+                                ),
                             },
                             "fields": {
                                 "type": "string",
                                 "description": (
-                                    "Comma-separated fields to return in the results. "
-                                    "Use '*all' for all fields, or specify individual "
-                                    "fields like 'summary,status,assignee,priority'"
+                                    "JSON string of fields to update during the transition. "
+                                    "Some transitions require specific fields to be set. "
+                                    'Example: \'{"resolution": {"name": "Fixed"}}\''
                                 ),
-                                "default": "*all",
+                                "default": "{}",
                             },
-                            "startAt": {
-                                "type": "number",
-                                "description": "Starting index for pagination (0-based)",
-                                "default": 0,
-                            },
-                            "limit": {
-                                "type": "number",
-                                "description": "Maximum number of results (1-50)",
-                                "default": 10,
-                                "minimum": 1,
-                                "maximum": 50,
+                            "comment": {
+                                "type": "string",
+                                "description": (
+                                    "Comment to add during the transition (optional). "
+                                    "This will be visible in the issue history."
+                                ),
                             },
                         },
-                        "required": ["sprint_id"],
-                    },
-                ),
-                Tool(
-                    name="jira_update_sprint",
-                    description="Update jira sprint",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "sprint_id": {
-                                "type": "string",
-                                "description": "The id of sprint (e.g., '10001')",
-                            },
-                            "sprint_name": {
-                                "type": "string",
-                                "description": "Optional: New name for the sprint",
-                            },
-                            "state": {
-                                "type": "string",
-                                "description": "Optional: New state for the sprint (future|active|closed)",
-                            },
-                            "start_date": {
-                                "type": "string",
-                                "description": "Optional: New start date for the sprint",
-                            },
-                            "end_date": {
-                                "type": "string",
-                                "description": "Optional: New end date for the sprint",
-                            },
-                            "goal": {
-                                "type": "string",
-                                "description": "Optional: New goal for the sprint",
-                            },
-                        },
-                        "required": ["sprint_id"],
+                        "required": ["issue_key", "transition_id"],
                     },
                 ),
             ]
-        )
 
-        # Only add write operations if not in read-only mode
-        if not read_only:
-            tools.extend(
-                [
-                    Tool(
-                        name="jira_create_issue",
-                        description="Create a new Jira issue with optional Epic link or parent for subtasks",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "project_key": {
-                                    "type": "string",
-                                    "description": (
-                                        "The JIRA project key (e.g. 'PROJ', 'DEV', 'SUPPORT'). "
-                                        "This is the prefix of issue keys in your project. "
-                                        "Never assume what it might be, always ask the user."
-                                    ),
-                                },
-                                "summary": {
-                                    "type": "string",
-                                    "description": "Summary/title of the issue",
-                                },
-                                "issue_type": {
-                                    "type": "string",
-                                    "description": (
-                                        "Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). "
-                                        "The available types depend on your project configuration. "
-                                        "For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields."
-                                    ),
-                                },
-                                "assignee": {
-                                    "type": "string",
-                                    "description": "Assignee of the ticket (accountID, full name or e-mail)",
-                                    "default": None,
-                                },
-                                "description": {
-                                    "type": "string",
-                                    "description": "Issue description",
-                                    "default": "",
-                                },
-                                "components": {
-                                    "type": "string",
-                                    "description": "Comma-separated list of component names to assign (e.g., 'Frontend,API')",
-                                    "default": "",
-                                },
-                                "additional_fields": {
-                                    "type": "string",
-                                    "description": (
-                                        "Optional JSON string of additional fields to set. "
-                                        "Examples:\n"
-                                        '- Set priority: {"priority": {"name": "High"}}\n'
-                                        '- Add labels: {"labels": ["frontend", "urgent"]}\n'
-                                        '- Link to parent (for any issue type): {"parent": "PROJ-123"}\n'
-                                        '- Set Fix Version/s: {"fixVersions": [{"id": "10020"}]}\n'
-                                        '- Custom fields: {"customfield_10010": "value"}'
-                                    ),
-                                    "default": "{}",
-                                },
-                            },
-                            "required": ["project_key", "summary", "issue_type"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_batch_create_issues",
-                        description="Create multiple Jira issues in a batch",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issues": {
-                                    "type": "string",
-                                    "description": (
-                                        "JSON array of issue objects. Each object should contain:\n"
-                                        "- project_key (required): The project key (e.g., 'PROJ')\n"
-                                        "- summary (required): Issue summary/title\n"
-                                        "- issue_type (required): Type of issue (e.g., 'Task', 'Bug')\n"
-                                        "- description (optional): Issue description\n"
-                                        "- assignee (optional): Assignee username or email\n"
-                                        "- components (optional): Array of component names\n"
-                                        "Example: [\n"
-                                        '  {"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"},\n'
-                                        '  {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}\n'
-                                        "]"
-                                    ),
-                                },
-                                "validate_only": {
-                                    "type": "boolean",
-                                    "description": "If true, only validates the issues without creating them",
-                                    "default": False,
-                                },
-                            },
-                            "required": ["issues"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_batch_get_changelogs",
-                        description="Get changelogs for multiple Jira issues (Cloud only)",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issue_ids_or_keys": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "List of Jira issue IDs or keys, e.g. ['PROJ-123', 'PROJ-124']",
-                                },
-                                "fields": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "Filter the changelogs by fields, e.g. ['status', 'assignee']. Default to [] for all fields.",
-                                    "default": [],
-                                },
-                                "limit": {
-                                    "type": "integer",
-                                    "description": (
-                                        "Maximum number of changelogs to return in result for each issue. "
-                                        "Default to -1 for all changelogs. "
-                                        "Notice that it only limits the results in the response, "
-                                        "the function will still fetch all the data."
-                                    ),
-                                    "default": -1,
-                                },
-                            },
-                            "required": ["issue_ids_or_keys"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_update_issue",
-                        description="Update an existing Jira issue including changing status, adding Epic links, updating fields, etc.",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issue_key": {
-                                    "type": "string",
-                                    "description": "Jira issue key (e.g., 'PROJ-123')",
-                                },
-                                "fields": {
-                                    "type": "string",
-                                    "description": (
-                                        "A valid JSON object of fields to update as a string. "
-                                        'Example: \'{"summary": "New title", "description": "Updated description", '
-                                        '"priority": {"name": "High"}, "assignee": "john.doe"}\''
-                                    ),
-                                },
-                                "additional_fields": {
-                                    "type": "string",
-                                    "description": "Optional JSON string of additional fields to update. Use this for custom fields or more complex updates.",
-                                    "default": "{}",
-                                },
-                                "attachments": {
-                                    "type": "string",
-                                    "description": "Optional JSON string or comma-separated list of file paths to attach to the issue. "
-                                    'Example: "/path/to/file1.txt,/path/to/file2.txt" or "["/path/to/file1.txt","/path/to/file2.txt"]"',
-                                },
-                            },
-                            "required": ["issue_key", "fields"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_delete_issue",
-                        description="Delete an existing Jira issue",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issue_key": {
-                                    "type": "string",
-                                    "description": "Jira issue key (e.g. PROJ-123)",
-                                },
-                            },
-                            "required": ["issue_key"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_add_comment",
-                        description="Add a comment to a Jira issue",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issue_key": {
-                                    "type": "string",
-                                    "description": "Jira issue key (e.g., 'PROJ-123')",
-                                },
-                                "comment": {
-                                    "type": "string",
-                                    "description": "Comment text in Markdown format",
-                                },
-                            },
-                            "required": ["issue_key", "comment"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_add_worklog",
-                        description="Add a worklog entry to a Jira issue",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issue_key": {
-                                    "type": "string",
-                                    "description": "Jira issue key (e.g., 'PROJ-123')",
-                                },
-                                "time_spent": {
-                                    "type": "string",
-                                    "description": (
-                                        "Time spent in Jira format. Examples: "
-                                        "'1h 30m' (1 hour and 30 minutes), "
-                                        "'1d' (1 day), '30m' (30 minutes), "
-                                        "'4h' (4 hours)"
-                                    ),
-                                },
-                                "comment": {
-                                    "type": "string",
-                                    "description": "Optional comment for the worklog in Markdown format",
-                                },
-                                "started": {
-                                    "type": "string",
-                                    "description": (
-                                        "Optional start time in ISO format. "
-                                        "If not provided, the current time will be used. "
-                                        "Example: '2023-08-01T12:00:00.000+0000'"
-                                    ),
-                                },
-                            },
-                            "required": ["issue_key", "time_spent"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_link_to_epic",
-                        description="Link an existing issue to an epic",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issue_key": {
-                                    "type": "string",
-                                    "description": "The key of the issue to link (e.g., 'PROJ-123')",
-                                },
-                                "epic_key": {
-                                    "type": "string",
-                                    "description": "The key of the epic to link to (e.g., 'PROJ-456')",
-                                },
-                            },
-                            "required": ["issue_key", "epic_key"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_create_issue_link",
-                        description="Create a link between two Jira issues",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "link_type": {
-                                    "type": "string",
-                                    "description": "The type of link to create (e.g., 'Duplicate', 'Blocks', 'Relates to')",
-                                },
-                                "inward_issue_key": {
-                                    "type": "string",
-                                    "description": "The key of the inward issue (e.g., 'PROJ-123')",
-                                },
-                                "outward_issue_key": {
-                                    "type": "string",
-                                    "description": "The key of the outward issue (e.g., 'PROJ-456')",
-                                },
-                                "comment": {
-                                    "type": "string",
-                                    "description": "Optional comment to add to the link",
-                                },
-                                "comment_visibility": {
-                                    "type": "object",
-                                    "description": "Optional visibility settings for the comment",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "description": "Type of visibility restriction (e.g., 'group')",
-                                        },
-                                        "value": {
-                                            "type": "string",
-                                            "description": "Value for the visibility restriction (e.g., 'jira-software-users')",
-                                        },
-                                    },
-                                },
-                            },
-                            "required": [
-                                "link_type",
-                                "inward_issue_key",
-                                "outward_issue_key",
-                            ],
-                        },
-                    ),
-                    Tool(
-                        name="jira_remove_issue_link",
-                        description="Remove a link between two Jira issues",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "link_id": {
-                                    "type": "string",
-                                    "description": "The ID of the link to remove",
-                                },
-                            },
-                            "required": ["link_id"],
-                        },
-                    ),
-                    Tool(
-                        name="jira_get_link_types",
-                        description="Get all available issue link types",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {},
-                            "required": [],
-                        },
-                    ),
-                    Tool(
-                        name="jira_transition_issue",
-                        description="Transition a Jira issue to a new status",
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "issue_key": {
-                                    "type": "string",
-                                    "description": "Jira issue key (e.g., 'PROJ-123')",
-                                },
-                                "transition_id": {
-                                    "type": "string",
-                                    "description": (
-                                        "ID of the transition to perform. Use the jira_get_transitions tool first "
-                                        "to get the available transition IDs for the issue. "
-                                        "Example values: '11', '21', '31'"
-                                    ),
-                                },
-                                "fields": {
-                                    "type": "string",
-                                    "description": (
-                                        "JSON string of fields to update during the transition. "
-                                        "Some transitions require specific fields to be set. "
-                                        'Example: \'{"resolution": {"name": "Fixed"}}\''
-                                    ),
-                                    "default": "{}",
-                                },
-                                "comment": {
-                                    "type": "string",
-                                    "description": (
-                                        "Comment to add during the transition (optional). "
-                                        "This will be visible in the issue history."
-                                    ),
-                                },
-                            },
-                            "required": ["issue_key", "transition_id"],
-                        },
-                    ),
-                ]
-            )
+            # Filter and add write tools
+            for tool in jira_write_tools:
+                if should_include_tool(tool.name, ctx.enabled_tools):
+                    tools.append(tool)
 
     return tools
 

--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -15,26 +15,11 @@ from .jira import JiraFetcher
 from .jira.config import JiraConfig
 from .utils.io import is_read_only_mode
 from .utils.logging import log_config_param
+from .utils.tools import get_enabled_tools, should_include_tool
 from .utils.urls import is_atlassian_cloud_url
 
 # Configure logging
 logger = logging.getLogger("mcp-atlassian")
-
-
-def get_enabled_tools() -> list[str] | None:
-    """Get the list of enabled tools from environment variable."""
-    enabled_tools_str = os.getenv("ENABLED_TOOLS")
-    if enabled_tools_str:
-        # Split by commas and strip whitespace
-        return [tool.strip() for tool in enabled_tools_str.split(",")]
-    return None
-
-
-def should_include_tool(tool_name: str, enabled_tools: list[str] | None) -> bool:
-    """Check if a tool should be included based on the enabled tools list."""
-    if enabled_tools is None:
-        return True
-    return tool_name in enabled_tools
 
 
 @dataclass

--- a/src/mcp_atlassian/utils/tools.py
+++ b/src/mcp_atlassian/utils/tools.py
@@ -1,0 +1,50 @@
+"""Tool-related utility functions for MCP Atlassian."""
+
+import os
+
+
+def get_enabled_tools() -> list[str] | None:
+    """Get the list of enabled tools from environment variable.
+
+    This function reads and parses the ENABLED_TOOLS environment variable
+    to determine which tools should be available in the server.
+
+    The environment variable should contain a comma-separated list of tool names.
+    Whitespace around tool names is stripped.
+
+    Returns:
+        List of enabled tool names if ENABLED_TOOLS is set and non-empty,
+        None if ENABLED_TOOLS is not set or empty after stripping whitespace.
+
+    Examples:
+        ENABLED_TOOLS="tool1,tool2" -> ["tool1", "tool2"]
+        ENABLED_TOOLS="tool1, tool2 , tool3" -> ["tool1", "tool2", "tool3"]
+        ENABLED_TOOLS="" -> None
+        ENABLED_TOOLS not set -> None
+        ENABLED_TOOLS=" , " -> None
+    """
+    enabled_tools_str = os.getenv("ENABLED_TOOLS")
+    if not enabled_tools_str:
+        return None
+
+    # Split by comma and strip whitespace
+    tools = [tool.strip() for tool in enabled_tools_str.split(",")]
+    # Filter out empty strings
+    tools = [tool for tool in tools if tool]
+
+    return tools if tools else None
+
+
+def should_include_tool(tool_name: str, enabled_tools: list[str] | None) -> bool:
+    """Check if a tool should be included based on the enabled tools list.
+
+    Args:
+        tool_name: The name of the tool to check.
+        enabled_tools: List of enabled tool names, or None to include all tools.
+
+    Returns:
+        True if the tool should be included, False otherwise.
+    """
+    if enabled_tools is None:
+        return True
+    return tool_name in enabled_tools

--- a/tests/unit/utils/test_tools.py
+++ b/tests/unit/utils/test_tools.py
@@ -1,0 +1,73 @@
+"""Tests for tool utility functions."""
+
+import os
+from unittest.mock import patch
+
+from mcp_atlassian.utils.tools import get_enabled_tools, should_include_tool
+
+
+def test_get_enabled_tools_not_set():
+    """Test get_enabled_tools when ENABLED_TOOLS is not set."""
+    with patch.dict(os.environ, {}, clear=True):
+        assert get_enabled_tools() is None
+
+
+def test_get_enabled_tools_empty_string():
+    """Test get_enabled_tools with empty string."""
+    with patch.dict(os.environ, {"ENABLED_TOOLS": ""}, clear=True):
+        assert get_enabled_tools() is None
+
+
+def test_get_enabled_tools_only_whitespace():
+    """Test get_enabled_tools with string containing only whitespace."""
+    with patch.dict(os.environ, {"ENABLED_TOOLS": "   "}, clear=True):
+        assert get_enabled_tools() is None
+
+
+def test_get_enabled_tools_only_commas():
+    """Test get_enabled_tools with string containing only commas."""
+    with patch.dict(os.environ, {"ENABLED_TOOLS": ",,,,"}, clear=True):
+        assert get_enabled_tools() is None
+
+
+def test_get_enabled_tools_whitespace_and_commas():
+    """Test get_enabled_tools with string containing whitespace and commas."""
+    with patch.dict(os.environ, {"ENABLED_TOOLS": " , , , "}, clear=True):
+        assert get_enabled_tools() is None
+
+
+def test_get_enabled_tools_single_tool():
+    """Test get_enabled_tools with a single tool."""
+    with patch.dict(os.environ, {"ENABLED_TOOLS": "tool1"}, clear=True):
+        assert get_enabled_tools() == ["tool1"]
+
+
+def test_get_enabled_tools_multiple_tools():
+    """Test get_enabled_tools with multiple tools."""
+    with patch.dict(os.environ, {"ENABLED_TOOLS": "tool1,tool2,tool3"}, clear=True):
+        assert get_enabled_tools() == ["tool1", "tool2", "tool3"]
+
+
+def test_get_enabled_tools_with_whitespace():
+    """Test get_enabled_tools with whitespace around tool names."""
+    with patch.dict(
+        os.environ, {"ENABLED_TOOLS": " tool1 , tool2 , tool3 "}, clear=True
+    ):
+        assert get_enabled_tools() == ["tool1", "tool2", "tool3"]
+
+
+def test_should_include_tool_none_enabled():
+    """Test should_include_tool when enabled_tools is None."""
+    assert should_include_tool("any_tool", None) is True
+
+
+def test_should_include_tool_tool_enabled():
+    """Test should_include_tool when tool is in enabled list."""
+    enabled_tools = ["tool1", "tool2", "tool3"]
+    assert should_include_tool("tool2", enabled_tools) is True
+
+
+def test_should_include_tool_tool_not_enabled():
+    """Test should_include_tool when tool is not in enabled list."""
+    enabled_tools = ["tool1", "tool2", "tool3"]
+    assert should_include_tool("tool4", enabled_tools) is False


### PR DESCRIPTION
# Add enabled tools flag and environment variable to filter available tools

## Description

This PR adds the ability to filter which tools are available in the MCP Atlassian server through both a command-line flag and an environment variable. This enhancement provides users with fine-grained control over which tools are exposed by the server, allowing for better security and customization of the server's functionality.

Fixes: #259 

## Changes

- Added new `--enabled-tools` command-line option to specify which tools to enable
- Added `ENABLED_TOOLS` environment variable support for tool filtering
- Implemented tool filtering logic in the server's `list_tools()` function
- Added helper functions `get_enabled_tools()` and `should_include_tool()` for tool filtering
- Updated logging to provide feedback about tool filtering configuration
- Tools are filtered based on their names using a comma-separated list
- All tools remain enabled by default if no filtering is specified

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed:
  - Verified tool filtering works with command-line flag using MCP inspector
  - Verified tool filtering works with environment variable using MCP inspector
  - Confirmed default behavior (all tools enabled) when no filtering is specified using MCP inspector
  - Tested with various combinations of enabled tools using MCP inspector

Default behavior:
![image](https://github.com/user-attachments/assets/9f54a97f-7f3d-45f4-9cf0-b91e9a07c394)

With filtering applied:
![image](https://github.com/user-attachments/assets/7d8b1baa-0547-4608-9d5b-8887f420a466)


## Checklist

- [x] Code follows project style guidelines (linting passes)
- [x] Tests added/updated for changes
- [x] All tests pass locally
- [x] Documentation updated with new command-line option and environment variable