### PR TITLE
feat: Implement Bring Your Own Token (BYOT) OAuth Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,37 @@ MCP Atlassian supports three authentication methods:
 8. Add obtained credentials to `.env` or IDE config:
    - `ATLASSIAN_OAUTH_CLOUD_ID` (from wizard)
    - `ATLASSIAN_OAUTH_CLIENT_ID`
+   - `ATLASSIAN_OAUTH_CLIENT_ID`
    - `ATLASSIAN_OAUTH_CLIENT_SECRET`
    - `ATLASSIAN_OAUTH_REDIRECT_URI`
    - `ATLASSIAN_OAUTH_SCOPE`
 
 > [!IMPORTANT]
-> Include `offline_access` in scope for persistent auth (e.g., `read:jira-work write:jira-work offline_access`)
+> For the standard OAuth flow described above, include `offline_access` in your scope (e.g., `read:jira-work write:jira-work offline_access`). This allows the server to refresh the access token automatically.
+
+<details>
+<summary>Alternative: Using a Pre-existing OAuth Access Token (BYOT)</summary>
+
+If you are running mcp-atlassian part of a larger system that manages Atlassian OAuth 2.0 access tokens externally (e.g., through a central identity provider or another application), you can provide an access token directly to this MCP server. This method bypasses the interactive setup wizard and the server's internal token management (including refresh capabilities).
+
+**Requirements:**
+- A valid Atlassian OAuth 2.0 Access Token with the necessary scopes for the intended operations.
+- The corresponding `ATLASSIAN_OAUTH_CLOUD_ID` for your Atlassian instance.
+
+**Configuration:**
+To use this method, set the following environment variables (or use the corresponding command-line flags when starting the server):
+- `ATLASSIAN_OAUTH_CLOUD_ID`: Your Atlassian Cloud ID. (CLI: `--oauth-cloud-id`)
+- `ATLASSIAN_OAUTH_ACCESS_TOKEN`: Your pre-existing OAuth 2.0 access token. (CLI: `--oauth-access-token`)
+
+**Important Considerations for BYOT:**
+- **Token Lifecycle Management:** When using BYOT, the MCP server **does not** handle token refresh. The responsibility for obtaining, refreshing (before expiry), and revoking the access token lies entirely with you or the external system providing the token.
+- **Unused Variables:** The standard OAuth client variables (`ATLASSIAN_OAUTH_CLIENT_ID`, `ATLASSIAN_OAUTH_CLIENT_SECRET`, `ATLASSIAN_OAUTH_REDIRECT_URI`, `ATLASSIAN_OAUTH_SCOPE`) are **not** used and can be omitted when configuring for BYOT.
+- **No Setup Wizard:** The `--oauth-setup` wizard is not applicable and should not be used for this approach.
+- **No Token Cache Volume:** The Docker volume mount for token storage (e.g., `-v "${HOME}/.mcp-atlassian:/home/app/.mcp-atlassian"`) is also not necessary if you are exclusively using the BYOT method, as no tokens are stored or managed by this server.
+- **Scope:** The provided access token must already have the necessary permissions (scopes) for the Jira/Confluence operations you intend to perform.
+
+This option is useful in scenarios where OAuth credential management is centralized or handled by other infrastructure components.
+</details>
 
 ### 📦 2. Installation
 
@@ -221,7 +246,11 @@ For Server/Data Center deployments, use direct variable passing:
 <summary>OAuth 2.0 Configuration (Cloud Only)</summary>
 <a name="oauth-20-configuration-example-cloud-only"></a>
 
-This example shows how to configure `mcp-atlassian` in your IDE (like Cursor or Claude Desktop) when using OAuth 2.0 for Atlassian Cloud. Ensure you have completed the [OAuth setup wizard](#c-oauth-20-authentication-cloud-only) first.
+These examples show how to configure `mcp-atlassian` in your IDE (like Cursor or Claude Desktop) when using OAuth 2.0 for Atlassian Cloud.
+
+**Example for Standard OAuth 2.0 Flow (using Setup Wizard):**
+
+This configuration is for when you use the server's built-in OAuth client and have completed the [OAuth setup wizard](#c-oauth-20-authentication-cloud---advanced).
 
 ```json
 {
@@ -240,7 +269,7 @@ This example shows how to configure `mcp-atlassian` in your IDE (like Cursor or 
         "-e", "ATLASSIAN_OAUTH_REDIRECT_URI",
         "-e", "ATLASSIAN_OAUTH_SCOPE",
         "-e", "ATLASSIAN_OAUTH_CLOUD_ID",
-        "ghcr.io/sooperset/mcp-atlassian:latest",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
       ],
       "env": {
         "JIRA_URL": "https://your-company.atlassian.net",
@@ -257,9 +286,47 @@ This example shows how to configure `mcp-atlassian` in your IDE (like Cursor or 
 ```
 
 > [!NOTE]
-> - `ATLASSIAN_OAUTH_CLOUD_ID` is obtained from the `--oauth-setup` wizard output.
-> - Other `ATLASSIAN_OAUTH_*` variables are those you configured for your OAuth app in the Atlassian Developer Console (and used as input to the setup wizard).
-> - `JIRA_URL` and `CONFLUENCE_URL` for your Cloud instances are still required.
+> - For the Standard Flow:
+>   - `ATLASSIAN_OAUTH_CLOUD_ID` is obtained from the `--oauth-setup` wizard output or is known for your instance.
+>   - Other `ATLASSIAN_OAUTH_*` client variables are from your OAuth app in the Atlassian Developer Console.
+>   - `JIRA_URL` and `CONFLUENCE_URL` for your Cloud instances are always required.
+>   - The volume mount (`-v .../.mcp-atlassian:/home/app/.mcp-atlassian`) is crucial for persisting the OAuth tokens obtained by the wizard, enabling automatic refresh.
+
+**Example for Pre-existing Access Token (BYOT - Bring Your Own Token):**
+
+This configuration is for when you are providing your own externally managed OAuth 2.0 access token.
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e", "JIRA_URL",
+        "-e", "CONFLUENCE_URL",
+        "-e", "ATLASSIAN_OAUTH_CLOUD_ID",
+        "-e", "ATLASSIAN_OAUTH_ACCESS_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "ATLASSIAN_OAUTH_CLOUD_ID": "YOUR_KNOWN_CLOUD_ID",
+        "ATLASSIAN_OAUTH_ACCESS_TOKEN": "YOUR_PRE_EXISTING_OAUTH_ACCESS_TOKEN"
+      }
+    }
+  }
+}
+```
+
+> [!NOTE]
+> - For the BYOT Method:
+>   - You primarily need `JIRA_URL`, `CONFLUENCE_URL`, `ATLASSIAN_OAUTH_CLOUD_ID`, and `ATLASSIAN_OAUTH_ACCESS_TOKEN`.
+>   - Standard OAuth client variables (`ATLASSIAN_OAUTH_CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`, `SCOPE`) are **not** used.
+>   - Token lifecycle (e.g., refreshing the token before it expires and restarting mcp-atlassian) is your responsibility, as the server will not refresh BYOT tokens.
 
 </details>
 

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -128,6 +128,11 @@ logger = setup_logging(logging_level)
     "--oauth-cloud-id",
     help="Atlassian Cloud ID for OAuth 2.0 authentication",
 )
+@click.option(
+    "--oauth-access-token",
+    help="Atlassian Cloud OAuth 2.0 access token (if you have your own you'd like to "
+    "use for the session.)",
+)
 def main(
     verbose: int,
     env_file: str | None,
@@ -155,6 +160,7 @@ def main(
     oauth_redirect_uri: str | None,
     oauth_scope: str | None,
     oauth_cloud_id: str | None,
+    oauth_access_token: str | None,
 ) -> None:
     """MCP Atlassian Server - Jira and Confluence functionality for MCP
 
@@ -273,6 +279,8 @@ def main(
         os.environ["ATLASSIAN_OAUTH_SCOPE"] = oauth_scope
     if click_ctx and was_option_provided(click_ctx, "oauth_cloud_id"):
         os.environ["ATLASSIAN_OAUTH_CLOUD_ID"] = oauth_cloud_id
+    if click_ctx and was_option_provided(click_ctx, "oauth_access_token"):
+        os.environ["ATLASSIAN_OAUTH_ACCESS_TOKEN"] = oauth_access_token
     if click_ctx and was_option_provided(click_ctx, "read_only"):
         os.environ["READ_ONLY_MODE"] = str(read_only).lower()
     if click_ctx and was_option_provided(click_ctx, "confluence_ssl_verify"):

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -5,7 +5,11 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.oauth import OAuthConfig
+from ..utils.oauth import (
+    BYOAccessTokenOAuthConfig,
+    OAuthConfig,
+    get_oauth_config_from_env,
+)
 from ..utils.urls import is_atlassian_cloud_url
 
 
@@ -23,7 +27,7 @@ class ConfluenceConfig:
     username: str | None = None  # Email or username
     api_token: str | None = None  # API token used as password
     personal_token: str | None = None  # Personal access token (Server/DC)
-    oauth_config: OAuthConfig | None = None  # OAuth 2.0 configuration
+    oauth_config: OAuthConfig | BYOAccessTokenOAuthConfig | None = None
     ssl_verify: bool = True  # Whether to verify SSL certificates
     spaces_filter: str | None = None  # List of space keys to filter searches
     http_proxy: str | None = None  # HTTP proxy URL
@@ -71,7 +75,7 @@ class ConfluenceConfig:
         personal_token = os.getenv("CONFLUENCE_PERSONAL_TOKEN")
 
         # Check for OAuth configuration
-        oauth_config = OAuthConfig.from_env()
+        oauth_config = get_oauth_config_from_env()
         auth_type = None
 
         # Use the shared utility function directly
@@ -134,11 +138,21 @@ class ConfluenceConfig:
         if self.auth_type == "oauth":
             return bool(
                 self.oauth_config
-                and self.oauth_config.client_id
-                and self.oauth_config.client_secret
-                and self.oauth_config.redirect_uri
-                and self.oauth_config.scope
-                and self.oauth_config.cloud_id
+                and (
+                    (
+                        isinstance(self.oauth_config, OAuthConfig)
+                        and self.oauth_config.client_id
+                        and self.oauth_config.client_secret
+                        and self.oauth_config.redirect_uri
+                        and self.oauth_config.scope
+                        and self.oauth_config.cloud_id
+                    )
+                    or (
+                        isinstance(self.oauth_config, BYOAccessTokenOAuthConfig)
+                        and self.oauth_config.cloud_id
+                        and self.oauth_config.access_token
+                    )
+                )
             )
         elif self.auth_type == "token":
             return bool(self.personal_token)

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -5,7 +5,11 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.oauth import OAuthConfig
+from ..utils.oauth import (
+    BYOAccessTokenOAuthConfig,
+    OAuthConfig,
+    get_oauth_config_from_env,
+)
 from ..utils.urls import is_atlassian_cloud_url
 
 
@@ -23,7 +27,7 @@ class JiraConfig:
     username: str | None = None  # Email or username (Cloud)
     api_token: str | None = None  # API token (Cloud)
     personal_token: str | None = None  # Personal access token (Server/DC)
-    oauth_config: OAuthConfig | None = None  # OAuth 2.0 configuration
+    oauth_config: OAuthConfig | BYOAccessTokenOAuthConfig | None = None
     ssl_verify: bool = True  # Whether to verify SSL certificates
     projects_filter: str | None = None  # List of project keys to filter searches
     http_proxy: str | None = None  # HTTP proxy URL
@@ -71,7 +75,7 @@ class JiraConfig:
         personal_token = os.getenv("JIRA_PERSONAL_TOKEN")
 
         # Check for OAuth configuration
-        oauth_config = OAuthConfig.from_env()
+        oauth_config = get_oauth_config_from_env()
         auth_type = None
 
         # Use the shared utility function directly
@@ -134,11 +138,21 @@ class JiraConfig:
         if self.auth_type == "oauth":
             return bool(
                 self.oauth_config
-                and self.oauth_config.client_id
-                and self.oauth_config.client_secret
-                and self.oauth_config.redirect_uri
-                and self.oauth_config.scope
-                and self.oauth_config.cloud_id
+                and (
+                    (
+                        isinstance(self.oauth_config, OAuthConfig)
+                        and self.oauth_config.client_id
+                        and self.oauth_config.client_secret
+                        and self.oauth_config.redirect_uri
+                        and self.oauth_config.scope
+                        and self.oauth_config.cloud_id
+                    )
+                    or (
+                        isinstance(self.oauth_config, BYOAccessTokenOAuthConfig)
+                        and self.oauth_config.cloud_id
+                        and self.oauth_config.access_token
+                    )
+                )
             )
         elif self.auth_type == "pat":
             return bool(self.personal_token)

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -31,6 +31,17 @@ def get_available_services() -> dict[str, bool | None]:
             logger.info(
                 "Using Confluence OAuth 2.0 (3LO) authentication (Cloud-only features)"
             )
+        elif all(
+            [
+                os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN"),
+                os.getenv("ATLASSIAN_OAUTH_CLOUD_ID"),
+            ]
+        ):
+            confluence_is_setup = True
+            logger.info(
+                "Using Confluence OAuth 2.0 (3LO) authentication (Cloud-only features) "
+                "with provided access token"
+            )
         elif is_cloud:  # Cloud non-OAuth
             if all(
                 [
@@ -68,6 +79,17 @@ def get_available_services() -> dict[str, bool | None]:
             jira_is_setup = True
             logger.info(
                 "Using Jira OAuth 2.0 (3LO) authentication (Cloud-only features)"
+            )
+        elif all(
+            [
+                os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN"),
+                os.getenv("ATLASSIAN_OAUTH_CLOUD_ID"),
+            ]
+        ):
+            jira_is_setup = True
+            logger.info(
+                "Using Confluence OAuth 2.0 (3LO) authentication (Cloud-only features) "
+                "with provided access token"
             )
         elif is_cloud:  # Cloud non-OAuth
             if all(

--- a/src/mcp_atlassian/utils/oauth.py
+++ b/src/mcp_atlassian/utils/oauth.py
@@ -416,8 +416,58 @@ class OAuthConfig:
         return config
 
 
+@dataclass
+class BYOAccessTokenOAuthConfig:
+    """OAuth configuration when providing a pre-existing access token.
+
+    This class is used when the user provides their own Atlassian Cloud ID
+    and access token directly, bypassing the full OAuth 2.0 (3LO) flow.
+    It's suitable for scenarios like service accounts or CI/CD pipelines
+    where an access token is already available.
+
+    This configuration does not support token refreshing.
+    """
+
+    cloud_id: str
+    access_token: str
+    refresh_token: None = None
+    expires_at: None = None
+
+    @classmethod
+    def from_env(cls) -> Optional["BYOAccessTokenOAuthConfig"]:
+        """Create a BYOAccessTokenOAuthConfig from environment variables.
+
+        Reads `ATLASSIAN_OAUTH_CLOUD_ID` and `ATLASSIAN_OAUTH_ACCESS_TOKEN`.
+
+        Returns:
+            BYOAccessTokenOAuthConfig instance or None if required
+            environment variables are missing.
+        """
+        cloud_id = os.getenv("ATLASSIAN_OAUTH_CLOUD_ID")
+        access_token = os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN")
+
+        if not all([cloud_id, access_token]):
+            return None
+
+        return cls(cloud_id=cloud_id, access_token=access_token)
+
+
+def get_oauth_config_from_env() -> OAuthConfig | BYOAccessTokenOAuthConfig | None:
+    """Get the appropriate OAuth configuration from environment variables.
+
+    This function attempts to load standard OAuth configuration first (OAuthConfig).
+    If that's not available, it tries to load a "Bring Your Own Access Token"
+    configuration (BYOAccessTokenOAuthConfig).
+
+    Returns:
+        An instance of OAuthConfig or BYOAccessTokenOAuthConfig if environment
+        variables are set for either, otherwise None.
+    """
+    return OAuthConfig.from_env() or BYOAccessTokenOAuthConfig.from_env() or None
+
+
 def configure_oauth_session(
-    session: requests.Session, oauth_config: OAuthConfig
+    session: requests.Session, oauth_config: OAuthConfig | BYOAccessTokenOAuthConfig
 ) -> bool:
     """Configure a requests session with OAuth 2.0 authentication.
 
@@ -445,6 +495,11 @@ def configure_oauth_session(
         return True
     logger.debug("configure_oauth_session: Proceeding to ensure_valid_token.")
     # Otherwise, ensure we have a valid token (refresh if needed)
+    if isinstance(oauth_config, BYOAccessTokenOAuthConfig):
+        logger.error(
+            "configure_oauth_session: oauth access token configuration provided as empty string."
+        )
+        return False
     if not oauth_config.ensure_valid_token():
         logger.error(
             f"configure_oauth_session: ensure_valid_token returned False. "

--- a/tests/unit/confluence/test_client_oauth.py
+++ b/tests/unit/confluence/test_client_oauth.py
@@ -8,7 +8,7 @@ import pytest
 from mcp_atlassian.confluence.client import ConfluenceClient
 from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
-from mcp_atlassian.utils.oauth import OAuthConfig
+from mcp_atlassian.utils.oauth import BYOAccessTokenOAuthConfig, OAuthConfig
 
 
 class TestConfluenceClientOAuth:
@@ -83,6 +83,141 @@ class TestConfluenceClientOAuth:
             # Verify preprocessor was initialized
             assert client.preprocessor == mock_preprocessor.return_value
 
+    def test_init_with_byo_access_token_oauth_config(self):
+        """Test initializing the client with BYOAccessTokenOAuthConfig."""
+        # Create a mock BYO OAuth config
+        byo_oauth_config = BYOAccessTokenOAuthConfig(
+            cloud_id="test-byo-cloud-id",
+            access_token="test-byo-access-token",
+        )
+
+        # Create a Confluence config with BYO OAuth
+        config = ConfluenceConfig(
+            url="https://test.atlassian.net/wiki",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config,
+        )
+
+        # Mock dependencies
+        with (
+            patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+            patch(
+                "mcp_atlassian.confluence.client.configure_oauth_session"
+            ) as mock_configure_oauth,
+            patch(
+                "mcp_atlassian.confluence.client.configure_ssl_verification"
+            ) as mock_configure_ssl,
+            patch(
+                "mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"
+            ) as mock_preprocessor,
+        ):
+            # Configure the mock to return success for OAuth configuration
+            mock_configure_oauth.return_value = True
+
+            # Initialize client
+            client = ConfluenceClient(config=config)
+
+            # Verify OAuth session configuration was called
+            mock_configure_oauth.assert_called_once()
+
+            # Verify Confluence was initialized with the expected parameters
+            mock_confluence.assert_called_once()
+            conf_kwargs = mock_confluence.call_args[1]
+            assert (
+                conf_kwargs["url"]
+                == f"https://api.atlassian.com/ex/confluence/{byo_oauth_config.cloud_id}"
+            )
+            assert "session" in conf_kwargs
+            assert conf_kwargs["cloud"] is True
+
+            # Verify SSL verification was configured
+            mock_configure_ssl.assert_called_once()
+
+            # Verify preprocessor was initialized
+            assert client.preprocessor == mock_preprocessor.return_value
+
+    def test_init_with_byo_oauth_missing_cloud_id(self):
+        """Test initializing the client with BYO OAuth but missing cloud_id."""
+        # Create a mock BYO OAuth config without cloud_id
+        byo_oauth_config = BYOAccessTokenOAuthConfig(
+            access_token="test-byo-access-token",
+            cloud_id="",  # Explicitly empty or None
+        )
+
+        # Create a Confluence config with BYO OAuth
+        config = ConfluenceConfig(
+            url="https://test.atlassian.net/wiki",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config,
+        )
+
+        # Verify error is raised by ConfluenceClient's validation
+        with pytest.raises(
+            ValueError, match="OAuth authentication requires a valid cloud_id"
+        ):
+            ConfluenceClient(config=config)
+
+    def test_init_with_byo_oauth_failed_session_config(self):
+        """Test initializing with BYO OAuth but failed session configuration."""
+        # Create a mock BYO OAuth config
+        byo_oauth_config = BYOAccessTokenOAuthConfig(
+            cloud_id="test-byo-cloud-id",
+            access_token="test-byo-access-token",
+        )
+
+        # Create a Confluence config with BYO OAuth
+        config = ConfluenceConfig(
+            url="https://test.atlassian.net/wiki",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config,
+        )
+
+        # Mock dependencies with OAuth configuration failure
+        with patch(
+            "mcp_atlassian.confluence.client.configure_oauth_session"
+        ) as mock_configure_oauth:
+            # Configure the mock to return failure for OAuth configuration
+            mock_configure_oauth.return_value = False
+
+            # Verify error is raised
+            with pytest.raises(
+                MCPAtlassianAuthenticationError,
+                match="Failed to configure OAuth session",
+            ):
+                ConfluenceClient(config=config)
+
+    def test_init_with_byo_oauth_empty_token_failed_session_config(self):
+        """Test init with BYO OAuth, empty token, and failed session config."""
+        # Create a mock BYO OAuth config
+        byo_oauth_config = BYOAccessTokenOAuthConfig(
+            cloud_id="test-byo-cloud-id",
+            access_token="",  # Empty access token
+        )
+
+        # Create a Confluence config with BYO OAuth
+        config = ConfluenceConfig(
+            url="https://test.atlassian.net/wiki",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config,
+        )
+
+        # Mock dependencies with OAuth configuration failure
+        # configure_oauth_session might not even be called if token is validated earlier,
+        # but if it is, it should fail.
+        # For now, assume client init will fail due to invalid config before session setup,
+        # or session setup fails because token is invalid.
+        # The ConfluenceClient itself should raise error due to invalid oauth_config
+        with patch(
+            "mcp_atlassian.confluence.client.configure_oauth_session"
+        ) as mock_configure_oauth:
+            mock_configure_oauth.return_value = False  # Assume it's called and fails
+            with pytest.raises(
+                MCPAtlassianAuthenticationError,  # Or ValueError depending on where empty token is caught
+                # For consistency with Jira, let's assume MCPAtlassianAuthenticationError if session config is attempted
+                match="Failed to configure OAuth session",  # This may change if validation is earlier
+            ):
+                ConfluenceClient(config=config)
+
     def test_init_with_oauth_missing_cloud_id(self):
         """Test initializing the client with OAuth but missing cloud_id."""
         # Create a mock OAuth config without cloud_id
@@ -151,36 +286,43 @@ class TestConfluenceClientOAuth:
             ):
                 ConfluenceClient(config=config)
 
-    def test_from_env_with_oauth(self):
-        """Test creating client from environment variables with OAuth configuration."""
-        # Mock environment variables
+    def test_from_env_with_standard_oauth(self):
+        """Test creating client from env vars with standard OAuth configuration."""
+        # Mock environment variables - NO CONFLUENCE_AUTH_TYPE
         env_vars = {
             "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
-            "CONFLUENCE_AUTH_TYPE": "oauth",  # Add auth_type to env vars
+            "CONFLUENCE_AUTH_TYPE": "oauth",
             "ATLASSIAN_OAUTH_CLIENT_ID": "env-client-id",
             "ATLASSIAN_OAUTH_CLIENT_SECRET": "env-client-secret",
             "ATLASSIAN_OAUTH_REDIRECT_URI": "https://example.com/callback",
             "ATLASSIAN_OAUTH_SCOPE": "read:confluence-space.summary",
             "ATLASSIAN_OAUTH_CLOUD_ID": "env-cloud-id",
+            "ATLASSIAN_OAUTH_ACCESS_TOKEN": "env-access-token",  # Needed by OAuthConfig
+            "ATLASSIAN_OAUTH_REFRESH_TOKEN": "env-refresh-token",  # Needed by OAuthConfig
         }
 
-        # Mock OAuth config and token loading
-        mock_oauth_config = MagicMock()
-        mock_oauth_config.cloud_id = "env-cloud-id"
-        mock_oauth_config.access_token = "env-access-token"
-        mock_oauth_config.refresh_token = "env-refresh-token"
-        mock_oauth_config.expires_at = 9999999999.0
-
-        # Set is_token_expired as a property
-        type(mock_oauth_config).is_token_expired = MagicMock(return_value=False)
-        # Set ensure_valid_token as a method
-        mock_oauth_config.ensure_valid_token = MagicMock(return_value=True)
+        # Mock OAuthConfig instance
+        mock_standard_oauth_config = OAuthConfig(
+            client_id="env-client-id",
+            client_secret="env-client-secret",
+            redirect_uri="https://example.com/callback",
+            scope="read:confluence-space.summary",
+            cloud_id="env-cloud-id",
+            access_token="env-access-token",
+            refresh_token="env-refresh-token",
+            expires_at=9999999999.0,
+        )
+        # Mock its token validation methods
+        type(mock_standard_oauth_config).is_token_expired = PropertyMock(
+            return_value=False
+        )
+        mock_standard_oauth_config.ensure_valid_token = MagicMock(return_value=True)
 
         with (
-            patch.dict(os.environ, env_vars),
+            patch.dict(os.environ, env_vars, clear=True),  # Clear other env vars
             patch(
-                "mcp_atlassian.confluence.config.OAuthConfig.from_env",
-                return_value=mock_oauth_config,
+                "mcp_atlassian.confluence.config.get_oauth_config_from_env",  # Patch the correct utility
+                return_value=mock_standard_oauth_config,
             ),
             patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
             patch(
@@ -192,21 +334,82 @@ class TestConfluenceClientOAuth:
             ) as mock_configure_ssl,
         ):
             # Initialize client from environment
-            client = ConfluenceClient()
+            client = ConfluenceClient()  # Calls ConfluenceConfig.from_env() internally
 
             # Verify client was initialized with OAuth
             assert client.config.auth_type == "oauth"
-            assert client.config.oauth_config is mock_oauth_config
+            assert client.config.oauth_config is mock_standard_oauth_config
 
             # Verify Confluence was initialized correctly
             mock_confluence.assert_called_once()
             conf_kwargs = mock_confluence.call_args[1]
             assert (
                 conf_kwargs["url"]
-                == f"https://api.atlassian.com/ex/confluence/{mock_oauth_config.cloud_id}"
+                == f"https://api.atlassian.com/ex/confluence/{mock_standard_oauth_config.cloud_id}"
             )
             assert "session" in conf_kwargs
             assert conf_kwargs["cloud"] is True
 
             # Verify OAuth session was configured
             mock_configure_oauth.assert_called_once()
+
+    def test_from_env_with_byo_token_oauth(self):
+        """Test creating client from env vars with BYO token OAuth config."""
+        env_vars = {
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+            "ATLASSIAN_OAUTH_ACCESS_TOKEN": "env-byo-access-token",
+            "ATLASSIAN_OAUTH_CLOUD_ID": "env-byo-cloud-id",
+            # No other OAuth vars needed for BYO if get_oauth_config_from_env handles it
+        }
+
+        mock_byo_oauth_config = BYOAccessTokenOAuthConfig(
+            cloud_id="env-byo-cloud-id", access_token="env-byo-access-token"
+        )
+
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            patch(
+                "mcp_atlassian.confluence.config.get_oauth_config_from_env",
+                return_value=mock_byo_oauth_config,
+            ),
+            patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+            patch(
+                "mcp_atlassian.confluence.client.configure_oauth_session",
+                return_value=True,
+            ) as mock_configure_oauth,
+            patch(
+                "mcp_atlassian.confluence.client.configure_ssl_verification"
+            ) as mock_configure_ssl,
+        ):
+            client = ConfluenceClient()
+
+            assert client.config.auth_type == "oauth"
+            assert client.config.oauth_config is mock_byo_oauth_config
+            mock_confluence.assert_called_once()
+            conf_kwargs = mock_confluence.call_args[1]
+            assert (
+                conf_kwargs["url"]
+                == f"https://api.atlassian.com/ex/confluence/{mock_byo_oauth_config.cloud_id}"
+            )
+            mock_configure_oauth.assert_called_once()
+
+    def test_from_env_with_no_oauth_config_found(self):
+        """Test client creation from env when no OAuth config is found by the utility."""
+        env_vars = {
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+            # Deliberately missing other auth variables (basic, token, or complete OAuth)
+        }
+
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            patch(
+                "mcp_atlassian.confluence.config.get_oauth_config_from_env",
+                return_value=None,  # Simulate no OAuth config found by the utility
+            ),
+        ):
+            # ConfluenceConfig.from_env should raise ValueError if no auth can be determined
+            with pytest.raises(
+                ValueError,
+                match="Cloud authentication requires CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN, or OAuth configuration",
+            ):
+                ConfluenceClient()  # This will call ConfluenceConfig.from_env()

--- a/tests/unit/jira/test_client_oauth.py
+++ b/tests/unit/jira/test_client_oauth.py
@@ -8,7 +8,7 @@ import pytest
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.jira.client import JiraClient
 from mcp_atlassian.jira.config import JiraConfig
-from mcp_atlassian.utils.oauth import OAuthConfig
+from mcp_atlassian.utils.oauth import BYOAccessTokenOAuthConfig, OAuthConfig
 
 
 class TestJiraClientOAuth:
@@ -156,6 +156,132 @@ class TestJiraClientOAuth:
             ):
                 JiraClient(config=config)
 
+    def test_init_with_byo_access_token_oauth_config(self):
+        """Test initializing the client with BYO Access Token OAuth configuration."""
+        # Create a mock BYO OAuth config
+        byo_oauth_config = BYOAccessTokenOAuthConfig(
+            cloud_id="test-cloud-id", access_token="my-byo-token"
+        )
+
+        # Create a Jira config with OAuth
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config,
+        )
+
+        # Mock dependencies
+        with (
+            patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+            patch(
+                "mcp_atlassian.jira.client.configure_oauth_session"
+            ) as mock_configure_oauth,
+            patch(
+                "mcp_atlassian.jira.client.configure_ssl_verification"
+            ) as mock_configure_ssl,
+        ):
+            # Configure the mock to return success for OAuth configuration
+            mock_configure_oauth.return_value = True
+
+            # Initialize client
+            client = JiraClient(config=config)
+
+            # Verify OAuth session configuration was called
+            mock_configure_oauth.assert_called_once()
+
+            # Verify Jira was initialized with the expected parameters
+            mock_jira.assert_called_once()
+            jira_kwargs = mock_jira.call_args[1]
+            assert (
+                jira_kwargs["url"]
+                == f"https://api.atlassian.com/ex/jira/{byo_oauth_config.cloud_id}"
+            )
+            assert "session" in jira_kwargs
+            assert jira_kwargs["cloud"] is True
+
+            # Verify SSL verification was configured
+            mock_configure_ssl.assert_called_once()
+
+    def test_init_with_byo_oauth_missing_cloud_id(self):
+        """Test initializing with BYO OAuth but missing cloud_id."""
+        # Create a mock BYO OAuth config with an empty cloud_id
+        byo_oauth_config = BYOAccessTokenOAuthConfig(
+            cloud_id="", access_token="my-byo-token"
+        )
+
+        # Create a Jira config with OAuth
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config,
+        )
+
+        # Verify error is raised
+        with pytest.raises(
+            ValueError, match="OAuth authentication requires a valid cloud_id"
+        ):
+            JiraClient(config=config)
+
+    def test_init_with_byo_oauth_failed_session_config(self):
+        """Test init with BYO OAuth but failed session configuration."""
+        # Create a mock BYO OAuth config
+        byo_oauth_config = BYOAccessTokenOAuthConfig(
+            cloud_id="test-cloud-id", access_token="my_byo_token"
+        )
+
+        # Create a Jira config with OAuth
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config,
+        )
+
+        # Mock dependencies with OAuth configuration failure
+        with (
+            patch("mcp_atlassian.jira.client.Jira"),  # No need to assert mock_jira
+            patch(
+                "mcp_atlassian.jira.client.configure_oauth_session"
+            ) as mock_configure_oauth,
+            patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+        ):
+            # Configure the mock to return failure for OAuth configuration
+            mock_configure_oauth.return_value = False
+
+            # Verify error is raised
+            with pytest.raises(
+                MCPAtlassianAuthenticationError,
+                match="Failed to configure OAuth session",
+            ):
+                JiraClient(config=config)
+
+    def test_init_with_byo_oauth_empty_token_failed_session_config(self):
+        """Test init with BYO OAuth, empty token, so session config fails."""
+        # Create a mock BYO OAuth config with an empty token
+        byo_oauth_config_empty_token = BYOAccessTokenOAuthConfig(
+            cloud_id="test-cloud-id",
+            access_token="",  # Empty token
+        )
+
+        # Create a Jira config with OAuth
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="oauth",
+            oauth_config=byo_oauth_config_empty_token,
+        )
+
+        # Mock dependencies - configure_oauth_session will be called with real logic
+        with (
+            patch("mcp_atlassian.jira.client.Jira"),
+            patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+            # We want to test the actual behavior of configure_oauth_session here for empty token
+        ):
+            # Verify error is raised
+            with pytest.raises(
+                MCPAtlassianAuthenticationError,
+                match="Failed to configure OAuth session",
+            ):
+                JiraClient(config=config)
+
     def test_from_env_with_oauth(self):
         # Mock environment variables
         env_vars = {
@@ -182,7 +308,7 @@ class TestJiraClientOAuth:
         with (
             patch.dict(os.environ, env_vars),
             patch(
-                "mcp_atlassian.jira.config.OAuthConfig.from_env",
+                "mcp_atlassian.jira.config.get_oauth_config_from_env",
                 return_value=mock_oauth_config,
             ),
             patch("mcp_atlassian.jira.client.Jira") as mock_jira,
@@ -212,3 +338,75 @@ class TestJiraClientOAuth:
 
             # Verify OAuth session was configured
             mock_configure_oauth.assert_called_once()
+
+    def test_from_env_with_byo_token_oauth(self):
+        """Test JiraClient.from_env() when BYO token OAuth config is found."""
+        env_vars = {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_AUTH_TYPE": "oauth",
+            "ATLASSIAN_OAUTH_ACCESS_TOKEN": "env-byo-access-token",
+            "ATLASSIAN_OAUTH_CLOUD_ID": "env-byo-cloud-id",
+            # Ensure other standard OAuth env vars are not set or are ignored
+            "ATLASSIAN_OAUTH_CLIENT_ID": "",
+            "ATLASSIAN_OAUTH_CLIENT_SECRET": "",
+        }
+
+        # Mock BYO OAuth config
+        mock_byo_oauth_config = MagicMock(spec=BYOAccessTokenOAuthConfig)
+        mock_byo_oauth_config.cloud_id = "env-byo-cloud-id"
+        mock_byo_oauth_config.access_token = "env-byo-access-token"
+        # BYO config does not have refresh_token or expires_at in the same way
+        # and does not have is_token_expired or ensure_valid_token methods
+
+        with (
+            patch.dict(os.environ, env_vars),
+            patch(
+                "mcp_atlassian.jira.config.get_oauth_config_from_env",
+                return_value=mock_byo_oauth_config,
+            ),
+            patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+            patch(
+                "mcp_atlassian.jira.client.configure_oauth_session", return_value=True
+            ) as mock_configure_oauth,
+            patch(
+                "mcp_atlassian.jira.client.configure_ssl_verification"
+            ) as mock_configure_ssl,
+        ):
+            client = JiraClient()  # Initializes from env via JiraConfig.from_env()
+
+            assert client.config.auth_type == "oauth"
+            assert client.config.oauth_config is mock_byo_oauth_config
+
+            # Verify OAuth session configuration was called
+            mock_configure_oauth.assert_called_once()
+
+            mock_jira.assert_called_once()
+            jira_kwargs = mock_jira.call_args[1]
+            assert (
+                jira_kwargs["url"]
+                == f"https://api.atlassian.com/ex/jira/{mock_byo_oauth_config.cloud_id}"
+            )
+            mock_configure_ssl.assert_called_once()
+
+    def test_from_env_with_no_oauth_config_found(self):
+        """Test JiraClient.from_env() when no OAuth config is found."""
+        env_vars = {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_AUTH_TYPE": "oauth",
+            # No OAuth specific variables set
+            "ATLASSIAN_OAUTH_CLIENT_ID": "",
+            "ATLASSIAN_OAUTH_ACCESS_TOKEN": "",
+        }
+
+        with (
+            patch.dict(os.environ, env_vars),
+            patch(
+                "mcp_atlassian.jira.config.get_oauth_config_from_env",
+                return_value=None,  # Simulate no config found
+            ),
+        ):
+            with pytest.raises(
+                ValueError,  # Adjusted to actual error raised by JiraConfig.from_env
+                match="Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN, or OAuth configuration",
+            ):
+                JiraClient()

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -10,8 +10,10 @@ import requests
 from mcp_atlassian.utils.oauth import (
     KEYRING_SERVICE_NAME,
     TOKEN_EXPIRY_MARGIN,
+    BYOAccessTokenOAuthConfig,
     OAuthConfig,
     configure_oauth_session,
+    get_oauth_config_from_env,
 )
 
 
@@ -590,28 +592,189 @@ class TestOAuthConfig:
         assert config is None
 
 
-def test_configure_oauth_session_success():
-    """Test successful configure_oauth_session."""
+class TestBYOAccessTokenOAuthConfig:
+    """Tests for the BYOAccessTokenOAuthConfig class."""
+
+    def test_init_with_required_params(self):
+        """Test initialization with required parameters."""
+        config = BYOAccessTokenOAuthConfig(
+            cloud_id="byo-cloud-id", access_token="byo-access-token"
+        )
+        assert config.cloud_id == "byo-cloud-id"
+        assert config.access_token == "byo-access-token"
+        assert config.refresh_token is None
+        assert config.expires_at is None
+
+    @patch("os.getenv")
+    def test_from_env_success(self, mock_getenv):
+        """Test from_env success for BYOAccessTokenOAuthConfig."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "ATLASSIAN_OAUTH_CLOUD_ID": "env-byo-cloud-id",
+            "ATLASSIAN_OAUTH_ACCESS_TOKEN": "env-byo-access-token",
+        }.get(key, default)
+
+        config = BYOAccessTokenOAuthConfig.from_env()
+
+        assert config is not None
+        assert config.cloud_id == "env-byo-cloud-id"
+        assert config.access_token == "env-byo-access-token"
+        mock_getenv.assert_any_call("ATLASSIAN_OAUTH_CLOUD_ID")
+        mock_getenv.assert_any_call("ATLASSIAN_OAUTH_ACCESS_TOKEN")
+
+    @patch("os.getenv")
+    def test_from_env_missing_cloud_id(self, mock_getenv):
+        """Test from_env with missing cloud_id for BYOAccessTokenOAuthConfig."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "ATLASSIAN_OAUTH_ACCESS_TOKEN": "env-byo-access-token",
+        }.get(key, default)
+
+        config = BYOAccessTokenOAuthConfig.from_env()
+        assert config is None
+
+    @patch("os.getenv")
+    def test_from_env_missing_access_token(self, mock_getenv):
+        """Test from_env with missing access_token for BYOAccessTokenOAuthConfig."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "ATLASSIAN_OAUTH_CLOUD_ID": "env-byo-cloud-id",
+        }.get(key, default)
+
+        config = BYOAccessTokenOAuthConfig.from_env()
+        assert config is None
+
+    @patch("os.getenv")
+    def test_from_env_missing_both(self, mock_getenv):
+        """Test from_env with both missing for BYOAccessTokenOAuthConfig."""
+        mock_getenv.return_value = None  # Covers all calls returning None
+        config = BYOAccessTokenOAuthConfig.from_env()
+        assert config is None
+
+
+@patch("mcp_atlassian.utils.oauth.BYOAccessTokenOAuthConfig.from_env")
+@patch("mcp_atlassian.utils.oauth.OAuthConfig.from_env")
+def test_get_oauth_config_prefers_standard_oauth(
+    mock_oauth_from_env, mock_byo_from_env
+):
+    """Test get_oauth_config_from_env prefers OAuthConfig."""
+    mock_oauth_config = MagicMock(spec=OAuthConfig)
+    mock_oauth_from_env.return_value = mock_oauth_config
+    mock_byo_config = MagicMock(spec=BYOAccessTokenOAuthConfig)
+    mock_byo_from_env.return_value = mock_byo_config  # This shouldn't be returned
+
+    result = get_oauth_config_from_env()
+    assert result == mock_oauth_config
+    mock_oauth_from_env.assert_called_once()
+    mock_byo_from_env.assert_not_called()  # Important: BYO should not be called if OAuthConfig is found
+
+
+@patch("mcp_atlassian.utils.oauth.BYOAccessTokenOAuthConfig.from_env")
+@patch("mcp_atlassian.utils.oauth.OAuthConfig.from_env")
+def test_get_oauth_config_falls_back_to_byo_token_config(
+    mock_oauth_from_env, mock_byo_from_env
+):
+    """Test get_oauth_config_from_env falls back to BYOAccessTokenOAuthConfig."""
+    mock_oauth_from_env.return_value = None  # Standard OAuth not configured
+    mock_byo_config = MagicMock(spec=BYOAccessTokenOAuthConfig)
+    mock_byo_from_env.return_value = mock_byo_config
+
+    result = get_oauth_config_from_env()
+    assert result == mock_byo_config
+    mock_oauth_from_env.assert_called_once()
+    mock_byo_from_env.assert_called_once()
+
+
+@patch("mcp_atlassian.utils.oauth.BYOAccessTokenOAuthConfig.from_env")
+@patch("mcp_atlassian.utils.oauth.OAuthConfig.from_env")
+def test_get_oauth_config_returns_none_if_both_unavailable(
+    mock_oauth_from_env, mock_byo_from_env
+):
+    """Test get_oauth_config_from_env returns None if neither is available."""
+    mock_oauth_from_env.return_value = None
+    mock_byo_from_env.return_value = None
+
+    result = get_oauth_config_from_env()
+    assert result is None
+    mock_oauth_from_env.assert_called_once()
+    mock_byo_from_env.assert_called_once()
+
+
+def test_configure_oauth_session_success_with_oauth_config():
+    """Test successful configure_oauth_session with OAuthConfig."""
     session = requests.Session()
-    oauth_config = MagicMock()
-    oauth_config.ensure_valid_token.return_value = True
+    # Explicitly use OAuthConfig and mock its specific methods/attributes
+    oauth_config = MagicMock(spec=OAuthConfig)
     oauth_config.access_token = "test-access-token"
+    oauth_config.refresh_token = "test-refresh-token"  # Crucial for this path
+    oauth_config.ensure_valid_token.return_value = True
 
     result = configure_oauth_session(session, oauth_config)
 
-    # Check result
     assert result is True
     assert session.headers["Authorization"] == "Bearer test-access-token"
+    oauth_config.ensure_valid_token.assert_called_once()
 
 
-def test_configure_oauth_session_failure():
-    """Test failed configure_oauth_session."""
+def test_configure_oauth_session_failure_with_oauth_config():
+    """Test failed configure_oauth_session with OAuthConfig (token refresh fails)."""
     session = requests.Session()
-    oauth_config = MagicMock()
-    oauth_config.ensure_valid_token.return_value = False
+    oauth_config = MagicMock(spec=OAuthConfig)
+    oauth_config.access_token = None  # Start with no access token initially
+    oauth_config.refresh_token = "test-refresh-token"  # Has a refresh token
+    oauth_config.ensure_valid_token.return_value = False  # Refresh fails
 
     result = configure_oauth_session(session, oauth_config)
 
-    # Check result
     assert result is False
     assert "Authorization" not in session.headers
+    oauth_config.ensure_valid_token.assert_called_once()
+
+
+def test_configure_oauth_session_success_with_byo_config():
+    """Test successful configure_oauth_session with BYOAccessTokenOAuthConfig."""
+    session = requests.Session()
+    byo_config = BYOAccessTokenOAuthConfig(
+        cloud_id="byo-cloud-id", access_token="byo-valid-token"
+    )
+    # Ensure ensure_valid_token is not called on BYOAccessTokenOAuthConfig if it were a MagicMock
+    # by not creating it as a MagicMock or by not setting ensure_valid_token if it were.
+
+    result = configure_oauth_session(session, byo_config)
+
+    assert result is True
+    assert session.headers["Authorization"] == "Bearer byo-valid-token"
+
+
+@patch("mcp_atlassian.utils.oauth.logger")
+def test_configure_oauth_session_byo_config_empty_token_logs_error(mock_logger):
+    """Test configure_oauth_session with BYO config and empty token logs error."""
+    session = requests.Session()
+    # BYO config with an effectively invalid (empty) access token
+    byo_config = BYOAccessTokenOAuthConfig(cloud_id="byo-cloud-id", access_token="")
+
+    result = configure_oauth_session(session, byo_config)
+
+    assert result is False
+    assert "Authorization" not in session.headers
+    mock_logger.error.assert_called_once_with(
+        "configure_oauth_session: oauth access token configuration provided as empty string."
+    )
+
+
+@patch("mcp_atlassian.utils.oauth.logger")
+def test_configure_oauth_session_byo_config_no_refresh_token_direct_use(mock_logger):
+    """Test BYO config (with access_token, no refresh_token) uses token directly."""
+    session = requests.Session()
+    oauth_config = BYOAccessTokenOAuthConfig(
+        cloud_id="test_cloud_id", access_token="my_access_token"
+    )
+
+    # We don't need to mock ensure_valid_token because it shouldn't be called.
+    # The actual BYOAccessTokenOAuthConfig instance does not have this method.
+
+    result = configure_oauth_session(session, oauth_config)
+
+    assert result is True
+    assert session.headers["Authorization"] == "Bearer my_access_token"
+    # Check that the specific log message for direct use is present
+    mock_logger.info.assert_any_call(
+        "configure_oauth_session: Using provided OAuth access token directly (no refresh_token)."
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->
This pull request introduces support for "Bring Your Own Token" (BYOT) OAuth authentication in the `mcp-atlassian` server. This allows users to provide a pre-existing, externally managed OAuth 2.0 access token directly to the server, bypassing its internal token fetching and refresh mechanisms.

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

This PR enables `mcp-atlassian` to use an externally provided OAuth 2.0 access token. It is needed for scenarios where `mcp-atlassian` is integrated into larger systems (e.g., an MCP Gateway) that manage OAuth token lifecycles externally. This allows for greater flexibility in diverse authentication environments.

This feature enhancement was proposed in [sooperset/mcp-atlassian#477](https://github.com/sooperset/mcp-atlassian/discussions/477) but I decided to just go for it!

Fixes: N/A (Feature enhancement based on discussion)

## Changes

<!-- Briefly list the key changes made. -->

- Added `BYOAccessTokenOAuthConfig` dataclass to handle configurations with directly provided access tokens.
- Updated `get_oauth_config_from_env` to support falling back to `BYOAccessTokenOAuthConfig`.
- Modified `configure_oauth_session` to use the BYOT token directly without attempting refresh.
- Updated `JiraConfig` and `ConfluenceConfig` to use the new OAuth loading logic.
- Enhanced `README.md` with documentation for the BYOT method, including use cases and configuration examples.
- Added and updated unit tests for `BYOAccessTokenOAuthConfig`, `get_oauth_config_from_env`, and client initializations with BYOT.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated (for `utils/oauth.py`, `jira/client.py`, `confluence/client.py`).
- [x] Integration tests passed (as part of pre-commit hooks that run all tests).
- [x] Manual checks performed: Configured the server with the new configuration introduced and confirmed the ability to make successful Jira API calls

## Checklist

- [x] Code follows project style guidelines (linting passes via pre-commit hooks).
- [x] Tests added/updated for changes.
- [x] All tests pass locally (confirmed by pre-commit hook execution).
- [x] Documentation updated (README.md has been updated).
