### PR TITLE
docs(jira): Improve field description in get_issue function

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -27,8 +27,9 @@ async def get_issue(
         str | None,
         Field(
             description=(
-                "Fields to return. Can be a comma-separated list (e.g., 'summary,status,customfield_10010'), "
-                "'*all' for all fields (including custom fields), or omitted for essential fields only."
+                "Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'). "
+                "You may also provide a single field as a string (e.g., 'duedate'). "
+                "Use '*all' for all fields (including custom fields), or omit for essential fields only."
             ),
             default=",".join(DEFAULT_READ_JIRA_FIELDS),
         ),
@@ -72,7 +73,7 @@ async def get_issue(
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
-        fields: Fields to return.
+        fields: Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'), a single field as a string (e.g., 'duedate'), '*all' for all fields, or omitted for essentials.
         expand: Optional fields to expand.
         comment_limit: Maximum number of comments.
         properties: Issue properties to return.
@@ -80,6 +81,9 @@ async def get_issue(
 
     Returns:
         JSON string representing the Jira issue object.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
     """
     lifespan_ctx = ctx.request_context.lifespan_context
     if not lifespan_ctx or not lifespan_ctx.jira:


### PR DESCRIPTION
## Description

Closes #390

Updates the description for the `fields` parameter in the `jira_get_issue` tool to clarify that a single field name string is also a valid input. The previous description only mentioned a comma-separated list, which could cause confusion.

## Changes

- Clarified the `fields` parameter description in the `jira_get_issue` tool to explicitly mention that a single field string (e.g., `"duedate"`) is a valid input, in addition to comma-separated lists or `*all`.
- Updated the Args section in the docstring for the `fields` parameter to maintain consistency.

## Testing

- Tested locally using MCP Inspector to call the `jira_get_issue` tool with:
    - `fields="duedate"`: Verified correct behavior.
    - `fields="summary,status"`: Verified correct behavior.
    - `fields="*all"`: Verified correct behavior.
    - `fields=None` (default): Verified correct behavior.
- Manual check with Cursor client (as reported in the issue) by passing a single string to the `fields` parameter to confirm the type error is resolved.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes. (Note: No new tests added as this is a documentation/description clarification of existing behavior).
- [x] All tests pass locally.
- [x] Documentation updated (parameter description).