### PR TITLE
feature: Tool to list available jira projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ Here's a complete example of setting up multi-user authentication with streamabl
 - `jira_update_issue`: Update an existing issue
 - `jira_transition_issue`: Transition an issue to a new status
 - `jira_add_comment`: Add a comment to an issue
+- `jira_get_all_projects`: List all Jira projects accessible to the current user
 - `jira_get_project_versions`: List all fix versions for a project
 - `jira_create_version`: Create a new version (fix version) in a Jira project
 
@@ -566,9 +567,10 @@ Here's a complete example of setting up multi-user authentication with streamabl
 |-----------|-------------------------------|--------------------------------|
 | **Read**  | `jira_search`                 | `confluence_search`            |
 |           | `jira_get_issue`              | `confluence_get_page`          |
-|           | `jira_get_project_issues`     | `confluence_get_page_children` |
-|           | `jira_get_worklog`            | `confluence_get_comments`      |
-|           | `jira_get_transitions`        | `confluence_get_labels`        |
+|           | `jira_get_all_projects`       | `confluence_get_page_children` |
+|           | `jira_get_project_issues`     | `confluence_get_comments`      |
+|           | `jira_get_worklog`            | `confluence_get_labels`        |
+|           | `jira_get_transitions`        |                                |
 |           | `jira_search_fields`          |                                |
 |           | `jira_get_agile_boards`       |                                |
 |           | `jira_get_board_issues`       |                                |

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1415,9 +1415,33 @@ async def get_all_projects(
 
     Returns:
         JSON string representing a list of project objects accessible to the user.
+        Project keys are always returned in uppercase.
+        If JIRA_PROJECTS_FILTER is configured, only returns projects matching those keys.
     """
     jira = await get_jira_fetcher(ctx)
     projects = jira.get_all_projects(include_archived=include_archived)
+
+    # Ensure all project keys are uppercase
+    for project in projects:
+        if "key" in project:
+            project["key"] = project["key"].upper()
+
+    # Apply project filter if configured
+    if jira.config.projects_filter:
+        # Split projects filter by commas and handle possible whitespace
+        allowed_project_keys = [
+            p.strip().upper() for p in jira.config.projects_filter.split(",")
+        ]
+
+        # Filter projects to only include those in the allowed list
+        filtered_projects = []
+        for project in projects:
+            project_key = project.get("key", "")
+            if project_key in allowed_project_keys:
+                filtered_projects.append(project)
+
+        projects = filtered_projects
+
     return json.dumps(projects, indent=2, ensure_ascii=False)
 
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1396,6 +1396,31 @@ async def get_project_versions(
     return json.dumps(versions, indent=2, ensure_ascii=False)
 
 
+@jira_mcp.tool(tags={"jira", "read"})
+async def get_all_projects(
+    ctx: Context,
+    include_archived: Annotated[
+        bool,
+        Field(
+            description="Whether to include archived projects in the results",
+            default=False,
+        ),
+    ] = False,
+) -> str:
+    """Get all Jira projects accessible to the current user.
+
+    Args:
+        ctx: The FastMCP context.
+        include_archived: Whether to include archived projects.
+
+    Returns:
+        JSON string representing a list of project objects accessible to the user.
+    """
+    jira = await get_jira_fetcher(ctx)
+    projects = jira.get_all_projects(include_archived=include_archived)
+    return json.dumps(projects, indent=2, ensure_ascii=False)
+
+
 @convert_empty_defaults_to_none
 @jira_mcp.tool(tags={"jira", "write"})
 @check_write_access


### PR DESCRIPTION
## Summary
Adds get_all_projects MCP tool to retrieve all Jira projects accessible to the current user.

## Motivation
Many existing MCP tools require project keys as input (e.g., create_issue, get_project_issues), but there was no way for users to discover what projects they have access to. This tool fills that gap by enabling project discovery before using project-specific tools.

## Implementation
- Uses existing ProjectsMixin.get_all_projects() method
- Includes optional include_archived parameter (defaults to false)
- Returns JSON array of project objects with keys, names, descriptions, etc.
- Follows existing codebase patterns and conventions

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`
 The tool correctly lists projects in my Jira account

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
