### PR TITLE
feat(jira): add visibility parameter to add_comment

### DIFF
--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -52,13 +52,14 @@ class CommentsMixin(JiraClient):
             logger.error(f"Error getting comments for issue {issue_key}: {str(e)}")
             raise Exception(f"Error getting comments: {str(e)}") from e
 
-    def add_comment(self, issue_key: str, comment: str) -> dict[str, Any]:
+    def add_comment(self, issue_key: str, comment: str, visibility: dict = None) -> dict[str, Any]:
         """
         Add a comment to an issue.
 
         Args:
             issue_key: The issue key (e.g. 'PROJ-123')
             comment: Comment text to add (in Markdown format)
+            visibility: (optional) Restrict comment visibility (e.g. {"type":"group","value:"jira-users"})
 
         Returns:
             The created comment details
@@ -70,7 +71,7 @@ class CommentsMixin(JiraClient):
             # Convert Markdown to Jira's markup format
             jira_formatted_comment = self._markdown_to_jira(comment)
 
-            result = self.jira.issue_add_comment(issue_key, jira_formatted_comment)
+            result = self.jira.issue_add_comment(issue_key, jira_formatted_comment, visibility)
             if not isinstance(result, dict):
                 msg = f"Unexpected return value type from `jira.issue_add_comment`: {type(result)}"
                 logger.error(msg)

--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -53,7 +53,7 @@ class CommentsMixin(JiraClient):
             raise Exception(f"Error getting comments: {str(e)}") from e
 
     def add_comment(
-        self, issue_key: str, comment: str, visibility: dict = None
+        self, issue_key: str, comment: str, visibility: dict[str, str] = None
     ) -> dict[str, Any]:
         """
         Add a comment to an issue.

--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -52,7 +52,9 @@ class CommentsMixin(JiraClient):
             logger.error(f"Error getting comments for issue {issue_key}: {str(e)}")
             raise Exception(f"Error getting comments: {str(e)}") from e
 
-    def add_comment(self, issue_key: str, comment: str, visibility: dict = None) -> dict[str, Any]:
+    def add_comment(
+        self, issue_key: str, comment: str, visibility: dict = None
+    ) -> dict[str, Any]:
         """
         Add a comment to an issue.
 
@@ -71,7 +73,9 @@ class CommentsMixin(JiraClient):
             # Convert Markdown to Jira's markup format
             jira_formatted_comment = self._markdown_to_jira(comment)
 
-            result = self.jira.issue_add_comment(issue_key, jira_formatted_comment, visibility)
+            result = self.jira.issue_add_comment(
+                issue_key, jira_formatted_comment, visibility
+            )
             if not isinstance(result, dict):
                 msg = f"Unexpected return value type from `jira.issue_add_comment`: {type(result)}"
                 logger.error(msg)

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -986,7 +986,7 @@ async def add_comment(
     issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],
     comment: Annotated[str, Field(description="Comment text in Markdown format")],
     visibility: Annotated[
-        dict,
+        dict[str, str],
         Field(
             description="""(Optional) Comment visibility (e.g. {"type":"group","value":"jira-users"})"""
         ),

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -985,6 +985,7 @@ async def add_comment(
     ctx: Context,
     issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],
     comment: Annotated[str, Field(description="Comment text in Markdown format")],
+    visibility: Annotated[dict, Field(description="""(Optional) Comment visibility (e.g. {"type":"group","value":"jira-users"})""")] = None,
 ) -> str:
     """Add a comment to a Jira issue.
 
@@ -992,6 +993,7 @@ async def add_comment(
         ctx: The FastMCP context.
         issue_key: Jira issue key.
         comment: Comment text in Markdown.
+        visibility: (Optional) Comment visibility (e.g. {"type":"group","value":"jira-users"}).
 
     Returns:
         JSON string representing the added comment object.
@@ -1001,7 +1003,7 @@ async def add_comment(
     """
     jira = await get_jira_fetcher(ctx)
     # add_comment returns dict
-    result = jira.add_comment(issue_key, comment)
+    result = jira.add_comment(issue_key, comment, visibility)
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -985,7 +985,12 @@ async def add_comment(
     ctx: Context,
     issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],
     comment: Annotated[str, Field(description="Comment text in Markdown format")],
-    visibility: Annotated[dict, Field(description="""(Optional) Comment visibility (e.g. {"type":"group","value":"jira-users"})""")] = None,
+    visibility: Annotated[
+        dict,
+        Field(
+            description="""(Optional) Comment visibility (e.g. {"type":"group","value":"jira-users"})"""
+        ),
+    ] = None,
 ) -> str:
     """Add a comment to a Jira issue.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->

Allow restricting comment visibility when adding comments to Jira issues. The visibility parameter accepts a dictionary specifying access restrictions (e.g., `{"type":"group","value":"jira-users"}`).
<!-- Link related issues: Fixes #<issue_number> -->


## Changes

<!-- Briefly list the key changes made. -->

- **Added visibility parameter** to `add_comment` method in `src/mcp_atlassian/jira/comments.py`
- **Enhanced server endpoint** in `src/mcp_atlassian/servers/jira.py` to accept optional visibility parameter
- **Updated tests**

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: Tested a comment add via claude code both with and without requests to restrict visibility.

Note I did not run the integration tests locally.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (N/A).
