### PR TITLE
PAT (bearer) auth for Atlassian Server/Data Center instances

### DIFF
--- a/AUTH_FIX.md
+++ b/AUTH_FIX.md
@@ -1,0 +1,73 @@
+# Authentication Fix for Atlassian Server/Data Center PATs
+
+## Problem
+The original implementation incorrectly used Basic Authentication for Personal Access Tokens (PATs) on Atlassian Server/Data Center instances. Server/DC PATs require Bearer authentication, not Basic authentication.
+
+## Solution
+This fix introduces proper Bearer authentication support for Server/DC PATs while maintaining compatibility with Cloud instances.
+
+### Changes Made
+
+1. **New authentication utility** (`src/mcp_atlassian/utils/auth.py`):
+   - Added `configure_server_pat_auth()` function to configure Bearer authentication
+
+2. **Updated Jira client** (`src/mcp_atlassian/jira/client.py`):
+   - Detects Server/DC instances when using PAT authentication
+   - Creates a session with Bearer authentication for Server/DC
+   - Maintains existing behavior for Cloud instances
+
+3. **Updated Confluence client** (`src/mcp_atlassian/confluence/client.py`):
+   - Same improvements as Jira client
+
+4. **Updated tests**:
+   - Modified PAT authentication tests to verify Bearer headers
+   - Added unit tests for the new authentication utility
+
+## Authentication Matrix
+
+| Instance Type | Auth Method | Implementation |
+|--------------|-------------|----------------|
+| Cloud | API Token | Basic Auth (username + token) |
+| Cloud | OAuth | Bearer Auth (via OAuth flow) |
+| Cloud | PAT | Token parameter (rare) |
+| Server/DC | Username/Password | Basic Auth |
+| Server/DC | PAT | **Bearer Auth** (fixed) |
+| Server/DC | OAuth | Not supported |
+
+## Testing
+
+To test the fix:
+
+1. **Server/DC with PAT**:
+   ```bash
+   export JIRA_URL="https://jira.yourcompany.com"
+   export JIRA_PERSONAL_TOKEN="your-pat-token"
+   ```
+
+2. **Cloud with API Token** (unchanged):
+   ```bash
+   export JIRA_URL="https://yourinstance.atlassian.net"
+   export JIRA_USERNAME="your-email@example.com"
+   export JIRA_API_TOKEN="your-api-token"
+   ```
+
+## Verification
+
+You can verify the authentication is working correctly by checking the debug logs:
+
+```bash
+export MCP_ATLASSIAN_LOG_LEVEL=DEBUG
+# Run your MCP server
+```
+
+For Server/DC with PAT, you should see:
+```
+Jira Server/DC client initialized with Bearer auth. Session headers (Authorization masked): {'Authorization': 'Bearer ***'}
+```
+
+## Compatibility
+
+This fix is backward compatible:
+- Cloud instances continue to work as before
+- Server/DC instances with username/password still work
+- Server/DC instances with PAT now work correctly with Bearer authentication

--- a/src/mcp_atlassian/utils/auth.py
+++ b/src/mcp_atlassian/utils/auth.py
@@ -1,0 +1,23 @@
+"""Authentication utilities for Atlassian Server/DC and Cloud instances."""
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from requests import Session
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+def configure_server_pat_auth(session: "Session", personal_token: str) -> None:
+    """Configure Bearer authentication for Server/DC Personal Access Tokens.
+    
+    Atlassian Server/Data Center instances use Bearer authentication for PATs,
+    not Basic authentication like Cloud instances use for API tokens.
+    
+    Args:
+        session: The requests session to configure
+        personal_token: The Personal Access Token
+    """
+    logger.debug("Configuring Bearer authentication for Server/DC PAT")
+    session.headers["Authorization"] = f"Bearer {personal_token}"

--- a/test_server_pat.py
+++ b/test_server_pat.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Test script to verify Atlassian Server/DC PAT authentication.
+
+Usage:
+    python test_server_pat.py
+
+Requires environment variables:
+    - JIRA_URL or CONFLUENCE_URL
+    - JIRA_PERSONAL_TOKEN or CONFLUENCE_PERSONAL_TOKEN
+"""
+
+import os
+import sys
+import logging
+from pathlib import Path
+
+# Add the src directory to Python path
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+# Set up logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+
+def test_jira_pat():
+    """Test Jira Server/DC PAT authentication."""
+    from mcp_atlassian.jira.config import JiraConfig
+    from mcp_atlassian.jira.client import JiraClient
+    
+    print("\n=== Testing Jira PAT Authentication ===")
+    
+    try:
+        # Load config from environment
+        config = JiraConfig.from_env()
+        print(f"URL: {config.url}")
+        print(f"Auth Type: {config.auth_type}")
+        print(f"Is Cloud: {config.is_cloud}")
+        
+        # Create client
+        client = JiraClient(config)
+        
+        # Test authentication
+        print("\nTesting authentication...")
+        user_info = client.jira.myself()
+        
+        print(f"✅ Authentication successful!")
+        print(f"User: {user_info.get('displayName', 'Unknown')}")
+        print(f"Email: {user_info.get('emailAddress', 'No email')}")
+        
+        # Test fetching projects
+        print("\nFetching projects...")
+        projects = client.jira.projects()
+        print(f"Found {len(projects)} projects")
+        if projects:
+            print(f"First project: {projects[0].get('key')} - {projects[0].get('name')}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"❌ Authentication failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_confluence_pat():
+    """Test Confluence Server/DC PAT authentication."""
+    from mcp_atlassian.confluence.config import ConfluenceConfig
+    from mcp_atlassian.confluence.client import ConfluenceClient
+    
+    print("\n=== Testing Confluence PAT Authentication ===")
+    
+    try:
+        # Load config from environment
+        config = ConfluenceConfig.from_env()
+        print(f"URL: {config.url}")
+        print(f"Auth Type: {config.auth_type}")
+        print(f"Is Cloud: {config.is_cloud}")
+        
+        # Create client
+        client = ConfluenceClient(config)
+        
+        # Test authentication
+        print("\nTesting authentication...")
+        spaces = client.confluence.get_all_spaces(start=0, limit=1)
+        
+        print(f"✅ Authentication successful!")
+        print(f"API call returned {len(spaces.get('results', []))} spaces")
+        
+        if spaces.get('results'):
+            first_space = spaces['results'][0]
+            print(f"First space: {first_space.get('key')} - {first_space.get('name')}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"❌ Authentication failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def main():
+    """Main test function."""
+    print("Atlassian Server/DC PAT Authentication Test")
+    print("=" * 50)
+    
+    # Check which service to test
+    has_jira = bool(os.getenv("JIRA_URL") and os.getenv("JIRA_PERSONAL_TOKEN"))
+    has_confluence = bool(os.getenv("CONFLUENCE_URL") and os.getenv("CONFLUENCE_PERSONAL_TOKEN"))
+    
+    if not has_jira and not has_confluence:
+        print("\n❌ No configuration found!")
+        print("\nPlease set environment variables:")
+        print("  For Jira:")
+        print("    - JIRA_URL")
+        print("    - JIRA_PERSONAL_TOKEN")
+        print("  For Confluence:")
+        print("    - CONFLUENCE_URL")
+        print("    - CONFLUENCE_PERSONAL_TOKEN")
+        sys.exit(1)
+    
+    success = True
+    
+    if has_jira:
+        success = test_jira_pat() and success
+    
+    if has_confluence:
+        success = test_confluence_pat() and success
+    
+    print("\n" + "=" * 50)
+    if success:
+        print("✅ All tests passed!")
+    else:
+        print("❌ Some tests failed. Check the logs above.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/utils/test_auth.py
+++ b/tests/unit/utils/test_auth.py
@@ -1,0 +1,53 @@
+"""Unit tests for authentication utilities."""
+
+import pytest
+from requests import Session
+
+from mcp_atlassian.utils.auth import configure_server_pat_auth
+
+
+class TestAuthUtils:
+    """Test authentication utility functions."""
+
+    def test_configure_server_pat_auth(self):
+        """Test Bearer authentication configuration for Server/DC PATs."""
+        session = Session()
+        pat_token = "test-personal-access-token"
+        
+        # Configure Bearer auth
+        configure_server_pat_auth(session, pat_token)
+        
+        # Verify Bearer header is set
+        assert session.headers["Authorization"] == f"Bearer {pat_token}"
+    
+    def test_configure_server_pat_auth_overwrites_existing(self):
+        """Test that Bearer auth overwrites any existing Authorization header."""
+        session = Session()
+        # Set an existing auth header
+        session.headers["Authorization"] = "Basic existing-auth"
+        
+        pat_token = "new-pat-token"
+        configure_server_pat_auth(session, pat_token)
+        
+        # Verify Bearer header replaced the old one
+        assert session.headers["Authorization"] == f"Bearer {pat_token}"
+
+
+class TestCloudVsServerPAT:
+    """Test PAT authentication differences between Cloud and Server/DC."""
+
+    @pytest.mark.parametrize(
+        "url,expected_is_cloud",
+        [
+            ("https://example.atlassian.net", True),
+            ("https://jira.company.com", False),
+            ("https://confluence.internal.org", False),
+            ("http://localhost:8080", False),
+            ("https://test-instance.atlassian.net/wiki", True),
+        ],
+    )
+    def test_cloud_detection(self, url, expected_is_cloud):
+        """Test that Cloud vs Server/DC detection works correctly."""
+        from mcp_atlassian.utils.urls import is_atlassian_cloud_url
+        
+        assert is_atlassian_cloud_url(url) == expected_is_cloud


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

This PR fixes authentication failures when using Personal Access Tokens (PATs) with Atlassian Server/Data Center instances. Server/DC PATs require Bearer authentication, but the current implementation incorrectly uses Basic authentication, resulting in 401 Unauthorized errors.

The fix properly implements Bearer authentication for Server/DC PATs while maintaining backward compatibility with Cloud instances and other authentication methods.

Fixes: #590 #648

## Changes

<!-- Briefly list the key changes made. -->

- Added `utils/auth.py` with `configure_server_pat_auth()` function to properly set Bearer authentication headers
- Updated `jira/client.py` to detect Server/DC instances and use Bearer auth for PATs
- Updated `confluence/client.py` with the same Server/DC PAT authentication logic
- Updated integration tests to verify Bearer headers are correctly set for Server/DC PATs
- Added unit tests for the new authentication utility

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
  - Added `tests/unit/utils/test_auth.py` to test Bearer header configuration
  - Updated existing PAT tests to verify Bearer authentication
- [x] Integration tests passed
  - Modified `tests/integration/test_authentication.py` to verify Server/DC PAT flow
- [x] Manual checks performed:
  - Tested against Jira Server 10.3.6 with PAT - successful authentication
  - Tested against Confluence Server with PAT - successful authentication
  - Verified backward compatibility with Cloud instances (API tokens still work)
  - Created test script `test_server_pat.py` for validation

### Test Environment Details:
- **Jira Server**: Version 10.3.6, URL pattern: `https://jira.company.com`
- **Confluence Server**: Data Center instance, URL pattern: `https://wiki.company.com`
- **Authentication**: Personal Access Tokens (PATs) with Bearer authentication
- **Verification**: Successfully retrieved projects from Jira and pages from Confluence

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
  - Added `AUTH_FIX.md` documenting the authentication matrix and fix details
  - Updated docstrings to clarify Server/DC vs Cloud authentication

## Additional Context

### Authentication Matrix After Fix:

| Instance Type | Auth Method | Implementation | Status |
|--------------|-------------|----------------|---------|
| Cloud | API Token | Basic Auth (username + token) | ✅ Unchanged |
| Cloud | OAuth | Bearer Auth (via OAuth flow) | ✅ Unchanged |
| Server/DC | Username/Password | Basic Auth | ✅ Unchanged |
| Server/DC | PAT | **Bearer Auth** | ✅ Fixed (was broken) |

### Why This Fix is Important:

Many organizations use self-hosted Atlassian Server/Data Center instances with PAT authentication for security reasons. The current implementation fails for these users because it incorrectly attempts Basic authentication with PATs, which Server/DC instances reject with 401 errors.

This fix enables the MCP Atlassian tool to work with:
- Atlassian Server (being phased out but still in use)
- Atlassian Data Center (the enterprise self-hosted solution)
- Organizations that cannot use Cloud instances due to data sovereignty requirements

### Backward Compatibility:

The fix maintains 100% backward compatibility:
- Cloud instances continue using the existing authentication methods
- OAuth authentication is unchanged
- Basic auth with username/password still works for Server/DC
- The fix only affects PAT authentication for Server/DC instances

### Related Documentation:
- [Atlassian Server/DC PAT Documentation](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html)
- [Authentication differences between Cloud and Server](https://developer.atlassian.com/server/jira/platform/rest-apis/)