### PR TITLE
docs: add missing OAuth scopes to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 #ATLASSIAN_OAUTH_CLIENT_ID=your_oauth_client_id
 #ATLASSIAN_OAUTH_CLIENT_SECRET=your_oauth_client_secret
 #ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback # Must match your app's redirect URI
-#ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-space.summary read:confluence-content.all write:confluence-content offline_access # IMPORTANT: 'offline_access' is crucial for refresh tokens
+#ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:jira-user read:confluence-space.summary read:confluence-content.summary read:confluence-content.all write:confluence-content search:confluence read:page:confluence offline_access # IMPORTANT: 'offline_access' is crucial for refresh tokens
 
 # Required for the server AFTER running --oauth-setup (this ID is printed by the setup wizard):
 #ATLASSIAN_OAUTH_CLOUD_ID=your_atlassian_cloud_id_from_oauth_setup


### PR DESCRIPTION
## Summary
- Add required OAuth scopes that were missing from `.env.example`
- The `read:page:confluence` granular scope is required for Confluence v2 API operations with OAuth

## Added scopes
- `read:jira-user`: Required for Jira user operations
- `read:confluence-content.summary`: Required for Confluence content summary
- `search:confluence`: Required for Confluence search operations
- `read:page:confluence`: **Granular scope** required for Confluence v2 API

## Context
OAuth authentication uses the Confluence v2 API which requires the granular scope `read:page:confluence` for page operations. Without this scope, users get 401 Unauthorized errors when trying to read Confluence pages via OAuth.

## Test plan
- [x] Verified OAuth setup works with new scopes
- [x] Tested `confluence_get_page` with OAuth authentication
- [x] Tested `confluence_search` with OAuth authentication
- [x] Tested Jira operations continue to work