### PR TITLE
fix: Resolve AttributeError by using context for read-only check in Confluence and Jira tools

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -8,8 +8,10 @@ from fastmcp import Context, FastMCP
 from pydantic import Field
 
 from mcp_atlassian.servers.dependencies import get_confluence_fetcher
-
-from ..utils import convert_empty_defaults_to_none
+from mcp_atlassian.utils.decorators import (
+    check_write_access,
+    convert_empty_defaults_to_none,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -372,6 +374,7 @@ async def get_labels(
 
 
 @confluence_mcp.tool(tags={"confluence", "write"})
+@check_write_access
 async def add_label(
     ctx: Context,
     page_id: Annotated[str, Field(description="The ID of the page to update")],
@@ -391,19 +394,6 @@ async def add_label(
         ValueError: If in read-only mode or Confluence client is unavailable.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
-    lifespan_ctx_dict = ctx.request_context.lifespan_context
-    app_lifespan_ctx = (
-        lifespan_ctx_dict.get("app_lifespan_context")
-        if isinstance(lifespan_ctx_dict, dict)
-        else None
-    )
-    logger.debug(
-        f"add_label: app_lifespan_ctx.read_only = {app_lifespan_ctx.read_only if app_lifespan_ctx else 'N/A (app_lifespan_ctx is None)'}"
-    )
-    if app_lifespan_ctx is not None and app_lifespan_ctx.read_only:
-        logger.warning("Attempted to call add_label in read-only mode.")
-        raise ValueError("Cannot add label in read-only mode.")
-
     labels = confluence_fetcher.add_page_label(page_id, name)
     formatted_labels = [label.to_simplified_dict() for label in labels]
     return json.dumps(formatted_labels, indent=2, ensure_ascii=False)
@@ -411,6 +401,7 @@ async def add_label(
 
 @convert_empty_defaults_to_none
 @confluence_mcp.tool(tags={"confluence", "write"})
+@check_write_access
 async def create_page(
     ctx: Context,
     space_key: Annotated[
@@ -450,19 +441,6 @@ async def create_page(
         ValueError: If in read-only mode or Confluence client is unavailable.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
-    lifespan_ctx_dict = ctx.request_context.lifespan_context
-    app_lifespan_ctx = (
-        lifespan_ctx_dict.get("app_lifespan_context")
-        if isinstance(lifespan_ctx_dict, dict)
-        else None
-    )
-    logger.debug(
-        f"create_page: app_lifespan_ctx.read_only = {app_lifespan_ctx.read_only if app_lifespan_ctx else 'N/A (app_lifespan_ctx is None)'}"
-    )
-    if app_lifespan_ctx is not None and app_lifespan_ctx.read_only:
-        logger.warning("Attempted to call create_page in read-only mode.")
-        raise ValueError("Cannot create page in read-only mode.")
-
     page = confluence_fetcher.create_page(
         space_key=space_key,
         title=title,
@@ -480,6 +458,7 @@ async def create_page(
 
 @convert_empty_defaults_to_none
 @confluence_mcp.tool(tags={"confluence", "write"})
+@check_write_access
 async def update_page(
     ctx: Context,
     page_id: Annotated[str, Field(description="The ID of the page to update")],
@@ -516,19 +495,6 @@ async def update_page(
         ValueError: If Confluence client is not configured or available.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
-    lifespan_ctx_dict = ctx.request_context.lifespan_context
-    app_lifespan_ctx = (
-        lifespan_ctx_dict.get("app_lifespan_context")
-        if isinstance(lifespan_ctx_dict, dict)
-        else None
-    )
-    logger.debug(
-        f"update_page: app_lifespan_ctx.read_only = {app_lifespan_ctx.read_only if app_lifespan_ctx else 'N/A (app_lifespan_ctx is None)'}"
-    )
-    if app_lifespan_ctx is not None and app_lifespan_ctx.read_only:
-        logger.warning("Attempted to call update_page in read-only mode.")
-        raise ValueError("Cannot update page in read-only mode.")
-
     # TODO: revert this once Cursor IDE handles optional parameters with Union types correctly.
     actual_parent_id = parent_id if parent_id else None
 
@@ -550,6 +516,7 @@ async def update_page(
 
 
 @confluence_mcp.tool(tags={"confluence", "write"})
+@check_write_access
 async def delete_page(
     ctx: Context,
     page_id: Annotated[str, Field(description="The ID of the page to delete")],
@@ -567,19 +534,6 @@ async def delete_page(
         ValueError: If Confluence client is not configured or available.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
-    lifespan_ctx_dict = ctx.request_context.lifespan_context
-    app_lifespan_ctx = (
-        lifespan_ctx_dict.get("app_lifespan_context")
-        if isinstance(lifespan_ctx_dict, dict)
-        else None
-    )
-    logger.debug(
-        f"delete_page: app_lifespan_ctx.read_only = {app_lifespan_ctx.read_only if app_lifespan_ctx else 'N/A (app_lifespan_ctx is None)'}"
-    )
-    if app_lifespan_ctx is not None and app_lifespan_ctx.read_only:
-        logger.warning("Attempted to call delete_page in read-only mode.")
-        raise ValueError("Cannot delete page in read-only mode.")
-
     try:
         result = confluence_fetcher.delete_page(page_id=page_id)
         if result:
@@ -604,6 +558,7 @@ async def delete_page(
 
 
 @confluence_mcp.tool(tags={"confluence", "write"})
+@check_write_access
 async def add_comment(
     ctx: Context,
     page_id: Annotated[
@@ -627,16 +582,6 @@ async def add_comment(
         ValueError: If in read-only mode or Confluence client is unavailable.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
-    lifespan_ctx_dict = ctx.request_context.lifespan_context
-    app_lifespan_ctx = (
-        lifespan_ctx_dict.get("app_lifespan_context")
-        if isinstance(lifespan_ctx_dict, dict)
-        else None
-    )
-    if app_lifespan_ctx is not None and app_lifespan_ctx.read_only:
-        logger.warning("Attempted to call add_comment in read-only mode.")
-        raise ValueError("Cannot add comment in read-only mode.")
-
     try:
         comment = confluence_fetcher.add_comment(page_id=page_id, content=content)
         if comment:

--- a/src/mcp_atlassian/utils/decorators.py
+++ b/src/mcp_atlassian/utils/decorators.py
@@ -4,6 +4,8 @@ from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import Any, TypeVar
 
+from fastmcp import Context
+
 from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.jira.config import JiraConfig
 
@@ -114,3 +116,35 @@ def convert_empty_defaults_to_none(func: Callable) -> Callable:
         return await func(*final_call_args, **final_call_kwargs)
 
     return wrapper
+
+
+F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
+
+
+def check_write_access(func: F) -> F:
+    """
+    Decorator for FastMCP tools to check if the application is in read-only mode.
+    If in read-only mode, it raises a ValueError.
+    Assumes the decorated function is async and has `ctx: Context` as its first argument.
+    """
+
+    @wraps(func)
+    async def wrapper(ctx: Context, *args: Any, **kwargs: Any) -> Any:
+        lifespan_ctx_dict = ctx.request_context.lifespan_context
+        app_lifespan_ctx = (
+            lifespan_ctx_dict.get("app_lifespan_context")
+            if isinstance(lifespan_ctx_dict, dict)
+            else None
+        )  # type: ignore
+
+        if app_lifespan_ctx is not None and app_lifespan_ctx.read_only:
+            tool_name = func.__name__
+            action_description = tool_name.replace(
+                "_", " "
+            )  # e.g., "create_issue" -> "create issue"
+            logger.warning(f"Attempted to call tool '{tool_name}' in read-only mode.")
+            raise ValueError(f"Cannot {action_description} in read-only mode.")
+
+        return await func(ctx, *args, **kwargs)
+
+    return wrapper  # type: ignore

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.utils.decorators import check_write_access
+
+
+class DummyContext:
+    def __init__(self, read_only):
+        self.request_context = MagicMock()
+        self.request_context.lifespan_context = {
+            "app_lifespan_context": MagicMock(read_only=read_only)
+        }
+
+
+@pytest.mark.asyncio
+async def test_check_write_access_blocks_in_read_only():
+    @check_write_access
+    async def dummy_tool(ctx, x):
+        return x * 2
+
+    ctx = DummyContext(read_only=True)
+    with pytest.raises(ValueError) as exc:
+        await dummy_tool(ctx, 3)
+    assert "read-only mode" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_check_write_access_allows_in_writable():
+    @check_write_access
+    async def dummy_tool(ctx, x):
+        return x * 2
+
+    ctx = DummyContext(read_only=False)
+    result = await dummy_tool(ctx, 4)
+    assert result == 8


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

This PR addresses an `AttributeError: 'JiraConfig' object has no attribute 'read_only'` that occurred in Jira write tools and standardizes read-only mode checks across all Jira and Confluence write-enabled tools.

The `read_only` flag was previously moved to `MainAppContext`, but Jira tools were still attempting to access it via `jira.config.read_only`. This PR introduces a `@check_write_access` decorator that correctly uses the application context for these checks. This decorator has now been applied to all write tools in both `src/mcp_atlassian/servers/jira.py` and `src/mcp_atlassian/servers/confluence.py`, ensuring consistent behavior and cleaner code.

Fixes: #434

## Changes

-   **New Decorator:**
    -   Created `@check_write_access` in `src/mcp_atlassian/utils/decorators.py` to handle read-only mode checks based on `MainAppContext`.
-   **Jira Tools Refactor:**
    -   Applied `@check_write_access` to all Jira write tools.
    -   Removed incorrect `if jira.config.read_only:` checks from Jira tools.
-   **Confluence Tools Refactor:**
    -   Applied `@check_write_access` to all Confluence write tools.
    -   Removed manual read-only checks ( `if app_lifespan_ctx is not None and app_lifespan_ctx.read_only:` ) from Confluence tools.
-   **Testing:**
    -   Added unit tests for the new `@check_write_access` decorator in `tests/unit/utils/test_decorators.py`.

## Testing

-   [x] Unit tests added/updated:
    -   New unit tests for the `@check_write_access` decorator verify its functionality.
    -   Existing tool unit tests implicitly benefit as the read-only check is now part of the decorator's responsibility.
-   [ ] Integration tests to be enhanced to cover read-only scenarios for all write tools.
-   [x] Manual checks performed:
    -   Verified Jira and Confluence write tools correctly block operations in read-only mode (`READ_ONLY_MODE=true`).
    -   Verified Jira and Confluence write tools succeed when not in read-only mode.

## Checklist

-   [x] Code follows project style guidelines (linting passes).
-   [x] Tests added/updated for changes.
-   [x] All tests pass locally.
-   [ ] Documentation updated (if needed). *(No direct user-facing documentation changes required for this refactor.)*