### PR TITLE
Feature: update jira_get_issue to honor the project filter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,66 +5,90 @@ Thank you for your interest in contributing to MCP Atlassian! This document prov
 ## Development Setup
 
 1. Make sure you have Python 3.10+ installed
-2. Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
-3. Fork the repository
-4. Clone your fork: `git clone https://github.com/YOUR-USERNAME/mcp-atlassian.git`
-5. Add the upstream remote: `git remote add upstream https://github.com/sooperset/mcp-atlassian.git`
-6. Install dependencies:
-```bash
-uv sync --frozen --all-extras --dev
-```
-7. Set up pre-commit hooks:
-```bash
-pre-commit install
-```
-8. Set up environment variables (copy from .env.example):
-```bash
-cp .env.example .env
-```
+1. Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
+1. Fork the repository
+1. Clone your fork: `git clone https://github.com/YOUR-USERNAME/mcp-atlassian.git`
+1. Add the upstream remote: `git remote add upstream https://github.com/sooperset/mcp-atlassian.git`
+1. Install dependencies:
+
+    ```sh
+    uv sync
+    uv sync --frozen --all-extras --dev
+    ```
+
+1. Activate the virtual environment:
+
+    __macOS and Linux__:
+
+    ```sh
+    source .venv/bin/activate
+    ```
+
+    __Windows__:
+
+    ```powershell
+    .venv\Scripts\activate.ps1
+    ```
+
+1. Set up pre-commit hooks:
+
+    ```sh
+    pre-commit install
+    ```
+
+1. Set up environment variables (copy from .env.example):
+
+    ```bash
+    cp .env.example .env
+    ```
 
 ## Development Setup with local VSCode devcontainer
 
 1. Clone your fork: `git clone https://github.com/YOUR-USERNAME/mcp-atlassian.git`
-2. Add the upstream remote: `git remote add upstream https://github.com/sooperset/mcp-atlassian.git`
-3. Open the project with VSCode and open with devcontainer
-4. Add this bit of config to your `.vscode/settings.json`:
-```json
-{
-    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-    "[python]": {
-      "editor.defaultFormatter": "charliermarsh.ruff",
-      "editor.formatOnSave": true
+1. Add the upstream remote: `git remote add upstream https://github.com/sooperset/mcp-atlassian.git`
+1. Open the project with VSCode and open with devcontainer
+1. Add this bit of config to your `.vscode/settings.json`:
+
+    ```json
+    {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true
+        }
     }
-}
-```
+    ```
 
 ## Development Workflow
 
 1. Create a feature or fix branch:
-```bash
-git checkout -b feature/your-feature-name
-# or
-git checkout -b fix/issue-description
-```
 
-2. Make your changes
+    ```sh
+    git checkout -b feature/your-feature-name
+    # or
+    git checkout -b fix/issue-description
+    ```
 
-3. Ensure tests pass:
-```bash
-uv run pytest
+1. Make your changes
 
-# With coverage
-uv run pytest --cov=mcp_atlassian
-```
+1. Ensure tests pass:
 
-4. Run code quality checks using pre-commit:
-```bash
-pre-commit run --all-files
-```
+    ```sh
+    uv run pytest
 
-6. Commit your changes with clear, concise commit messages referencing issues when applicable
+    # With coverage
+    uv run pytest --cov=mcp_atlassian
+    ```
 
-7. Submit a pull request to the main branch
+1. Run code quality checks using pre-commit:
+
+    ```bash
+    pre-commit run --all-files
+    ```
+
+1. Commit your changes with clear, concise commit messages referencing issues when applicable
+
+1. Submit a pull request to the main branch
 
 ## Code Style
 
@@ -80,23 +104,23 @@ pre-commit run --all-files
   - Standard collection types with subscripts: `list[str]`, `dict[str, Any]`
 - Add docstrings to all public modules, functions, classes, and methods using Google-style format:
 
-```python
-def function_name(param1: str, param2: int) -> bool:
-    """Summary of function purpose.
+        ```python
+        def function_name(param1: str, param2: int) -> bool:
+            """Summary of function purpose.
 
-    More detailed description if needed.
+            More detailed description if needed.
 
-    Args:
-        param1: Description of param1
-        param2: Description of param2
+            Args:
+                param1: Description of param1
+                param2: Description of param2
 
-    Returns:
-        Description of return value
+            Returns:
+                Description of return value
 
-    Raises:
-        ValueError: When and why this exception is raised
-    """
-```
+            Raises:
+                ValueError: When and why this exception is raised
+            """
+        ```
 
 ## Pull Request Process
 

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -76,8 +76,8 @@ class IssuesMixin(
                 if issue_key_project not in projects:
                     # If the project key not in the filter, return an empty issue
                     msg = (
-                        "Issue with with project prefix "
-                        f"'{issue_key_project}' are restricted"
+                        "Issue with project prefix "
+                        f"'{issue_key_project}' are restricted by configuration"
                     )
                     raise ValueError(msg)
 

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -61,6 +61,26 @@ class IssuesMixin(
             Exception: If there is an error retrieving the issue
         """
         try:
+            # Obtain the projects filter from the config.
+            # These should NOT be overridden by the request.
+            filter_to_use = self.config.projects_filter
+
+            # Apply projects filter if present
+            if filter_to_use:
+                # Split projects filter by commas and handle possible whitespace
+                projects = [p.strip() for p in filter_to_use.split(",")]
+
+                # Obtain the project key from issue_key
+                issue_key_project = issue_key.split("-")[0]
+
+                if issue_key_project not in projects:
+                    # If the project key not in the filter, return an empty issue
+                    msg = (
+                        "Issue with with project prefix "
+                        f"'{issue_key_project}' are restricted"
+                    )
+                    raise ValueError(msg)
+
             # Determine fields_param: use provided fields or default from constant
             fields_param = fields
             if fields_param is None:

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1523,8 +1523,10 @@ class TestIssuesMixin:
         assert result.key == "TEST-123"
         assert result.labels == ["bug", "frontend"]
 
-    def test_get_issue_with_config_projects_filter(self, issues_mixin: IssuesMixin):
-        """Test get with projects filter from config."""
+    def test_get_issue_with_config_projects_filter_restricted(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test get_issue with projects filter from config - restricted case."""
         # Setup mock response
         mock_issues = {
             "issues": [
@@ -1554,7 +1556,113 @@ class TestIssuesMixin:
             Exception,
             match=(
                 "Error retrieving issue TEST-123: "
-                "Issue with with project prefix 'TEST' are restricted"
+                "Issue with project prefix 'TEST' are restricted by configuration"
             ),
         ):
             issues_mixin.get_issue("TEST-123")
+
+    def test_get_issue_with_config_projects_filter_allowed(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test get_issue with projects filter from config - allowed case."""
+        # Setup mock response for a project that matches the filter
+        mock_issue_data = {
+            "id": "10001",
+            "key": "DEV-123",
+            "fields": {
+                "summary": "Test issue",
+                "description": "This is a test issue",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = mock_issue_data
+        issues_mixin.config.url = "https://example.atlassian.net"
+        issues_mixin.config.projects_filter = "DEV"
+
+        # Call the method
+        result = issues_mixin.get_issue("DEV-123")
+
+        # Verify the API call was made correctly
+        issues_mixin.jira.get_issue.assert_called_once_with(
+            "DEV-123",
+            expand=None,
+            fields=ANY,
+            properties=None,
+            update_history=True,
+        )
+
+        # Verify the result
+        assert isinstance(result, JiraIssue)
+        assert result.key == "DEV-123"
+        assert result.summary == "Test issue"
+
+    def test_get_issue_with_multiple_projects_filter(self, issues_mixin: IssuesMixin):
+        """Test get_issue with multiple projects in the filter."""
+        # Setup mock response for a project that matches one of the multiple filters
+        mock_issue_data = {
+            "id": "10001",
+            "key": "PROD-123",
+            "fields": {
+                "summary": "Production issue",
+                "description": "This is a production issue",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = mock_issue_data
+        issues_mixin.config.url = "https://example.atlassian.net"
+        issues_mixin.config.projects_filter = "DEV,PROD"
+
+        # Call the method
+        result = issues_mixin.get_issue("PROD-123")
+
+        # Verify the API call was made correctly
+        issues_mixin.jira.get_issue.assert_called_once_with(
+            "PROD-123",
+            expand=None,
+            fields=ANY,
+            properties=None,
+            update_history=True,
+        )
+
+        # Verify the result
+        assert isinstance(result, JiraIssue)
+        assert result.key == "PROD-123"
+        assert result.summary == "Production issue"
+
+    def test_get_issue_with_whitespace_in_projects_filter(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test get_issue with extra whitespace in the projects filter."""
+        # Setup mock response for a project that matches the filter with whitespace
+        mock_issue_data = {
+            "id": "10001",
+            "key": "DEV-123",
+            "fields": {
+                "summary": "Development issue",
+                "description": "This is a development issue",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = mock_issue_data
+        issues_mixin.config.url = "https://example.atlassian.net"
+        issues_mixin.config.projects_filter = " DEV , PROD "  # Extra whitespace
+
+        # Call the method
+        result = issues_mixin.get_issue("DEV-123")
+
+        # Verify the API call was made correctly
+        issues_mixin.jira.get_issue.assert_called_once_with(
+            "DEV-123",
+            expand=None,
+            fields=ANY,
+            properties=None,
+            update_history=True,
+        )
+
+        # Verify the result
+        assert isinstance(result, JiraIssue)
+        assert result.key == "DEV-123"
+        assert result.summary == "Development issue"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

This PR adds logic to the `jira_get_issue` to have it honor the project filter configuration such that when a request for a Jira Issue is rejected if it's prefix does NOT match any project filters (if defined). 

The user's request should NOT be able to override this.

Fixes: #478 

## Changes

<!-- Briefly list the key changes made. -->

- Modified the CONTRIBUTING.md to align use standard markdown numbers and key steps I needed to get it the env operational
- Modify jira/get_issue logic to honor the project filter config
- Added a unit test

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
