### PR TITLE
docs: revert OAuth 2.0 documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,108 +1,127 @@
-# MCP-ATLASSIAN CONFIGURATION
-# Note: Do not use double quotes for any values in this file
+# MCP-ATLASSIAN CONFIGURATION EXAMPLE
+# -------------------------------------
+# Copy this file to .env and fill in your details.
+# - Do not use double quotes for string values in this file, unless the value itself contains spaces.
 
 # =============================================
-# GENERAL CONFIGURATION
+# ESSENTIAL ATLASSIAN INSTANCE URLS
 # =============================================
-
-# Transport Options
-# CLI: --transport [stdio|sse], --port PORT
-# Default: stdio transport
-# Note: PORT is only used when TRANSPORT=sse
-# TRANSPORT=stdio        # Options: stdio, sse
-# PORT=8000              # Only used when TRANSPORT=sse
-
-# Read-only Mode (disables all write operations)
-# CLI: --read-only
-# READ_ONLY_MODE=true
-
-# Debug Options
-# CLI: -v/--verbose (once for INFO, twice for DEBUG)
-# Default logging level is WARNING (minimal output)
-# MCP_VERBOSE=true           # For INFO level (same as -v)
-# MCP_VERY_VERBOSE=true      # For DEBUG level (same as -vv)
+# REQUIRED: Replace with your Atlassian instance URLs.
+# Example Cloud: https://your-company.atlassian.net
+# Example Server/DC: https://jira.your-internal-domain.com
+JIRA_URL=https://your-company.atlassian.net
+# Example Cloud: https://your-company.atlassian.net/wiki
+# Example Server/DC: https://confluence.your-internal-domain.com
+CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 
 # =============================================
-# OAUTH 2.0 CONFIGURATION (CLOUD ONLY)
+# AUTHENTICATION: CHOOSE ONE METHOD PER PRODUCT (Jira/Confluence)
 # =============================================
-# CLI: --oauth-client-id, --oauth-client-secret, --oauth-redirect-uri, --oauth-scope, --oauth-cloud-id
-# Note: OAuth 2.0 (3LO) authentication is only supported for Atlassian Cloud
-# If configured, OAuth takes precedence over other authentication methods
-# IMPORTANT: The 'offline_access' scope is required for refresh tokens to work properly
-# ATLASSIAN_OAUTH_CLIENT_ID=your_oauth_client_id
-# ATLASSIAN_OAUTH_CLIENT_SECRET=your_oauth_client_secret
-# ATLASSIAN_OAUTH_REDIRECT_URI=https://your-domain.com/oauth/callback
-# ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-space.summary write:confluence-content offline_access
-# ATLASSIAN_OAUTH_CLOUD_ID=your_cloud_id
+# mcp-atlassian will attempt to auto-detect the auth method based on the credentials you provide below.
+# Precedence for auto-detection:
+#   1. OAuth (if OAuth Client ID/Secret are set)
+#   2. Personal Access Token (if URL is Server/DC and PAT is set)
+#   3. Username/API Token (Basic Auth)
 
-# =============================================
-# CONFLUENCE CONFIGURATION
-# =============================================
+# --- METHOD 1: OAUTH 2.0 (Recommended for Atlassian Cloud) ---
+# 1. Create an OAuth 2.0 (3LO) app in Atlassian Developer Console:
+#    https://developer.atlassian.com/console/myapps/
+# 2. Set the Callback/Redirect URI in your app (e.g., http://localhost:8080/callback).
+# 3. Grant necessary scopes (see ATLASSIAN_OAUTH_SCOPE below).
+# 4. Run 'mcp-atlassian --oauth-setup -v' (or 'uvx mcp-atlassian@latest --oauth-setup -v').
+#    This wizard will guide you through authorization and provide your ATLASSIAN_OAUTH_CLOUD_ID.
+#    Tokens are stored securely (keyring or a local file in ~/.mcp-atlassian/).
 
-## ---- CLOUD DEPLOYMENT ----
-# CLI: --confluence-url, --confluence-username, --confluence-token
-CONFLUENCE_URL=https://your-domain.atlassian.net/wiki
-CONFLUENCE_USERNAME=your.email@domain.com
-CONFLUENCE_API_TOKEN=your_api_token
+# Required for --oauth-setup and for the server to use OAuth:
+#ATLASSIAN_OAUTH_CLIENT_ID=your_oauth_client_id
+#ATLASSIAN_OAUTH_CLIENT_SECRET=your_oauth_client_secret
+#ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback # Must match your app's redirect URI
+#ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-space.summary read:confluence-content.all write:confluence-content offline_access # IMPORTANT: 'offline_access' is crucial for refresh tokens
 
-# Optional: Filter spaces
-# CLI: --confluence-spaces-filter
-# CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC
+# Required for the server AFTER running --oauth-setup (this ID is printed by the setup wizard):
+#ATLASSIAN_OAUTH_CLOUD_ID=your_atlassian_cloud_id_from_oauth_setup
 
-## ---- SERVER/DATA CENTER DEPLOYMENT ----
-# CLI: --confluence-url, --[no-]confluence-ssl-verify
-# CONFLUENCE_URL=https://confluence.your-company.com
-# CONFLUENCE_SSL_VERIFY=true           # CLI: --[no-]confluence-ssl-verify
+# --- METHOD 2: API TOKEN (Atlassian Cloud - Uses Basic Authentication) ---
+# Get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
+#JIRA_USERNAME=your.email@example.com
+#JIRA_API_TOKEN=your_jira_api_token
 
-## Authentication options (choose one):
+#CONFLUENCE_USERNAME=your.email@example.com
+#CONFLUENCE_API_TOKEN=your_confluence_api_token
 
-# 1. Using Personal Access Token (recommended):
-# CLI: --confluence-personal-token
-# CONFLUENCE_PERSONAL_TOKEN=your_personal_access_token
+# --- METHOD 3: PERSONAL ACCESS TOKEN (PAT) (Server / Data Center - Recommended) ---
+# Create PATs in your Jira/Confluence profile settings (usually under "Personal Access Tokens").
+#JIRA_PERSONAL_TOKEN=your_jira_personal_access_token
 
-# 2. Using Basic Authentication (username/password):
-# CLI: --confluence-username, --confluence-token
-# CONFLUENCE_USERNAME=your_username
-# CONFLUENCE_API_TOKEN=your_password
+#CONFLUENCE_PERSONAL_TOKEN=your_confluence_personal_access_token
 
-# =============================================
-# JIRA CONFIGURATION
-# =============================================
+# --- METHOD 4: USERNAME/PASSWORD (Server / Data Center - Uses Basic Authentication) ---
+# Not recommended for Cloud. For Server/DC, PAT (Method 3) is generally preferred.
+#JIRA_USERNAME=your_server_dc_username
+#JIRA_API_TOKEN=your_jira_server_dc_password # For Server/DC Basic Auth, API_TOKEN holds the actual password
 
-## ---- CLOUD DEPLOYMENT ----
-# CLI: --jira-url, --jira-username, --jira-token
-JIRA_URL=https://your-domain.atlassian.net
-JIRA_USERNAME=your.email@domain.com
-JIRA_API_TOKEN=your_api_token
+#CONFLUENCE_USERNAME=your_server_dc_username
+#CONFLUENCE_API_TOKEN=your_confluence_server_dc_password
 
-# Optional: Filter projects
-# CLI: --jira-projects-filter
-# JIRA_PROJECTS_FILTER=PROJ,DEV,SUPPORT
-
-## ---- SERVER/DATA CENTER DEPLOYMENT ----
-# CLI: --jira-url, --jira-personal-token, --[no-]jira-ssl-verify
-# JIRA_URL=https://jira.your-company.com
-# JIRA_PERSONAL_TOKEN=your_personal_access_token
-# JIRA_SSL_VERIFY=true                 # CLI: --[no-]jira-ssl-verify
 
 # =============================================
-# PROXY CONFIGURATION (Optional)
+# SERVER/DATA CENTER SPECIFIC SETTINGS
+# =============================================
+# Only applicable if your JIRA_URL/CONFLUENCE_URL points to a Server/DC instance (not *.atlassian.net).
+# Default is true. Set to false if using self-signed certificates (not recommended for production environments).
+#JIRA_SSL_VERIFY=true
+#CONFLUENCE_SSL_VERIFY=true
+
+
+# =============================================
+# OPTIONAL CONFIGURATION
 # =============================================
 
-# Global proxy settings (applies to both Jira and Confluence unless overridden)
-# HTTP_PROXY=http://proxy.example.com:8080
-# HTTPS_PROXY=https://user:pass@proxy.example.com:8443  # Credentials can be included
-# SOCKS_PROXY=socks5://proxy.example.com:1080
-# NO_PROXY=localhost,127.0.0.1,.internal.example.com # Comma-separated list of hosts/domains to bypass the proxy for
+# --- General Server Settings ---
+# Transport mode for the MCP server. Default is 'stdio'.
+# Options: stdio, sse
+#TRANSPORT=stdio
+# Port for 'sse' transport. Default is 8000.
+#PORT=8000
+# Host for 'sse' transport. Default is '0.0.0.0'.
+#HOST=0.0.0.0
 
-# Jira-specific proxy settings (override global if set)
-# JIRA_HTTP_PROXY=http://jira-proxy.example.com:8080
-# JIRA_HTTPS_PROXY=https://jira-proxy.example.com:8443
-# JIRA_SOCKS_PROXY=socks5://jira-proxy.example.com:1080
-# JIRA_NO_PROXY=localhost,127.0.0.1,.internal.jira.com # Comma-separated list to bypass Jira proxy
+# --- Read-Only Mode ---
+# Disables all write operations (create, update, delete). Default is false.
+#READ_ONLY_MODE=false
 
-# Confluence-specific proxy settings (override global if set)
-# CONFLUENCE_HTTP_PROXY=http://confluence-proxy.example.com:8080
-# CONFLUENCE_HTTPS_PROXY=https://confluence-proxy.example.com:8443
-# CONFLUENCE_SOCKS_PROXY=socks5://confluence-proxy.example.com:1080
-# CONFLUENCE_NO_PROXY=localhost,127.0.0.1,.internal.confluence.com # Comma-separated list to bypass Confluence proxy
+# --- Logging Verbosity ---
+# MCP_VERBOSE=true      # Enables INFO level logging (equivalent to 'mcp-atlassian -v')
+# MCP_VERY_VERBOSE=true # Enables DEBUG level logging (equivalent to 'mcp-atlassian -vv')
+# Default logging level is WARNING (minimal output).
+
+# --- Tool Filtering ---
+# Comma-separated list of tool names to enable. If not set, all tools are enabled
+# (subject to read-only mode and configured services).
+# Example: ENABLED_TOOLS=confluence_search,jira_get_issue
+#ENABLED_TOOLS=
+
+# --- Content Filtering ---
+# Optional: Comma-separated list of Confluence space keys to limit searches and other operations to.
+#CONFLUENCE_SPACES_FILTER=DEV,TEAM,DOC
+# Optional: Comma-separated list of Jira project keys to limit searches and other operations to.
+#JIRA_PROJECTS_FILTER=PROJ,DEVOPS
+
+# --- Proxy Configuration (Advanced) ---
+# Global proxy settings (applies to both Jira and Confluence unless overridden by service-specific proxy settings below).
+#HTTP_PROXY=http://proxy.example.com:8080
+#HTTPS_PROXY=https://user:pass@proxy.example.com:8443 # Credentials can be included
+#SOCKS_PROXY=socks5://proxy.example.com:1080 # Requires 'requests[socks]' to be installed
+#NO_PROXY=localhost,127.0.0.1,.internal.example.com # Comma-separated list of hosts/domains to bypass proxy
+
+# Jira-specific proxy settings (these override global proxy settings for Jira requests).
+#JIRA_HTTP_PROXY=http://jira-proxy.example.com:8080
+#JIRA_HTTPS_PROXY=https://jira-proxy.example.com:8443
+#JIRA_SOCKS_PROXY=socks5://jira-proxy.example.com:1080
+#JIRA_NO_PROXY=localhost,127.0.0.1,.internal.jira.com
+
+# Confluence-specific proxy settings (these override global proxy settings for Confluence requests).
+#CONFLUENCE_HTTP_PROXY=http://confluence-proxy.example.com:8080
+#CONFLUENCE_HTTPS_PROXY=https://confluence-proxy.example.com:8443
+#CONFLUENCE_SOCKS_PROXY=socks5://confluence-proxy.example.com:1080
+#CONFLUENCE_NO_PROXY=localhost,127.0.0.1,.internal.confluence.com

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ MCP Atlassian supports three authentication methods:
 2. Click **Create token**, name it, set expiry
 3. Copy the token immediately
 
+#### C. OAuth 2.0 Authentication (Cloud only)
+
+1. Go to [Atlassian Developer Console](https://developer.atlassian.com/console/myapps/)
+2. Create an "OAuth 2.0 integration"
+3. Configure necessary **Permissions** (scopes) for Jira/Confluence
+4. Set **Callback URL** (e.g., `http://localhost:8080/callback` for setup wizard)
+5. Run the OAuth setup wizard:
+   ```bash
+   uvx mcp-atlassian@latest --oauth-setup -v
+   ```
+6. Follow the prompts to enter your `Client ID`, `Client Secret`, `Redirect URI` and `Scope`.
+7. Complete the authorization in the opened browser window
+8. Add the `ATLASSIAN_OAUTH_CLOUD_ID` (obtained from the wizard output) along with your OAuth app's `CLIENT_ID`, `SECRET`, `REDIRECT_URI`, and `SCOPE` to your `.env` file or IDE's MCP server configuration. See the [OAuth 2.0 Configuration Example](#oauth-20-configuration-example-cloud-only) in the "Configuration Examples" section for IDE integration.
+
+> [!IMPORTANT]
+> Include `offline_access` in your `ATLASSIAN_OAUTH_SCOPE` for persistent authentication (e.g., `read:jira-work write:jira-work offline_access`).
+
 ### 2. Installation
 
 MCP Atlassian is distributed as a Docker image. This is the recommended way to run the server, especially for IDE integration. Ensure you have Docker installed.
@@ -185,6 +202,51 @@ For Server/Data Center deployments, use direct variable passing:
 
 > [!NOTE]
 > Set `CONFLUENCE_SSL_VERIFY` and `JIRA_SSL_VERIFY` to "false" only if you have self-signed certificates.
+
+</details>
+
+<details>
+<summary>OAuth 2.0 Configuration (Cloud Only)</summary>
+<a name="oauth-20-configuration-example-cloud-only"></a>
+
+This example shows how to configure `mcp-atlassian` in your IDE (like Cursor or Claude Desktop) when using OAuth 2.0 for Atlassian Cloud. Ensure you have completed the [OAuth setup wizard](#c-oauth-20-authentication-cloud-only) first.
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "JIRA_URL",
+        "-e", "CONFLUENCE_URL",
+        "-e", "ATLASSIAN_OAUTH_CLIENT_ID",
+        "-e", "ATLASSIAN_OAUTH_CLIENT_SECRET",
+        "-e", "ATLASSIAN_OAUTH_REDIRECT_URI",
+        "-e", "ATLASSIAN_OAUTH_SCOPE",
+        "-e", "ATLASSIAN_OAUTH_CLOUD_ID",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "ATLASSIAN_OAUTH_CLIENT_ID": "YOUR_OAUTH_APP_CLIENT_ID",
+        "ATLASSIAN_OAUTH_CLIENT_SECRET": "YOUR_OAUTH_APP_CLIENT_SECRET",
+        "ATLASSIAN_OAUTH_REDIRECT_URI": "http://localhost:8080/callback",
+        "ATLASSIAN_OAUTH_SCOPE": "read:jira-work write:jira-work read:confluence-content.all write:confluence-content offline_access",
+        "ATLASSIAN_OAUTH_CLOUD_ID": "YOUR_CLOUD_ID_FROM_SETUP_WIZARD"
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> - `ATLASSIAN_OAUTH_CLOUD_ID` is obtained from the `--oauth-setup` wizard output.
+> - Other `ATLASSIAN_OAUTH_*` variables are those you configured for your OAuth app in the Atlassian Developer Console (and used as input to the setup wizard).
+> - `JIRA_URL` and `CONFLUENCE_URL` for your Cloud instances are still required.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -215,19 +215,9 @@ This example shows how to configure `mcp-atlassian` in your IDE (like Cursor or 
 {
   "mcpServers": {
     "mcp-atlassian": {
-      "command": "docker",
+      "command": "uvx",
       "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e", "JIRA_URL",
-        "-e", "CONFLUENCE_URL",
-        "-e", "ATLASSIAN_OAUTH_CLIENT_ID",
-        "-e", "ATLASSIAN_OAUTH_CLIENT_SECRET",
-        "-e", "ATLASSIAN_OAUTH_REDIRECT_URI",
-        "-e", "ATLASSIAN_OAUTH_SCOPE",
-        "-e", "ATLASSIAN_OAUTH_CLOUD_ID",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
+        "mcp-atlassian",
       ],
       "env": {
         "JIRA_URL": "https://your-company.atlassian.net",


### PR DESCRIPTION
## Description

Revert OAuth 2.0 authentication documentation with clearer instructions in `.env.example` and `README.md` to streamline the user setup experience.

Refs #404 

## Changes

- Restructured `.env.example` with comprehensive OAuth 2.0 setup guidance
- Revert "OAuth 2.0 Authentication" section to README's Quick Start Guide
