### PR TITLE
feat: Add get_page_labels tool to Confluence MCP Server

### DIFF
--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -18,7 +18,19 @@ class ConfluenceFetcher(SearchMixin, SpacesMixin, PagesMixin, CommentsMixin):
     API as the original ConfluenceFetcher class.
     """
 
-    pass
+    def get_page_labels(self, page_id: str) -> list[str]:
+        """
+        Get labels of a specific Confluence page.
+
+        This method calls the implementation in PagesMixin.
+
+        Args:
+            page_id: The ID of the page to get labels for.
+
+        Returns:
+            List of label strings, or an empty list if an error occurs.
+        """
+        return super().get_page_labels(page_id)
 
 
 __all__ = ["ConfluenceFetcher", "ConfluenceConfig", "ConfluenceClient"]

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -435,3 +435,30 @@ class PagesMixin(ConfluenceClient):
         except Exception as e:
             logger.error(f"Error deleting page {page_id}: {str(e)}")
             raise Exception(f"Failed to delete page {page_id}: {str(e)}") from e
+
+    def get_page_labels(self, page_id: str) -> list[str]:
+        """
+        Get labels of a specific Confluence page.
+
+        Args:
+            page_id: The ID of the page to get labels for.
+
+        Returns:
+            List of label strings, or an empty list if an error occurs.
+        """
+        try:
+            labels_data = self.confluence.get_page_labels(page_id=page_id)
+            # The API returns a dict with a 'results' key, which is a list of label objects
+            # Each label object has a 'name' key.
+            # Example: {'results': [{'prefix': 'global', 'name': 'label-one', 'id': '123', 'label': 'label-one'}, ...]}
+            if labels_data and "results" in labels_data:
+                label_names = [label["name"] for label in labels_data["results"]]
+                logger.info(f"Successfully fetched labels for page {page_id}: {label_names}")
+                return label_names
+            else:
+                logger.info(f"No labels found or unexpected response format for page {page_id}: {labels_data}")
+                return []
+        except Exception as e:
+            logger.error(f"Error fetching labels for page {page_id}: {str(e)}")
+            logger.debug("Full exception details:", exc_info=True)
+            return []


### PR DESCRIPTION
This commit introduces a new tool `confluence_get_page_labels` to the Confluence MCP Server.

The tool allows you to retrieve the labels associated with a specific Confluence page by providing its `page_id`.

Key changes include:
- Added `get_page_labels` method to `PagesMixin` to fetch and process labels from the Confluence API.
- Exposed `get_page_labels` through the `ConfluenceFetcher` class.
- Registered `confluence_get_page_labels` in the server's tool listing.
- Implemented the corresponding tool calling logic in the server.
- Added comprehensive unit tests for the `get_page_labels` method in `PagesMixin`, covering success, no labels, API errors, and unexpected response scenarios.

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
