### PR TITLE
fix: recognize api.atlassian.com as Cloud URL for Multi-Cloud OAuth support

### DIFF
--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -35,4 +35,5 @@ def is_atlassian_cloud_url(url: str) -> bool:
         ".atlassian.net" in hostname
         or ".jira.com" in hostname
         or ".jira-dev.com" in hostname
+        or "api.atlassian.com" in hostname
     )

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -22,6 +22,21 @@ def test_is_atlassian_cloud_url_cloud():
     assert is_atlassian_cloud_url("https://team.jira-dev.com") is True
 
 
+def test_is_atlassian_cloud_url_multi_cloud_oauth():
+    """Test that is_atlassian_cloud_url returns True for Multi-Cloud OAuth URLs."""
+    # Test api.atlassian.com URLs used by Multi-Cloud OAuth
+    assert (
+        is_atlassian_cloud_url("https://api.atlassian.com/ex/jira/abc123/rest/api/2/")
+        is True
+    )
+    assert (
+        is_atlassian_cloud_url("https://api.atlassian.com/ex/confluence/xyz789/")
+        is True
+    )
+    assert is_atlassian_cloud_url("http://api.atlassian.com/ex/jira/test/") is True
+    assert is_atlassian_cloud_url("https://api.atlassian.com") is True
+
+
 def test_is_atlassian_cloud_url_server():
     """Test that is_atlassian_cloud_url returns False for Atlassian Server/Data Center URLs."""
     # Test with various server/data center domains


### PR DESCRIPTION
## Description

Fixes Multi-Cloud OAuth mode where `api.atlassian.com` URLs were not recognized as Cloud instances, causing email-based user lookups to fail with "The 'accountId' query parameter needs to be provided" error.

Fixes: #560

## Changes

- Add `api.atlassian.com` to the Cloud URL detection pattern in `is_atlassian_cloud_url()`
- Add test coverage for Multi-Cloud OAuth URL pattern (`https://api.atlassian.com/ex/jira/{cloud_id}/`)
- Ensures proper Cloud detection for Multi-Cloud OAuth mode

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Verified email-based user lookups work with Multi-Cloud OAuth URLs

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
