### PR TITLE
fix: remove 500 space limit in confluence page retrieval

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -155,26 +155,16 @@ class PagesMixin(ConfluenceClient):
             ConfluencePage model containing the page content and metadata, or None if not found
         """
         try:
-            # First check if the space exists
-            spaces = self.confluence.get_all_spaces(start=0, limit=500)
-
-            # Handle case where spaces can be a dictionary with a "results" key
-            if isinstance(spaces, dict) and "results" in spaces:
-                space_keys = [s["key"] for s in spaces["results"]]
-            else:
-                space_keys = [s["key"] for s in spaces]
-
-            if space_key not in space_keys:
-                logger.warning(f"Space {space_key} not found")
-                return None
-
-            # Then try to find the page by title
+            # Directly try to find the page by title
             page = self.confluence.get_page_by_title(
                 space=space_key, title=title, expand="body.storage,version"
             )
 
             if not page:
-                logger.warning(f"Page '{title}' not found in space {space_key}")
+                logger.warning(
+                    f"Page '{title}' not found in space '{space_key}'. "
+                    f"The space may be invalid, the page may not exist, or permissions may be insufficient."
+                )
                 return None
 
             content = page["body"]["storage"]["value"]


### PR DESCRIPTION
## Description

This PR fixes a critical bug where `get_page_by_title` fails to retrieve valid pages in Confluence environments with more than 500 spaces. The function was performing an unnecessary space existence check that was limited to fetching only the first 500 spaces.

Fixes: #518

## Changes

- Removed the space existence validation from `get_page_by_title` method
- Updated error message to be more comprehensive about potential failure reasons
- Updated tests to reflect the new behavior without space pre-validation

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: All existing tests pass, new behavior validates that the API handles non-existent spaces gracefully

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).