### PR TITLE
DRAFT - fix(decorators): Propagate API errors instead of returning empty list

### DIFF
--- a/src/mcp_atlassian/utils/decorators.py
+++ b/src/mcp_atlassian/utils/decorators.py
@@ -88,13 +88,6 @@ def handle_atlassian_api_errors(service_name: str = "Atlassian API") -> Callable
                 operation_name = getattr(func, "__name__", "API operation")
                 logger.error(f"Error processing {operation_name} results: {str(e)}")
                 return []
-            except Exception as e:  # noqa: BLE001 - Intentional fallback with logging
-                operation_name = getattr(func, "__name__", "API operation")
-                logger.error(f"Unexpected error during {operation_name}: {str(e)}")
-                logger.debug(
-                    f"Full exception details for {operation_name}:", exc_info=True
-                )
-                return []
 
         return wrapper
 


### PR DESCRIPTION
# DRAFT 

## Description

This PR fixes a bug (introduced in #3ca6e4c) where the `@handle_atlassian_api_errors` decorator was suppressing important API errors (like `400 Bad Request` for invalid CQL) and returning an empty list (`[]`) instead. This caused the MCP server to incorrectly report a successful tool call, which misled the client-side AI agent into thinking a search simply had no results.

The fix removes the overly broad `except Exception` block, allowing specific API errors like `atlassian.errors.ApiValueError` to propagate up to the FastMCP server. The server can then correctly report a `ToolError` to the client, providing accurate feedback on the failed tool call.

Fixes an issue identified from server logs where an invalid CQL query resulted in a successful response.

## Changes

-   Removed the generic `except Exception` block in `src/mcp_atlassian/utils/decorators.py`.
-   Added a regression test in `tests/unit/confluence/test_search.py` to ensure `ApiValueError` is no longer suppressed.

## Testing

-   [x] Unit tests added/updated (`test_search_api_value_error_is_raised`)
-   [x] Integration tests passed
-   [x] Manual checks performed: Verified that a `400 Bad Request` from the API now correctly results in a `ToolError` response from the MCP server, as intended.

## Checklist

-   [x] Code follows project style guidelines (linting passes).
-   [x] Tests added/updated for changes.
-   [x] All tests pass locally.
-   [x] Documentation updated (if needed).