### PR TITLE
feat(jira): add JiraSearchResult.to_simplified_dict method

### DIFF
--- a/src/mcp_atlassian/models/jira/search.py
+++ b/src/mcp_atlassian/models/jira/search.py
@@ -96,3 +96,12 @@ class JiraSearchResult(ApiModel):
             The validated JiraSearchResult instance
         """
         return self
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        return {
+            "total": self.total,
+            "start_at": self.start_at,
+            "max_results": self.max_results,
+            "issues": [issue.to_simplified_dict() for issue in self.issues],
+        }

--- a/tests/unit/models/test_jira_models.py
+++ b/tests/unit/models/test_jira_models.py
@@ -1098,6 +1098,96 @@ class TestJiraSearchResult:
         assert search_result.max_results == -1
         assert len(search_result.issues) == 1  # Assuming mock data has issues
 
+    def test_to_simplified_dict(self, jira_search_data):
+        """Test converting JiraSearchResult to a simplified dictionary."""
+        search_result = JiraSearchResult.from_api_response(jira_search_data)
+        simplified = search_result.to_simplified_dict()
+
+        # Verify the structure and basic metadata
+        assert isinstance(simplified, dict)
+        assert "total" in simplified
+        assert "start_at" in simplified
+        assert "max_results" in simplified
+        assert "issues" in simplified
+
+        # Verify metadata values
+        assert simplified["total"] == 34
+        assert simplified["start_at"] == 0
+        assert simplified["max_results"] == 5
+
+        # Verify issues array
+        assert isinstance(simplified["issues"], list)
+        assert len(simplified["issues"]) == 1
+
+        # Verify that each issue is a simplified dict (not a JiraIssue object)
+        issue = simplified["issues"][0]
+        assert isinstance(issue, dict)
+        assert issue["key"] == "PROJ-123"
+        assert issue["summary"] == "Test Issue Summary"
+
+        # Verify that the issues are properly simplified (calling to_simplified_dict on each)
+        # This ensures field filtering works properly
+        assert "id" in issue  # ID is included in simplified version
+        assert "expand" not in issue  # Should be filtered out in simplified version
+
+        # Verify that issue contains expected fields
+        assert "assignee" in issue
+        assert "created" in issue
+        assert "updated" in issue
+
+    def test_to_simplified_dict_empty_result(self):
+        """Test converting an empty JiraSearchResult to a simplified dictionary."""
+        search_result = JiraSearchResult()
+        simplified = search_result.to_simplified_dict()
+
+        assert isinstance(simplified, dict)
+        assert simplified["total"] == 0
+        assert simplified["start_at"] == 0
+        assert simplified["max_results"] == 0
+        assert simplified["issues"] == []
+
+    def test_to_simplified_dict_with_multiple_issues(self):
+        """Test converting JiraSearchResult with multiple issues to a simplified dictionary."""
+        # Create mock data with multiple issues
+        mock_data = {
+            "total": 2,
+            "startAt": 0,
+            "maxResults": 10,
+            "issues": [
+                {
+                    "id": "12345",
+                    "key": "PROJ-123",
+                    "fields": {
+                        "summary": "First Issue",
+                        "status": {"name": "In Progress"},
+                    },
+                },
+                {
+                    "id": "12346",
+                    "key": "PROJ-124",
+                    "fields": {
+                        "summary": "Second Issue",
+                        "status": {"name": "Done"},
+                    },
+                },
+            ],
+        }
+
+        search_result = JiraSearchResult.from_api_response(mock_data)
+        simplified = search_result.to_simplified_dict()
+
+        # Verify metadata
+        assert simplified["total"] == 2
+        assert simplified["start_at"] == 0
+        assert simplified["max_results"] == 10
+
+        # Verify issues
+        assert len(simplified["issues"]) == 2
+        assert simplified["issues"][0]["key"] == "PROJ-123"
+        assert simplified["issues"][0]["summary"] == "First Issue"
+        assert simplified["issues"][1]["key"] == "PROJ-124"
+        assert simplified["issues"][1]["summary"] == "Second Issue"
+
 
 class TestJiraProject:
     """Tests for the JiraProject model."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

This PR fixes a issue where the `get_sprint_issues` tool accepts a `fields` parameter but doesn't actually use it in the implementation. The issue was that `JiraSearchResult` was missing the `to_simplified_dict()` method, which is required for proper field filtering in search results.

When `get_sprint_issues` is called with specific fields (e.g., `fields=["key", "summary", "status"]`), the `requested_fields` parameter was being passed down to individual `JiraIssue` objects but the search result serialization wasn't respecting this filtering. This PR adds the missing `to_simplified_dict()` method to `JiraSearchResult`, enabling proper field filtering functionality.

The implementation ensures that search results properly respect the `requested_fields` parameter by calling `to_simplified_dict()` on each individual issue.

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- Added `to_simplified_dict()` method to `JiraSearchResult` model for proper API response serialization
- Implemented field filtering by delegating to individual issue `to_simplified_dict()` calls
- Added comprehensive test coverage including empty results, and multiple issues scenarios

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `Verified all 6 TestJiraSearchResult tests pass, including new tests for missing metadata handling, simplified dict conversion, empty results, and multiple issues scenarios`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).