### PR TITLE
fix: use accountId parameter for user lookups in Jira Cloud OAuth mode

### DIFF
--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -45,7 +45,17 @@ class JiraConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
-        return is_atlassian_cloud_url(self.url)
+        # Multi-Cloud OAuth mode: URL might be None, but we use api.atlassian.com
+        if (
+            self.auth_type == "oauth"
+            and self.oauth_config
+            and self.oauth_config.cloud_id
+        ):
+            # OAuth with cloud_id uses api.atlassian.com which is always Cloud
+            return True
+
+        # For other auth types, check the URL
+        return is_atlassian_cloud_url(self.url) if self.url else False
 
     @property
     def verify_ssl(self) -> bool:

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -179,3 +179,27 @@ def test_from_env_proxy_settings():
         assert config.https_proxy == "https://jira-proxy.example.com:8443"
         assert config.socks_proxy == "socks5://user:pass@jira-proxy.example.com:1080"
         assert config.no_proxy == "localhost,127.0.0.1,.internal.example.com"
+
+
+def test_is_cloud_oauth_with_cloud_id():
+    """Test that is_cloud returns True for OAuth with cloud_id regardless of URL."""
+    from mcp_atlassian.utils.oauth import BYOAccessTokenOAuthConfig
+
+    # OAuth with cloud_id and no URL - should be Cloud
+    oauth_config = BYOAccessTokenOAuthConfig(
+        cloud_id="test-cloud-id", access_token="test-token"
+    )
+    config = JiraConfig(
+        url=None,  # URL can be None in Multi-Cloud OAuth mode
+        auth_type="oauth",
+        oauth_config=oauth_config,
+    )
+    assert config.is_cloud is True
+
+    # OAuth with cloud_id and server URL - should still be Cloud
+    config = JiraConfig(
+        url="https://jira.example.com",  # Server-like URL
+        auth_type="oauth",
+        oauth_config=oauth_config,
+    )
+    assert config.is_cloud is True


### PR DESCRIPTION
## Description

This PR fixes an issue where `jira_get_user_profile` fails in Multi-Cloud OAuth mode when called with an email address. The API was incorrectly using the `username` parameter instead of `accountId` for Jira Cloud instances.

Fixes: #560, #580

## Changes

- Updated `JiraConfig.is_cloud` property to correctly identify Multi-Cloud OAuth as a Cloud instance
- OAuth configurations with `cloud_id` now always return `True` for `is_cloud` check
- Added unit test to verify OAuth cloud detection behavior

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Verified that `is_cloud` returns `True` for OAuth with cloud_id

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).

## Additional Context

In Multi-Cloud OAuth mode, the `JIRA_URL` environment variable may be None or empty, but the actual API URL used is `https://api.atlassian.com/ex/jira/{cloud_id}` which is definitely a Cloud URL. The fix ensures that when OAuth is configured with a cloud_id, it's always treated as a Cloud instance, regardless of the configured URL.

This resolves the issue where user lookups were failing with the error: "The 'accountId' query parameter needs to be provided" because the API was incorrectly using `username` parameter for email-based lookups on Jira Cloud.