### PR TITLE
refactor: simplify transport lifecycle tests after stdin monitoring removal

### DIFF
--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -1,8 +1,9 @@
-"""Unit tests for transport-specific execution path selection.
+"""Unit tests for transport selection and execution.
 
-These tests verify that the main entry point correctly chooses between
-direct server execution (for stdio) and lifecycle-monitored execution
-(for other transports) to prevent stdio conflicts.
+These tests verify that:
+1. All transports use direct execution (no stdin monitoring)
+2. Transport selection logic works correctly (CLI vs environment)
+3. Error handling is preserved
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -30,14 +31,16 @@ class TestMainTransportSelection:
             mock_run.side_effect = lambda coro: setattr(mock_run, "_called_with", coro)
             yield mock_run
 
-    def test_stdio_transport_uses_direct_execution(self, mock_server, mock_asyncio_run):
-        """Test that stdio transport uses direct execution.
+    @pytest.mark.parametrize("transport", ["stdio", "sse", "streamable-http"])
+    def test_all_transports_use_direct_execution(
+        self, mock_server, mock_asyncio_run, transport
+    ):
+        """Verify all transports use direct execution without stdin monitoring.
 
-        This test verifies the fix for issue #519 where stdio transport
-        conflicted with the MCP server's internal stdio handling.
+        This is a regression test for issues #519 and #524.
         """
         with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
-            with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
+            with patch.dict("os.environ", {"TRANSPORT": transport}):
                 with patch("sys.argv", ["mcp-atlassian"]):
                     try:
                         main()
@@ -51,54 +54,8 @@ class TestMainTransportSelection:
                     called_coro = mock_asyncio_run._called_with
                     coro_repr = repr(called_coro)
 
-                    # All transports now use direct execution
-                    # Should be the direct run_async coroutine
-                    assert "run_async" in coro_repr or hasattr(called_coro, "cr_code")
-
-    def test_sse_transport_uses_direct_execution(self, mock_server, mock_asyncio_run):
-        """Test that SSE transport uses direct execution.
-
-        After PR #528, all transports use direct execution without stdin monitoring.
-        """
-        with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
-            with patch.dict("os.environ", {"TRANSPORT": "sse"}):
-                with patch("sys.argv", ["mcp-atlassian"]):
-                    try:
-                        main()
-                    except SystemExit:
-                        pass
-
-                    # Verify asyncio.run was called
-                    assert mock_asyncio_run.called
-
-                    # Get the coroutine info
-                    called_coro = mock_asyncio_run._called_with
-                    coro_repr = repr(called_coro)
-
-                    # All transports now use direct execution
-                    assert "run_async" in coro_repr or hasattr(called_coro, "cr_code")
-
-    def test_http_transport_uses_direct_execution(self, mock_server, mock_asyncio_run):
-        """Test that HTTP transport uses direct execution.
-
-        After PR #528, all transports use direct execution without stdin monitoring.
-        """
-        with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
-            with patch.dict("os.environ", {"TRANSPORT": "streamable-http"}):
-                with patch("sys.argv", ["mcp-atlassian"]):
-                    try:
-                        main()
-                    except SystemExit:
-                        pass
-
-                    # Verify asyncio.run was called
-                    assert mock_asyncio_run.called
-
-                    # Get the coroutine info
-                    called_coro = mock_asyncio_run._called_with
-                    coro_repr = repr(called_coro)
-
-                    # All transports now use direct execution
+                    # All transports must use direct execution
+                    assert "run_with_stdio_monitoring" not in coro_repr
                     assert "run_async" in coro_repr or hasattr(called_coro, "cr_code")
 
     def test_cli_overrides_env_transport(self, mock_server, mock_asyncio_run):
@@ -116,26 +73,6 @@ class TestMainTransportSelection:
                     called_coro = mock_asyncio_run._called_with
                     coro_repr = repr(called_coro)
                     assert "run_async" in coro_repr or hasattr(called_coro, "cr_code")
-
-    @pytest.mark.parametrize("transport", ["stdio", "sse", "streamable-http"])
-    def test_transport_passed_to_server(self, mock_server, transport):
-        """Test that the correct transport is passed to the server."""
-        with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
-            with patch("asyncio.run"):
-                with patch.dict("os.environ", {"TRANSPORT": transport}):
-                    with patch("sys.argv", ["mcp-atlassian"]):
-                        try:
-                            main()
-                        except SystemExit:
-                            pass
-
-                        # Verify run_async was set up to be called with correct transport
-                        # The actual call happens inside asyncio.run, but we can verify
-                        # the mock was configured
-                        assert (
-                            mock_server.run_async.call_count == 0
-                        )  # Not called directly
-                        # The coroutine should be created with the right transport
 
     def test_signal_handlers_always_setup(self, mock_server):
         """Test that signal handlers are set up regardless of transport."""


### PR DESCRIPTION
## Description

This PR refactors the transport lifecycle tests from #523 to align with the simplified architecture introduced in #528. After stdin monitoring was completely removed, the original tests were over-engineered and contained redundant checks for behavior that no longer exists.

The refactoring maintains the same level of protection against regression of issues #519 (stdio transport conflicts) and #524 (HTTP session termination) while significantly reducing complexity and improving maintainability.

Related to: #523, #528, #519, #524

## Changes

- **Consolidated redundant tests**: Merged 5 separate transport tests into a single parameterized test since all transports now behave identically
- **Removed obsolete tests**: Eliminated tests for stdin monitoring functionality that no longer exists
- **Added regression prevention**: Added explicit test to ensure `run_with_stdio_monitoring` is never reintroduced
- **Simplified test structure**: Reduced integration tests from 19 to 9 while maintaining coverage
- **Improved documentation**: Added clear comments explaining the historical context and purpose of each test

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: All tests pass with `uv run pytest --integration`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).