### PR TITLE
fix: include child folders in get_page_children results

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -467,48 +467,76 @@ class PagesMixin(ConfluenceClient):
         expand: str = "version",
         *,
         convert_to_markdown: bool = True,
+        include_folders: bool = True,
     ) -> list[ConfluencePage]:
         """
-        Get child pages of a specific Confluence page.
+        Get child pages and folders of a specific Confluence page.
 
         Args:
             page_id: The ID of the parent page
             start: The starting index for pagination
-            limit: Maximum number of child pages to return
+            limit: Maximum number of child items to return
             expand: Fields to expand in the response
             convert_to_markdown: When True, returns content in markdown format,
                                otherwise returns raw HTML (keyword-only)
+            include_folders: When True, also returns child folders (keyword-only)
 
         Returns:
-            List of ConfluencePage models containing the child pages
+            List of ConfluencePage models containing the child pages and folders
         """
         try:
             # Use the Atlassian Python API's get_page_child_by_type method
-            results = self.confluence.get_page_child_by_type(
+            # First, get child pages
+            page_results = self.confluence.get_page_child_by_type(
                 page_id=page_id, type="page", start=start, limit=limit, expand=expand
             )
 
+            # Handle both pagination modes for pages
+            if isinstance(page_results, dict) and "results" in page_results:
+                child_items = page_results.get("results", [])
+            else:
+                child_items = page_results or []
+
+            # Also get child folders if requested
+            if include_folders:
+                try:
+                    folder_results = self.confluence.get_page_child_by_type(
+                        page_id=page_id,
+                        type="folder",
+                        start=start,
+                        limit=limit,
+                        expand=expand,
+                    )
+
+                    # Handle both pagination modes for folders
+                    if isinstance(folder_results, dict) and "results" in folder_results:
+                        child_folders = folder_results.get("results", [])
+                    else:
+                        child_folders = folder_results or []
+
+                    # Combine pages and folders
+                    child_items = child_items + child_folders
+                except Exception as folder_err:
+                    # Log but don't fail if folder fetching fails
+                    # (e.g., older Confluence versions might not support folders)
+                    logger.debug(
+                        f"Could not fetch child folders for page {page_id}: {folder_err}"
+                    )
+
             # Process results
             page_models = []
-
-            # Handle both pagination modes
-            if isinstance(results, dict) and "results" in results:
-                child_pages = results.get("results", [])
-            else:
-                child_pages = results or []
-
             space_key = ""
 
             # Get space key from the first result if available
-            if child_pages and "space" in child_pages[0]:
-                space_key = child_pages[0].get("space", {}).get("key", "")
+            if child_items and "space" in child_items[0]:
+                space_key = child_items[0].get("space", {}).get("key", "")
 
-            # Process each child page
-            for page in child_pages:
+            # Process each child item (page or folder)
+            for item in child_items:
                 # Only process content if we have "body" expanded
                 content_override = None
-                if "body" in page and convert_to_markdown:
-                    content = page.get("body", {}).get("storage", {}).get("value", "")
+                if "body" in item and convert_to_markdown:
+                    content = item.get("body", {}).get("storage", {}).get("value", "")
                     if content:
                         _, processed_markdown = self.preprocessor.process_html_content(
                             content,
@@ -517,9 +545,9 @@ class PagesMixin(ConfluenceClient):
                         )
                         content_override = processed_markdown
 
-                # Create the page model
+                # Create the page model (works for both pages and folders)
                 page_model = ConfluencePage.from_api_response(
-                    page,
+                    item,
                     base_url=self.config.url,
                     include_body=True,
                     content_override=content_override,

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -245,7 +245,7 @@ async def get_page_children(
     limit: Annotated[
         int,
         Field(
-            description="Maximum number of child pages to return (1-50)",
+            description="Maximum number of child items to return (1-50)",
             default=25,
             ge=1,
             le=50,
@@ -269,20 +269,28 @@ async def get_page_children(
         int,
         Field(description="Starting index for pagination (0-based)", default=0, ge=0),
     ] = 0,
+    include_folders: Annotated[
+        bool,
+        Field(
+            description="Whether to include child folders in addition to child pages",
+            default=True,
+        ),
+    ] = True,
 ) -> str:
-    """Get child pages of a specific Confluence page.
+    """Get child pages and folders of a specific Confluence page.
 
     Args:
         ctx: The FastMCP context.
         parent_id: The ID of the parent page.
         expand: Fields to expand.
-        limit: Maximum number of child pages.
+        limit: Maximum number of child items.
         include_content: Whether to include page content.
         convert_to_markdown: Convert content to markdown if include_content is true.
         start: Starting index for pagination.
+        include_folders: Whether to include child folders (default: True).
 
     Returns:
-        JSON string representing a list of child page objects.
+        JSON string representing a list of child page and folder objects.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
     if include_content and "body" not in expand:
@@ -295,6 +303,7 @@ async def get_page_children(
             limit=limit,
             expand=expand,
             convert_to_markdown=convert_to_markdown,
+            include_folders=include_folders,
         )
         child_pages = [page.to_simplified_dict() for page in pages]
         result = {


### PR DESCRIPTION
## Summary

Previously, `get_page_children` only queried for children of type `"page"`, completely missing folders. This fix adds a second query for type `"folder"` and merges the results.

- Add `include_folders` parameter (default: `True`) to `get_page_children`
- Query both page and folder children when `include_folders=True`
- Handle folder fetch errors gracefully (log and continue with pages only)
- Update MCP tool definition to expose `include_folders` parameter
- Add tests for folder functionality

## Test plan

- [x] Unit tests pass (`pytest tests/unit/confluence/test_pages.py -k get_page_children`)
- [x] Server tests pass (`pytest tests/unit/servers/test_confluence_server.py -k get_page_children`)
- [x] Manually tested against real Confluence instance - folders now appear in results

Fixes #165