### PR TITLE
feat: list Jira project versions (Milestone 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Here's a complete example of setting up multi-user authentication with streamabl
 - `jira_update_issue`: Update an existing issue
 - `jira_transition_issue`: Transition an issue to a new status
 - `jira_add_comment`: Add a comment to an issue
+- `jira_get_project_versions`: List all fix versions for a project
 
 #### Confluence Tools
 

--- a/src/mcp_atlassian/models/jira/version.py
+++ b/src/mcp_atlassian/models/jira/version.py
@@ -1,0 +1,43 @@
+from typing import Any
+from ..base import ApiModel
+
+class JiraVersion(ApiModel):
+    """
+    Model representing a Jira project version (fix version).
+    """
+    id: str
+    name: str
+    description: str | None = None
+    startDate: str | None = None
+    releaseDate: str | None = None
+    released: bool = False
+    archived: bool = False
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraVersion":
+        """Create JiraVersion from API response."""
+        return cls(
+            id=str(data.get("id", "")),
+            name=str(data.get("name", "")),
+            description=data.get("description"),
+            startDate=data.get("startDate"),
+            releaseDate=data.get("releaseDate"),
+            released=bool(data.get("released", False)),
+            archived=bool(data.get("archived", False)),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simple dict for API output."""
+        result = {
+            "id": self.id,
+            "name": self.name,
+            "released": self.released,
+            "archived": self.archived,
+        }
+        if self.description is not None:
+            result["description"] = self.description
+        if self.startDate is not None:
+            result["startDate"] = self.startDate
+        if self.releaseDate is not None:
+            result["releaseDate"] = self.releaseDate
+        return result

--- a/src/mcp_atlassian/models/jira/version.py
+++ b/src/mcp_atlassian/models/jira/version.py
@@ -1,15 +1,18 @@
 from typing import Any
+
 from ..base import ApiModel
+
 
 class JiraVersion(ApiModel):
     """
     Model representing a Jira project version (fix version).
     """
+
     id: str
     name: str
     description: str | None = None
-    startDate: str | None = None
-    releaseDate: str | None = None
+    startDate: str | None = None  # noqa: N815
+    releaseDate: str | None = None  # noqa: N815
     released: bool = False
     archived: bool = False
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1383,3 +1383,14 @@ async def update_sprint(
         return json.dumps(error_payload, indent=2, ensure_ascii=False)
     else:
         return json.dumps(sprint.to_simplified_dict(), indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(tags={"jira", "read"})
+async def get_project_versions(
+    ctx: Context,
+    project_key: Annotated[str, Field(description="Jira project key (e.g., 'PROJ')")],
+) -> str:
+    """Get all fix versions for a specific Jira project."""
+    jira = await get_jira_fetcher(ctx)
+    versions = jira.get_project_versions(project_key)
+    return json.dumps(versions, indent=2, ensure_ascii=False)

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -267,28 +267,35 @@ def test_get_project_components_non_list_response(projects_mixin: ProjectsMixin)
 def test_get_project_versions(projects_mixin: ProjectsMixin, mock_versions: list[dict]):
     """Test get_project_versions method."""
     projects_mixin.jira.get_project_versions.return_value = mock_versions
-
+    # Simplified dicts should include id, name, released and archived
+    expected = [
+        {
+            "id": v["id"],
+            "name": v["name"],
+            "released": v.get("released", False),
+            "archived": v.get("archived", False),
+        }
+        for v in mock_versions
+    ]
     result = projects_mixin.get_project_versions("PROJ1")
-    assert result == mock_versions
+    assert result == expected
     projects_mixin.jira.get_project_versions.assert_called_once_with(key="PROJ1")
 
 
 def test_get_project_versions_exception(projects_mixin: ProjectsMixin):
     """Test get_project_versions method with exception."""
     projects_mixin.jira.get_project_versions.side_effect = Exception("API error")
-
     result = projects_mixin.get_project_versions("PROJ1")
     assert result == []
-    projects_mixin.jira.get_project_versions.assert_called_once()
+    projects_mixin.jira.get_project_versions.assert_called_once_with(key="PROJ1")
 
 
 def test_get_project_versions_non_list_response(projects_mixin: ProjectsMixin):
     """Test get_project_versions method with non-list response."""
     projects_mixin.jira.get_project_versions.return_value = "not a list"
-
     result = projects_mixin.get_project_versions("PROJ1")
     assert result == []
-    projects_mixin.jira.get_project_versions.assert_called_once()
+    projects_mixin.jira.get_project_versions.assert_called_once_with(key="PROJ1")
 
 
 def test_get_project_roles(


### PR DESCRIPTION
Hi @sooperset - I have some wishlist items for this repo I want to help out with surrounding release versions. There is some really good automation opportunities here for larger Jira workflows with regulated releases like mine. MCP support for project versions (a.k.a. Releases or Fix Versions in JIRA) is a good starting point. Looking to have a few more PRs to extend this functionality further.

## Summary

- Added **get_project_versions** in  to retrieve and simplify project version data
- Introduced **JiraVersion** model for parsing API responses and producing simplified output
- Exposed new **jira_get_project_versions** FastMCP tool endpoint in 
- Added unit tests covering success, empty results, and error scenarios for version listing

Let me know if there are any issues.
