### PR TITLE
fix: resolve MRO conflict causing transition status lookup failures

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1016,8 +1016,8 @@ class IssuesMixin(
                 raise TypeError(msg)
             return JiraIssue.from_api_response(issue_data)
 
-        # Get available transitions
-        transitions = self.get_available_transitions(issue_key)
+        # Get available transitions (uses TransitionsMixin's normalized implementation)
+        transitions = self.get_available_transitions(issue_key)  # type: ignore[attr-defined]
 
         # Extract status name or ID depending on what we received
         status_name = None
@@ -1053,9 +1053,8 @@ class IssuesMixin(
         # Find the appropriate transition
         transition_id = None
         for transition in transitions:
-            to_status = transition.get("to", {})
-            transition_status_name = to_status.get("name", "")
-            transition_status_id = to_status.get("id")
+            # TransitionsMixin returns normalized transitions with 'to_status' field
+            transition_status_name = transition.get("to_status", "")
 
             # Match by name (case-insensitive)
             if (
@@ -1069,18 +1068,6 @@ class IssuesMixin(
                 )
                 break
 
-            # Match by ID
-            if (
-                status_id
-                and transition_status_id
-                and str(transition_status_id) == str(status_id)
-            ):
-                transition_id = transition.get("id")
-                logger.info(
-                    f"Found transition ID {transition_id} matching status ID '{status_id}'"
-                )
-                break
-
             # Direct transition ID match (if status is actually a transition ID)
             if status_id and str(transition.get("id", "")) == str(status_id):
                 transition_id = transition.get("id")
@@ -1088,12 +1075,23 @@ class IssuesMixin(
                 break
 
         if not transition_id:
-            available_statuses = ", ".join(
-                [t.get("to", {}).get("name", "") for t in transitions]
+            # Build list of available statuses from normalized transitions
+            available_statuses = []
+            for t in transitions:
+                # Include transition name and target status if available
+                transition_name = t.get("name", "")
+                to_status = t.get("to_status", "")
+                if to_status:
+                    available_statuses.append(f"{transition_name} -> {to_status}")
+                elif transition_name:
+                    available_statuses.append(transition_name)
+
+            available_statuses_str = (
+                ", ".join(available_statuses) if available_statuses else "None found"
             )
             error_msg = (
                 f"Could not find transition to status '{status}'. "
-                f"Available statuses: {available_statuses}"
+                f"Available transitions: {available_statuses_str}"
             )
             logger.error(error_msg)
             raise ValueError(error_msg)
@@ -1183,15 +1181,19 @@ class IssuesMixin(
         except Exception as e:
             logger.warning(f"Error processing field for epic data: {str(e)}")
 
-    def get_available_transitions(self, issue_key: str) -> list[dict]:
+    def _get_raw_transitions(self, issue_key: str) -> list[dict]:
         """
-        Get all available transitions for an issue.
+        Get raw transition data from the Jira API.
+
+        This is an internal method that returns unprocessed transition data.
+        For normalized transitions with proper structure, use get_available_transitions()
+        from TransitionsMixin instead.
 
         Args:
             issue_key: The key of the issue
 
         Returns:
-            List of available transitions
+            List of raw transition data from the API
 
         Raises:
             Exception: If there is an error getting transitions

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -676,13 +676,13 @@ class TestIssuesMixin:
             return_value=JiraIssue(key="TEST-123", description="")
         )
 
-        # Mock available transitions
+        # Mock available transitions (using TransitionsMixin's normalized format)
         issues_mixin.get_available_transitions = MagicMock(
             return_value=[
                 {
                     "id": "21",
                     "name": "In Progress",
-                    "to": {"name": "In Progress", "id": "3"},
+                    "to_status": "In Progress",
                 }
             ]
         )


### PR DESCRIPTION
## Description

This PR fixes a critical issue where status transitions fail for Jira Server/Data Center users with the error "Could not find transition to status 'In Progress'. Available statuses: , , , , , ,".

The root cause was a Method Resolution Order (MRO) conflict where `IssuesMixin.get_available_transitions()` was overriding `TransitionsMixin.get_available_transitions()`. The IssuesMixin version lacked the robust transition format handling needed for Jira Server API responses.

Fixes: #455

## Changes

- Renamed `IssuesMixin.get_available_transitions()` to `_get_raw_transitions()` to resolve MRO conflict
- Updated `_update_issue_with_status()` to use TransitionsMixin's normalized transition format
- Improved error messages to clearly show available transitions instead of empty status lists
- Added handling for transitions that use `to_status` field instead of nested `to` object

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed  
- [ ] Manual checks performed: `Need testing with actual Jira Server instance`

### Testing Notes for Reviewers

This fix specifically addresses Jira Server/Data Center instances that return transitions in different formats than Jira Cloud. To properly test:

1. Test with a Jira Server or Data Center instance (not Cloud)
2. Try updating an issue's status using `jira_update_issue` with the status field
3. Verify that the available transitions are shown correctly in error messages
4. Confirm that status transitions work properly

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).