### PR TITLE
Add Confluence comment tool for adding comments to pages

### DIFF
--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -83,3 +83,64 @@ class CommentsMixin(ConfluenceClient):
             logger.error(f"Unexpected error fetching comments: {str(e)}")
             logger.debug("Full exception details for comments:", exc_info=True)
             return []
+
+    def add_comment(self, page_id: str, content: str) -> ConfluenceComment | None:
+        """
+        Add a comment to a Confluence page.
+
+        Args:
+            page_id: The ID of the page to add the comment to
+            content: The content of the comment (in Confluence storage format)
+
+        Returns:
+            ConfluenceComment object if comment was added successfully, None otherwise
+        """
+        try:
+            # Get page info to extract space details
+            page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
+            space_key = page.get("space", {}).get("key", "")
+
+            # Convert markdown to Confluence storage format if needed
+            # The atlassian-python-api expects content in Confluence storage format
+            if not content.strip().startswith("<"):
+                # If content doesn't appear to be HTML/XML, treat it as markdown
+                content = self.preprocessor.markdown_to_confluence_storage(content)
+
+            # Add the comment via the Confluence API
+            response = self.confluence.add_comment(page_id, content)
+
+            if not response:
+                logger.error("Failed to add comment: empty response")
+                return None
+
+            # Process the comment to return a consistent model
+            processed_html, processed_markdown = self.preprocessor.process_html_content(
+                response.get("body", {}).get("view", {}).get("value", ""),
+                space_key=space_key,
+            )
+
+            # Modify the response to include processed content
+            modified_response = response.copy()
+            if "body" not in modified_response:
+                modified_response["body"] = {}
+            if "view" not in modified_response["body"]:
+                modified_response["body"]["view"] = {}
+
+            modified_response["body"]["view"]["value"] = processed_markdown
+
+            # Create and return the comment model
+            return ConfluenceComment.from_api_response(
+                modified_response,
+                base_url=self.config.url,
+            )
+
+        except requests.RequestException as e:
+            logger.error(f"Network error when adding comment: {str(e)}")
+            return None
+        except (ValueError, TypeError, KeyError) as e:
+            logger.error(f"Error processing comment data: {str(e)}")
+            return None
+        except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging
+            logger.error(f"Unexpected error adding comment: {str(e)}")
+            logger.debug("Full exception details for adding comment:", exc_info=True)
+            return None

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -136,3 +136,132 @@ class TestCommentsMixin:
         # Assert
         assert isinstance(result, list)
         assert len(result) == 0  # Empty list with no comments
+
+    def test_add_comment_success(self, comments_mixin):
+        """Test adding a comment with success response."""
+        # Setup
+        page_id = "12345"
+        content = "This is a test comment"
+
+        # Mock the page retrieval
+        comments_mixin.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+
+        # Mock the preprocessor's conversion method
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>This is a test comment</p>"
+        )
+
+        # Configure the mock to return a successful response
+        comments_mixin.confluence.add_comment.return_value = {
+            "id": "98765",
+            "body": {"view": {"value": "<p>This is a test comment</p>"}},
+            "version": {"number": 1},
+            "author": {"displayName": "Test User"},
+        }
+
+        # Mock the HTML processing
+        comments_mixin.preprocessor.process_html_content.return_value = (
+            "<p>This is a test comment</p>",
+            "This is a test comment",
+        )
+
+        # Call the method
+        result = comments_mixin.add_comment(page_id, content)
+
+        # Verify
+        comments_mixin.confluence.add_comment.assert_called_once_with(
+            page_id, "<p>This is a test comment</p>"
+        )
+        assert result is not None
+        assert result.id == "98765"
+        assert result.body == "This is a test comment"
+
+    def test_add_comment_with_html_content(self, comments_mixin):
+        """Test adding a comment with HTML content."""
+        # Setup
+        page_id = "12345"
+        content = "<p>This is an <strong>HTML</strong> comment</p>"
+
+        # Mock the page retrieval
+        comments_mixin.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+
+        # Configure the mock to return a successful response
+        comments_mixin.confluence.add_comment.return_value = {
+            "id": "98765",
+            "body": {
+                "view": {"value": "<p>This is an <strong>HTML</strong> comment</p>"}
+            },
+            "version": {"number": 1},
+            "author": {"displayName": "Test User"},
+        }
+
+        # Mock the HTML processing
+        comments_mixin.preprocessor.process_html_content.return_value = (
+            "<p>This is an <strong>HTML</strong> comment</p>",
+            "This is an **HTML** comment",
+        )
+
+        # Call the method
+        result = comments_mixin.add_comment(page_id, content)
+
+        # Verify - should not call markdown conversion since content is already HTML
+        comments_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+        comments_mixin.confluence.add_comment.assert_called_once_with(page_id, content)
+        assert result is not None
+        assert result.body == "This is an **HTML** comment"
+
+    def test_add_comment_api_error(self, comments_mixin):
+        """Test handling of API errors when adding a comment."""
+        # Setup
+        page_id = "12345"
+        content = "This is a test comment"
+
+        # Mock the page retrieval
+        comments_mixin.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+
+        # Mock the preprocessor's conversion method
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>This is a test comment</p>"
+        )
+
+        # Mock the API to raise an exception
+        comments_mixin.confluence.add_comment.side_effect = requests.RequestException(
+            "API error"
+        )
+
+        # Call the method
+        result = comments_mixin.add_comment(page_id, content)
+
+        # Verify
+        assert result is None
+
+    def test_add_comment_empty_response(self, comments_mixin):
+        """Test handling of empty API response when adding a comment."""
+        # Setup
+        page_id = "12345"
+        content = "This is a test comment"
+
+        # Mock the page retrieval
+        comments_mixin.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+
+        # Mock the preprocessor's conversion method
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>This is a test comment</p>"
+        )
+
+        # Configure the mock to return an empty response
+        comments_mixin.confluence.add_comment.return_value = None
+
+        # Call the method
+        result = comments_mixin.add_comment(page_id, content)
+
+        # Verify
+        assert result is None


### PR DESCRIPTION
## Description

This PR adds a new "add_comment" tool for Confluence.

Fixes: #276

## Changes

- Added `add_comment` method to `CommentsMixin` class for the Confluence client
- Added `add_comment` tool to the Confluence MCP server
- Added tests for both the client method and the server tool
- Added read-only mode protection for the comment tool

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed (on my personal tenant)
- [x] Manual checks performed: Tested adding comments to a real Confluence page via API token auth

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (tool is self-documenting).
