### PR TITLE
Patch: Fixed bug with Confluence url construction

### DIFF
--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -206,7 +206,7 @@ class ConfluencePage(ApiModel, TimestampMixin):
             if is_cloud:
                 # Cloud format: {base_url}/spaces/{space_key}/pages/{page_id}
                 space_key = space.key if space and space.key else "unknown"
-                url = f"{base_url}/spaces/{space_key}/pages/{page_id}"
+                url = f"{base_url}/wiki/spaces/{space_key}/pages/{page_id}"
             else:
                 # Server format: {base_url}/pages/viewpage.action?pageId={page_id}
                 url = f"{base_url}/pages/viewpage.action?pageId={page_id}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
Small fix for the url construction of Confluence pages. It needs /wiki/ before /spaces/ to work properly, otherwise it gives 404.

<!-- Link related issues: Fixes #<issue_number> -->
Run into this problem while I was using the server. Did not find any relevant issues.

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- in pages.py I simply added /wiki/ in the url construction.
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [X] Manual checks performed: `Tested with my integration and Confluence links work normally now` 

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
