### PR TITLE
Refactor: Improve Tool Listing by Validating Service Authentication

### DIFF
--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -1,5 +1,6 @@
 """Configuration module for the Confluence client."""
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Literal
@@ -122,3 +123,28 @@ class ConfluenceConfig:
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
         )
+
+    def is_auth_configured(self) -> bool:
+        """Check if the current authentication configuration is complete and valid for making API calls.
+
+        Returns:
+            bool: True if authentication is fully configured, False otherwise.
+        """
+        logger = logging.getLogger("mcp-atlassian.confluence.config")
+        if self.auth_type == "oauth":
+            return bool(
+                self.oauth_config
+                and self.oauth_config.client_id
+                and self.oauth_config.client_secret
+                and self.oauth_config.redirect_uri
+                and self.oauth_config.scope
+                and self.oauth_config.cloud_id
+            )
+        elif self.auth_type == "token":
+            return bool(self.personal_token)
+        elif self.auth_type == "basic":
+            return bool(self.username and self.api_token)
+        logger.warning(
+            f"Unknown or unsupported auth_type: {self.auth_type} in ConfluenceConfig"
+        )
+        return False

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -1,5 +1,6 @@
 """Configuration module for Jira API interactions."""
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Literal
@@ -122,3 +123,28 @@ class JiraConfig:
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
         )
+
+    def is_auth_configured(self) -> bool:
+        """Check if the current authentication configuration is complete and valid for making API calls.
+
+        Returns:
+            bool: True if authentication is fully configured, False otherwise.
+        """
+        logger = logging.getLogger("mcp-atlassian.jira.config")
+        if self.auth_type == "oauth":
+            return bool(
+                self.oauth_config
+                and self.oauth_config.client_id
+                and self.oauth_config.client_secret
+                and self.oauth_config.redirect_uri
+                and self.oauth_config.scope
+                and self.oauth_config.cloud_id
+            )
+        elif self.auth_type == "token":
+            return bool(self.personal_token)
+        elif self.auth_type == "basic":
+            return bool(self.username and self.api_token)
+        logger.warning(
+            f"Unknown or unsupported auth_type: {self.auth_type} in JiraConfig"
+        )
+        return False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

This PR addresses an issue where tools for Jira or Confluence services were listed (`tools/list`) even if the respective service was not fully or correctly authenticated. For example, if only `JIRA_URL` was provided without any authentication tokens, Jira tools would still appear as available. This could lead to user confusion, especially in single-service setups or when a configuration is incomplete.

This change ensures that only tools for fully authenticated services are listed.

Fixes:

## Changes

- **Added `is_auth_configured()` method to `JiraConfig` and `ConfluenceConfig`:**
  - This new method checks if all required authentication details (e.g., tokens, OAuth client credentials, cloud_id) are present and valid for the chosen `auth_type`.
- **Updated Server Lifespan (`main_lifespan`):**
  - The `MainAppContext` now only stores `JiraConfig` or `ConfluenceConfig` instances if `is_auth_configured()` returns `True` for them. Otherwise, the respective `full_jira_config` or `full_confluence_config` in the context will be `None`.
  - Added warning logs if a service URL is found but authentication is incomplete.
- **Enhanced `AtlassianMCP._mcp_list_tools`:**
  - This method now checks if `app_lifespan_state.full_jira_config` or `app_lifespan_state.full_confluence_config` is `None` before including Jira or Confluence tools in the list.
  - Tools associated with unconfigured/unauthenticated services are now excluded from the `tools/list` response.

## Testing

- [ ] Unit tests added/updated (Consider adding tests for `is_auth_configured` in `Config` classes and for `_mcp_list_tools` filtering logic if feasible).
- [ ] Integration tests passed (If applicable).
- [ ] Manual checks performed:
    - Verified that if only Jira is configured (with full auth), only Jira tools are listed.
    - Verified that if only Confluence is configured (with full auth), only Confluence tools are listed.
    - Verified that if a service URL is present but auth details are missing (e.g., `JIRA_URL` but no `JIRA_API_TOKEN`), tools for that service are NOT listed.
    - Verified that if both services are fully configured, all relevant tools are listed (subject to `ENABLED_TOOLS` and `READ_ONLY_MODE`).
    - Checked server logs for new warning messages regarding incomplete configurations.

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [X] All tests pass locally.
- [ ] Documentation updated (if needed, e.g., in `README.md` if this impacts user-facing configuration behavior significantly, though it's more of an internal correctness fix).