### PR TITLE
fix: Fix sub-task creation compatability with Jira 9+

### DIFF
--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -250,9 +250,9 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
             List of issue type data dictionaries
         """
         try:
-            meta = self.jira.issue_createmeta(project=project_key)
+            meta = self.jira.issue_createmeta_issuetypes(project=project_key)
             if not isinstance(meta, dict):
-                msg = f"Unexpected return value type from `jira.issue_createmeta`: {type(meta)}"
+                msg = f"Unexpected return value type from `jira.issue_createmeta_issuetypes`: {type(meta)}"
                 logger.error(msg)
                 raise TypeError(msg)
 


### PR DESCRIPTION
## Description

This PR fixes the ability to create sub-tasks in a Jira 9+ environment. The original function is deprecated, and will fail against Jira 9+ servers. See https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html

Fixes: 1

## Changes

- Replaced usage of jira.issue_createmeta with jira.issue_createmeta_issuetypes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `Built Dockerfile and ran MCP against cloud Jira instance. I was successful in creating tasks with sub-tasks as a result. `

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
