### PR TITLE
fix(jira): fix multi-level bullet list indentation

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -313,23 +313,27 @@ class JiraPreprocessor(BasePreprocessor):
         )
 
         # Multi-level bulleted list
+        def bulleted_list_fn(match: re.Match) -> str:
+            ident = len(match.group(1)) if match.group(1) else 0
+            level = ident // 2 + 1
+            return str("*" * level + " " + match.group(2))
+
         output = re.sub(
-            r"^(\s*)- (.*)$",
-            lambda match: (
-                "* " + match.group(2)
-                if not match.group(1)
-                else "  " * (len(match.group(1)) // 2) + "* " + match.group(2)
-            ),
+            r"^(\s+)?[-+*] (.*)$",
+            bulleted_list_fn,
             output,
             flags=re.MULTILINE,
         )
 
         # Multi-level numbered list
+        def numbered_list_fn(match: re.Match) -> str:
+            ident = len(match.group(1)) if match.group(1) else 0
+            level = ident // 2 + 1
+            return str("#" * level + " " + match.group(2))
+
         output = re.sub(
-            r"^(\s+)1\. (.*)$",
-            lambda match: "#" * (int(len(match.group(1)) / 4) + 2)
-            + " "
-            + match.group(2),
+            r"^(\s+)?\d+\. (.*)$",
+            numbered_list_fn,
             output,
             flags=re.MULTILINE,
         )

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -290,6 +290,22 @@ For more information, see [our website](https://example.com).
     assert "[our website|https://example.com]" in converted
 
 
+def test_markdown_nested_bullet_list_2space(preprocessor_with_jira):
+    """Test that 2-space indented bullet lists convert correctly to Jira format."""
+    markdown = "* Item A\n  * Sub-item A.1\n    * Sub-sub A.1.1\n* Item B"
+    expected = "* Item A\n** Sub-item A.1\n*** Sub-sub A.1.1\n* Item B"
+    result = preprocessor_with_jira.markdown_to_jira(markdown)
+    assert result == expected
+
+
+def test_markdown_nested_numbered_list_2space(preprocessor_with_jira):
+    """Test that 2-space indented numbered lists convert correctly to Jira format."""
+    markdown = "1. Item A\n  1. Sub-item A.1\n    1. Sub-sub A.1.1\n2. Item B"
+    expected = "# Item A\n## Sub-item A.1\n### Sub-sub A.1.1\n# Item B"
+    result = preprocessor_with_jira.markdown_to_jira(markdown)
+    assert result == expected
+
+
 def test_markdown_to_confluence_storage(preprocessor_with_confluence):
     """Test conversion of Markdown to Confluence storage format."""
     markdown = """# Heading 1


### PR DESCRIPTION
## Summary
- Fixes multi-level bullet list conversion from Markdown to Jira wiki format
- Handles standard 2-space indentation

## Changes
- Changed indent formula from `ident // 4` to `ident // 2`
- Updated bulleted list regex to match `*`, `-`, `+` markers
- Updated numbered list regex to match any digit prefix
- Added test cases for 2-space indented nested lists

## Test case
Input:
```
* Item A
  * Sub-item A.1
    * Sub-sub A.1.1
* Item B
```

Expected output:
```
* Item A
** Sub-item A.1
*** Sub-sub A.1.1
* Item B
```

Fixes #717
Based on work from PR #773 by @vkrasnoselskikh