### PR TITLE
docs(jira): Clarify assignee field description in tool schemas (#391)

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -617,7 +617,7 @@ async def create_issue(
     assignee: Annotated[
         str | None,
         Field(
-            description="Assignee of the ticket (accountID, full name or e-mail)",
+            description="Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...')",
             default=None,
         ),
     ] = None,
@@ -653,7 +653,7 @@ async def create_issue(
         project_key: The JIRA project key.
         summary: Summary/title of the issue.
         issue_type: Issue type (e.g., 'Task', 'Bug', 'Story', 'Epic', 'Subtask').
-        assignee: Assignee of the ticket (accountID, full name or e-mail).
+        assignee: Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...').
         description: Issue description.
         components: Comma-separated list of component names.
         additional_fields: Dictionary of additional fields.
@@ -860,9 +860,8 @@ async def update_issue(
         dict[str, Any],
         Field(
             description=(
-                "A valid dictionary of fields to update. "
-                "Example: {'summary': 'New title', 'description': 'Updated description', "
-                "'priority': {'name': 'High'}, 'assignee': 'john.doe'}"
+                "Dictionary of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). "
+                "Example: `{'assignee': 'user@example.com', 'summary': 'New Summary'}`"
             )
         ),
     ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Clarifies expected format for `assignee` field in Jira tools to resolve user confusion.

Fixes: #391

## Changes

<!-- Briefly list the key changes made. -->

- Updated `assignee` parameter description in `jira_create_issue` schema
- Updated `fields` parameter description in `jira_update_issue` schema to explain `assignee` format
- Made explicit that string identifiers (email, name, or accountId) are expected

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `Verified documentation-only change; underlying functionality confirmed working in #391`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).