### PR TITLE
feat: Add --version flag to display CLI version (#448)

### DIFF
--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -19,6 +19,7 @@ if os.getenv("MCP_VERBOSE", "").lower() in ("true", "1", "yes"):
 logger = setup_logging(logging_level)
 
 
+@click.version_option(__version__, prog_name="mcp-atlassian")
 @click.command()
 @click.option(
     "-v",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

This pull request introduces a `--version` command-line option to the `mcp-atlassian` CLI. This allows users to easily check the installed version of the server, which is helpful for updates and diagnostics, similar to the functionality present in other MCP servers like `github-mcp-server`.

Fixes: #448

## Changes

- Added `@click.version_option` to the `main` CLI command in `src/mcp_atlassian/__init__.py`.
- Configured the `prog_name` to "mcp-atlassian" for consistent version output.
- The `__version__` string already defined in the module is used to provide the version information.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [X] Manual checks performed:
  - Built the package locally and ran `uv run mcp-atlassian -- --version`. Verified correct version output.
  - Ran `uv run mcp-atlassian -- --help`. Verified `--version` option is listed.
  - Built a Docker image with the changes and ran `docker run -i --rm <image_name> --version`. Verified correct version output.

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes. <!-- (Decided manual testing sufficient for this Click feature) -->
- [X] All tests pass locally.
- [ ] Documentation updated (if needed). <!-- (README usage instructions for CLI might be updated, but the flag is standard) -->