### PR TITLE
fix: handle empty JQL and ORDER BY clauses with project filters

### DIFF
--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -64,12 +64,15 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                     project_query = f"project IN ({projects_list})"
 
                 # Add the project filter to existing query
-                if jql and project_query:
-                    if "project = " not in jql and "project IN" not in jql:
-                        # Only add if not already filtering by project
-                        jql = f"({jql}) AND {project_query}"
-                else:
+                if not jql:
+                    # Empty JQL - just use project filter
                     jql = project_query
+                elif jql.strip().upper().startswith("ORDER BY"):
+                    # JQL starts with ORDER BY - prepend project filter
+                    jql = f"{project_query} {jql}"
+                elif "project = " not in jql and "project IN" not in jql:
+                    # Only add if not already filtering by project
+                    jql = f"({jql}) AND {project_query}"
 
                 logger.info(f"Applied projects filter to query: {jql}")
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the Jira search tool would generate invalid JQL syntax when using the `JIRA_PROJECTS_FILTER` environment variable or `projects_filter` parameter with empty queries or queries starting with `ORDER BY`.

Fixes: #573

## Changes

- Modified JQL construction logic in `search_issues()` to detect and handle empty/None JQL queries
- Added special handling for JQL queries that start with `ORDER BY` clause
- Added comprehensive test coverage for both scenarios with single and multiple projects

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: All existing tests pass, new tests verify the fix works for both Cloud and Server/DC

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).