### PR TITLE
fix: #691 - rstrip the unnecessary rightmost '/' in the confluence url if exists

### DIFF
--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -207,7 +207,7 @@ class ConfluencePage(ApiModel, TimestampMixin):
                 url_id = container_data.get("id")
             else:
                 url_id = data.get("id")
-
+            base_url = base_url.rstrip("/")
             # Use different URL format based on whether it's cloud or server
             is_cloud = kwargs.get("is_cloud", False)
             if is_cloud:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #691 

## Changes

- added an rstrip to the build_url parameter to remove the unnecessary '\' at the confluence path if exists

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [X] Integration tests passed
- [X] Manual checks performed: added '\' to right of the confluence url and reproduced the issue described, then tested with the fix and saw issue solved

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [X] All tests pass locally.
- [ ] Documentation updated (if needed).
