### PR TITLE
feat: Add /healthz endpoint for K8s probes (#359)

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -7,6 +7,8 @@ from contextlib import asynccontextmanager
 from fastmcp import FastMCP
 from fastmcp.tools import Tool as FastMCPTool
 from mcp.types import Tool as MCPTool
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.config import ConfluenceConfig
@@ -21,6 +23,12 @@ from .context import MainAppContext
 from .jira import jira_mcp
 
 logger = logging.getLogger("mcp-atlassian.server.main")
+
+
+async def health_check(request: Request) -> JSONResponse:
+    """Simple health check endpoint for Kubernetes probes."""
+    logger.debug("Received health check request.")
+    return JSONResponse({"status": "ok"})
 
 
 @asynccontextmanager
@@ -143,3 +151,12 @@ main_mcp = AtlassianMCP(name="Atlassian MCP", lifespan=main_lifespan)
 # Mount the Jira and Confluence sub-servers
 main_mcp.mount("jira", jira_mcp)
 main_mcp.mount("confluence", confluence_mcp)
+
+# Add the health check endpoint using the decorator
+@main_mcp.custom_route(
+    "/healthz", methods=["GET"], include_in_schema=False
+)
+async def _health_check_route(request: Request) -> JSONResponse:
+    return await health_check(request)
+
+logger.info("Added /healthz endpoint for Kubernetes probes")

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -152,11 +152,11 @@ main_mcp = AtlassianMCP(name="Atlassian MCP", lifespan=main_lifespan)
 main_mcp.mount("jira", jira_mcp)
 main_mcp.mount("confluence", confluence_mcp)
 
+
 # Add the health check endpoint using the decorator
-@main_mcp.custom_route(
-    "/healthz", methods=["GET"], include_in_schema=False
-)
+@main_mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)
 async def _health_check_route(request: Request) -> JSONResponse:
     return await health_check(request)
+
 
 logger.info("Added /healthz endpoint for Kubernetes probes")

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -3,6 +3,9 @@
 from unittest.mock import patch
 
 import pytest
+import httpx
+from starlette.testclient import TestClient
+from starlette.routing import ASGIApp
 
 from mcp_atlassian.servers.main import main_mcp
 
@@ -33,5 +36,17 @@ async def test_run_server_invalid_transport():
     with pytest.raises(ValueError) as excinfo:
         await main_mcp.run_async(transport="invalid")  # type: ignore
 
-    assert "Unsupported transport" in str(excinfo.value)
-    assert "Use 'stdio' or 'sse'" in str(excinfo.value)
+    assert "Unknown transport" in str(excinfo.value)
+    assert "invalid" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_health_check_endpoint():
+    """Test the health check endpoint returns 200 and correct JSON response."""
+    app = main_mcp.sse_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/healthz")
+        
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -2,10 +2,8 @@
 
 from unittest.mock import patch
 
-import pytest
 import httpx
-from starlette.testclient import TestClient
-from starlette.routing import ASGIApp
+import pytest
 
 from mcp_atlassian.servers.main import main_mcp
 
@@ -47,6 +45,6 @@ async def test_health_check_endpoint():
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/healthz")
-        
+
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}


### PR DESCRIPTION
Fixes #359

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

I accidentally removed healthz endpoint during fastmcp v2 refactoring (#371).

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- registered the `health_check` endpoint

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
