### PR TITLE
fix(server): FastMCP 2.14.x compatibility and read-only mode filtering

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -106,12 +106,12 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
 class AtlassianMCP(FastMCP[MainAppContext]):
     """Custom FastMCP server class for Atlassian integration with tool filtering."""
 
-    async def _mcp_list_tools(self) -> list[MCPTool]:
+    async def _list_tools_mcp(self) -> list[MCPTool]:
         # Filter tools based on enabled_tools, read_only mode, and service configuration from the lifespan context.
         req_context = self._mcp_server.request_context
         if req_context is None or req_context.lifespan_context is None:
             logger.warning(
-                "Lifespan context not available during _main_mcp_list_tools call."
+                "Lifespan context not available during _list_tools_mcp call."
             )
             return []
 
@@ -132,7 +132,7 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             else None
         )
         logger.debug(
-            f"_main_mcp_list_tools: read_only={read_only}, enabled_tools_filter={enabled_tools_filter}"
+            f"_list_tools_mcp: read_only={read_only}, enabled_tools_filter={enabled_tools_filter}"
         )
 
         all_tools: dict[str, FastMCPTool] = await self.get_tools()
@@ -181,7 +181,7 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             filtered_tools.append(tool_obj.to_mcp_tool(name=registered_name))
 
         logger.debug(
-            f"_main_mcp_list_tools: Total tools after filtering: {len(filtered_tools)}"
+            f"_list_tools_mcp: Total tools after filtering: {len(filtered_tools)}"
         )
         return filtered_tools
 
@@ -190,13 +190,14 @@ class AtlassianMCP(FastMCP[MainAppContext]):
         path: str | None = None,
         middleware: list[Middleware] | None = None,
         transport: Literal["streamable-http", "sse"] = "streamable-http",
+        **kwargs: Any,
     ) -> "Starlette":
         user_token_mw = Middleware(UserTokenMiddleware, mcp_server_ref=self)
         final_middleware_list = [user_token_mw]
         if middleware:
             final_middleware_list.extend(middleware)
         app = super().http_app(
-            path=path, middleware=final_middleware_list, transport=transport
+            path=path, middleware=final_middleware_list, transport=transport, **kwargs
         )
         return app
 

--- a/tests/integration/test_mcp_protocol.py
+++ b/tests/integration/test_mcp_protocol.py
@@ -166,7 +166,7 @@ class TestMCPProtocolIntegration:
                 atlassian_mcp_server.get_tools = mock_get_tools
 
                 # Get filtered tools
-                tools = await atlassian_mcp_server._mcp_list_tools()
+                tools = await atlassian_mcp_server._list_tools_mcp()
 
                 # Assert all tools are available
                 tool_names = [tool.name for tool in tools]
@@ -246,7 +246,7 @@ class TestMCPProtocolIntegration:
             atlassian_mcp_server.get_tools = mock_get_tools
 
             # Get filtered tools
-            tools = await atlassian_mcp_server._mcp_list_tools()
+            tools = await atlassian_mcp_server._list_tools_mcp()
 
             # Assert only read tools are available
             tool_names = [tool.name for tool in tools]
@@ -317,7 +317,7 @@ class TestMCPProtocolIntegration:
             atlassian_mcp_server.get_tools = mock_get_tools
 
             # Get filtered tools
-            tools = await atlassian_mcp_server._mcp_list_tools()
+            tools = await atlassian_mcp_server._list_tools_mcp()
 
             # Assert only enabled tools are available
             tool_names = [tool.name for tool in tools]
@@ -383,7 +383,7 @@ class TestMCPProtocolIntegration:
             atlassian_mcp_server.get_tools = mock_get_tools
 
             # Get filtered tools
-            tools = await atlassian_mcp_server._mcp_list_tools()
+            tools = await atlassian_mcp_server._list_tools_mcp()
 
             # Assert no tools are available when services not configured
             assert len(tools) == 0
@@ -851,7 +851,7 @@ class TestMCPProtocolIntegration:
             atlassian_mcp_server.get_tools = mock_get_tools
 
             # Get filtered tools
-            tools = await atlassian_mcp_server._mcp_list_tools()
+            tools = await atlassian_mcp_server._list_tools_mcp()
 
             # Only jira_get_issue should pass all filters
             tool_names = [tool.name for tool in tools]
@@ -870,7 +870,7 @@ class TestMCPProtocolIntegration:
         atlassian_mcp_server.get_tools = mock_get_tools
 
         # Get filtered tools
-        tools = await atlassian_mcp_server._mcp_list_tools()
+        tools = await atlassian_mcp_server._list_tools_mcp()
 
         # Should return empty list
         assert tools == []


### PR DESCRIPTION
## Description

Fixes compatibility issues with FastMCP 2.14.x and read-only mode tool filtering that were discovered during pre-release testing.

## Changes

- Add `**kwargs` to `http_app()` override to support new FastMCP 2.14.x parameters (e.g., `json_response`)
- Rename `_mcp_list_tools` to `_list_tools_mcp` to match FastMCP's expected method name for tool listing override
- Update test references in `test_mcp_protocol.py` to use correct method name

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Comprehensive pre-release testing including:
  - All 3 transport modes (stdio, streamable-http, sse)
  - Docker build and deployment
  - Read-only mode filtering (now correctly excludes write tools)
  - Write operations (create/update/delete for Jira and Confluence)
  - 991 unit tests pass

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).