### PR TITLE
fix(oauth_setup): sanitize user input for interactive prompts

### DIFF
--- a/src/mcp_atlassian/utils/oauth_setup.py
+++ b/src/mcp_atlassian/utils/oauth_setup.py
@@ -41,8 +41,9 @@ def _sanitize_input(user_input: str) -> str:
         return user_input
     # Remove leading/trailing whitespace and various line endings
     # Handle Windows (\r\n), Unix (\n), and Mac (\r) line endings
-    sanitized = user_input.strip().rstrip('\r\n').strip()
+    sanitized = user_input.strip().rstrip("\r\n").strip()
     return sanitized
+
 
 class CallbackHandler(http.server.BaseHTTPRequestHandler):
     """HTTP request handler for OAuth callback."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description
* Add `_sanitize_input` to trim leading/trailing whitespace and remove Windows/Unix/Mac line endings.
* Use `_sanitize_input` in `_prompt_for_input` for both env-default and manual input branches.
* Prevents accidental CRLFs or trailing/leading whitespace from corrupting values (redirect URIs, client IDs, secrets) during the OAuth setup wizard.

<!-- What does this PR do? Why is it needed? -->
I faced an issue while using oauth config script on windows machine, where it kept adding \r\n as part of parameters passed from console. this 
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
