### PR TITLE
fix: handle localized issue type names for Epic and Subtask

### DIFF
--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -155,6 +155,23 @@ class FieldsOperationsProto(Protocol):
 
 
 @runtime_checkable
+class ProjectsOperationsProto(Protocol):
+    """Protocol defining project operations interface."""
+
+    @abstractmethod
+    def get_project_issue_types(self, project_key: str) -> list[dict[str, Any]]:
+        """
+        Get all issue types available for a project.
+
+        Args:
+            project_key: The project key
+
+        Returns:
+            List of issue type data dictionaries
+        """
+
+
+@runtime_checkable
 class UsersOperationsProto(Protocol):
     """Protocol defining user operations interface."""
 

--- a/tests/unit/jira/test_client_oauth.py
+++ b/tests/unit/jira/test_client_oauth.py
@@ -399,10 +399,13 @@ class TestJiraClientOAuth:
             # No OAuth specific variables set
             "ATLASSIAN_OAUTH_CLIENT_ID": "",
             "ATLASSIAN_OAUTH_ACCESS_TOKEN": "",
+            # Explicitly clear basic auth credentials
+            "JIRA_USERNAME": "",
+            "JIRA_API_TOKEN": "",
         }
 
         with (
-            patch.dict(os.environ, env_vars),
+            patch.dict(os.environ, env_vars, clear=True),
             patch(
                 "mcp_atlassian.jira.config.get_oauth_config_from_env",
                 return_value=None,  # Simulate no config found
@@ -410,6 +413,6 @@ class TestJiraClientOAuth:
         ):
             with pytest.raises(
                 ValueError,  # Adjusted to actual error raised by JiraConfig.from_env
-                match="Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN, or OAuth configuration",
+                match=r"Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN, or OAuth configuration.*",
             ):
                 JiraClient()


### PR DESCRIPTION
## Description

This PR fixes test failures that occur when running against Jira instances configured in non-English languages. The issue was that the code was doing exact string matching for issue types like "Epic" and "Subtask", but these are localized in non-English Jira instances (e.g., "에픽" and "하위 작업" in Korean).

Related to: #537, #536

## Changes

- Add dynamic issue type resolution in `create_issue()` that queries the API to find localized names
- Update Epic validation logic to handle multiple language variants
- Add `ProjectsOperationsProto` protocol for proper type checking
- Fix OAuth configuration test to properly isolate environment variables

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: All 11 previously failing tests now pass

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).