### PR TITLE
Upgrade Python to 3.12 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a Python image with uv pre-installed
-FROM ghcr.io/astral-sh/uv:python3.10-alpine AS uv
+FROM ghcr.io/astral-sh/uv:python3.12-alpine AS uv
 
 # Install the project into `/app`
 WORKDIR /app
@@ -34,7 +34,7 @@ RUN find /app/.venv -name '__pycache__' -type d -exec rm -rf {} + && \
     echo "Cleaned up .venv"
 
 # Final stage
-FROM python:3.10-alpine
+FROM python:3.12-alpine
 
 # Create a non-root user 'app'
 RUN adduser -D -h /home/app -s /bin/sh app


### PR DESCRIPTION
## Description

In this PR I upgrade Python to `3.12` in Dockerfile. I actually need that to successfully combine `mcp-atlassian` with [mcpo](https://github.com/open-webui/mcpo/blob/main/Dockerfile) and expose Atlassian MCP server with OpenAPI HTTP interface. But I think it's useful overall given that I've tested it and saw it working.

## Changes

The Docker image now uses Python `3.12` instead of Python `3.10`.

## Testing

- [x] Manual checks performed: I've run the MCP Server wrapped into `mcpo`, made requests to connected LLM with questions about Confluence, and received valid responses.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes (no changes in tests).
- [ ] All tests pass locally (I did not configure connection to Atlassian in the project).
- [ ] Documentation updated (if needed) (no updates).
