### PR TITLE
feat(jira): add DISABLE_JIRA_MARKUP_TRANSLATION configuration parameter

### DIFF
--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -133,7 +133,10 @@ class JiraClient:
             self._apply_custom_headers()
 
         # Initialize the text preprocessor for text processing capabilities
-        self.preprocessor = JiraPreprocessor(base_url=self.config.url)
+        self.preprocessor = JiraPreprocessor(
+            base_url=self.config.url,
+            disable_translation=self.config.disable_jira_markup_translation,
+        )
         self._field_ids_cache = None
         self._current_user_account_id = None
 

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -36,6 +36,9 @@ class JiraConfig:
     no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
     socks_proxy: str | None = None  # SOCKS proxy URL (optional)
     custom_headers: dict[str, str] | None = None  # Custom HTTP headers
+    disable_jira_markup_translation: bool = (
+        False  # Disable automatic markup translation between formats
+    )
 
     @property
     def is_cloud(self) -> bool:
@@ -127,6 +130,11 @@ class JiraConfig:
         # Custom headers - service-specific only
         custom_headers = get_custom_headers("JIRA_CUSTOM_HEADERS")
 
+        # Markup translation setting
+        disable_jira_markup_translation = (
+            os.getenv("DISABLE_JIRA_MARKUP_TRANSLATION", "false").lower() == "true"
+        )
+
         return cls(
             url=url,
             auth_type=auth_type,
@@ -141,6 +149,7 @@ class JiraConfig:
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
             custom_headers=custom_headers,
+            disable_jira_markup_translation=disable_jira_markup_translation,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/formatting.py
+++ b/src/mcp_atlassian/jira/formatting.py
@@ -41,9 +41,16 @@ class FormattingMixin(
 
         # Use the JiraPreprocessor with the base URL from the client
         base_url = ""
+        disable_translation = False
         if hasattr(self, "config") and hasattr(self.config, "url"):
             base_url = self.config.url
-        self.preprocessor = JiraPreprocessor(base_url=base_url)
+        if hasattr(self, "config") and hasattr(
+            self.config, "disable_jira_markup_translation"
+        ):
+            disable_translation = self.config.disable_jira_markup_translation
+        self.preprocessor = JiraPreprocessor(
+            base_url=base_url, disable_translation=disable_translation
+        )
 
     def markdown_to_jira(self, markdown_text: str) -> str:
         """

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -22,6 +22,13 @@ def preprocessor_with_jira():
 
 
 @pytest.fixture
+def preprocessor_with_jira_markup_translation_disabled():
+    return JiraPreprocessor(
+        base_url="https://example.atlassian.net", disable_translation=True
+    )
+
+
+@pytest.fixture
 def preprocessor_with_confluence():
     return ConfluencePreprocessor(base_url="https://example.atlassian.net")
 
@@ -288,6 +295,35 @@ For more information, see [our website](https://example.com).
     assert "* Feature 1" in converted
     assert "{code:python}" in converted
     assert "[our website|https://example.com]" in converted
+
+
+def test_jira_markup_translation_disabled(
+    preprocessor_with_jira_markup_translation_disabled,
+):
+    """Test that markup translation is disabled and original text is preserved."""
+    mixed_markup = "h1. Jira Heading with **markdown bold** and {{jira code}} and *markdown italic*"
+
+    # Both methods should return the original text unchanged
+    assert (
+        preprocessor_with_jira_markup_translation_disabled.markdown_to_jira(
+            mixed_markup
+        )
+        == mixed_markup
+    )
+    assert (
+        preprocessor_with_jira_markup_translation_disabled.jira_to_markdown(
+            mixed_markup
+        )
+        == mixed_markup
+    )
+
+    # clean_jira_text should also preserve markup (only process mentions/links)
+    result = preprocessor_with_jira_markup_translation_disabled.clean_jira_text(
+        mixed_markup
+    )
+    assert "h1. Jira Heading" in result
+    assert "**markdown bold**" in result
+    assert "{{jira code}}" in result
 
 
 def test_markdown_to_confluence_storage(preprocessor_with_confluence):


### PR DESCRIPTION
## Description

Add `DISABLE_JIRA_MARKUP_TRANSLATION` environment variable to allow users to disable automatic markup translation between Jira markup and Markdown formats.

This addresses formatting corruption during roundtrips caused by imperfect regex-based translation. When disabled, the preprocessor returns original text unchanged, allowing LLMs to handle syntax adaptation instead of relying on automatic conversion.

## Changes

- Add `disable_jira_markup_translation` boolean field to `JiraConfig` with environment variable support
- Update `JiraPreprocessor` to skip translation when disabled, preserving original markup
- Pass configuration flag through all Jira client classes (`JiraClient`, `FormattingMixin`)
- Add comprehensive test coverage for disabled translation functionality
- Maintain backward compatibility (translation enabled by default)

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Verified translation is skipped when `DISABLE_JIRA_MARKUP_TRANSLATION=true`, existing functionality preserved be default

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).