### PR TITLE
fix(confluence): use parent page ID for attachment URLs

### DIFF
--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -199,17 +199,23 @@ class ConfluencePage(ApiModel, TimestampMixin):
         # Construct URL if base_url is provided
         url = None
         if base_url := kwargs.get("base_url"):
-            page_id = data.get("id")
+            # For attachments, use parent container's page ID instead of attachment ID
+            content_type = data.get("type", "page")
+            container_data = data.get("container", {})
+            if content_type == "attachment" and container_data:
+                url_id = container_data.get("id")
+            else:
+                url_id = data.get("id")
 
             # Use different URL format based on whether it's cloud or server
             is_cloud = kwargs.get("is_cloud", False)
             if is_cloud:
                 # Cloud format: {base_url}/spaces/{space_key}/pages/{page_id}
                 space_key = space.key if space and space.key else "unknown"
-                url = f"{base_url}/spaces/{space_key}/pages/{page_id}"
+                url = f"{base_url}/spaces/{space_key}/pages/{url_id}"
             else:
                 # Server format: {base_url}/pages/viewpage.action?pageId={page_id}
-                url = f"{base_url}/pages/viewpage.action?pageId={page_id}"
+                url = f"{base_url}/pages/viewpage.action?pageId={url_id}"
 
         return cls(
             id=str(data.get("id", CONFLUENCE_DEFAULT_ID)),

--- a/tests/unit/models/test_confluence_models.py
+++ b/tests/unit/models/test_confluence_models.py
@@ -550,6 +550,61 @@ class TestConfluencePage:
             == "https://wiki.corp.example.com/pages/viewpage.action?pageId=123456"
         )
 
+    def test_attachment_url_uses_parent_page_id_server(self):
+        """Test that attachment URLs use parent page ID for server format."""
+        attachment_data = {
+            "id": "att105348",
+            "type": "attachment",
+            "title": "document.pdf",
+            "container": {"id": "12345", "type": "page"},
+        }
+
+        page = ConfluencePage.from_api_response(
+            attachment_data,
+            base_url="http://wiki.example.com",
+            is_cloud=False,
+        )
+
+        assert "pageId=12345" in page.url
+        assert "att105348" not in page.url
+
+    def test_attachment_url_uses_parent_page_id_cloud(self):
+        """Test that attachment URLs use parent page ID for cloud format."""
+        attachment_data = {
+            "id": "att105348",
+            "type": "attachment",
+            "title": "document.pdf",
+            "space": {"key": "TEST"},
+            "container": {"id": "12345", "type": "page"},
+        }
+
+        page = ConfluencePage.from_api_response(
+            attachment_data,
+            base_url="https://example.atlassian.net/wiki",
+            is_cloud=True,
+        )
+
+        assert "/pages/12345" in page.url
+        assert "att105348" not in page.url
+
+    def test_attachment_without_container_falls_back_to_own_id(self):
+        """Test that attachments without container fall back to their own ID."""
+        attachment_data = {
+            "id": "att105348",
+            "type": "attachment",
+            "title": "document.pdf",
+            # No container field
+        }
+
+        page = ConfluencePage.from_api_response(
+            attachment_data,
+            base_url="http://wiki.example.com",
+            is_cloud=False,
+        )
+
+        # Falls back to attachment ID when no container
+        assert "pageId=att105348" in page.url
+
 
 class TestConfluenceSearchResult:
     """Tests for the ConfluenceSearchResult model."""


### PR DESCRIPTION
## Summary
- Fixes broken URLs for attachments in Confluence search results
- Attachments now correctly link to their parent page

## Problem
When `confluence_search` returns attachments, the URL was constructed
using the Attachment ID instead of the parent Page ID, resulting in
404 errors.

## Solution
Check if content type is "attachment" and use the `container.id`
(parent page ID) for URL construction instead of the attachment's own ID.

## Test plan
- [x] Unit tests for attachment URLs (server format)
- [x] Unit tests for attachment URLs (cloud format)
- [x] Unit tests for regular page URLs (unchanged behavior)

Closes #790