### PR TITLE
Refactor: Remove jira_get_epic_issues and confluence_get_page_ancestors tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,6 @@ For Jira Server/DC, use:
 |`confluence_search`|`jira_get_issue`|
 |`confluence_get_page`|`jira_search`|
 |`confluence_get_page_children`|`jira_get_project_issues`|
-|`confluence_get_page_ancestors`|`jira_get_epic_issues`|
 |`confluence_get_comments`|`jira_create_issue`|
 |`confluence_create_page`|`jira_batch_create_issues`|
 |`confluence_update_page`|`jira_update_issue`|

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -254,33 +254,6 @@ async def get_page_children(
 
 
 @confluence_mcp.tool(tags={"confluence", "read"})
-async def get_page_ancestors(
-    ctx: Context[Any, MainAppContext],
-    page_id: Annotated[
-        str,
-        Field(description="The ID of the page whose ancestors you want to retrieve"),
-    ],
-) -> str:
-    """Get ancestor (parent) pages of a specific Confluence page.
-
-    Args:
-        ctx: The FastMCP context.
-        page_id: The ID of the page.
-
-    Returns:
-        JSON string representing a list of ancestor page objects.
-    """
-    lifespan_ctx = ctx.request_context.lifespan_context
-    if not lifespan_ctx or not lifespan_ctx.confluence:
-        raise ValueError("Confluence client is not configured or available.")
-    confluence = lifespan_ctx.confluence
-
-    ancestors = confluence.get_page_ancestors(page_id)
-    ancestor_pages = [page.to_simplified_dict() for page in ancestors]
-    return json.dumps(ancestor_pages, indent=2, ensure_ascii=False)
-
-
-@confluence_mcp.tool(tags={"confluence", "read"})
 async def get_comments(
     ctx: Context[Any, MainAppContext],
     page_id: Annotated[

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -267,57 +267,6 @@ async def get_project_issues(
 
 
 @jira_mcp.tool(tags={"jira", "read"})
-async def get_epic_issues(
-    ctx: Context[Any, MainAppContext],
-    epic_key: Annotated[
-        str, Field(description="The key of the epic (e.g., 'PROJ-123')")
-    ],
-    limit: Annotated[
-        int,
-        Field(
-            description="Maximum number of issues to return (1-50)",
-            default=10,
-            ge=1,
-            le=50,
-        ),
-    ] = 10,
-    start_at: Annotated[
-        int,
-        Field(description="Starting index for pagination (0-based)", default=0, ge=0),
-    ] = 0,
-) -> str:
-    """Get all issues linked to a specific epic.
-
-    Args:
-        ctx: The FastMCP context.
-        epic_key: The key of the epic.
-        limit: Maximum number of issues to return.
-        start_at: Starting index for pagination.
-
-    Returns:
-        JSON string representing the search results including pagination info.
-    """
-    lifespan_ctx = ctx.request_context.lifespan_context
-    if not lifespan_ctx or not lifespan_ctx.jira:
-        raise ValueError("Jira client is not configured or available.")
-    jira = lifespan_ctx.jira
-
-    # Note: Underlying jira.get_epic_issues returns list[JiraIssue]
-    issues_list = jira.get_epic_issues(epic_key=epic_key, start=start_at, limit=limit)
-
-    # Manually construct the response format expected by the original server
-    issues_simplified = [issue.to_simplified_dict() for issue in issues_list]
-    # Since the underlying method doesn't return total count, we can only report what we fetched
-    result = {
-        "total": len(issues_simplified),
-        "start_at": start_at,
-        "max_results": limit,
-        "issues": issues_simplified,
-    }
-    return json.dumps(result, indent=2, ensure_ascii=False)
-
-
-@jira_mcp.tool(tags={"jira", "read"})
 async def get_transitions(
     ctx: Context[Any, MainAppContext],
     issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -40,9 +40,6 @@ def mock_confluence_fetcher():
     # Mock get_page_children method
     mock_fetcher.get_page_children.return_value = [mock_page]
 
-    # Mock get_page_ancestors method
-    mock_fetcher.get_page_ancestors.return_value = [mock_page]
-
     # Mock get_page_comments method
     mock_comment = MagicMock()
     mock_comment.to_simplified_dict.return_value = {
@@ -106,7 +103,6 @@ def test_confluence_mcp(mock_confluence_fetcher):
         get_comments,
         get_labels,
         get_page,  # Renamed from get_page_content
-        get_page_ancestors,
         get_page_children,
         search,
         update_page,
@@ -116,7 +112,6 @@ def test_confluence_mcp(mock_confluence_fetcher):
     test_mcp.tool()(search)
     test_mcp.tool(name="get_page")(get_page)  # Explicitly name the tool
     test_mcp.tool()(get_page_children)
-    test_mcp.tool()(get_page_ancestors)
     test_mcp.tool()(get_comments)
     test_mcp.tool()(get_labels)
     test_mcp.tool()(add_label)
@@ -156,7 +151,6 @@ def read_only_test_confluence_mcp(mock_confluence_fetcher):
         get_comments,
         get_labels,
         get_page,
-        get_page_ancestors,
         get_page_children,
         search,
         update_page,
@@ -165,7 +159,6 @@ def read_only_test_confluence_mcp(mock_confluence_fetcher):
     test_mcp.tool()(search)
     test_mcp.tool(name="get_page")(get_page)
     test_mcp.tool()(get_page_children)
-    test_mcp.tool()(get_page_ancestors)
     test_mcp.tool()(get_comments)
     test_mcp.tool()(get_labels)
     test_mcp.tool()(add_label)
@@ -203,7 +196,6 @@ def no_fetcher_test_confluence_mcp():
         get_comments,
         get_labels,
         get_page,
-        get_page_ancestors,
         get_page_children,
         search,
         update_page,
@@ -212,7 +204,6 @@ def no_fetcher_test_confluence_mcp():
     test_mcp.tool()(search)
     test_mcp.tool(name="get_page")(get_page)
     test_mcp.tool()(get_page_children)
-    test_mcp.tool()(get_page_ancestors)
     test_mcp.tool()(get_comments)
     test_mcp.tool()(get_labels)
     test_mcp.tool()(add_label)
@@ -341,19 +332,6 @@ async def test_get_page_children(client, mock_confluence_fetcher):
     assert "results" in result_data
     assert len(result_data["results"]) > 0
     assert result_data["results"][0]["title"] == "Test Page Mock Title"
-
-
-@pytest.mark.anyio
-async def test_get_page_ancestors(client, mock_confluence_fetcher):
-    """Test the get_page_ancestors tool."""
-    response = await client.call_tool("get_page_ancestors", {"page_id": "123456"})
-
-    mock_confluence_fetcher.get_page_ancestors.assert_called_once_with("123456")
-
-    result_data = json.loads(response[0].text)
-    assert isinstance(result_data, list)
-    assert len(result_data) > 0
-    assert result_data[0]["title"] == "Test Page Mock Title"
 
 
 @pytest.mark.anyio

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -228,7 +228,6 @@ def test_jira_mcp(mock_jira_fetcher):
         download_attachments,
         get_agile_boards,
         get_board_issues,
-        get_epic_issues,
         get_issue,
         get_link_types,
         get_project_issues,
@@ -250,7 +249,6 @@ def test_jira_mcp(mock_jira_fetcher):
     test_mcp.tool()(search)
     test_mcp.tool()(search_fields)
     test_mcp.tool()(get_project_issues)
-    test_mcp.tool()(get_epic_issues)
     test_mcp.tool()(get_transitions)
     test_mcp.tool()(get_worklog)
     test_mcp.tool()(download_attachments)
@@ -476,32 +474,3 @@ async def test_batch_create_issues_invalid_json(jira_client):
 
     # Check error message comes from Pydantic/FastMCP validation
     assert "invalid json in issues" in str(excinfo.value).lower()
-
-
-@pytest.mark.anyio
-async def test_get_epic_issues(jira_client, mock_jira_fetcher):
-    """Test getting issues from an epic."""
-    response = await jira_client.call_tool(
-        "get_epic_issues",
-        {"epic_key": "TEST-100", "limit": 10, "start_at": 0},
-    )
-
-    # Verify the response
-    assert len(response) == 1
-    text_content = response[0]
-    assert text_content.type == "text"
-
-    # Parse the response JSON
-    content = json.loads(text_content.text)
-    assert "total" in content
-    assert "issues" in content
-    assert content["total"] == 3  # Based on mock setup
-    assert len(content["issues"]) == 3
-    assert "key" in content["issues"][0]
-    assert "summary" in content["issues"][0]
-    assert content["issues"][0]["key"] == "TEST-1"  # Based on mock setup
-
-    # Verify the mock was called correctly
-    mock_jira_fetcher.get_epic_issues.assert_called_once_with(
-        epic_key="TEST-100", start=0, limit=10
-    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
This PR removes the `jira_get_epic_issues` and `confluence_get_page_ancestors` tools from the MCP server.

The `jira_get_epic_issues` tool was identified as not working reliably across different Jira instances due to variability in Epic linking fields. Both tools' functionalities can be achieved using the more general `search` tools (`jira_search` and `confluence_search`) with appropriate JQL/CQL queries. This change simplifies the available toolset for users and reduces maintenance.

<!-- Link related issues: Fixes #<issue_number> -->
Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- Removed `get_epic_issues` tool function and registration from `src/mcp_atlassian/servers/jira.py`.
- Removed `get_page_ancestors` tool function and registration from `src/mcp_atlassian/servers/confluence.py`.
- Updated test fixtures (`test_jira_mcp`, `test_confluence_mcp`) in server unit tests to no longer register the removed tools.
- Removed unit tests specifically targeting the removed tools in `tests/unit/servers/test_jira_server.py` and `tests/unit/servers/test_confluence_server.py`.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [X] Unit tests updated (removed tests for the deleted tools, ensured remaining tests pass).
- [ ] Integration tests passed (assuming they exist and cover remaining functionality).
- [ ] Manual checks performed: Verified server starts and `list_tools` no longer shows the removed tools.

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [X] Tests added/updated for changes.
- [X] All tests pass locally.
- [ ] Documentation updated (if needed - e.g., README tool list). <!-- Needs final check -->