### PR TITLE
fix: resolve stdio transport conflict with lifecycle monitoring

### DIFF
--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -341,11 +341,13 @@ def main(
     try:
         logger.debug("Starting asyncio event loop...")
 
-        # Create a wrapper coroutine that handles both the server and stdin monitoring
+        # For stdio transport, don't monitor stdin as MCP server handles it internally
+        # This prevents race conditions where both try to read from the same stdin
         if final_transport == "stdio":
-            asyncio.run(run_with_stdio_monitoring(main_mcp.run_async, run_kwargs))
-        else:
             asyncio.run(main_mcp.run_async(**run_kwargs))
+        else:
+            # For other transports (SSE, HTTP), use stdin monitoring for container shutdown
+            asyncio.run(run_with_stdio_monitoring(main_mcp.run_async, run_kwargs))
     except (KeyboardInterrupt, SystemExit) as e:
         logger.info(f"Server shutdown initiated: {type(e).__name__}")
     except Exception as e:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

This PR fixes a critical issue where the MCP Atlassian server fails immediately when running in Docker containers with stdio transport. The lifecycle monitoring introduced in PR #514 conflicts with the MCP server's internal stdio handling, causing a race condition that results in "I/O operation on closed file" errors.

Fixes: #519

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
