### PR TITLE
feat: Enhance confluence_get_page tool to support lookup by page title and space key

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -113,8 +113,10 @@ async def get_page(
         str,
         Field(
             description=(
-                "Confluence page ID (numeric ID). Provide this OR both 'title' and 'space_key'. "
-                "If page_id is provided, title and space_key will be ignored."
+                "Confluence page ID (numeric ID, can be found in the page URL). "
+                "For example, in the URL 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', "
+                "the page ID is '123456789'. "
+                "Provide this OR both 'title' and 'space_key'. If page_id is provided, title and space_key will be ignored."
             ),
             default="",
         ),

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -105,6 +105,7 @@ async def search(
     return json.dumps(search_results, indent=2, ensure_ascii=False)
 
 
+@convert_empty_defaults_to_none
 @confluence_mcp.tool(tags={"confluence", "read"})
 async def get_page(
     ctx: Context,
@@ -112,16 +113,34 @@ async def get_page(
         str,
         Field(
             description=(
-                "Confluence page ID (numeric ID, can be found in the page URL). "
-                "For example, in the URL 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', "
-                "the page ID is '123456789'"
-            )
+                "Confluence page ID (numeric ID). Provide this OR both 'title' and 'space_key'. "
+                "If page_id is provided, title and space_key will be ignored."
+            ),
+            default="",
         ),
-    ],
+    ] = "",
+    title: Annotated[
+        str,
+        Field(
+            description=(
+                "The exact title of the Confluence page. Use this with 'space_key' if 'page_id' is not known."
+            ),
+            default="",
+        ),
+    ] = "",
+    space_key: Annotated[
+        str,
+        Field(
+            description=(
+                "The key of the Confluence space where the page resides (e.g., 'DEV', 'TEAM'). Required if using 'title'."
+            ),
+            default="",
+        ),
+    ] = "",
     include_metadata: Annotated[
         bool,
         Field(
-            description="Whether to include page metadata such as creation date, last update, version, and labels",
+            description="Whether to include page metadata such as creation date, last update, version, and labels.",
             default=True,
         ),
     ] = True,
@@ -137,28 +156,70 @@ async def get_page(
         ),
     ] = True,
 ) -> str:
-    """Get content of a specific Confluence page by ID.
+    """Get content of a specific Confluence page by its ID, or by its title and space key.
 
     Args:
         ctx: The FastMCP context.
-        page_id: Confluence page ID.
+        page_id: Confluence page ID. If provided, 'title' and 'space_key' are ignored.
+        title: The exact title of the page. Must be used with 'space_key'.
+        space_key: The key of the space. Must be used with 'title'.
         include_metadata: Whether to include page metadata.
         convert_to_markdown: Convert content to markdown (true) or keep raw HTML (false).
 
     Returns:
-        JSON string representing the page content and/or metadata.
+        JSON string representing the page content and/or metadata, or an error if not found or parameters are invalid.
     """
     lifespan_ctx = ctx.request_context.lifespan_context
     if not lifespan_ctx or not lifespan_ctx.confluence:
         raise ValueError("Confluence client is not configured or available.")
     confluence = lifespan_ctx.confluence
 
-    page = confluence.get_page_content(page_id, convert_to_markdown=convert_to_markdown)
+    page_object = None  # Expects ConfluencePage | None
+
+    if page_id:
+        if title or space_key:
+            logger.warning(
+                "page_id was provided; title and space_key parameters will be ignored."
+            )
+        try:
+            page_object = confluence.get_page_content(
+                page_id, convert_to_markdown=convert_to_markdown
+            )
+        except Exception as e:
+            logger.error(f"Error fetching page by ID '{page_id}': {e}")
+            return json.dumps(
+                {"error": f"Failed to retrieve page by ID '{page_id}': {e}"},
+                indent=2,
+                ensure_ascii=False,
+            )
+    elif title and space_key:
+        page_object = confluence.get_page_by_title(
+            space_key, title, convert_to_markdown=convert_to_markdown
+        )
+        if not page_object:
+            return json.dumps(
+                {
+                    "error": f"Page with title '{title}' not found in space '{space_key}'."
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+    else:
+        raise ValueError(
+            "Either 'page_id' OR both 'title' and 'space_key' must be provided."
+        )
+
+    if not page_object:
+        return json.dumps(
+            {"error": "Page not found with the provided identifiers."},
+            indent=2,
+            ensure_ascii=False,
+        )
 
     if include_metadata:
-        result = {"metadata": page.to_simplified_dict()}
+        result = {"metadata": page_object.to_simplified_dict()}
     else:
-        result = {"content": page.content}
+        result = {"content": page_object.content}
 
     return json.dumps(result, indent=2, ensure_ascii=False)
 

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -517,7 +517,11 @@ async def test_invalid_arguments(client):
     with pytest.raises(Exception) as excinfo:
         await client.call_tool("get_page", {})  # Missing page_id
     error_msg = str(excinfo.value).lower()
-    assert "validation error" in error_msg or "missing" in error_msg
+    assert (
+        "validation error" in error_msg
+        or "missing" in error_msg
+        or "must be provided" in error_msg
+    )
 
 
 @pytest.mark.anyio
@@ -553,3 +557,84 @@ async def test_add_comment(client, mock_confluence_fetcher):
     assert result_data["success"] is True
     assert "comment" in result_data
     assert result_data["comment"]["id"] == "987"
+
+
+@pytest.mark.anyio
+async def test_get_page_by_title_and_space_key(client, mock_confluence_fetcher):
+    """Test get_page tool with title and space_key lookup."""
+    mock_page = MagicMock(spec=ConfluencePage)
+    mock_page.to_simplified_dict.return_value = {
+        "id": "654321",
+        "title": "Title Lookup Page",
+        "url": "https://example.atlassian.net/wiki/spaces/TEST/pages/654321/Title+Lookup",
+        "content": {
+            "value": "Content by title lookup",
+            "format": "markdown",
+        },
+    }
+    mock_page.content = "Content by title lookup"
+    mock_confluence_fetcher.get_page_by_title.return_value = mock_page
+
+    response = await client.call_tool(
+        "get_page", {"title": "Title Lookup Page", "space_key": "TEST"}
+    )
+    mock_confluence_fetcher.get_page_by_title.assert_called_once_with(
+        "TEST", "Title Lookup Page", convert_to_markdown=True
+    )
+    result_data = json.loads(response[0].text)
+    assert "metadata" in result_data
+    assert result_data["metadata"]["title"] == "Title Lookup Page"
+    assert result_data["metadata"]["content"]["value"] == "Content by title lookup"
+
+
+@pytest.mark.anyio
+async def test_get_page_by_title_and_space_key_not_found(
+    client, mock_confluence_fetcher
+):
+    """Test get_page tool with title and space_key when page is not found."""
+    mock_confluence_fetcher.get_page_by_title.return_value = None
+    response = await client.call_tool(
+        "get_page", {"title": "Missing Page", "space_key": "TEST"}
+    )
+    result_data = json.loads(response[0].text)
+    assert "error" in result_data
+    assert "not found" in result_data["error"]
+
+
+@pytest.mark.anyio
+async def test_get_page_error_missing_space_key(client, mock_confluence_fetcher):
+    """Test get_page tool with title but missing space_key (should error)."""
+    with pytest.raises(Exception) as excinfo:
+        await client.call_tool("get_page", {"title": "Some Page"})
+    assert "must be provided" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+async def test_get_page_error_missing_title(client, mock_confluence_fetcher):
+    """Test get_page tool with space_key but missing title (should error)."""
+    with pytest.raises(Exception) as excinfo:
+        await client.call_tool("get_page", {"space_key": "TEST"})
+    assert "must be provided" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+async def test_get_page_error_no_identifiers(client, mock_confluence_fetcher):
+    """Test get_page tool with neither page_id nor title+space_key (should error)."""
+    with pytest.raises(Exception) as excinfo:
+        await client.call_tool("get_page", {})
+    assert "must be provided" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+async def test_get_page_precedence_page_id(client, mock_confluence_fetcher):
+    """Test get_page tool uses page_id even if title and space_key are provided."""
+    response = await client.call_tool(
+        "get_page", {"page_id": "123456", "title": "Ignored", "space_key": "IGNORED"}
+    )
+    mock_confluence_fetcher.get_page_content.assert_called_once_with(
+        "123456", convert_to_markdown=True
+    )
+    mock_confluence_fetcher.get_page_by_title.assert_not_called()
+    result_data = json.loads(response[0].text)
+    assert "metadata" in result_data
+    assert result_data["metadata"]["title"] == "Test Page Mock Title"


### PR DESCRIPTION
## Description

Enhances the `confluence_get_page` tool to allow retrieving a Confluence page by either its numeric `page_id` or by specifying both `title` and `space_key`. This improves usability for users and LLMs who may not know the page ID.

Fixes: #335

## Changes

- Made `page_id` optional; added `title` and `space_key` as alternative parameters.
- Added validation to ensure correct parameter combinations.
- Updated parameter descriptions for clarity.
- Applied `@convert_empty_defaults_to_none` for robust input handling.
- Consistent JSON response for both lookup methods.
- Expanded and updated unit tests for all new behaviors and error cases.

## Testing

- [x] Unit tests added/updated (including all new logic and error cases)
- [x] All tests pass locally
- [x] Manual checks: verified both ID-based and title/space-based lookups, and error handling for invalid input

## Checklist

- [x] Code follows project style guidelines (linting passes)
- [x] Tests added/updated for changes
- [x] All tests pass locally
- [x] Documentation updated (parameter descriptions and usage examples)
