### PR TITLE
feat(jira): include human-readable names for Jira custom fields

### DIFF
--- a/tests/fixtures/jira_mocks.py
+++ b/tests/fixtures/jira_mocks.py
@@ -128,6 +128,13 @@ MOCK_JIRA_ISSUE_RESPONSE = {
             {"value": "Custom MultiSelect 2"},
         ],
     },
+    "names": {
+        "customfield_10011": "Epic Name",
+        "customfield_10014": "Epic Link",
+        "customfield_10001": "My Custom Text Field",
+        "customfield_10002": "My Custom Select",
+        "customfield_10003": "My Custom MultiSelect",
+    },
 }
 
 MOCK_JIRA_JQL_RESPONSE = {
@@ -239,6 +246,10 @@ MOCK_JIRA_JQL_RESPONSE = {
             },
         }
     ],
+    "names": {
+        "customfield_10011": "Epic Name",
+        "customfield_10014": "Epic Link",
+    },
 }
 
 # Generic mock Jira comments data without any company-specific information

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -189,8 +189,10 @@ class TestIssuesMixin:
             assert issue.summary == "Test Issue"
 
             # Verify that the epic information is in the custom fields
-            assert issue.custom_fields.get("customfield_10010") == "EPIC-456"
-            assert issue.custom_fields.get("customfield_10011") == "Epic Name Value"
+            assert issue.custom_fields.get("customfield_10010") == {"value": "EPIC-456"}
+            assert issue.custom_fields.get("customfield_10011") == {
+                "value": "Epic Name Value"
+            }
 
         except Exception as e:
             pytest.fail(f"Test failed: {e}")
@@ -865,7 +867,7 @@ class TestIssuesMixin:
         # Check the result
         simplified = issue.to_simplified_dict()
         assert "customfield_10049" in simplified
-        assert simplified["customfield_10049"] == "Custom value"
+        assert simplified["customfield_10049"] == {"value": "Custom value"}
         assert "description" not in simplified
 
         # Test with list format
@@ -886,7 +888,7 @@ class TestIssuesMixin:
         # Check the result
         simplified = issue.to_simplified_dict()
         assert "customfield_10050" in simplified
-        assert simplified["customfield_10050"] == "Option value"
+        assert simplified["customfield_10050"] == {"value": "Option value"}
 
     def test_get_issue_with_all_fields(self, issues_mixin: IssuesMixin):
         """Test get_issue with '*all' fields parameter."""

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -434,7 +434,7 @@ class TestSearchMixin:
         assert "assignee" in simplified
         assert "customfield_10049" in simplified
 
-        assert simplified["customfield_10049"] == "Custom value"
+        assert simplified["customfield_10049"] == {"value": "Custom value"}
         assert "assignee" in simplified
         assert simplified["assignee"]["display_name"] == "Test User"
 

--- a/tests/unit/models/test_jira_models.py
+++ b/tests/unit/models/test_jira_models.py
@@ -689,7 +689,9 @@ class TestJiraIssue:
         assert simplified_specific["project"]["key"] == "PROJ"
         assert simplified_specific["resolution"]["name"] == "Fixed"
         assert len(simplified_specific["subtasks"]) == 1
-        assert simplified_specific["customfield_10011"] == "Epic Name Example"
+        assert simplified_specific["customfield_10011"] == {
+            "value": "Epic Name Example"
+        }
 
     def test_find_custom_field_in_api_response(self):
         """Test the _find_custom_field_in_api_response method with different field patterns."""
@@ -861,6 +863,7 @@ class TestJiraIssue:
         assert "customfield_10002" in simplified
         assert "summary" not in simplified
         assert "customfield_10001" not in simplified
+        assert simplified["customfield_10002"] == {"value": "Custom Select Value"}
 
         issue = JiraIssue.from_api_response(jira_issue_data, requested_fields="*all")
         simplified = issue.to_simplified_dict()
@@ -875,7 +878,7 @@ class TestJiraIssue:
         )
         simplified_specific = issue_specific.to_simplified_dict()
         assert "customfield_10014" in simplified_specific
-        assert simplified_specific.get("customfield_10014") == "EPIC-KEY-1"
+        assert simplified_specific.get("customfield_10014") == {"value": "EPIC-KEY-1"}
 
     def test_jira_issue_with_default_fields(self, jira_issue_data):
         """Test that JiraIssue returns only essential fields by default."""

--- a/tests/unit/models/test_jira_models.py
+++ b/tests/unit/models/test_jira_models.py
@@ -492,6 +492,18 @@ class TestJiraIssue:
         assert issue.worklog["total"] == 0
         assert issue.worklog["maxResults"] == 20
 
+        # Verify custom_fields structure after from_api_response
+        assert "customfield_10001" in issue.custom_fields
+        assert issue.custom_fields["customfield_10001"] == {
+            "value": "Custom Text Field Value",
+            "name": "My Custom Text Field",
+        }
+        assert "customfield_10002" in issue.custom_fields
+        assert issue.custom_fields["customfield_10002"] == {
+            "value": {"value": "Custom Select Value"},  # Original value is a dict
+            "name": "My Custom Select",
+        }
+
     def test_from_api_response_with_new_fields(self):
         """Test creating a JiraIssue focusing on parsing the new fields."""
         # Construct local mock data including the new fields
@@ -689,9 +701,14 @@ class TestJiraIssue:
         assert simplified_specific["project"]["key"] == "PROJ"
         assert simplified_specific["resolution"]["name"] == "Fixed"
         assert len(simplified_specific["subtasks"]) == 1
-        assert simplified_specific["customfield_10011"] == {
-            "value": "Epic Name Example"
-        }
+        # Check custom field output
+        assert (
+            simplified_specific["customfield_10011"]
+            == {
+                "value": "Epic Name Example",
+                "name": "Epic Name",  # Comes from the "names" map in MOCK_JIRA_ISSUE_RESPONSE
+            }
+        )
 
     def test_find_custom_field_in_api_response(self):
         """Test the _find_custom_field_in_api_response method with different field patterns."""
@@ -842,6 +859,9 @@ class TestJiraIssue:
         simplified = issue.to_simplified_dict()
         assert simplified["key"] == "PROJ-123"
         assert simplified["summary"] == "Test Issue Summary"
+        # By default (no requested_fields or default set), custom fields are not included
+        # unless they are part of DEFAULT_READ_JIRA_FIELDS (which they are not).
+        # So, this assertion should be that they are NOT present.
         assert "customfield_10001" not in simplified
         assert "customfield_10002" not in simplified
         assert "customfield_10003" not in simplified
@@ -853,6 +873,8 @@ class TestJiraIssue:
         assert "key" in simplified
         assert "summary" in simplified
         assert "customfield_10001" in simplified
+        assert simplified["customfield_10001"]["value"] == "Custom Text Field Value"
+        assert simplified["customfield_10001"]["name"] == "My Custom Text Field"
         assert "customfield_10002" not in simplified
 
         issue = JiraIssue.from_api_response(
@@ -863,14 +885,19 @@ class TestJiraIssue:
         assert "customfield_10002" in simplified
         assert "summary" not in simplified
         assert "customfield_10001" not in simplified
-        assert simplified["customfield_10002"] == {"value": "Custom Select Value"}
+        assert simplified["customfield_10002"]["value"] == "Custom Select Value"
+        assert simplified["customfield_10002"]["name"] == "My Custom Select"
 
         issue = JiraIssue.from_api_response(jira_issue_data, requested_fields="*all")
         simplified = issue.to_simplified_dict()
         assert "key" in simplified
         assert "summary" in simplified
         assert "customfield_10001" in simplified
+        assert simplified["customfield_10001"]["value"] == "Custom Text Field Value"
+        assert simplified["customfield_10001"]["name"] == "My Custom Text Field"
         assert "customfield_10002" in simplified
+        assert simplified["customfield_10002"]["value"] == "Custom Select Value"
+        assert simplified["customfield_10002"]["name"] == "My Custom Select"
         assert "customfield_10003" in simplified
 
         issue_specific = JiraIssue.from_api_response(
@@ -878,7 +905,10 @@ class TestJiraIssue:
         )
         simplified_specific = issue_specific.to_simplified_dict()
         assert "customfield_10014" in simplified_specific
-        assert simplified_specific.get("customfield_10014") == {"value": "EPIC-KEY-1"}
+        assert simplified_specific.get("customfield_10014") == {
+            "value": "EPIC-KEY-1",
+            "name": "Epic Link",
+        }
 
     def test_jira_issue_with_default_fields(self, jira_issue_data):
         """Test that JiraIssue returns only essential fields by default."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

This PR enhances the `JiraIssue` model to consistently include human-readable names for custom fields, alongside their values, by utilizing the `names` map from the Jira API response. Custom fields are now always keyed by their `customfield_XXXXX` ID, with values stored as `{'value': <api_value>, 'name': <readable_name>}`.

This change improves data richness and resolves inconsistencies related to custom field representation (#440).

Fixes: #440

## Changes

- `JiraIssue.from_api_response`: Now uses the API's `names` map to store custom field display names along with their values.
- `JiraIssue.to_simplified_dict`: Outputs custom fields with their `customfield_XXXXX` ID as the key and a structured value `{"value": ..., "name": ...}`. Logic for `requested_fields` updated accordingly.
- `JiraIssue._process_custom_field_value`: Refined to correctly simplify the `value` part of the new custom field structure.
- **Tests**: Updated fixtures and unit tests to reflect and verify these changes.

## Testing

- [X] Unit tests added/updated to verify the new custom field structure in `JiraIssue` and its serialized output.
- [X] Fixtures updated with `names` map for custom fields.
- [ ] Integration tests passed.
- [ ] Manual checks performed: `[N/A - covered by unit tests]`

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [X] Tests added/updated for changes.
- [X] All tests pass locally.
- [ ] Documentation updated (if needed).