### PR TITLE
feat: add client certificate authentication (mTLS) support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,18 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 #JIRA_SSL_VERIFY=true
 #CONFLUENCE_SSL_VERIFY=true
 
+# --- CLIENT CERTIFICATE AUTHENTICATION (mTLS) ---
+# For mutual TLS authentication with Server/DC instances.
+# Provide paths to client certificate and private key files (.pem format).
+# This is typically used in corporate environments with strict security requirements.
+#JIRA_CLIENT_CERT=/path/to/jira-client-cert.pem
+#JIRA_CLIENT_KEY=/path/to/jira-client-key.pem
+#JIRA_CLIENT_KEY_PASSWORD=password_for_encrypted_key # Optional: Only if private key is encrypted
+
+#CONFLUENCE_CLIENT_CERT=/path/to/confluence-client-cert.pem
+#CONFLUENCE_CLIENT_KEY=/path/to/confluence-client-key.pem
+#CONFLUENCE_CLIENT_KEY_PASSWORD=password_for_encrypted_key # Optional: Only if private key is encrypted
+
 
 # =============================================
 # OPTIONAL CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ There are two main approaches to configure the Docker container:
 > - `MCP_LOGGING_STDOUT`: Set to "true" to log to stdout instead of stderr
 > - `ENABLED_TOOLS`: Comma-separated list of tool names to enable (e.g., "confluence_search,jira_get_issue")
 >
+> **Client Certificate Authentication (mTLS):**
+> - `JIRA_CLIENT_CERT`: Path to client certificate file (.pem)
+> - `JIRA_CLIENT_KEY`: Path to client private key file (.pem)
+> - `JIRA_CLIENT_KEY_PASSWORD`: Password for encrypted private key (optional)
+> - `CONFLUENCE_CLIENT_CERT`: Path to client certificate file (.pem)
+> - `CONFLUENCE_CLIENT_KEY`: Path to client private key file (.pem)
+> - `CONFLUENCE_CLIENT_KEY_PASSWORD`: Password for encrypted private key (optional)
+>
 > See the [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) file for all available options.
 
 

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -94,6 +94,9 @@ class ConfluenceClient:
             url=self.config.url,
             session=self.confluence._session,
             ssl_verify=self.config.ssl_verify,
+            client_cert=self.config.client_cert,
+            client_key=self.config.client_key,
+            client_key_password=self.config.client_key_password,
         )
 
         # Proxy configuration

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -36,6 +36,9 @@ class ConfluenceConfig:
     no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
     socks_proxy: str | None = None  # SOCKS proxy URL (optional)
     custom_headers: dict[str, str] | None = None  # Custom HTTP headers
+    client_cert: str | None = None  # Client certificate file path (.pem)
+    client_key: str | None = None  # Client private key file path (.pem)
+    client_key_password: str | None = None  # Password for encrypted private key
 
     @property
     def is_cloud(self) -> bool:
@@ -127,6 +130,11 @@ class ConfluenceConfig:
         # Custom headers - service-specific only
         custom_headers = get_custom_headers("CONFLUENCE_CUSTOM_HEADERS")
 
+        # Client certificate settings
+        client_cert = os.getenv("CONFLUENCE_CLIENT_CERT")
+        client_key = os.getenv("CONFLUENCE_CLIENT_KEY")
+        client_key_password = os.getenv("CONFLUENCE_CLIENT_KEY_PASSWORD")
+
         return cls(
             url=url,
             auth_type=auth_type,
@@ -141,6 +149,9 @@ class ConfluenceConfig:
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
             custom_headers=custom_headers,
+            client_cert=client_cert,
+            client_key=client_key,
+            client_key_password=client_key_password,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -108,6 +108,9 @@ class JiraClient:
             url=self.config.url,
             session=self.jira._session,
             ssl_verify=self.config.ssl_verify,
+            client_cert=self.config.client_cert,
+            client_key=self.config.client_key,
+            client_key_password=self.config.client_key_password,
         )
 
         # Proxy configuration

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -36,6 +36,9 @@ class JiraConfig:
     no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
     socks_proxy: str | None = None  # SOCKS proxy URL (optional)
     custom_headers: dict[str, str] | None = None  # Custom HTTP headers
+    client_cert: str | None = None  # Client certificate file path (.pem)
+    client_key: str | None = None  # Client private key file path (.pem)
+    client_key_password: str | None = None  # Password for encrypted private key
 
     @property
     def is_cloud(self) -> bool:
@@ -127,6 +130,11 @@ class JiraConfig:
         # Custom headers - service-specific only
         custom_headers = get_custom_headers("JIRA_CUSTOM_HEADERS")
 
+        # Client certificate settings
+        client_cert = os.getenv("JIRA_CLIENT_CERT")
+        client_key = os.getenv("JIRA_CLIENT_KEY")
+        client_key_password = os.getenv("JIRA_CLIENT_KEY_PASSWORD")
+
         return cls(
             url=url,
             auth_type=auth_type,
@@ -141,6 +149,9 @@ class JiraConfig:
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
             custom_headers=custom_headers,
+            client_cert=client_cert,
+            client_key=client_key,
+            client_key_password=client_key_password,
         )
 
     def is_auth_configured(self) -> bool:

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -49,6 +49,9 @@ def test_init_with_basic_auth():
             url="https://test.atlassian.net/wiki",
             session=mock_confluence.return_value._session,
             ssl_verify=True,
+            client_cert=None,
+            client_key=None,
+            client_key_password=None,
         )
 
 
@@ -92,6 +95,9 @@ def test_init_with_token_auth():
             url="https://confluence.example.com",
             session=mock_confluence.return_value._session,
             ssl_verify=False,
+            client_cert=None,
+            client_key=None,
+            client_key_password=None,
         )
 
 

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -183,3 +183,44 @@ def test_is_cloud_oauth_with_cloud_id():
         oauth_config=oauth_config,
     )
     assert config.is_cloud is True
+
+
+def test_from_env_with_client_cert():
+    """Test loading config with client certificate settings from environment."""
+    with patch.dict(
+        "os.environ",
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_USERNAME": "test_user",
+            "CONFLUENCE_API_TOKEN": "test_token",
+            "CONFLUENCE_CLIENT_CERT": "/path/to/cert.pem",
+            "CONFLUENCE_CLIENT_KEY": "/path/to/key.pem",
+            "CONFLUENCE_CLIENT_KEY_PASSWORD": "secret",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+
+        assert config.url == "https://confluence.example.com"
+        assert config.client_cert == "/path/to/cert.pem"
+        assert config.client_key == "/path/to/key.pem"
+        assert config.client_key_password == "secret"
+
+
+def test_from_env_without_client_cert():
+    """Test loading config without client certificate settings."""
+    with patch.dict(
+        "os.environ",
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_USERNAME": "test_user",
+            "CONFLUENCE_API_TOKEN": "test_token",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+
+        assert config.url == "https://confluence.example.com"
+        assert config.client_cert is None
+        assert config.client_key is None
+        assert config.client_key_password is None

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -52,6 +52,9 @@ def test_init_with_basic_auth():
             url="https://test.atlassian.net",
             session=mock_jira.return_value._session,
             ssl_verify=True,
+            client_cert=None,
+            client_key=None,
+            client_key_password=None,
         )
 
         assert client.config == config
@@ -90,6 +93,9 @@ def test_init_with_token_auth():
             url="https://jira.example.com",
             session=mock_jira.return_value._session,
             ssl_verify=False,
+            client_cert=None,
+            client_key=None,
+            client_key_password=None,
         )
 
         assert client.config == config

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -203,3 +203,44 @@ def test_is_cloud_oauth_with_cloud_id():
         oauth_config=oauth_config,
     )
     assert config.is_cloud is True
+
+
+def test_from_env_with_client_cert():
+    """Test loading config with client certificate settings from environment."""
+    with patch.dict(
+        "os.environ",
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_USERNAME": "test_user",
+            "JIRA_API_TOKEN": "test_token",
+            "JIRA_CLIENT_CERT": "/path/to/cert.pem",
+            "JIRA_CLIENT_KEY": "/path/to/key.pem",
+            "JIRA_CLIENT_KEY_PASSWORD": "secret",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+
+        assert config.url == "https://jira.example.com"
+        assert config.client_cert == "/path/to/cert.pem"
+        assert config.client_key == "/path/to/key.pem"
+        assert config.client_key_password == "secret"
+
+
+def test_from_env_without_client_cert():
+    """Test loading config without client certificate settings."""
+    with patch.dict(
+        "os.environ",
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_USERNAME": "test_user",
+            "JIRA_API_TOKEN": "test_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+
+        assert config.url == "https://jira.example.com"
+        assert config.client_cert is None
+        assert config.client_key is None
+        assert config.client_key_password is None

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -163,3 +163,99 @@ def test_ssl_ignore_adapter():
     with patch.object(HTTPAdapter, "cert_verify") as mock_cert_verify:
         adapter.cert_verify(conn, url, verify=False, cert=cert)
         mock_cert_verify.assert_called_once_with(conn, url, verify=False, cert=cert)
+
+
+def test_configure_ssl_with_client_cert():
+    """Test configure_ssl_verification with client certificate."""
+    # Arrange
+    session = MagicMock()
+    logger_mock = MagicMock()
+
+    with patch("mcp_atlassian.utils.ssl.logger", logger_mock):
+        # Act
+        configure_ssl_verification(
+            service_name="TestService",
+            url="https://example.com",
+            session=session,
+            ssl_verify=True,
+            client_cert="/path/to/cert.pem",
+            client_key="/path/to/key.pem",
+        )
+
+        # Assert
+        assert session.cert == ("/path/to/cert.pem", "/path/to/key.pem")
+        logger_mock.info.assert_called_once_with(
+            "TestService client certificate authentication configured with cert: /path/to/cert.pem"
+        )
+
+
+def test_configure_ssl_with_encrypted_key():
+    """Test configure_ssl_verification with encrypted private key."""
+    # Arrange
+    session = MagicMock()
+    logger_mock = MagicMock()
+
+    with patch("mcp_atlassian.utils.ssl.logger", logger_mock):
+        # Act
+        configure_ssl_verification(
+            service_name="TestService",
+            url="https://example.com",
+            session=session,
+            ssl_verify=True,
+            client_cert="/path/to/cert.pem",
+            client_key="/path/to/key.pem",
+            client_key_password="secret",
+        )
+
+        # Assert
+        assert session.cert == ("/path/to/cert.pem", "/path/to/key.pem")
+        # Should warn about encrypted keys
+        logger_mock.warning.assert_called_once()
+        assert "encrypted keys" in logger_mock.warning.call_args[0][0]
+
+
+def test_configure_ssl_without_client_cert():
+    """Test configure_ssl_verification without client certificate."""
+    # Arrange
+    session = MagicMock()
+    logger_mock = MagicMock()
+
+    with patch("mcp_atlassian.utils.ssl.logger", logger_mock):
+        # Act
+        configure_ssl_verification(
+            service_name="TestService",
+            url="https://example.com",
+            session=session,
+            ssl_verify=True,
+        )
+
+        # Assert - session.cert should not be set
+        assert not hasattr(session, "cert") or session.cert != ("", "")
+        logger_mock.info.assert_not_called()
+
+
+def test_configure_ssl_disabled_with_client_cert():
+    """Test configure_ssl_verification with both SSL disabled and client certificate."""
+    # Arrange
+    session = MagicMock()
+    logger_mock = MagicMock()
+
+    with patch("mcp_atlassian.utils.ssl.logger", logger_mock):
+        with patch("mcp_atlassian.utils.ssl.SSLIgnoreAdapter") as mock_adapter_class:
+            mock_adapter = MagicMock()
+            mock_adapter_class.return_value = mock_adapter
+
+            # Act
+            configure_ssl_verification(
+                service_name="TestService",
+                url="https://example.com",
+                session=session,
+                ssl_verify=False,
+                client_cert="/path/to/cert.pem",
+                client_key="/path/to/key.pem",
+            )
+
+            # Assert - Both client cert and SSL adapter should be configured
+            assert session.cert == ("/path/to/cert.pem", "/path/to/key.pem")
+            mock_adapter_class.assert_called_once()
+            assert session.mount.call_count == 2


### PR DESCRIPTION
## Summary

  This PR adds client certificate authentication (mutual TLS) support for Server/Data Center deployments of Jira
  and Confluence. This feature is essential for enterprise environments that require mTLS for API access to their
  Atlassian instances.

  ## What's Changed

  ### New Environment Variables
  - **Jira**: `JIRA_CLIENT_CERT`, `JIRA_CLIENT_KEY`, `JIRA_CLIENT_KEY_PASSWORD`
  - **Confluence**: `CONFLUENCE_CLIENT_CERT`, `CONFLUENCE_CLIENT_KEY`, `CONFLUENCE_CLIENT_KEY_PASSWORD`

  ### Implementation Details
  - Extended `JiraConfig` and `ConfluenceConfig` to include client certificate properties
  - Updated `configure_ssl_verification()` function to configure client certificates on the requests session
  - Modified `JiraClient` and `ConfluenceClient` to pass certificate information to SSL configuration

  ### Documentation
  - Updated README.md with new environment variables in the configuration section
  - Added client certificate configuration examples to .env.example

  ## Testing
  - Added 8 new unit tests covering client certificate configuration
  - Updated 4 existing tests to include new SSL configuration parameters
  - All tests pass
  - Pre-commit checks pass

  ## Limitations
  - Encrypted private keys (with passwords) are not fully supported by the underlying `requests` library
  - Users with encrypted keys will receive a warning and need to decrypt their keys beforehand

  ## Checklist
  - [x] Tests added/updated
  - [x] Documentation updated
  - [x] Pre-commit checks pass