### PR TITLE
feat: add support for configuring custom HTTP headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,3 +135,10 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 #CONFLUENCE_HTTPS_PROXY=https://confluence-proxy.example.com:8443
 #CONFLUENCE_SOCKS_PROXY=socks5://confluence-proxy.example.com:1080
 #CONFLUENCE_NO_PROXY=localhost,127.0.0.1,.internal.confluence.com
+
+# --- Custom HTTP Headers (Advanced) ---
+# Jira-specific custom headers.
+#JIRA_CUSTOM_HEADERS=X-Jira-Service=mcp-integration,X-Custom-Auth=jira-token,X-Forwarded-User=service-account
+
+# Confluence-specific custom headers.
+#CONFLUENCE_CUSTOM_HEADERS=X-Confluence-Service=mcp-integration,X-Custom-Auth=confluence-token,X-ALB-Token=secret-token

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -114,6 +114,10 @@ class ConfluenceClient:
             os.environ["NO_PROXY"] = self.config.no_proxy
             log_config_param(logger, "Confluence", "NO_PROXY", self.config.no_proxy)
 
+        # Apply custom headers if configured
+        if self.config.custom_headers:
+            self._apply_custom_headers()
+
         # Import here to avoid circular imports
         from ..preprocessing.confluence import ConfluencePreprocessor
 
@@ -157,6 +161,18 @@ class ConfluenceClient:
                 f"{get_masked_session_headers(dict(self.confluence._session.headers))}"
             )
             raise MCPAtlassianAuthenticationError(error_msg) from e
+
+    def _apply_custom_headers(self) -> None:
+        """Apply custom headers to the Confluence session."""
+        if not self.config.custom_headers:
+            return
+
+        logger.debug(
+            f"Applying {len(self.config.custom_headers)} custom headers to Confluence session"
+        )
+        for header_name, header_value in self.config.custom_headers.items():
+            self.confluence._session.headers[header_name] = header_value
+            logger.debug(f"Applied custom header: {header_name}")
 
     def _process_html_content(
         self, html_content: str, space_key: str

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import is_env_ssl_verify
+from ..utils.env import get_custom_headers, is_env_ssl_verify
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -35,6 +35,7 @@ class ConfluenceConfig:
     https_proxy: str | None = None  # HTTPS proxy URL
     no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
     socks_proxy: str | None = None  # SOCKS proxy URL (optional)
+    custom_headers: dict[str, str] | None = None  # Custom HTTP headers
 
     @property
     def is_cloud(self) -> bool:
@@ -113,6 +114,9 @@ class ConfluenceConfig:
         no_proxy = os.getenv("CONFLUENCE_NO_PROXY", os.getenv("NO_PROXY"))
         socks_proxy = os.getenv("CONFLUENCE_SOCKS_PROXY", os.getenv("SOCKS_PROXY"))
 
+        # Custom headers - service-specific only
+        custom_headers = get_custom_headers("CONFLUENCE_CUSTOM_HEADERS")
+
         return cls(
             url=url,
             auth_type=auth_type,
@@ -126,6 +130,7 @@ class ConfluenceConfig:
             https_proxy=https_proxy,
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
+            custom_headers=custom_headers,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -128,6 +128,10 @@ class JiraClient:
             os.environ["NO_PROXY"] = self.config.no_proxy
             log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
 
+        # Apply custom headers if configured
+        if self.config.custom_headers:
+            self._apply_custom_headers()
+
         # Initialize the text preprocessor for text processing capabilities
         self.preprocessor = JiraPreprocessor(base_url=self.config.url)
         self._field_ids_cache = None
@@ -169,6 +173,18 @@ class JiraClient:
                 f"{get_masked_session_headers(dict(self.jira._session.headers))}"
             )
             raise MCPAtlassianAuthenticationError(error_msg) from e
+
+    def _apply_custom_headers(self) -> None:
+        """Apply custom headers to the Jira session."""
+        if not self.config.custom_headers:
+            return
+
+        logger.debug(
+            f"Applying {len(self.config.custom_headers)} custom headers to Jira session"
+        )
+        for header_name, header_value in self.config.custom_headers.items():
+            self.jira._session.headers[header_name] = header_value
+            logger.debug(f"Applied custom header: {header_name}")
 
     def _clean_text(self, text: str) -> str:
         """Clean text content by:

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import is_env_ssl_verify
+from ..utils.env import get_custom_headers, is_env_ssl_verify
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -35,6 +35,7 @@ class JiraConfig:
     https_proxy: str | None = None  # HTTPS proxy URL
     no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
     socks_proxy: str | None = None  # SOCKS proxy URL (optional)
+    custom_headers: dict[str, str] | None = None  # Custom HTTP headers
 
     @property
     def is_cloud(self) -> bool:
@@ -113,6 +114,9 @@ class JiraConfig:
         no_proxy = os.getenv("JIRA_NO_PROXY", os.getenv("NO_PROXY"))
         socks_proxy = os.getenv("JIRA_SOCKS_PROXY", os.getenv("SOCKS_PROXY"))
 
+        # Custom headers - service-specific only
+        custom_headers = get_custom_headers("JIRA_CUSTOM_HEADERS")
+
         return cls(
             url=url,
             auth_type=auth_type,
@@ -126,6 +130,7 @@ class JiraConfig:
             https_proxy=https_proxy,
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
+            custom_headers=custom_headers,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/utils/env.py
+++ b/src/mcp_atlassian/utils/env.py
@@ -49,3 +49,45 @@ def is_env_ssl_verify(env_var_name: str, default: str = "true") -> bool:
         True unless explicitly set to false values
     """
     return os.getenv(env_var_name, default).lower() not in ("false", "0", "no")
+
+
+def get_custom_headers(env_var_name: str) -> dict[str, str]:
+    """Parse custom headers from environment variable containing comma-separated key=value pairs.
+
+    Args:
+        env_var_name: Name of the environment variable to read
+
+    Returns:
+        Dictionary of parsed headers
+
+    Examples:
+        >>> # With CUSTOM_HEADERS="X-Custom=value1,X-Other=value2"
+        >>> parse_custom_headers("CUSTOM_HEADERS")
+        {'X-Custom': 'value1', 'X-Other': 'value2'}
+        >>> # With unset environment variable
+        >>> parse_custom_headers("UNSET_VAR")
+        {}
+    """
+    header_string = os.getenv(env_var_name)
+    if not header_string or not header_string.strip():
+        return {}
+
+    headers = {}
+    pairs = header_string.split(",")
+
+    for pair in pairs:
+        pair = pair.strip()
+        if not pair:
+            continue
+
+        if "=" not in pair:
+            continue
+
+        key, value = pair.split("=", 1)  # Split on first = only
+        key = key.strip()
+        value = value.strip()
+
+        if key:  # Only add if key is not empty
+            headers[key] = value
+
+    return headers

--- a/tests/unit/confluence/test_custom_headers.py
+++ b/tests/unit/confluence/test_custom_headers.py
@@ -1,0 +1,154 @@
+"""Tests for Confluence custom headers functionality."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from mcp_atlassian.confluence.client import ConfluenceClient
+from mcp_atlassian.confluence.config import ConfluenceConfig
+
+
+class TestConfluenceConfigCustomHeaders:
+    """Test ConfluenceConfig parsing of custom headers."""
+
+    def test_no_custom_headers(self):
+        """Test ConfluenceConfig when no custom headers are configured."""
+        with patch.dict(
+            os.environ,
+            {
+                "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+                "CONFLUENCE_USERNAME": "test_user",
+                "CONFLUENCE_API_TOKEN": "test_token",
+            },
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            assert config.custom_headers == {}
+
+    def test_service_specific_headers_only(self):
+        """Test ConfluenceConfig parsing of service-specific headers only."""
+        with patch.dict(
+            os.environ,
+            {
+                "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+                "CONFLUENCE_USERNAME": "test_user",
+                "CONFLUENCE_API_TOKEN": "test_token",
+                "CONFLUENCE_CUSTOM_HEADERS": "X-Confluence-Specific=confluence_value,X-Service=service_value",
+            },
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            expected = {
+                "X-Confluence-Specific": "confluence_value",
+                "X-Service": "service_value",
+            }
+            assert config.custom_headers == expected
+
+    def test_malformed_headers_are_ignored(self):
+        """Test that malformed headers are ignored gracefully."""
+        with patch.dict(
+            os.environ,
+            {
+                "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+                "CONFLUENCE_USERNAME": "test_user",
+                "CONFLUENCE_API_TOKEN": "test_token",
+                "CONFLUENCE_CUSTOM_HEADERS": "malformed-header,X-Valid=valid_value,another-malformed",
+            },
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            expected = {"X-Valid": "valid_value"}
+            assert config.custom_headers == expected
+
+    def test_empty_header_strings(self):
+        """Test handling of empty header strings."""
+        with patch.dict(
+            os.environ,
+            {
+                "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+                "CONFLUENCE_USERNAME": "test_user",
+                "CONFLUENCE_API_TOKEN": "test_token",
+                "CONFLUENCE_CUSTOM_HEADERS": "   ",
+            },
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            assert config.custom_headers == {}
+
+
+class TestConfluenceClientCustomHeaders:
+    """Test ConfluenceClient custom headers application."""
+
+    def test_no_custom_headers_applied(self, monkeypatch):
+        """Test that no headers are applied when none are configured."""
+        # Mock Confluence and related dependencies
+        mock_confluence = MagicMock()
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_confluence._session = mock_session
+
+        monkeypatch.setattr(
+            "mcp_atlassian.confluence.client.Confluence",
+            lambda **kwargs: mock_confluence,
+        )
+        monkeypatch.setattr(
+            "mcp_atlassian.confluence.client.configure_ssl_verification",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor",
+            lambda **kwargs: MagicMock(),
+        )
+
+        config = ConfluenceConfig(
+            url="https://test.atlassian.net/wiki",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+            custom_headers={},
+        )
+
+        client = ConfluenceClient(config=config)
+
+        # Verify no custom headers were applied
+        assert mock_session.headers == {}
+
+    def test_custom_headers_applied_to_session(self, monkeypatch):
+        """Test that custom headers are applied to the Confluence session."""
+        # Mock Confluence and related dependencies
+        mock_confluence = MagicMock()
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_confluence._session = mock_session
+
+        monkeypatch.setattr(
+            "mcp_atlassian.confluence.client.Confluence",
+            lambda **kwargs: mock_confluence,
+        )
+        monkeypatch.setattr(
+            "mcp_atlassian.confluence.client.configure_ssl_verification",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor",
+            lambda **kwargs: MagicMock(),
+        )
+
+        custom_headers = {
+            "X-Corp-Auth": "token123",
+            "X-Dept": "engineering",
+            "User-Agent": "CustomConfluenceClient/1.0",
+        }
+
+        config = ConfluenceConfig(
+            url="https://test.atlassian.net/wiki",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+            custom_headers=custom_headers,
+        )
+
+        client = ConfluenceClient(config=config)
+
+        # Verify custom headers were applied to session
+        for header_name, header_value in custom_headers.items():
+            assert mock_session.headers[header_name] == header_value

--- a/tests/unit/jira/test_custom_headers.py
+++ b/tests/unit/jira/test_custom_headers.py
@@ -1,0 +1,141 @@
+"""Tests for JIRA custom headers functionality."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from mcp_atlassian.jira.client import JiraClient
+from mcp_atlassian.jira.config import JiraConfig
+
+
+class TestJiraConfigCustomHeaders:
+    """Test JiraConfig parsing of custom headers."""
+
+    def test_no_custom_headers(self):
+        """Test JiraConfig when no custom headers are configured."""
+        with patch.dict(
+            os.environ,
+            {
+                "JIRA_URL": "https://test.atlassian.net",
+                "JIRA_USERNAME": "test_user",
+                "JIRA_API_TOKEN": "test_token",
+            },
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            assert config.custom_headers == {}
+
+    def test_service_specific_headers_only(self):
+        """Test JiraConfig parsing of service-specific headers only."""
+        with patch.dict(
+            os.environ,
+            {
+                "JIRA_URL": "https://test.atlassian.net",
+                "JIRA_USERNAME": "test_user",
+                "JIRA_API_TOKEN": "test_token",
+                "JIRA_CUSTOM_HEADERS": "X-Jira-Specific=jira_value,X-Service=service_value",
+            },
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            expected = {"X-Jira-Specific": "jira_value", "X-Service": "service_value"}
+            assert config.custom_headers == expected
+
+    def test_malformed_headers_are_ignored(self):
+        """Test that malformed headers are ignored gracefully."""
+        with patch.dict(
+            os.environ,
+            {
+                "JIRA_URL": "https://test.atlassian.net",
+                "JIRA_USERNAME": "test_user",
+                "JIRA_API_TOKEN": "test_token",
+                "JIRA_CUSTOM_HEADERS": "malformed-header,X-Valid=valid_value,another-malformed",
+            },
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            expected = {"X-Valid": "valid_value"}
+            assert config.custom_headers == expected
+
+    def test_empty_header_strings(self):
+        """Test handling of empty header strings."""
+        with patch.dict(
+            os.environ,
+            {
+                "JIRA_URL": "https://test.atlassian.net",
+                "JIRA_USERNAME": "test_user",
+                "JIRA_API_TOKEN": "test_token",
+                "JIRA_CUSTOM_HEADERS": "   ",
+            },
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            assert config.custom_headers == {}
+
+
+class TestJiraClientCustomHeaders:
+    """Test JiraClient custom headers application."""
+
+    def test_no_custom_headers_applied(self, monkeypatch):
+        """Test that no headers are applied when none are configured."""
+        # Mock Jira and related dependencies
+        mock_jira = MagicMock()
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_jira._session = mock_session
+
+        monkeypatch.setattr(
+            "mcp_atlassian.jira.client.Jira", lambda **kwargs: mock_jira
+        )
+        monkeypatch.setattr(
+            "mcp_atlassian.jira.client.configure_ssl_verification",
+            lambda **kwargs: None,
+        )
+
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+            custom_headers={},
+        )
+
+        client = JiraClient(config=config)
+
+        # Verify no custom headers were applied
+        assert mock_session.headers == {}
+
+    def test_custom_headers_applied_to_session(self, monkeypatch):
+        """Test that custom headers are applied to the JIRA session."""
+        # Mock Jira and related dependencies
+        mock_jira = MagicMock()
+        mock_session = MagicMock()
+        mock_session.headers = {}
+        mock_jira._session = mock_session
+
+        monkeypatch.setattr(
+            "mcp_atlassian.jira.client.Jira", lambda **kwargs: mock_jira
+        )
+        monkeypatch.setattr(
+            "mcp_atlassian.jira.client.configure_ssl_verification",
+            lambda **kwargs: None,
+        )
+
+        custom_headers = {
+            "X-Corp-Auth": "token123",
+            "X-Dept": "engineering",
+            "User-Agent": "CustomJiraClient/1.0",
+        }
+
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+            custom_headers=custom_headers,
+        )
+
+        client = JiraClient(config=config)
+
+        # Verify custom headers were applied to session
+        for header_name, header_value in custom_headers.items():
+            assert mock_session.headers[header_name] == header_value

--- a/tests/unit/utils/test_custom_headers.py
+++ b/tests/unit/utils/test_custom_headers.py
@@ -1,0 +1,175 @@
+"""Tests for custom headers parsing functionality."""
+
+from mcp_atlassian.utils.env import get_custom_headers
+
+
+class TestParseCustomHeaders:
+    """Test the parse_custom_headers function."""
+
+    def test_empty_input(self, monkeypatch):
+        """Test parse_custom_headers with empty/None inputs."""
+        # Test unset environment variable
+        monkeypatch.delenv("TEST_HEADERS", raising=False)
+        assert get_custom_headers("TEST_HEADERS") == {}
+
+        # Test empty string
+        monkeypatch.setenv("TEST_HEADERS", "")
+        assert get_custom_headers("TEST_HEADERS") == {}
+
+        # Test whitespace only
+        monkeypatch.setenv("TEST_HEADERS", "   ")
+        assert get_custom_headers("TEST_HEADERS") == {}
+
+        monkeypatch.setenv("TEST_HEADERS", "\t\n")
+        assert get_custom_headers("TEST_HEADERS") == {}
+
+    def test_single_header(self, monkeypatch):
+        """Test parsing a single header."""
+        monkeypatch.setenv("TEST_HEADERS", "X-Custom=value123")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {"X-Custom": "value123"}
+
+        # Test with spaces around key and value
+        monkeypatch.setenv("TEST_HEADERS", " X-Spaced = value with spaces ")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {"X-Spaced": "value with spaces"}
+
+    def test_multiple_headers(self, monkeypatch):
+        """Test parsing multiple comma-separated headers."""
+        monkeypatch.setenv("TEST_HEADERS", "X-Corp-Auth=token123,X-Dept=engineering")
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {"X-Corp-Auth": "token123", "X-Dept": "engineering"}
+        assert result == expected
+
+    def test_headers_with_spaces(self, monkeypatch):
+        """Test parsing headers with various spacing."""
+        monkeypatch.setenv("TEST_HEADERS", " X-Key = value , X-Another = value2 ")
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {"X-Key": "value", "X-Another": "value2"}
+        assert result == expected
+
+    def test_value_with_equals_signs(self, monkeypatch):
+        """Test parsing headers where values contain equals signs."""
+        monkeypatch.setenv("TEST_HEADERS", "X-Token=abc=def=123")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {"X-Token": "abc=def=123"}
+
+        # Multiple headers with equals in values
+        monkeypatch.setenv(
+            "TEST_HEADERS", "X-Token=abc=def,X-URL=https://api.example.com/v1?key=value"
+        )
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {
+            "X-Token": "abc=def",
+            "X-URL": "https://api.example.com/v1?key=value",
+        }
+        assert result == expected
+
+    def test_malformed_headers(self, monkeypatch):
+        """Test handling of malformed header strings."""
+        # Header without equals sign - should be skipped
+        monkeypatch.setenv("TEST_HEADERS", "invalid-header-format")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {}
+
+        # Mix of valid and invalid headers
+        monkeypatch.setenv(
+            "TEST_HEADERS", "X-Valid=value,invalid-header,X-Another=value2"
+        )
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {"X-Valid": "value", "X-Another": "value2"}
+        assert result == expected
+
+    def test_empty_key_or_value(self, monkeypatch):
+        """Test handling of empty keys or values."""
+        # Empty key - should be skipped
+        monkeypatch.setenv("TEST_HEADERS", "=value")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {}
+
+        # Empty value - should be included
+        monkeypatch.setenv("TEST_HEADERS", "X-Empty=")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {"X-Empty": ""}
+
+        # Whitespace-only key - should be skipped
+        monkeypatch.setenv("TEST_HEADERS", "  =value")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {}
+
+        # Mix of empty and valid
+        monkeypatch.setenv("TEST_HEADERS", "=empty_key,X-Valid=value, =another_empty")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {"X-Valid": "value"}
+
+    def test_special_characters_in_values(self, monkeypatch):
+        """Test headers with special characters in values."""
+        monkeypatch.setenv("TEST_HEADERS", "X-Special=!@#$%^&*()_+-[]{}|;':\"/<>?")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {"X-Special": "!@#$%^&*()_+-[]{}|;':\"/<>?"}
+
+    def test_unicode_characters(self, monkeypatch):
+        """Test headers with unicode characters."""
+        monkeypatch.setenv("TEST_HEADERS", "X-Unicode=café,X-Emoji=🚀")
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {"X-Unicode": "café", "X-Emoji": "🚀"}
+        assert result == expected
+
+    def test_empty_pairs_in_list(self, monkeypatch):
+        """Test handling of empty pairs in comma-separated list."""
+        # Empty pairs should be skipped
+        monkeypatch.setenv("TEST_HEADERS", "X-First=value1,,X-Second=value2,")
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {"X-First": "value1", "X-Second": "value2"}
+        assert result == expected
+
+        # Only commas
+        monkeypatch.setenv("TEST_HEADERS", ",,,")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {}
+
+    def test_complex_real_world_example(self, monkeypatch):
+        """Test a complex real-world example."""
+        headers_string = (
+            "Authorization=Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9,"
+            "X-API-Key=sk-1234567890abcdef,"
+            "X-Request-ID=req_123456789,"
+            "X-Custom-Header=value with spaces and = signs,"
+            "User-Agent=MyApp/1.0 (Custom Agent)"
+        )
+
+        monkeypatch.setenv("TEST_HEADERS", headers_string)
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {
+            "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9",
+            "X-API-Key": "sk-1234567890abcdef",
+            "X-Request-ID": "req_123456789",
+            "X-Custom-Header": "value with spaces and = signs",
+            "User-Agent": "MyApp/1.0 (Custom Agent)",
+        }
+        assert result == expected
+
+    def test_case_sensitive_keys(self, monkeypatch):
+        """Test that header keys are case-sensitive."""
+        monkeypatch.setenv(
+            "TEST_HEADERS", "x-lower=value1,X-UPPER=value2,X-Mixed=value3"
+        )
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {"x-lower": "value1", "X-UPPER": "value2", "X-Mixed": "value3"}
+        assert result == expected
+
+    def test_duplicate_keys(self, monkeypatch):
+        """Test behavior with duplicate keys - later values should override."""
+        monkeypatch.setenv("TEST_HEADERS", "X-Duplicate=first,X-Duplicate=second")
+        result = get_custom_headers("TEST_HEADERS")
+        assert result == {"X-Duplicate": "second"}
+
+    def test_newlines_and_tabs_in_input(self, monkeypatch):
+        """Test handling of newlines and tabs in input."""
+        # These should be treated as part of values, not separators
+        monkeypatch.setenv(
+            "TEST_HEADERS", "X-Multi=line1\nline2,X-Tab=value\twith\ttabs"
+        )
+        result = get_custom_headers("TEST_HEADERS")
+        expected = {"X-Multi": "line1\nline2", "X-Tab": "value\twith\ttabs"}
+        assert result == expected


### PR DESCRIPTION
## Description

Fixes #436

## Changes

Added support for configuring custom HTTP headers for both Jira and Confluence API requests. This feature enables users, especially in corporate environments, to add required authentication, routing, or security headers.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `Ran MCP server locally to connect to our Confluence instance that requires a custom HTTP header to be usable`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).

---

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)