### PR TITLE
Feature/Discover the cloud-id from the provided OAuth token when in BYOAccessToken

### DIFF
--- a/src/mcp_atlassian/utils/oauth.py
+++ b/src/mcp_atlassian/utils/oauth.py
@@ -448,6 +448,7 @@ class BYOAccessTokenOAuthConfig:
 
         return cls(cloud_id=cloud_id, access_token=access_token)
 
+
 def get_cloud_id(access_token: str) -> str | None:
     """Get the cloud ID for the Atlassian instance.
 
@@ -479,6 +480,7 @@ def get_cloud_id(access_token: str) -> str | None:
     except Exception as e:
         logger.error(f"Failed to get cloud ID: {e}")
         return None
+
 
 def get_oauth_config_from_env() -> OAuthConfig | BYOAccessTokenOAuthConfig | None:
     """Get the appropriate OAuth configuration from environment variables.

--- a/src/mcp_atlassian/utils/oauth.py
+++ b/src/mcp_atlassian/utils/oauth.py
@@ -455,28 +455,24 @@ def get_cloud_id(access_token: str) -> str | None:
     This method queries the accessible resources endpoint to get the cloud ID.
     The cloud ID is needed for API calls with OAuth.
     """
-
-    cloud_id: str | None = None
-
     if not access_token:
         logger.debug("No access token provided")
         return None
 
     try:
-        headers = {"Authorization": f"Bearer {access_token}"}
-        response = requests.get(CLOUD_ID_URL, headers=headers)
+        response = requests.get(
+            CLOUD_ID_URL, headers={"Authorization": f"Bearer {access_token}"}
+        )
         response.raise_for_status()
+        resources = response.json() or []
+        cloud_id = resources[0].get("id") if resources else None
 
-        resources = response.json()
-        if resources and len(resources) > 0:
-            # Use the first cloud site (most users have only one)
-            # For users with multiple sites, they might need to specify which one to use
-            cloud_id = resources[0]["id"]
+        if cloud_id:
             logger.debug(f"Found cloud ID: {cloud_id}")
-            return cloud_id
         else:
             logger.warning("No Atlassian sites found in the response")
-            return None
+
+        return cloud_id
     except Exception as e:
         logger.error(f"Failed to get cloud ID: {e}")
         return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
Though we allow users to provide their own OAuth tokens for authentication (BringYourOwnAccessToken), having to set ATLASSIAN_OAUTH_CLOUD_ID limits the MCP server to a single Jira instance. This PR attempts to automatically discover the cloud-id based on the provided OAuth token.
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->
- When ATLASSIAN_OAUTH_CLOUD_ID is not set, use the `accessible-resources` endpoint (`CLOUD_ID_URL`) to find the accessible cloud-IDs for the user
- Use existing `get_cloud_id` (earlier `_get_cloud_id`) to discover the cloud-id for the provided OAuth token
- Retains the existing logic within `get_cloud_id` to use cloud-id of the first resource returned by the `accessible-resources` endpoint (`CLOUD_ID_URL`)

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
