### PR TITLE
in JQL, need to quote project name (usually forgiven but not always)

### DIFF
--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -283,7 +283,7 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
         """
         try:
             # Use JQL to count issues in the project
-            jql = f"project = {project_key}"
+            jql = f'project = "{project_key}"'
             result = self.jira.jql(jql=jql, fields="key", limit=1)
             if not isinstance(result, dict):
                 msg = f"Unexpected return value type from `jira.jql`: {type(result)}"
@@ -319,7 +319,7 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
         """
         try:
             # Use JQL to get issues in the project
-            jql = f"project = {project_key}"
+            jql = f'project = "{project_key}"'
 
             return self.search_issues(jql, start=start, limit=limit)
 

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -57,7 +57,7 @@ class SearchMixin(JiraClient, IssueOperationsProto):
 
                 # Build the project filter query part
                 if len(projects) == 1:
-                    project_query = f"project = {projects[0]}"
+                    project_query = f'project = "{projects[0]}"'
                 else:
                     quoted_projects = [f'"{p}"' for p in projects]
                     projects_list = ", ".join(quoted_projects)

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -166,7 +166,7 @@ def test_get_project_issues(projects_mixin: ProjectsMixin):
 
     # Verify search_issues was called, not jira.jql
     projects_mixin.search_issues.assert_called_once_with(
-        "project = TEST",
+        'project = "TEST"',
         start=0,
         limit=50,
     )
@@ -201,7 +201,7 @@ def test_get_project_issues_with_start(projects_mixin: ProjectsMixin) -> None:
 
     # Verify search_issues was called with the correct arguments
     projects_mixin.search_issues.assert_called_once_with(
-        f"project = {project_key}",
+        f'project = "{project_key}"',
         start=start_index,
         limit=5,
     )
@@ -468,7 +468,21 @@ def test_get_project_issues_count(projects_mixin: ProjectsMixin):
     result = projects_mixin.get_project_issues_count("PROJ1")
     assert result == 42
     projects_mixin.jira.jql.assert_called_once_with(
-        jql="project = PROJ1", fields="key", limit=1
+        jql='project = "PROJ1"', fields="key", limit=1
+    )
+
+
+def test_get_project_issues_count__project_with_reserved_keyword(
+    projects_mixin: ProjectsMixin,
+):
+    """Test get_project_issues_count method."""
+    jql_result = {"total": 42}
+    projects_mixin.jira.jql.return_value = jql_result
+
+    result = projects_mixin.get_project_issues_count("AND")
+    assert result == 42
+    projects_mixin.jira.jql.assert_called_once_with(
+        jql='project = "AND"', fields="key", limit=1
     )
 
 
@@ -508,7 +522,7 @@ def test_get_project_issues_with_search_mixin(projects_mixin: ProjectsMixin):
     result = projects_mixin.get_project_issues("PROJ1", start=10, limit=20)
     assert result == mock_search_result
     projects_mixin.search_issues.assert_called_once_with(
-        "project = PROJ1", start=10, limit=20
+        'project = "PROJ1"', start=10, limit=20
     )
     projects_mixin.jira.jql.assert_not_called()
 

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -291,7 +291,7 @@ class TestSearchMixin:
         # Test with single project filter
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
         search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project = TEST",
+            "(text ~ 'test') AND project = \"TEST\"",
             fields=ANY,
             start=0,
             limit=50,
@@ -350,7 +350,7 @@ class TestSearchMixin:
         # Test with override
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
         search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project = OVERRIDE",
+            "(text ~ 'test') AND project = \"OVERRIDE\"",
             fields=ANY,
             start=0,
             limit=50,
@@ -604,7 +604,7 @@ class TestSearchMixin:
 
         # Assert: JQL verification
         api_method_mock.assert_called_with(
-            "(text ~ 'test') AND project = TEST",  # Check constructed JQL
+            "(text ~ 'test') AND project = \"TEST\"",  # Check constructed JQL
             **expected_kwargs,
         )
 
@@ -670,5 +670,5 @@ class TestSearchMixin:
         search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
         # Assert: JQL verification
         api_method_mock.assert_called_with(
-            "(text ~ 'test') AND project = OVERRIDE", **expected_kwargs
+            "(text ~ 'test') AND project = \"OVERRIDE\"", **expected_kwargs
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Quote project name when accessing JIRA. This solves a bug where you can't request stuff from a project whose name is also a reserved keyword in JQL.
<!-- Link related issues: Fixes #<issue_number> -->


## Changes

<!-- Briefly list the key changes made. -->

Quote project name in 2 JQLs.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [X] Manual checks performed: Running it through my agent

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [X] All tests pass locally.
- [ ] Documentation updated (if needed).
