### PR TITLE
fix: complete removal of convert_empty_defaults_to_none decorator

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1173,7 +1173,6 @@ async def create_issue_link(
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 
-@convert_empty_defaults_to_none
 @jira_mcp.tool(tags={"jira", "write"})
 @check_write_access
 async def create_remote_issue_link(
@@ -1195,17 +1194,17 @@ async def create_remote_issue_link(
         ),
     ],
     summary: Annotated[
-        str, Field(description="(Optional) Description of the link")
-    ] = "",
+        str | None, Field(description="(Optional) Description of the link")
+    ] = None,
     relationship: Annotated[
-        str,
+        str | None,
         Field(
             description="(Optional) Relationship description (e.g., 'causes', 'relates to', 'documentation')"
         ),
-    ] = "",
+    ] = None,
     icon_url: Annotated[
-        str, Field(description="(Optional) URL to a 16x16 icon for the link")
-    ] = "",
+        str | None, Field(description="(Optional) URL to a 16x16 icon for the link")
+    ] = None,
 ) -> str:
     """Create a remote issue link (web link or Confluence link) for a Jira issue.
 


### PR DESCRIPTION
## Description

This PR completes the removal of the `convert_empty_defaults_to_none` decorator that was started in #515 . One function (`create_remote_issue_link`) was missed in the original refactoring, causing test failures in CI/CD due to missing import errors.

Fixes: #542

## Changes

- Removed `@convert_empty_defaults_to_none` decorator from `create_remote_issue_link` function
- Updated optional parameters to use `str | None` type with `None` defaults instead of empty strings
- Ensures consistency with the refactoring pattern established in #515

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Ran full test suite locally - all 1031 tests pass

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).