### PR TITLE
fix: add ATLASSIAN_OAUTH_ENABLE to MockEnvironment.clean_env()

### DIFF
--- a/tests/utils/mocks.py
+++ b/tests/utils/mocks.py
@@ -58,6 +58,7 @@ class MockEnvironment:
             "ATLASSIAN_OAUTH_REDIRECT_URI",
             "ATLASSIAN_OAUTH_SCOPE",
             "ATLASSIAN_OAUTH_CLOUD_ID",
+            "ATLASSIAN_OAUTH_ENABLE",
         ]
 
         # Remove auth vars from environment


### PR DESCRIPTION
## Description

This PR fixes a test failure in `test_no_services_configured` that was caused by the `ATLASSIAN_OAUTH_ENABLE` environment variable not being cleared in the test setup.

The `get_available_services()` function checks for this environment variable to enable minimal OAuth configuration. When this variable is set in the developer's environment, it causes the test to fail because the services are detected as available even when all other authentication variables are cleared.

## Changes

- Added `ATLASSIAN_OAUTH_ENABLE` to the list of environment variables cleared by `MockEnvironment.clean_env()` in `tests/utils/mocks.py`

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Ran `uv run pytest tests/unit/utils/test_environment.py::TestGetAvailableServices::test_no_services_configured -xvs` to verify the fix

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed). *(No documentation changes needed for this test fix)*