### PR TITLE
Atlassian MCP를 Container Apps에 배포 및 테스트 성공

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Authorization: Bearer <your_oauth_token>
 # X-Atlassian-Cloud-Id: <your_cloud_id>
 
-ENTRYPOINT ["mcp-atlassian"]
+ENTRYPOINT ["mcp-atlassian", "--transport", "streamable-http", "--port", "9000"]


### PR DESCRIPTION
## 📋 개요

MCP-ATLASSIAN을 Azure Container Apps에 성공적으로 배포하고, 다중 사용자가 각자의 API Token으로 접근할 수 있는 멀티 테넌트 인증 시스템을 구현했습니다.

## 🎯 주요 성과

### 1. Azure Container Apps 배포 성공
- 환경: Korea Central, rg-az1-co001501-sbox-poc-131
- 컨테이너 앱: mcp-atlassian
- Docker 이미지: ujeongeom/mcp-atlassian-containerapp:v9
- 상태: ✅ 정상 작동 (42ools enabled)

### 2. 보안 설계 구현
- 환경변수 최소화: URL 정보만 설정, 민감한 정보 저장하지 않음
- 동적 인증: 각 요청마다 헤더를 통해 사용자별 API Token 전달
- 사용자 격리: 서버에 사용자별 인증 정보 저장하지 않음

### 3. 핵심 코드 수정사항
#### main.py
- main_lifespan: URL만으로 기본 설정 생성, auth_type=api_token", ssl_verify=False
- UserTokenMiddleware: Bearer 토큰을 api_token 타입으로 처리
- _mcp_list_tools: 인증 검증 후 도구 목록 반환

#### dependencies.py
- 동적 설정 생성: 전역 설정 없을 때 기본 설정으로 사용자별 설정 생성
- API Token 처리: api_token 필드 사용, personal_token 대신

### 4 과정
1. Container Transport: stdio → streamable-http 수정
2. 0ols enabled: URL만으로 기본 설정 생성으로 해결
3. 인증 타입: pat → api_token 통일
4. SSL 검증: ssl_verify=False 설정
5. 토큰 필드: personal_token → api_token 필드 사용

## 🔧 기술적 세부사항

### 1. 인증 방식

Authorization: Bearer [user-api-token]
X-User-Email: [user-email]

### 2. 환경변수 설정

JIRA_URL: https://{your-domain}.atlassian.net
CONFLUENCE_URL: https://{your-domain}.atlassian.net/wiki

### 3. Cursor MCP 설정

```
    "mcp-atlassian": {
      "url": "https://mcp-atlassian.livelybeach-90f399a8.koreacentral.azurecontainerapps.io/mcp/",
      "headers": {
        "Authorization": "Bearer <api-token>",
        "X-User-Email": "<user-email>",
        "X-Atlassian-Cloud-Id": "<your-domain>"
      }
    }
```

## ✅ 검증 완료
- 42ools enabled: 모든 도구 정상 초기화
- Confluence 검색: `confluence_search` 도구 작동
- 페이지 조회: `confluence_get_page` 도구 작동
- Markdown 변환: HTML → Markdown 자동 변환
- 메타데이터: 페이지 정보 정상 조회

## 📚 문서화
Confluence 페이지 업데이트: "MCP-ATLASSIAN 페이지에 전체 구현 과정 문서화
보안 설계 원칙 명시
실제 환경변수 설정과 일치하도록 수정

## 🎉 결론
멀티 테넌트 지원, 보안 강화, Azure Container Apps 최적화를 통해 AI와 Atlassian 도구 간의 원활한 통합을 성공적으로 구현했습니다.