### PR TITLE
Use enhanced_jql_get_list_of_tickets to allow retrieving more than 50 issues

### DIFF
--- a/src/mcp_atlassian/server.py
+++ b/src/mcp_atlassian/server.py
@@ -1682,7 +1682,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent]:
             # Extract arguments
             jql = arguments.get("jql")
             fields = arguments.get("fields", ",".join(DEFAULT_READ_JIRA_FIELDS))
-            limit = min(int(arguments.get("limit", 10)), 50)
+            limit = int(arguments.get("limit", 10))
             projects_filter = arguments.get("projects_filter")
             start_at = arguments.get("startAt", 0)
             expand = arguments.get("expand")

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -55,7 +55,7 @@ class TestSearchMixin:
     @pytest.mark.parametrize(
         "is_cloud, expected_method_name",
         [
-            (True, "enhanced_jql"),  # Cloud scenario
+            (True, "enhanced_jql_get_list_of_tickets"),  # Cloud scenario
             (False, "jql"),  # Server/DC scenario
         ],
     )
@@ -75,12 +75,16 @@ class TestSearchMixin:
         )
 
         # Setup: Mock response for both API methods
-        search_mixin.jira.enhanced_jql = MagicMock(return_value=mock_issues_response)
+        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
+            return_value=mock_issues_response["issues"]
+        )
         search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
 
         # Determine other method name for assertion
         other_method_name = (
-            "jql" if expected_method_name == "enhanced_jql" else "enhanced_jql"
+            "jql"
+            if expected_method_name == "enhanced_jql_get_list_of_tickets"
+            else "enhanced_jql_get_list_of_tickets"
         )
 
         # Act
@@ -577,10 +581,12 @@ class TestSearchMixin:
         search_mixin.config.url = "https://test.example.com"
 
         # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql = MagicMock(return_value=mock_issues_response)
+        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
+            return_value=mock_issues_response["issues"]
+        )
         search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
         api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql" if is_cloud else "jql"
+            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
         )
 
         # Act: Single project filter
@@ -632,10 +638,12 @@ class TestSearchMixin:
         search_mixin.config.url = "https://test.example.com"
 
         # Setup mock response for both API methods
-        search_mixin.jira.enhanced_jql = MagicMock(return_value=mock_issues_response)
+        search_mixin.jira.enhanced_jql_get_list_of_tickets = MagicMock(
+            return_value=mock_issues_response["issues"]
+        )
         search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
         api_method_mock = getattr(
-            search_mixin.jira, "enhanced_jql" if is_cloud else "jql"
+            search_mixin.jira, "enhanced_jql_get_list_of_tickets" if is_cloud else "jql"
         )
 
         # Define expected kwargs based on is_cloud


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description
There was no way to retrieve more than 50 results from jira search. The changes added allows user to fetch more results using the `_enhanced_jql_get_list_of_tickets_` function instead of `enhanced_jql` one.
enhanced_jql uses nextPageToken to paginate the results but the token was not passed in the response.

Fixes: #

## Changes
- Changed the Jira Cloud search implementation to use enhanced_jql_get_list_of_tickets instead of enhanced_jql.
- Converting the list response form the function to a structure compatible with JiraSearchResult
- Setting correct total count values based on actual results
- Preserving the requested fields in the search result model


## Testing

- [ ] Unit tests updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `Searched various issues types using JQL and various limits`

## Checklist

https://github.com/user-attachments/assets/9e70c556-3b05-4be7-ba62-186f1fbe842e



- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally (Except for the create issue in test_server)
- [ ] Documentation updated (if needed).
