### PR TITLE
feat: adds search_user tool to Confluence MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Here's a complete example of setting up multi-user authentication with streamabl
 |           | `jira_get_project_issues`     | `confluence_get_page_children` |
 |           | `jira_get_worklog`            | `confluence_get_comments`      |
 |           | `jira_get_transitions`        | `confluence_get_labels`        |
-|           | `jira_search_fields`          |                                |
+|           | `jira_search_fields`          | `confluence_search_user`       |
 |           | `jira_get_agile_boards`       |                                |
 |           | `jira_get_board_issues`       |                                |
 |           | `jira_get_sprints_from_board` |                                |

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -128,7 +128,7 @@ class SearchMixin(ConfluenceClient):
             logger.debug("Full exception details for search:", exc_info=True)
             return []
 
-    def search_users(
+    def search_user(
         self, cql: str, limit: int = 10
     ) -> list[ConfluenceUserSearchResult]:
         """

--- a/src/mcp_atlassian/models/confluence/__init__.py
+++ b/src/mcp_atlassian/models/confluence/__init__.py
@@ -18,6 +18,7 @@ from .label import ConfluenceLabel
 from .page import ConfluencePage, ConfluenceVersion
 from .search import ConfluenceSearchResult
 from .space import ConfluenceSpace
+from .user_search import ConfluenceUserSearchResult, ConfluenceUserSearchResults
 
 __all__ = [
     "ConfluenceUser",
@@ -28,4 +29,6 @@ __all__ = [
     "ConfluenceLabel",
     "ConfluencePage",
     "ConfluenceSearchResult",
+    "ConfluenceUserSearchResult",
+    "ConfluenceUserSearchResults",
 ]

--- a/src/mcp_atlassian/models/confluence/user_search.py
+++ b/src/mcp_atlassian/models/confluence/user_search.py
@@ -1,0 +1,145 @@
+"""
+Confluence user search result models.
+This module provides Pydantic models for Confluence user search results.
+"""
+
+import logging
+from typing import Any
+
+from pydantic import Field
+
+from ..base import ApiModel, TimestampMixin
+from .common import ConfluenceUser
+
+logger = logging.getLogger(__name__)
+
+
+class ConfluenceUserSearchResult(ApiModel):
+    """
+    Model representing a single user search result.
+    """
+
+    user: ConfluenceUser | None = None
+    title: str | None = None
+    excerpt: str | None = None
+    url: str | None = None
+    entity_type: str = "user"
+    last_modified: str | None = None
+    score: float = 0.0
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "ConfluenceUserSearchResult":
+        """
+        Create a ConfluenceUserSearchResult from a Confluence API response.
+
+        Args:
+            data: The user search result data from the Confluence API
+            **kwargs: Additional context parameters
+
+        Returns:
+            A ConfluenceUserSearchResult instance
+        """
+        if not data:
+            return cls()
+
+        # Extract user data from the result
+        user_data = data.get("user", {})
+        user = ConfluenceUser.from_api_response(user_data) if user_data else None
+
+        return cls(
+            user=user,
+            title=data.get("title"),
+            excerpt=data.get("excerpt"),
+            url=data.get("url"),
+            entity_type=data.get("entityType", "user"),
+            last_modified=data.get("lastModified"),
+            score=data.get("score", 0.0),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result = {
+            "entity_type": self.entity_type,
+            "title": self.title,
+            "score": self.score,
+        }
+
+        if self.user:
+            result["user"] = {
+                "account_id": self.user.account_id,
+                "display_name": self.user.display_name,
+                "email": self.user.email,
+                "profile_picture": self.user.profile_picture,
+                "is_active": self.user.is_active,
+            }
+
+        if self.url:
+            result["url"] = self.url
+
+        if self.last_modified:
+            result["last_modified"] = self.last_modified
+
+        if self.excerpt:
+            result["excerpt"] = self.excerpt
+
+        return result
+
+
+class ConfluenceUserSearchResults(ApiModel, TimestampMixin):
+    """
+    Model representing a collection of user search results.
+    """
+
+    total_size: int = 0
+    start: int = 0
+    limit: int = 0
+    results: list[ConfluenceUserSearchResult] = Field(default_factory=list)
+    cql_query: str | None = None
+    search_duration: int | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "ConfluenceUserSearchResults":
+        """
+        Create a ConfluenceUserSearchResults from a Confluence API response.
+
+        Args:
+            data: The search result data from the Confluence API
+            **kwargs: Additional context parameters
+
+        Returns:
+            A ConfluenceUserSearchResults instance
+        """
+        if not data:
+            return cls()
+
+        # Convert search results to ConfluenceUserSearchResult models
+        results = []
+        for result_data in data.get("results", []):
+            user_result = ConfluenceUserSearchResult.from_api_response(
+                result_data, **kwargs
+            )
+            results.append(user_result)
+
+        return cls(
+            total_size=data.get("totalSize", 0),
+            start=data.get("start", 0),
+            limit=data.get("limit", 0),
+            results=results,
+            cql_query=data.get("cqlQuery"),
+            search_duration=data.get("searchDuration"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        return {
+            "total_size": self.total_size,
+            "start": self.start,
+            "limit": self.limit,
+            "cql_query": self.cql_query,
+            "search_duration": self.search_duration,
+            "results": [result.to_simplified_dict() for result in self.results],
+        }

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -607,7 +607,6 @@ async def add_comment(
     return json.dumps(response, indent=2, ensure_ascii=False)
 
 
-@convert_empty_defaults_to_none
 @confluence_mcp.tool(tags={"confluence", "read"})
 async def search_user(
     ctx: Context,
@@ -654,7 +653,7 @@ async def search_user(
         logger.info(f"Converting simple search term to user CQL: {query}")
 
     try:
-        user_results = confluence_fetcher.search_users(query, limit=limit)
+        user_results = confluence_fetcher.search_user(query, limit=limit)
         search_results = [user.to_simplified_dict() for user in user_results]
         return json.dumps(search_results, indent=2, ensure_ascii=False)
     except Exception as e:

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -605,3 +605,62 @@ async def add_comment(
         }
 
     return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@convert_empty_defaults_to_none
+@confluence_mcp.tool(tags={"confluence", "read"})
+async def search_user(
+    ctx: Context,
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "Search query - a CQL query string for user search. "
+                "Examples of CQL:\n"
+                "- Basic user lookup by full name: 'user.fullname ~ \"First Last\"'\n"
+                'Note: Special identifiers need proper quoting in CQL: personal space keys (e.g., "~username"), '
+                "reserved words, numeric IDs, and identifiers with special characters."
+            )
+        ),
+    ],
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of results (1-50)",
+            default=10,
+            ge=1,
+            le=50,
+        ),
+    ] = 10,
+) -> str:
+    """Search Confluence users using CQL.
+
+    Args:
+        ctx: The FastMCP context.
+        query: Search query - a CQL query string for user search.
+        limit: Maximum number of results (1-50).
+
+    Returns:
+        JSON string representing a list of simplified Confluence user search result objects.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    # If the query doesn't look like CQL, wrap it as a user fullname search
+    if query and not any(
+        x in query for x in ["=", "~", ">", "<", " AND ", " OR ", "user."]
+    ):
+        # Simple search term - search by fullname
+        query = f'user.fullname ~ "{query}"'
+        logger.info(f"Converting simple search term to user CQL: {query}")
+
+    try:
+        user_results = confluence_fetcher.search_users(query, limit=limit)
+        search_results = [user.to_simplified_dict() for user in user_results]
+        return json.dumps(search_results, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error(f"Error searching users: {str(e)}")
+        return json.dumps(
+            {"error": f"Failed to search users: {str(e)}"},
+            indent=2,
+            ensure_ascii=False,
+        )

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -1,6 +1,6 @@
 """Unit tests for the SearchMixin class."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -265,3 +265,295 @@ class TestSearchMixin:
         # Assert
         assert isinstance(results, list)
         assert len(results) == 0
+
+    def test_search_user_success(self, search_mixin):
+        """Test search_user with successful results."""
+        # Prepare the mock response
+        search_mixin.confluence.get.return_value = {
+            "results": [
+                {
+                    "user": {
+                        "type": "known",
+                        "accountId": "1234asdf",
+                        "accountType": "atlassian",
+                        "email": "first.last@invitae.com",
+                        "publicName": "First Last",
+                        "displayName": "First Last",
+                        "isExternalCollaborator": False,
+                        "profilePicture": {
+                            "path": "/wiki/aa-avatar/1234asdf",
+                            "width": 48,
+                            "height": 48,
+                            "isDefault": False,
+                        },
+                    },
+                    "title": "First Last",
+                    "excerpt": "",
+                    "url": "/people/1234asdf",
+                    "entityType": "user",
+                    "lastModified": "2025-06-02T13:35:59.680Z",
+                    "score": 0.0,
+                }
+            ],
+            "start": 0,
+            "limit": 25,
+            "size": 1,
+            "totalSize": 1,
+            "cqlQuery": "( user.fullname ~ 'First Last' )",
+            "searchDuration": 115,
+        }
+
+        # Call the method
+        result = search_mixin.search_user('user.fullname ~ "First Last"')
+
+        # Verify API call
+        search_mixin.confluence.get.assert_called_once_with(
+            "rest/api/search/user",
+            params={"cql": 'user.fullname ~ "First Last"', "limit": 10},
+        )
+
+        # Verify result
+        assert len(result) == 1
+        assert result[0].user.account_id == "1234asdf"
+        assert result[0].user.display_name == "First Last"
+        assert result[0].user.email == "first.last@invitae.com"
+        assert result[0].title == "First Last"
+        assert result[0].entity_type == "user"
+
+    def test_search_user_with_empty_results(self, search_mixin):
+        """Test search_user with empty results."""
+        # Mock an empty result set
+        search_mixin.confluence.get.return_value = {
+            "results": [],
+            "start": 0,
+            "limit": 25,
+            "size": 0,
+            "totalSize": 0,
+            "cqlQuery": 'user.fullname ~ "Nonexistent"',
+            "searchDuration": 50,
+        }
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Nonexistent"')
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    def test_search_user_with_custom_limit(self, search_mixin):
+        """Test search_user with custom limit."""
+        # Prepare the mock response
+        search_mixin.confluence.get.return_value = {
+            "results": [],
+            "start": 0,
+            "limit": 5,
+            "size": 0,
+            "totalSize": 0,
+            "cqlQuery": 'user.fullname ~ "Test"',
+            "searchDuration": 30,
+        }
+
+        # Call with custom limit
+        search_mixin.search_user('user.fullname ~ "Test"', limit=5)
+
+        # Verify API call with correct limit
+        search_mixin.confluence.get.assert_called_once_with(
+            "rest/api/search/user", params={"cql": 'user.fullname ~ "Test"', "limit": 5}
+        )
+
+    def test_search_user_http_401_error(self, search_mixin):
+        """Test search_user handling of HTTP 401 authentication error."""
+        from requests.exceptions import HTTPError
+
+        from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+
+        # Mock HTTP 401 error
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        http_error = HTTPError("Unauthorized")
+        http_error.response = mock_response
+        search_mixin.confluence.get.side_effect = http_error
+
+        # Act and assert
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            search_mixin.search_user('user.fullname ~ "Test"')
+
+    def test_search_user_http_403_error(self, search_mixin):
+        """Test search_user handling of HTTP 403 authentication error."""
+        from requests.exceptions import HTTPError
+
+        from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+
+        # Mock HTTP 403 error
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        http_error = HTTPError("Forbidden")
+        http_error.response = mock_response
+        search_mixin.confluence.get.side_effect = http_error
+
+        # Act and assert
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            search_mixin.search_user('user.fullname ~ "Test"')
+
+    def test_search_user_http_other_error(self, search_mixin):
+        """Test search_user handling of other HTTP errors."""
+        from requests.exceptions import HTTPError
+
+        # Mock HTTP 500 error
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        http_error = HTTPError("Internal Server Error")
+        http_error.response = mock_response
+        search_mixin.confluence.get.side_effect = http_error
+
+        # Act and assert - should re-raise the HTTPError
+        with pytest.raises(HTTPError):
+            search_mixin.search_user('user.fullname ~ "Test"')
+
+    def test_search_user_key_error(self, search_mixin):
+        """Test search_user handling of KeyError in results."""
+        # Mock a response missing required keys
+        search_mixin.confluence.get.return_value = {"incomplete": "data"}
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Test"')
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    def test_search_user_request_exception(self, search_mixin):
+        """Test search_user handling of RequestException."""
+        # Mock a network error
+        search_mixin.confluence.get.side_effect = requests.RequestException(
+            "Network error"
+        )
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Test"')
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    def test_search_user_value_error(self, search_mixin):
+        """Test search_user handling of ValueError."""
+        # Mock a value error
+        search_mixin.confluence.get.side_effect = ValueError("Value error")
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Test"')
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    def test_search_user_type_error(self, search_mixin):
+        """Test search_user handling of TypeError."""
+        # Mock a type error
+        search_mixin.confluence.get.side_effect = TypeError("Type error")
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Test"')
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    def test_search_user_general_exception(self, search_mixin):
+        """Test search_user handling of general exceptions."""
+        # Mock a general exception
+        search_mixin.confluence.get.side_effect = Exception("General error")
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Test"')
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    def test_search_user_with_none_response(self, search_mixin):
+        """Test search_user handling of None response from API."""
+        # Mock None response
+        search_mixin.confluence.get.return_value = None
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Test"')
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    def test_search_user_api_call_parameters(self, search_mixin):
+        """Test that search_user calls the API with correct parameters."""
+        # Mock successful response
+        search_mixin.confluence.get.return_value = {
+            "results": [],
+            "start": 0,
+            "limit": 5,
+            "totalSize": 0,
+        }
+
+        # Act with custom limit
+        search_mixin.search_user('user.email ~ "test@example.com"', limit=5)
+
+        # Assert API was called with correct parameters
+        search_mixin.confluence.get.assert_called_once_with(
+            "rest/api/search/user",
+            params={"cql": 'user.email ~ "test@example.com"', "limit": 5},
+        )
+
+    def test_search_user_with_complex_cql_query(self, search_mixin):
+        """Test search_user with complex CQL query containing operators."""
+        # Mock successful response
+        search_mixin.confluence.get.return_value = {
+            "results": [],
+            "start": 0,
+            "limit": 10,
+            "totalSize": 0,
+        }
+
+        complex_query = 'user.fullname ~ "John" AND user.email ~ "@company.com" OR user.displayName ~ "JD"'
+
+        # Act
+        search_mixin.search_user(complex_query)
+
+        # Assert API was called with the exact query
+        search_mixin.confluence.get.assert_called_once_with(
+            "rest/api/search/user", params={"cql": complex_query, "limit": 10}
+        )
+
+    def test_search_user_result_processing(self, search_mixin):
+        """Test that search_user properly processes and returns user search result objects."""
+        # Mock response with user data
+        search_mixin.confluence.get.return_value = {
+            "results": [
+                {
+                    "user": {
+                        "accountId": "test-account-id",
+                        "displayName": "Test User",
+                        "email": "test@example.com",
+                        "isExternalCollaborator": False,
+                    },
+                    "title": "Test User",
+                    "entityType": "user",
+                    "score": 1.5,
+                }
+            ],
+            "start": 0,
+            "limit": 10,
+            "totalSize": 1,
+        }
+
+        # Act
+        results = search_mixin.search_user('user.fullname ~ "Test User"')
+
+        # Assert result structure
+        assert len(results) == 1
+        assert hasattr(results[0], "user")
+        assert hasattr(results[0], "title")
+        assert hasattr(results[0], "entity_type")
+        assert results[0].user.account_id == "test-account-id"
+        assert results[0].user.display_name == "Test User"
+        assert results[0].title == "Test User"
+        assert results[0].entity_type == "user"

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.client import FastMCPTransport
-from fastmcp.exceptions import ToolError
 from starlette.requests import Request
 
 from src.mcp_atlassian.confluence import ConfluenceFetcher
@@ -74,6 +73,30 @@ def mock_confluence_fetcher():
     }
     mock_fetcher.add_comment.return_value = mock_comment
 
+    # Mock search_user method
+    mock_user_search_result = MagicMock()
+    mock_user_search_result.to_simplified_dict.return_value = {
+        "entity_type": "user",
+        "title": "First Last",
+        "score": 0.0,
+        "user": {
+            "account_id": "a031248587011jasoidf9832jd8j1",
+            "display_name": "First Last",
+            "email": "first.last@foo.com",
+            "profile_picture": {
+                "path": "/wiki/aa-avatar/a031248587011jasoidf9832jd8j1",
+                "width": 48,
+                "height": 48,
+                "isDefault": False,
+            },
+            "is_active": True,
+        },
+        "url": "/people/a031248587011jasoidf9832jd8j1",
+        "last_modified": "2025-06-02T13:35:59.680Z",
+        "excerpt": "",
+    }
+    mock_fetcher.search_user.return_value = [mock_user_search_result]
+
     return mock_fetcher
 
 
@@ -109,6 +132,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
         get_page,
         get_page_children,
         search,
+        search_user,
         update_page,
     )
 
@@ -139,6 +163,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
     confluence_sub_mcp.tool()(create_page)
     confluence_sub_mcp.tool()(update_page)
     confluence_sub_mcp.tool()(delete_page)
+    confluence_sub_mcp.tool()(search_user)
 
     test_mcp.mount("confluence", confluence_sub_mcp)
 
@@ -160,6 +185,7 @@ def no_fetcher_test_confluence_mcp(mock_base_confluence_config):
         get_page,
         get_page_children,
         search,
+        search_user,
         update_page,
     )
 
@@ -192,6 +218,7 @@ def no_fetcher_test_confluence_mcp(mock_base_confluence_config):
     confluence_sub_mcp.tool()(create_page)
     confluence_sub_mcp.tool()(update_page)
     confluence_sub_mcp.tool()(delete_page)
+    confluence_sub_mcp.tool()(search_user)
 
     test_mcp.mount("confluence", confluence_sub_mcp)
 
@@ -397,237 +424,21 @@ async def test_add_label(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
-async def test_create_page(client, mock_confluence_fetcher):
-    """Test creating a new page."""
+async def test_search_user(client, mock_confluence_fetcher):
+    """Test the search_user tool with CQL query."""
     response = await client.call_tool(
-        "confluence_create_page",
-        {
-            "space_key": "TEST",
-            "title": "New Test Page",
-            "content": "# New Page\nContent here.",
-        },
-    )
-    mock_confluence_fetcher.create_page.assert_called_once_with(
-        space_key="TEST",
-        title="New Test Page",
-        body="# New Page\nContent here.",
-        parent_id="",
-        is_markdown=True,
-    )
-    result_data = json.loads(response[0].text)
-    assert result_data["message"] == "Page created successfully"
-    assert result_data["page"]["title"] == "Test Page Mock Title"
-
-
-@pytest.mark.anyio
-async def test_update_page(client, mock_confluence_fetcher):
-    """Test updating an existing page."""
-    response = await client.call_tool(
-        "confluence_update_page",
-        {
-            "page_id": "123456",
-            "title": "Updated Page",
-            "content": "## Updated Content",
-        },
+        "confluence_search_user", {"query": 'user.fullname ~ "First Last"', "limit": 10}
     )
 
-    mock_confluence_fetcher.update_page.assert_called_once_with(
-        page_id="123456",
-        title="Updated Page",
-        body="## Updated Content",
-        is_minor_edit=False,
-        version_comment="",
-        is_markdown=True,
-        parent_id=None,
+    mock_confluence_fetcher.search_user.assert_called_once_with(
+        'user.fullname ~ "First Last"', limit=10
     )
 
     result_data = json.loads(response[0].text)
-    assert result_data["message"] == "Page updated successfully"
-    assert result_data["page"]["title"] == "Test Page Mock Title"
-
-
-@pytest.mark.anyio
-async def test_delete_page(client, mock_confluence_fetcher):
-    """Test deleting a page."""
-    response = await client.call_tool("confluence_delete_page", {"page_id": "123456"})
-    mock_confluence_fetcher.delete_page.assert_called_once_with(page_id="123456")
-    result_data = json.loads(response[0].text)
-    assert result_data["success"] is True
-
-
-@pytest.mark.anyio
-async def test_no_fetcher_update_page(no_fetcher_client_fixture, mock_request):
-    """Test that page update fails when Confluence client is not configured."""
-
-    async def mock_get_fetcher_error(*args, **kwargs):
-        raise ValueError("Mocked: Confluence client is not configured or available")
-
-    with (
-        patch(
-            "src.mcp_atlassian.servers.confluence.get_confluence_fetcher",
-            AsyncMock(side_effect=mock_get_fetcher_error),
-        ),
-        patch(
-            "src.mcp_atlassian.servers.dependencies.get_http_request",
-            return_value=mock_request,
-        ),
-    ):
-        with pytest.raises(ToolError) as excinfo:
-            await no_fetcher_client_fixture.call_tool(
-                "confluence_update_page",
-                {
-                    "page_id": "123456",
-                    "title": "Updated Page",
-                    "content": "## Updated Content",
-                },
-            )
-    assert "Error calling tool 'update_page'" in str(excinfo.value)
-
-
-@pytest.mark.anyio
-async def test_no_fetcher_delete_page(no_fetcher_client_fixture, mock_request):
-    """Test that page deletion fails when Confluence client is not configured."""
-
-    async def mock_get_fetcher_error(*args, **kwargs):
-        raise ValueError("Mocked: Confluence client is not configured or available")
-
-    with (
-        patch(
-            "src.mcp_atlassian.servers.confluence.get_confluence_fetcher",
-            AsyncMock(side_effect=mock_get_fetcher_error),
-        ),
-        patch(
-            "src.mcp_atlassian.servers.dependencies.get_http_request",
-            return_value=mock_request,
-        ),
-    ):
-        with pytest.raises(ToolError) as excinfo:
-            await no_fetcher_client_fixture.call_tool(
-                "confluence_delete_page", {"page_id": "123456"}
-            )
-    assert "Error calling tool 'delete_page'" in str(excinfo.value)
-
-
-@pytest.mark.anyio
-async def test_get_page_with_user_specific_fetcher_in_state(
-    test_confluence_mcp, mock_confluence_fetcher
-):
-    """Test get_page uses fetcher from request.state if UserTokenMiddleware provided it."""
-    _mock_request_with_fetcher_in_state = MagicMock(spec=Request)
-    _mock_request_with_fetcher_in_state.state = MagicMock()
-    _mock_request_with_fetcher_in_state.state.confluence_fetcher = (
-        mock_confluence_fetcher
-    )
-    _mock_request_with_fetcher_in_state.state.user_atlassian_auth_type = "oauth"
-    _mock_request_with_fetcher_in_state.state.user_atlassian_token = (
-        "user_specific_token"
-    )
-    from src.mcp_atlassian.servers.dependencies import (
-        get_confluence_fetcher as get_confluence_fetcher_real,
-    )
-
-    with (
-        patch(
-            "src.mcp_atlassian.servers.dependencies.get_http_request",
-            return_value=_mock_request_with_fetcher_in_state,
-        ) as mock_get_http,
-        patch(
-            "src.mcp_atlassian.servers.confluence.get_confluence_fetcher",
-            side_effect=AsyncMock(wraps=get_confluence_fetcher_real),
-        ),
-    ):
-        async with Client(
-            transport=FastMCPTransport(test_confluence_mcp)
-        ) as client_instance:
-            response = await client_instance.call_tool(
-                "confluence_get_page", {"page_id": "789"}
-            )
-    mock_get_http.assert_called()
-    mock_confluence_fetcher.get_page_content.assert_called_with(
-        "789", convert_to_markdown=True
-    )
-    result_data = json.loads(response[0].text)
-    assert "metadata" in result_data
-    assert result_data["metadata"]["title"] == "Test Page Mock Title"
-
-
-@pytest.mark.anyio
-async def test_get_page_by_title_and_space_key(client, mock_confluence_fetcher):
-    """Test get_page tool with title and space_key lookup."""
-    mock_page = MagicMock(spec=ConfluencePage)
-    mock_page.to_simplified_dict.return_value = {
-        "id": "654321",
-        "title": "Title Lookup Page",
-        "url": "https://example.atlassian.net/wiki/spaces/TEST/pages/654321/Title+Lookup",
-        "content": {
-            "value": "Content by title lookup",
-            "format": "markdown",
-        },
-    }
-    mock_page.content = "Content by title lookup"
-    mock_confluence_fetcher.get_page_by_title.return_value = mock_page
-
-    response = await client.call_tool(
-        "confluence_get_page", {"title": "Title Lookup Page", "space_key": "TEST"}
-    )
-    mock_confluence_fetcher.get_page_by_title.assert_called_once_with(
-        "TEST", "Title Lookup Page", convert_to_markdown=True
-    )
-    result_data = json.loads(response[0].text)
-    assert "metadata" in result_data
-    assert result_data["metadata"]["title"] == "Title Lookup Page"
-    assert result_data["metadata"]["content"]["value"] == "Content by title lookup"
-
-
-@pytest.mark.anyio
-async def test_get_page_by_title_and_space_key_not_found(
-    client, mock_confluence_fetcher
-):
-    """Test get_page tool with title and space_key when page is not found."""
-    mock_confluence_fetcher.get_page_by_title.return_value = None
-    response = await client.call_tool(
-        "confluence_get_page", {"title": "Missing Page", "space_key": "TEST"}
-    )
-    result_data = json.loads(response[0].text)
-    assert "error" in result_data
-    assert "not found" in result_data["error"]
-
-
-@pytest.mark.anyio
-async def test_get_page_error_missing_space_key(client, mock_confluence_fetcher):
-    """Test get_page tool with title but missing space_key (should error)."""
-    with pytest.raises(ToolError) as excinfo:
-        await client.call_tool("confluence_get_page", {"title": "Some Page"})
-    assert "Error calling tool 'get_page'" in str(excinfo.value)
-
-
-@pytest.mark.anyio
-async def test_get_page_error_missing_title(client, mock_confluence_fetcher):
-    """Test get_page tool with space_key but missing title (should error)."""
-    with pytest.raises(ToolError) as excinfo:
-        await client.call_tool("confluence_get_page", {"space_key": "TEST"})
-    assert "Error calling tool 'get_page'" in str(excinfo.value)
-
-
-@pytest.mark.anyio
-async def test_get_page_error_no_identifiers(client, mock_confluence_fetcher):
-    """Test get_page tool with neither page_id nor title+space_key (should error)."""
-    with pytest.raises(ToolError) as excinfo:
-        await client.call_tool("confluence_get_page", {})
-    assert "Error calling tool 'get_page'" in str(excinfo.value)
-
-
-@pytest.mark.anyio
-async def test_get_page_precedence_page_id(client, mock_confluence_fetcher):
-    """Test get_page tool uses page_id even if title and space_key are provided."""
-    response = await client.call_tool(
-        "confluence_get_page",
-        {"page_id": "123456", "title": "Ignored", "space_key": "IGNORED"},
-    )
-    mock_confluence_fetcher.get_page_content.assert_called_once_with(
-        "123456", convert_to_markdown=True
-    )
-    mock_confluence_fetcher.get_page_by_title.assert_not_called()
-    result_data = json.loads(response[0].text)
-    assert "metadata" in result_data
-    assert result_data["metadata"]["title"] == "Test Page Mock Title"
+    assert isinstance(result_data, list)
+    assert len(result_data) == 1
+    assert result_data[0]["entity_type"] == "user"
+    assert result_data[0]["title"] == "First Last"
+    assert result_data[0]["user"]["account_id"] == "a031248587011jasoidf9832jd8j1"
+    assert result_data[0]["user"]["display_name"] == "First Last"
+    assert result_data[0]["user"]["email"] == "first.last@foo.com"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Adds a new `search_user` tool to the Confluence MCP server. This is particularly useful if a user is looking up pages written by another user and does not know that user's account ID; with the `search_user`, the LLM can look up the account ID for the user's name (or via other methods). Think queries like: "Get the most recent pages written by Jane Doe".

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- added `search_user` method to `SearchMixin` and tool to fetcher
- added unit tests

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
