### PR TITLE
fix: Confluence PAT for Confluence Data Center

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -56,7 +56,7 @@ class ConfluenceClient:
                 cloud=True,  # OAuth is only for Cloud
                 verify_ssl=self.config.ssl_verify,
             )
-        elif self.config.auth_type == "token":
+        elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Confluence client with Token (PAT) auth. "
                 f"URL: {self.config.url}, "

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -24,7 +24,7 @@ class ConfluenceConfig:
     """
 
     url: str  # Base URL for Confluence
-    auth_type: Literal["basic", "token", "oauth"]  # Authentication type
+    auth_type: Literal["basic", "pat", "oauth"]  # Authentication type
     username: str | None = None  # Email or username
     api_token: str | None = None  # API token used as password
     personal_token: str | None = None  # Personal access token (Server/DC)
@@ -93,7 +93,7 @@ class ConfluenceConfig:
                 raise ValueError(error_msg)
         else:  # Server/Data Center
             if personal_token:
-                auth_type = "token"
+                auth_type = "pat"
             elif username and api_token:
                 # Allow basic auth for Server/DC too
                 auth_type = "basic"
@@ -167,7 +167,7 @@ class ConfluenceConfig:
             # Partial configuration is invalid
             logger.warning("Incomplete OAuth configuration detected")
             return False
-        elif self.auth_type == "token":
+        elif self.auth_type == "pat":
             return bool(self.personal_token)
         elif self.auth_type == "basic":
             return bool(self.username and self.api_token)


### PR DESCRIPTION
## Description

Fixed auth_type to check for the value "pat" to be consistent with server's checks, and enabling true multi-user requests in Confluence

Fixes: #

Fixed auth_type to check for the value "pat" to be consistent with server's checks

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [X] Manual checks performed: `[briefly describe]`

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
