### PR TITLE
feat: add wiki markup and storage format support

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -277,6 +277,7 @@ class PagesMixin(ConfluenceClient):
         *,
         is_markdown: bool = True,
         enable_heading_anchors: bool = False,
+        content_representation: str | None = None,
     ) -> ConfluencePage:
         """
         Create a new page in a Confluence space.
@@ -284,10 +285,11 @@ class PagesMixin(ConfluenceClient):
         Args:
             space_key: The key of the space to create the page in
             title: The title of the new page
-            body: The content of the page (markdown or storage format)
+            body: The content of the page (markdown, wiki markup, or storage format)
             parent_id: Optional ID of a parent page
             is_markdown: Whether the body content is in markdown format (default: True, keyword-only)
             enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False, keyword-only)
+            content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
 
         Returns:
             ConfluencePage model containing the new page's data
@@ -296,14 +298,17 @@ class PagesMixin(ConfluenceClient):
             Exception: If there is an error creating the page
         """
         try:
-            # Convert markdown to Confluence storage format if needed
-            storage_body = (
-                self.preprocessor.markdown_to_confluence_storage(
+            # Determine body and representation based on content type
+            if is_markdown:
+                # Convert markdown to Confluence storage format
+                final_body = self.preprocessor.markdown_to_confluence_storage(
                     body, enable_heading_anchors=enable_heading_anchors
                 )
-                if is_markdown
-                else body
-            )
+                representation = "storage"
+            else:
+                # Use body as-is with specified representation
+                final_body = body
+                representation = content_representation or "storage"
 
             # Use v2 API for OAuth authentication, v1 API for token/basic auth
             v2_adapter = self._v2_adapter
@@ -314,9 +319,9 @@ class PagesMixin(ConfluenceClient):
                 result = v2_adapter.create_page(
                     space_key=space_key,
                     title=title,
-                    body=storage_body,
+                    body=final_body,
                     parent_id=parent_id,
-                    representation="storage",
+                    representation=representation,
                 )
             else:
                 logger.debug(
@@ -325,9 +330,9 @@ class PagesMixin(ConfluenceClient):
                 result = self.confluence.create_page(
                     space=space_key,
                     title=title,
-                    body=storage_body,
+                    body=final_body,
                     parent_id=parent_id,
-                    representation="storage",
+                    representation=representation,
                 )
 
             # Get the new page content
@@ -355,6 +360,7 @@ class PagesMixin(ConfluenceClient):
         is_markdown: bool = True,
         parent_id: str | None = None,
         enable_heading_anchors: bool = False,
+        content_representation: str | None = None,
     ) -> ConfluencePage:
         """
         Update an existing page in Confluence.
@@ -362,12 +368,13 @@ class PagesMixin(ConfluenceClient):
         Args:
             page_id: The ID of the page to update
             title: The new title of the page
-            body: The new content of the page (markdown or storage format)
+            body: The new content of the page (markdown, wiki markup, or storage format)
             is_minor_edit: Whether this is a minor edit (keyword-only)
             version_comment: Optional comment for this version (keyword-only)
             is_markdown: Whether the body content is in markdown format (default: True, keyword-only)
             parent_id: Optional new parent page ID (keyword-only)
             enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False, keyword-only)
+            content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
 
         Returns:
             ConfluencePage model containing the updated page's data
@@ -376,14 +383,17 @@ class PagesMixin(ConfluenceClient):
             Exception: If there is an error updating the page
         """
         try:
-            # Convert markdown to Confluence storage format if needed
-            storage_body = (
-                self.preprocessor.markdown_to_confluence_storage(
+            # Determine body and representation based on content type
+            if is_markdown:
+                # Convert markdown to Confluence storage format
+                final_body = self.preprocessor.markdown_to_confluence_storage(
                     body, enable_heading_anchors=enable_heading_anchors
                 )
-                if is_markdown
-                else body
-            )
+                representation = "storage"
+            else:
+                # Use body as-is with specified representation
+                final_body = body
+                representation = content_representation or "storage"
 
             logger.debug(f"Updating page {page_id} with title '{title}'")
 
@@ -396,8 +406,8 @@ class PagesMixin(ConfluenceClient):
                 response = v2_adapter.update_page(
                     page_id=page_id,
                     title=title,
-                    body=storage_body,
-                    representation="storage",
+                    body=final_body,
+                    representation=representation,
                     version_comment=version_comment,
                 )
             else:
@@ -407,9 +417,9 @@ class PagesMixin(ConfluenceClient):
                 update_kwargs = {
                     "page_id": page_id,
                     "title": title,
-                    "body": storage_body,
+                    "body": final_body,
                     "type": "page",
-                    "representation": "storage",
+                    "representation": representation,
                     "minor_edit": is_minor_edit,
                     "version_comment": version_comment,
                     "always_update": True,

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -318,6 +318,49 @@ class TestPagesMixin:
         with pytest.raises(Exception, match="API Error"):
             pages_mixin.create_page("PROJ", "Test Page", "<p>Content</p>")
 
+    def test_create_page_with_wiki_format(self, pages_mixin):
+        """Test creating a new page with wiki markup format."""
+        # Arrange
+        space_key = "PROJ"
+        title = "Wiki Format Test Page"
+        wiki_body = "h1. This is a heading\n\n* Item 1\n* Item 2"
+
+        # Mock get_page_content to return a ConfluencePage
+        with patch.object(
+            pages_mixin,
+            "get_page_content",
+            return_value=ConfluencePage(
+                id="wiki123",
+                title=title,
+                content="Wiki page content",
+                space={"key": space_key, "name": "Project"},
+            ),
+        ):
+            # Act - use wiki format
+            result = pages_mixin.create_page(
+                space_key,
+                title,
+                wiki_body,
+                is_markdown=False,
+                content_representation="wiki",
+            )
+
+            # Assert
+            pages_mixin.confluence.create_page.assert_called_once_with(
+                space=space_key,
+                title=title,
+                body=wiki_body,  # Should be passed as-is
+                parent_id=None,
+                representation="wiki",  # Should use wiki representation
+            )
+
+            # Verify no markdown conversion happened
+            pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+
+            # Verify result is a ConfluencePage
+            assert isinstance(result, ConfluencePage)
+            assert result.id == "wiki123"
+
     def test_update_page_success(self, pages_mixin):
         """Test updating an existing page."""
         # Arrange
@@ -368,6 +411,52 @@ class TestPagesMixin:
         # Act/Assert
         with pytest.raises(Exception, match="Failed to update page"):
             pages_mixin.update_page("987654321", "Test Page", "<p>Content</p>")
+
+    def test_update_page_with_wiki_format(self, pages_mixin):
+        """Test updating a page with wiki markup format."""
+        # Arrange
+        page_id = "wiki987"
+        title = "Updated Wiki Page"
+        wiki_body = "h1. Updated Heading\n\n||Header 1||Header 2||\n|Cell 1|Cell 2|"
+        version_comment = "Wiki format update"
+
+        # Mock get_page_content to return a document
+        mock_document = ConfluencePage(
+            id=page_id,
+            title=title,
+            content="Updated wiki content",
+            space={"key": "PROJ", "name": "Project"},
+            version={"number": 2},
+        )
+        with patch.object(pages_mixin, "get_page_content", return_value=mock_document):
+            # Act - use wiki format
+            result = pages_mixin.update_page(
+                page_id,
+                title,
+                wiki_body,
+                version_comment=version_comment,
+                is_markdown=False,
+                content_representation="wiki",
+            )
+
+            # Assert
+            pages_mixin.confluence.update_page.assert_called_once_with(
+                page_id=page_id,
+                title=title,
+                body=wiki_body,  # Should be passed as-is
+                type="page",
+                representation="wiki",  # Should use wiki representation
+                minor_edit=False,
+                version_comment=version_comment,
+                always_update=True,
+            )
+
+            # Verify no markdown conversion happened
+            pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+
+            # Verify result is a ConfluencePage
+            assert isinstance(result, ConfluencePage)
+            assert result.id == page_id
 
     def test_delete_page_success(self, pages_mixin):
         """Test successfully deleting a page."""
@@ -832,6 +921,63 @@ class TestPagesOAuthMixin:
                 # Verify result is a ConfluencePage
                 assert isinstance(result, ConfluencePage)
                 assert result.id == "oauth_123456789"
+
+    def test_create_page_oauth_with_wiki_format(self, oauth_pages_mixin):
+        """Test that OAuth authentication uses v2 API for creating pages with wiki format."""
+        # Arrange
+        space_key = "PROJ"
+        title = "OAuth Wiki Test Page"
+        wiki_body = "h1. OAuth Wiki Test\n\n* Item 1\n* Item 2"
+
+        # Mock the v2 adapter
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceV2Adapter"
+        ) as mock_v2_adapter_class:
+            mock_v2_adapter = MagicMock()
+            mock_v2_adapter_class.return_value = mock_v2_adapter
+            mock_v2_adapter.create_page.return_value = {
+                "id": "oauth_wiki_123",
+                "title": title,
+            }
+
+            # Mock get_page_content to return a ConfluencePage
+            with patch.object(
+                oauth_pages_mixin,
+                "get_page_content",
+                return_value=ConfluencePage(
+                    id="oauth_wiki_123",
+                    title=title,
+                    content="OAuth wiki page content",
+                    space={"key": space_key, "name": "Project"},
+                ),
+            ):
+                # Act - use wiki format
+                result = oauth_pages_mixin.create_page(
+                    space_key,
+                    title,
+                    wiki_body,
+                    is_markdown=False,
+                    content_representation="wiki",
+                )
+
+                # Assert that v2 API was used with wiki representation
+                mock_v2_adapter.create_page.assert_called_once_with(
+                    space_key=space_key,
+                    title=title,
+                    body=wiki_body,
+                    parent_id=None,
+                    representation="wiki",
+                )
+
+                # Verify v1 API was NOT called
+                oauth_pages_mixin.confluence.create_page.assert_not_called()
+
+                # Verify no markdown conversion happened
+                oauth_pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+
+                # Verify result is a ConfluencePage
+                assert isinstance(result, ConfluencePage)
+                assert result.id == "oauth_wiki_123"
                 assert result.title == title
 
     def test_update_page_oauth_uses_v2_api(self, oauth_pages_mixin):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

This PR adds support for Confluence wiki markup and storage format content in the `confluence_create_page` and `confluence_update_page` tools. Previously, only Markdown content was supported, which was automatically converted to Confluence storage format. This enhancement allows users to directly provide content in wiki markup syntax (e.g., `{toc}`, `{panel}`, `{change-history}`) or raw storage format, enabling the use of Confluence-specific macros and formatting features.

Fixes: #526

## Changes

<!-- Briefly list the key changes made. -->

- Added `content_format` parameter to `confluence_create_page` and `confluence_update_page` tools with options: 'markdown' (default), 'wiki', or 'storage'
- Modified `PagesMixin.create_page()` and `PagesMixin.update_page()` methods to handle different content formats appropriately
- When `content_format='wiki'`, content is passed as-is with `representation='wiki'` to the Confluence API
- When `content_format='storage'`, content is passed as-is with `representation='storage'` to the Confluence API
- Maintains backward compatibility - existing code using Markdown continues to work as before
- Both v1 (token/basic auth) and v2 (OAuth) API paths properly handle the representation parameter

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [ ] Manual checks performed: `Requires live Confluence instance to test wiki markup rendering`

Additional test coverage:
- Added `test_create_page_with_wiki_format()` to verify wiki markup handling
- Added `test_update_page_with_wiki_format()` to verify wiki markup updates
- Existing tests continue to pass, confirming backward compatibility

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).

## Example Usage

### Creating a page with wiki markup:
```python
await confluence_create_page(
    ctx,
    space_key="TEAM",
    title="Wiki Markup Page",
    content="""
{panel:borderStyle=dashed}
Change History
{change-history:limit=3}
{panel}

h1. Summary
{info}This page uses wiki markup syntax{info}
""",
    content_format="wiki"
)
```

### Creating a page with Markdown (default behavior):
```python
await confluence_create_page(
    ctx,
    space_key="TEAM", 
    title="Markdown Page",
    content="# Summary\n\nThis page uses **Markdown** syntax"
    # content_format="markdown" is the default
)
```