### PR TITLE
docs: restructure documentation with uvx quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,505 +6,39 @@
 [![Run Tests](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml/badge.svg)](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml)
 ![License](https://img.shields.io/github/license/sooperset/mcp-atlassian)
 
-Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). This integration supports both Confluence & Jira Cloud and Server/Data Center deployments.
-
-## Example Usage
-
-Ask your AI assistant to:
-
-- **📝 Automatic Jira Updates** - "Update Jira from our meeting notes"
-- **🔍 AI-Powered Confluence Search** - "Find our OKR guide in Confluence and summarize it"
-- **🐛 Smart Jira Issue Filtering** - "Show me urgent bugs in PROJ project from last week"
-- **📄 Content Creation & Management** - "Create a tech design doc for XYZ feature"
-
-### Feature Demo
+Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.
 
 https://github.com/user-attachments/assets/35303504-14c6-4ae4-913b-7c25ea511c3e
 
-<details> <summary>Confluence Demo</summary>
+<details>
+<summary>Confluence Demo</summary>
 
 https://github.com/user-attachments/assets/7fe9c488-ad0c-4876-9b54-120b666bb785
 
 </details>
 
-### Compatibility
+## Quick Start
 
-| Product        | Deployment Type    | Support Status              |
-|----------------|--------------------|-----------------------------|
-| **Confluence** | Cloud              | ✅ Fully supported           |
-| **Confluence** | Server/Data Center | ✅ Supported (version 6.0+)  |
-| **Jira**       | Cloud              | ✅ Fully supported           |
-| **Jira**       | Server/Data Center | ✅ Supported (version 8.14+) |
+### 1. Get Your API Token
 
-> **Note**: Python 3.14 is not yet supported due to upstream pydantic-core/PyO3 limitations.
-> Use Python 3.10-3.13. Workaround: `uvx --python=3.12 mcp-atlassian`
+Go to https://id.atlassian.com/manage-profile/security/api-tokens and create a token.
 
-## Quick Start Guide
+> For Server/Data Center, use a Personal Access Token instead. See [Authentication](docs/authentication.md).
 
-### 🔐 1. Authentication Setup
+### 2. Configure Your IDE
 
-MCP Atlassian supports three authentication methods:
+Add to your Claude Desktop or Cursor MCP configuration:
 
-#### A. API Token Authentication (Cloud) - **Recommended**
-
-1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
-2. Click **Create API token**, name it
-3. Copy the token immediately
-
-#### B. Personal Access Token (Server/Data Center)
-
-1. Go to your profile (avatar) → **Profile** → **Personal Access Tokens**
-2. Click **Create token**, name it, set expiry
-3. Copy the token immediately
-
-#### C. OAuth 2.0 Authentication (Cloud) - **Advanced**
-
-> [!NOTE]
-> OAuth 2.0 is more complex to set up but provides enhanced security features. For most users, API Token authentication (Method A) is simpler and sufficient.
-
-1. Go to [Atlassian Developer Console](https://developer.atlassian.com/console/myapps/)
-2. Create an "OAuth 2.0 (3LO) integration" app
-3. Configure **Permissions** (scopes) for Jira/Confluence
-4. Set **Callback URL** (e.g., `http://localhost:8080/callback`)
-5. Run setup wizard:
-   ```bash
-   docker run --rm -i \
-     -p 8080:8080 \
-     -v "${HOME}/.mcp-atlassian:/home/app/.mcp-atlassian" \
-     ghcr.io/sooperset/mcp-atlassian:latest --oauth-setup -v
-   ```
-6. Follow prompts for `Client ID`, `Secret`, `URI`, and `Scope`
-7. Complete browser authorization
-8. Add obtained credentials to `.env` or IDE config:
-   - `ATLASSIAN_OAUTH_CLOUD_ID` (from wizard)
-   - `ATLASSIAN_OAUTH_CLIENT_ID`
-   - `ATLASSIAN_OAUTH_CLIENT_SECRET`
-   - `ATLASSIAN_OAUTH_REDIRECT_URI`
-   - `ATLASSIAN_OAUTH_SCOPE`
-
-> [!IMPORTANT]
-> For the standard OAuth flow described above, include `offline_access` in your scope (e.g., `read:jira-work write:jira-work offline_access`). This allows the server to refresh the access token automatically.
-
-<details>
-<summary>Alternative: Using a Pre-existing OAuth Access Token (BYOT)</summary>
-
-If you are running mcp-atlassian part of a larger system that manages Atlassian OAuth 2.0 access tokens externally (e.g., through a central identity provider or another application), you can provide an access token directly to this MCP server. This method bypasses the interactive setup wizard and the server's internal token management (including refresh capabilities).
-
-**Requirements:**
-- A valid Atlassian OAuth 2.0 Access Token with the necessary scopes for the intended operations.
-- The corresponding `ATLASSIAN_OAUTH_CLOUD_ID` for your Atlassian instance.
-
-**Configuration:**
-To use this method, set the following environment variables (or use the corresponding command-line flags when starting the server):
-- `ATLASSIAN_OAUTH_CLOUD_ID`: Your Atlassian Cloud ID. (CLI: `--oauth-cloud-id`)
-- `ATLASSIAN_OAUTH_ACCESS_TOKEN`: Your pre-existing OAuth 2.0 access token. (CLI: `--oauth-access-token`)
-
-**Important Considerations for BYOT:**
-- **Token Lifecycle Management:** When using BYOT, the MCP server **does not** handle token refresh. The responsibility for obtaining, refreshing (before expiry), and revoking the access token lies entirely with you or the external system providing the token.
-- **Unused Variables:** The standard OAuth client variables (`ATLASSIAN_OAUTH_CLIENT_ID`, `ATLASSIAN_OAUTH_CLIENT_SECRET`, `ATLASSIAN_OAUTH_REDIRECT_URI`, `ATLASSIAN_OAUTH_SCOPE`) are **not** used and can be omitted when configuring for BYOT.
-- **No Setup Wizard:** The `--oauth-setup` wizard is not applicable and should not be used for this approach.
-- **No Token Cache Volume:** The Docker volume mount for token storage (e.g., `-v "${HOME}/.mcp-atlassian:/home/app/.mcp-atlassian"`) is also not necessary if you are exclusively using the BYOT method, as no tokens are stored or managed by this server.
-- **Scope:** The provided access token must already have the necessary permissions (scopes) for the Jira/Confluence operations you intend to perform.
-
-This option is useful in scenarios where OAuth credential management is centralized or handled by other infrastructure components.
-</details>
-
-> [!TIP]
-> **Multi-Cloud OAuth Support**: If you're building a multi-tenant application where users provide their own OAuth tokens, see the [Multi-Cloud OAuth Support](#multi-cloud-oauth-support) section for minimal configuration setup.
-
-### 📦 2. Installation
-
-MCP Atlassian is distributed as a Docker image. This is the recommended way to run the server, especially for IDE integration. Ensure you have Docker installed.
-
-```bash
-# Pull Pre-built Image
-docker pull ghcr.io/sooperset/mcp-atlassian:latest
-```
-
-## 🛠️ IDE Integration
-
-MCP Atlassian is designed to be used with AI assistants through IDE integration.
-
-> [!TIP]
-> **For Claude Desktop**: Locate and edit the configuration file directly:
-> - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-> - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-> - **Linux**: `~/.config/Claude/claude_desktop_config.json`
->
-> **For Cursor**: Open Settings → MCP → + Add new global MCP server
-
-### ⚙️ Configuration Methods
-
-There are two main approaches to configure the Docker container:
-
-1. **Passing Variables Directly** (shown in examples below)
-2. **Using an Environment File** with `--env-file` flag (shown in collapsible sections)
-
-> [!NOTE]
-> Common environment variables include:
->
-> - `CONFLUENCE_SPACES_FILTER`: Filter by space keys (e.g., "DEV,TEAM,DOC")
-> - `JIRA_PROJECTS_FILTER`: Filter by project keys (e.g., "PROJ,DEV,SUPPORT")
-> - `READ_ONLY_MODE`: Set to "true" to disable write operations
-> - `MCP_VERBOSE`: Set to "true" for more detailed logging
-> - `MCP_LOGGING_STDOUT`: Set to "true" to log to stdout instead of stderr
-> - `ENABLED_TOOLS`: Comma-separated list of tool names to enable (e.g., "confluence_search,jira_get_issue")
->
-> See the [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) file for all available options.
-
-
-### 📝 Configuration Examples
-
-**Method 1 (Passing Variables Directly):**
 ```json
 {
   "mcpServers": {
     "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_USERNAME",
-        "-e", "CONFLUENCE_API_TOKEN",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_USERNAME",
-        "-e", "JIRA_API_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
       "env": {
-        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
-        "CONFLUENCE_USERNAME": "your.email@company.com",
-        "CONFLUENCE_API_TOKEN": "your_confluence_api_token",
         "JIRA_URL": "https://your-company.atlassian.net",
         "JIRA_USERNAME": "your.email@company.com",
-        "JIRA_API_TOKEN": "your_jira_api_token"
-      }
-    }
-  }
-}
-```
-
-<details>
-<summary>Alternative: Using Environment File</summary>
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "--env-file",
-        "/path/to/your/mcp-atlassian.env",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ]
-    }
-  }
-}
-```
-</details>
-
-<details>
-<summary>Server/Data Center Configuration</summary>
-
-For Server/Data Center deployments, use direct variable passing:
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_PERSONAL_TOKEN",
-        "-e", "CONFLUENCE_SSL_VERIFY",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_PERSONAL_TOKEN",
-        "-e", "JIRA_SSL_VERIFY",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "CONFLUENCE_URL": "https://confluence.your-company.com",
-        "CONFLUENCE_PERSONAL_TOKEN": "your_confluence_pat",
-        "CONFLUENCE_SSL_VERIFY": "false",
-        "JIRA_URL": "https://jira.your-company.com",
-        "JIRA_PERSONAL_TOKEN": "your_jira_pat",
-        "JIRA_SSL_VERIFY": "false"
-      }
-    }
-  }
-}
-```
-
-> [!NOTE]
-> Set `CONFLUENCE_SSL_VERIFY` and `JIRA_SSL_VERIFY` to "false" only if you have self-signed certificates.
-
-</details>
-
-<details>
-<summary>OAuth 2.0 Configuration (Cloud Only)</summary>
-<a name="oauth-20-configuration-example-cloud-only"></a>
-
-These examples show how to configure `mcp-atlassian` in your IDE (like Cursor or Claude Desktop) when using OAuth 2.0 for Atlassian Cloud.
-
-**Example for Standard OAuth 2.0 Flow (using Setup Wizard):**
-
-This configuration is for when you use the server's built-in OAuth client and have completed the [OAuth setup wizard](#c-oauth-20-authentication-cloud---advanced).
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-v", "<path_to_your_home>/.mcp-atlassian:/home/app/.mcp-atlassian",
-        "-e", "JIRA_URL",
-        "-e", "CONFLUENCE_URL",
-        "-e", "ATLASSIAN_OAUTH_CLIENT_ID",
-        "-e", "ATLASSIAN_OAUTH_CLIENT_SECRET",
-        "-e", "ATLASSIAN_OAUTH_REDIRECT_URI",
-        "-e", "ATLASSIAN_OAUTH_SCOPE",
-        "-e", "ATLASSIAN_OAUTH_CLOUD_ID",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "JIRA_URL": "https://your-company.atlassian.net",
-        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
-        "ATLASSIAN_OAUTH_CLIENT_ID": "YOUR_OAUTH_APP_CLIENT_ID",
-        "ATLASSIAN_OAUTH_CLIENT_SECRET": "YOUR_OAUTH_APP_CLIENT_SECRET",
-        "ATLASSIAN_OAUTH_REDIRECT_URI": "http://localhost:8080/callback",
-        "ATLASSIAN_OAUTH_SCOPE": "read:jira-work write:jira-work read:confluence-content.all write:confluence-content offline_access",
-        "ATLASSIAN_OAUTH_CLOUD_ID": "YOUR_CLOUD_ID_FROM_SETUP_WIZARD"
-      }
-    }
-  }
-}
-```
-
-> [!NOTE]
-> - For the Standard Flow:
->   - `ATLASSIAN_OAUTH_CLOUD_ID` is obtained from the `--oauth-setup` wizard output or is known for your instance.
->   - Other `ATLASSIAN_OAUTH_*` client variables are from your OAuth app in the Atlassian Developer Console.
->   - `JIRA_URL` and `CONFLUENCE_URL` for your Cloud instances are always required.
->   - The volume mount (`-v .../.mcp-atlassian:/home/app/.mcp-atlassian`) is crucial for persisting the OAuth tokens obtained by the wizard, enabling automatic refresh.
-
-**Example for Pre-existing Access Token (BYOT - Bring Your Own Token):**
-
-This configuration is for when you are providing your own externally managed OAuth 2.0 access token.
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "JIRA_URL",
-        "-e", "CONFLUENCE_URL",
-        "-e", "ATLASSIAN_OAUTH_CLOUD_ID",
-        "-e", "ATLASSIAN_OAUTH_ACCESS_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "JIRA_URL": "https://your-company.atlassian.net",
-        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
-        "ATLASSIAN_OAUTH_CLOUD_ID": "YOUR_KNOWN_CLOUD_ID",
-        "ATLASSIAN_OAUTH_ACCESS_TOKEN": "YOUR_PRE_EXISTING_OAUTH_ACCESS_TOKEN"
-      }
-    }
-  }
-}
-```
-
-> [!NOTE]
-> - For the BYOT Method:
->   - You primarily need `JIRA_URL`, `CONFLUENCE_URL`, `ATLASSIAN_OAUTH_CLOUD_ID`, and `ATLASSIAN_OAUTH_ACCESS_TOKEN`.
->   - Standard OAuth client variables (`ATLASSIAN_OAUTH_CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`, `SCOPE`) are **not** used.
->   - Token lifecycle (e.g., refreshing the token before it expires and restarting mcp-atlassian) is your responsibility, as the server will not refresh BYOT tokens.
-
-</details>
-
-<details>
-<summary>Proxy Configuration</summary>
-
-MCP Atlassian supports routing API requests through standard HTTP/HTTPS/SOCKS proxies. Configure using environment variables:
-
-- Supports standard `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `SOCKS_PROXY`.
-- Service-specific overrides are available (e.g., `JIRA_HTTPS_PROXY`, `CONFLUENCE_NO_PROXY`).
-- Service-specific variables override global ones for that service.
-
-Add the relevant proxy variables to the `args` (using `-e`) and `env` sections of your MCP configuration:
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e", "... existing Confluence/Jira vars",
-        "-e", "HTTP_PROXY",
-        "-e", "HTTPS_PROXY",
-        "-e", "NO_PROXY",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "... existing Confluence/Jira vars": "...",
-        "HTTP_PROXY": "http://proxy.internal:8080",
-        "HTTPS_PROXY": "http://proxy.internal:8080",
-        "NO_PROXY": "localhost,.your-company.com"
-      }
-    }
-  }
-}
-```
-
-Credentials in proxy URLs are masked in logs. If you set `NO_PROXY`, it will be respected for requests to matching hosts.
-
-</details>
-<details>
-<summary>Custom HTTP Headers Configuration</summary>
-
-MCP Atlassian supports adding custom HTTP headers to all API requests. This feature is particularly useful in corporate environments where additional headers are required for security, authentication, or routing purposes.
-
-Custom headers are configured using environment variables with comma-separated key=value pairs:
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_USERNAME",
-        "-e", "CONFLUENCE_API_TOKEN",
-        "-e", "CONFLUENCE_CUSTOM_HEADERS",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_USERNAME",
-        "-e", "JIRA_API_TOKEN",
-        "-e", "JIRA_CUSTOM_HEADERS",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
-        "CONFLUENCE_USERNAME": "your.email@company.com",
-        "CONFLUENCE_API_TOKEN": "your_confluence_api_token",
-        "CONFLUENCE_CUSTOM_HEADERS": "X-Confluence-Service=mcp-integration,X-Custom-Auth=confluence-token,X-ALB-Token=secret-token",
-        "JIRA_URL": "https://your-company.atlassian.net",
-        "JIRA_USERNAME": "your.email@company.com",
-        "JIRA_API_TOKEN": "your_jira_api_token",
-        "JIRA_CUSTOM_HEADERS": "X-Forwarded-User=service-account,X-Company-Service=mcp-atlassian,X-Jira-Client=mcp-integration"
-      }
-    }
-  }
-}
-```
-
-**Security Considerations:**
-
-- Custom header values are masked in debug logs to protect sensitive information
-- Ensure custom headers don't conflict with standard HTTP or Atlassian API headers
-- Avoid including sensitive authentication tokens in custom headers if already using basic auth or OAuth
-- Headers are sent with every API request - verify they don't interfere with API functionality
-
-</details>
-
-
-<details>
-<summary>Multi-Cloud OAuth Support</summary>
-
-MCP Atlassian supports multi-cloud OAuth scenarios where each user connects to their own Atlassian cloud instance. This is useful for multi-tenant applications, chatbots, or services where users provide their own OAuth tokens.
-
-**Minimal OAuth Configuration:**
-
-1. Enable minimal OAuth mode (no client credentials required):
-   ```bash
-   docker run -e ATLASSIAN_OAUTH_ENABLE=true -p 9000:9000 \
-     ghcr.io/sooperset/mcp-atlassian:latest \
-     --transport streamable-http --port 9000
-   ```
-
-2. Users provide authentication via HTTP headers:
-   - `Authorization: Bearer <user_oauth_token>`
-   - `X-Atlassian-Cloud-Id: <user_cloud_id>`
-
-**Example Integration (Python):**
-```python
-import asyncio
-from mcp.client.streamable_http import streamablehttp_client
-from mcp import ClientSession
-
-user_token = "user-specific-oauth-token"
-user_cloud_id = "user-specific-cloud-id"
-
-async def main():
-    # Connect to streamable HTTP server with custom headers
-    async with streamablehttp_client(
-        "http://localhost:9000/mcp",
-        headers={
-            "Authorization": f"Bearer {user_token}",
-            "X-Atlassian-Cloud-Id": user_cloud_id
-        }
-    ) as (read_stream, write_stream, _):
-        # Create a session using the client streams
-        async with ClientSession(read_stream, write_stream) as session:
-            # Initialize the connection
-            await session.initialize()
-
-            # Example: Get a Jira issue
-            result = await session.call_tool(
-                "jira_get_issue",
-                {"issue_key": "PROJ-123"}
-            )
-            print(result)
-
-asyncio.run(main())
-```
-
-**Configuration Notes:**
-- Each request can use a different cloud instance via the `X-Atlassian-Cloud-Id` header
-- User tokens are isolated per request - no cross-tenant data leakage
-- Falls back to global `ATLASSIAN_OAUTH_CLOUD_ID` if header not provided
-- Compatible with standard OAuth 2.0 bearer token authentication
-
-</details>
-
-<details> <summary>Single Service Configurations</summary>
-
-**For Confluence Cloud only:**
-
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_USERNAME",
-        "-e", "CONFLUENCE_API_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
+        "JIRA_API_TOKEN": "your_api_token",
         "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
         "CONFLUENCE_USERNAME": "your.email@company.com",
         "CONFLUENCE_API_TOKEN": "your_api_token"
@@ -514,369 +48,56 @@ asyncio.run(main())
 }
 ```
 
-For Confluence Server/DC, use:
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "CONFLUENCE_URL",
-        "-e", "CONFLUENCE_PERSONAL_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "CONFLUENCE_URL": "https://confluence.your-company.com",
-        "CONFLUENCE_PERSONAL_TOKEN": "your_personal_token"
-      }
-    }
-  }
-}
-```
+> **Python 3.14 not yet supported.** Use `["--python=3.12", "mcp-atlassian"]` as args if needed.
 
-**For Jira Cloud only:**
+### 3. Start Using
 
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_USERNAME",
-        "-e", "JIRA_API_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "JIRA_URL": "https://your-company.atlassian.net",
-        "JIRA_USERNAME": "your.email@company.com",
-        "JIRA_API_TOKEN": "your_api_token"
-      }
-    }
-  }
-}
-```
+Ask your AI assistant to:
+- **"Find issues assigned to me in PROJ project"**
+- **"Search Confluence for onboarding docs"**
+- **"Create a bug ticket for the login issue"**
+- **"Update the status of PROJ-123 to Done"**
 
-For Jira Server/DC, use:
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e", "JIRA_URL",
-        "-e", "JIRA_PERSONAL_TOKEN",
-        "ghcr.io/sooperset/mcp-atlassian:latest"
-      ],
-      "env": {
-        "JIRA_URL": "https://jira.your-company.com",
-        "JIRA_PERSONAL_TOKEN": "your_personal_token"
-      }
-    }
-  }
-}
-```
+## Documentation
 
-</details>
+| Topic | Description |
+|-------|-------------|
+| [Installation](docs/installation.md) | uvx, Docker, pip, from source |
+| [Authentication](docs/authentication.md) | API tokens, PAT, OAuth 2.0 |
+| [Configuration](docs/configuration.md) | IDE setup, environment variables |
+| [HTTP Transport](docs/http-transport.md) | SSE, streamable-http, multi-user |
+| [Tools Reference](docs/tools-reference.md) | All Jira & Confluence tools |
+| [Troubleshooting](docs/troubleshooting.md) | Common issues & debugging |
 
-### 👥 HTTP Transport Configuration
+## Compatibility
 
-Instead of using `stdio`, you can run the server as a persistent HTTP service using either:
-- `sse` (Server-Sent Events) transport at `/sse` endpoint
-- `streamable-http` transport at `/mcp` endpoint
+| Product | Deployment | Support |
+|---------|------------|---------|
+| Confluence | Cloud | Fully supported |
+| Confluence | Server/Data Center | Supported (v6.0+) |
+| Jira | Cloud | Fully supported |
+| Jira | Server/Data Center | Supported (v8.14+) |
 
-Both transport types support single-user and multi-user authentication:
+## Key Tools
 
-**Authentication Options:**
-- **Single-User**: Use server-level authentication configured via environment variables
-- **Multi-User**: Each user provides their own authentication:
-  - Cloud: OAuth 2.0 Bearer tokens
-  - Server/Data Center: Personal Access Tokens (PATs)
+| Jira | Confluence |
+|------|------------|
+| `jira_search` - Search with JQL | `confluence_search` - Search with CQL |
+| `jira_get_issue` - Get issue details | `confluence_get_page` - Get page content |
+| `jira_create_issue` - Create issues | `confluence_create_page` - Create pages |
+| `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
+| `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-<details> <summary>Basic HTTP Transport Setup</summary>
-
-1. Start the server with your chosen transport:
-
-    ```bash
-    # For SSE transport
-    docker run --rm -p 9000:9000 \
-      --env-file /path/to/your/.env \
-      ghcr.io/sooperset/mcp-atlassian:latest \
-      --transport sse --port 9000 -vv
-
-    # OR for streamable-http transport
-    docker run --rm -p 9000:9000 \
-      --env-file /path/to/your/.env \
-      ghcr.io/sooperset/mcp-atlassian:latest \
-      --transport streamable-http --port 9000 -vv
-    ```
-
-2. Configure your IDE (single-user example):
-
-    **SSE Transport Example:**
-    ```json
-    {
-      "mcpServers": {
-        "mcp-atlassian-http": {
-          "url": "http://localhost:9000/sse"
-        }
-      }
-    }
-    ```
-
-    **Streamable-HTTP Transport Example:**
-    ```json
-    {
-      "mcpServers": {
-        "mcp-atlassian-service": {
-          "url": "http://localhost:9000/mcp"
-        }
-      }
-    }
-    ```
-</details>
-
-<details> <summary>Multi-User Authentication Setup</summary>
-
-Here's a complete example of setting up multi-user authentication with streamable-HTTP transport:
-
-1. First, run the OAuth setup wizard to configure the server's OAuth credentials:
-   ```bash
-   docker run --rm -i \
-     -p 8080:8080 \
-     -v "${HOME}/.mcp-atlassian:/home/app/.mcp-atlassian" \
-     ghcr.io/sooperset/mcp-atlassian:latest --oauth-setup -v
-   ```
-
-2. Start the server with streamable-HTTP transport:
-   ```bash
-   docker run --rm -p 9000:9000 \
-     --env-file /path/to/your/.env \
-     ghcr.io/sooperset/mcp-atlassian:latest \
-     --transport streamable-http --port 9000 -vv
-   ```
-
-3. Configure your IDE's MCP settings:
-
-**Choose the appropriate Authorization method for your Atlassian deployment:**
-
-- **Cloud (OAuth 2.0):** Use this if your organization is on Atlassian Cloud and you have an OAuth access token for each user.
-- **Server/Data Center (PAT):** Use this if you are on Atlassian Server or Data Center and each user has a Personal Access Token (PAT).
-
-**Cloud (OAuth 2.0) Example:**
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian-service": {
-      "url": "http://localhost:9000/mcp",
-      "headers": {
-        "Authorization": "Bearer <USER_OAUTH_ACCESS_TOKEN>"
-      }
-    }
-  }
-}
-```
-
-**Server/Data Center (PAT) Example:**
-```json
-{
-  "mcpServers": {
-    "mcp-atlassian-service": {
-      "url": "http://localhost:9000/mcp",
-      "headers": {
-        "Authorization": "Token <USER_PERSONAL_ACCESS_TOKEN>"
-      }
-    }
-  }
-}
-```
-
-4. Required environment variables in `.env`:
-   ```bash
-   JIRA_URL=https://your-company.atlassian.net
-   CONFLUENCE_URL=https://your-company.atlassian.net/wiki
-   ATLASSIAN_OAUTH_CLIENT_ID=your_oauth_app_client_id
-   ATLASSIAN_OAUTH_CLIENT_SECRET=your_oauth_app_client_secret
-   ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback
-   ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-content.all write:confluence-content offline_access
-   ATLASSIAN_OAUTH_CLOUD_ID=your_cloud_id_from_setup_wizard
-   ```
-
-> [!NOTE]
-> - The server should have its own fallback authentication configured (e.g., via environment variables for API token, PAT, or its own OAuth setup using --oauth-setup). This is used if a request doesn't include user-specific authentication.
-> - **OAuth**: Each user needs their own OAuth access token from your Atlassian OAuth app.
-> - **PAT**: Each user provides their own Personal Access Token.
-> - **Multi-Cloud**: For OAuth users, optionally include `X-Atlassian-Cloud-Id` header to specify which Atlassian cloud instance to use
-> - The server will use the user's token for API calls when provided, falling back to server auth if not
-> - User tokens should have appropriate scopes for their needed operations
-
-</details>
-
-## Tools
-
-### Key Tools
-
-#### Jira Tools
-
-- `jira_get_issue`: Get details of a specific issue
-- `jira_search`: Search issues using JQL
-- `jira_create_issue`: Create a new issue
-- `jira_update_issue`: Update an existing issue
-- `jira_transition_issue`: Transition an issue to a new status
-- `jira_add_comment`: Add a comment to an issue
-
-#### Confluence Tools
-
-- `confluence_search`: Search Confluence content using CQL
-- `confluence_get_page`: Get content of a specific page
-- `confluence_create_page`: Create a new page
-- `confluence_update_page`: Update an existing page
-
-<details> <summary>View All Tools</summary>
-
-| Operation | Jira Tools                          | Confluence Tools               |
-|-----------|-------------------------------------|--------------------------------|
-| **Read**  | `jira_search`                       | `confluence_search`            |
-|           | `jira_get_issue`                    | `confluence_get_page`          |
-|           | `jira_get_all_projects`             | `confluence_get_page_children` |
-|           | `jira_get_project_issues`           | `confluence_get_comments`      |
-|           | `jira_get_worklog`                  | `confluence_get_labels`        |
-|           | `jira_get_transitions`              | `confluence_search_user`       |
-|           | `jira_search_fields`                |                                |
-|           | `jira_get_agile_boards`             |                                |
-|           | `jira_get_board_issues`             |                                |
-|           | `jira_get_sprints_from_board`       |                                |
-|           | `jira_get_sprint_issues`            |                                |
-|           | `jira_get_issue_link_types`         |                                |
-|           | `jira_batch_get_changelogs`*        |                                |
-|           | `jira_get_user_profile`             |                                |
-|           | `jira_download_attachments`         |                                |
-|           | `jira_get_project_versions`         |                                |
-| **Write** | `jira_create_issue`                 | `confluence_create_page`       |
-|           | `jira_update_issue`                 | `confluence_update_page`       |
-|           | `jira_delete_issue`                 | `confluence_delete_page`       |
-|           | `jira_batch_create_issues`          | `confluence_add_label`         |
-|           | `jira_add_comment`                  | `confluence_add_comment`       |
-|           | `jira_transition_issue`             |                                |
-|           | `jira_add_worklog`                  |                                |
-|           | `jira_link_to_epic`                 |                                |
-|           | `jira_create_sprint`                |                                |
-|           | `jira_update_sprint`                |                                |
-|           | `jira_create_issue_link`            |                                |
-|           | `jira_remove_issue_link`            |                                |
-|           | `jira_create_version`               |                                |
-|           | `jira_batch_create_versions`        |                                |
-
-</details>
-
-*Tool only available on Jira Cloud
-
-</details>
-
-### Tool Filtering and Access Control
-
-The server provides two ways to control tool access:
-
-1. **Tool Filtering**: Use `--enabled-tools` flag or `ENABLED_TOOLS` environment variable to specify which tools should be available:
-
-   ```bash
-   # Via environment variable
-   ENABLED_TOOLS="confluence_search,jira_get_issue,jira_search"
-
-   # Or via command line flag
-   docker run ... --enabled-tools "confluence_search,jira_get_issue,jira_search" ...
-   ```
-
-2. **Read/Write Control**: Tools are categorized as read or write operations. When `READ_ONLY_MODE` is enabled, only read operations are available regardless of `ENABLED_TOOLS` setting.
-
-## Troubleshooting & Debugging
-
-### Common Issues
-
-- **Authentication Failures**:
-    - For Cloud: Check your API tokens (not your account password)
-    - For Server/Data Center: Verify your personal access token is valid and not expired
-    - For older Confluence servers: Some older versions require basic authentication with `CONFLUENCE_USERNAME` and `CONFLUENCE_API_TOKEN` (where token is your password)
-- **SSL Certificate Issues**: If using Server/Data Center and encounter SSL errors, set `CONFLUENCE_SSL_VERIFY=false` or `JIRA_SSL_VERIFY=false`
-- **Permission Errors**: Ensure your Atlassian account has sufficient permissions to access the spaces/projects
-- **Custom Headers Issues**: See the ["Debugging Custom Headers"](#debugging-custom-headers) section below to analyze and resolve issues with custom headers
-
-### Debugging Custom Headers
-
-To verify custom headers are being applied correctly:
-
-1. **Enable Debug Logging**: Set `MCP_VERY_VERBOSE=true` to see detailed request logs
-   ```bash
-   # In your .env file or environment
-   MCP_VERY_VERBOSE=true
-   MCP_LOGGING_STDOUT=true
-   ```
-
-2. **Check Header Parsing**: Custom headers appear in logs with masked values for security:
-   ```
-   DEBUG Custom headers applied: {'X-Forwarded-User': '***', 'X-ALB-Token': '***'}
-   ```
-
-3. **Verify Service-Specific Headers**: Check logs to confirm the right headers are being used:
-   ```
-   DEBUG Jira request headers: service-specific headers applied
-   DEBUG Confluence request headers: service-specific headers applied
-   ```
-
-4. **Test Header Format**: Ensure your header string format is correct:
-   ```bash
-   # Correct format
-   JIRA_CUSTOM_HEADERS=X-Custom=value1,X-Other=value2
-   CONFLUENCE_CUSTOM_HEADERS=X-Custom=value1,X-Other=value2
-
-   # Incorrect formats (will be ignored)
-   JIRA_CUSTOM_HEADERS="X-Custom=value1,X-Other=value2"  # Extra quotes
-   JIRA_CUSTOM_HEADERS=X-Custom: value1,X-Other: value2  # Colon instead of equals
-   JIRA_CUSTOM_HEADERS=X-Custom = value1               # Spaces around equals
-   ```
-
-**Security Note**: Header values containing sensitive information (tokens, passwords) are automatically masked in logs to prevent accidental exposure.
-
-### Debugging Tools
-
-```bash
-# Using MCP Inspector for testing
-npx @modelcontextprotocol/inspector uvx mcp-atlassian ...
-
-# For local development version
-npx @modelcontextprotocol/inspector uv --directory /path/to/your/mcp-atlassian run mcp-atlassian ...
-
-# View logs
-# macOS
-tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
-# Windows
-type %APPDATA%\Claude\logs\mcp*.log | more
-```
+See [Tools Reference](docs/tools-reference.md) for the complete list.
 
 ## Security
 
-- Never share API tokens
-- Keep .env files secure and private
-- See [SECURITY.md](SECURITY.md) for best practices
+Never share API tokens. Keep `.env` files secure. See [SECURITY.md](SECURITY.md).
 
 ## Contributing
 
-We welcome contributions to MCP Atlassian! If you'd like to contribute:
-
-1. Check out our [CONTRIBUTING.md](CONTRIBUTING.md) guide for detailed development setup instructions.
-2. Make changes and submit a pull request.
-
-We use pre-commit hooks for code quality and follow semantic versioning for releases.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 
 ## License
 
-Licensed under MIT - see [LICENSE](LICENSE) file. This is not an official Atlassian product.
+MIT - See [LICENSE](LICENSE). Not an official Atlassian product.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,116 @@
+# Authentication
+
+MCP Atlassian supports three authentication methods depending on your Atlassian deployment type.
+
+## API Token (Cloud) - Recommended
+
+The simplest method for Atlassian Cloud users.
+
+1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+2. Click **Create API token**, name it
+3. Copy the token immediately
+
+**Environment variables:**
+```bash
+JIRA_URL=https://your-company.atlassian.net
+JIRA_USERNAME=your.email@company.com
+JIRA_API_TOKEN=your_api_token
+
+CONFLUENCE_URL=https://your-company.atlassian.net/wiki
+CONFLUENCE_USERNAME=your.email@company.com
+CONFLUENCE_API_TOKEN=your_api_token
+```
+
+## Personal Access Token (Server/Data Center)
+
+For Server or Data Center deployments.
+
+1. Go to your profile (avatar) → **Profile** → **Personal Access Tokens**
+2. Click **Create token**, name it, set expiry
+3. Copy the token immediately
+
+**Environment variables:**
+```bash
+JIRA_URL=https://jira.your-company.com
+JIRA_PERSONAL_TOKEN=your_personal_access_token
+
+CONFLUENCE_URL=https://confluence.your-company.com
+CONFLUENCE_PERSONAL_TOKEN=your_personal_access_token
+```
+
+> **Note**: For self-signed certificates, set `JIRA_SSL_VERIFY=false` and/or `CONFLUENCE_SSL_VERIFY=false`.
+
+## OAuth 2.0 (Cloud) - Advanced
+
+OAuth 2.0 provides enhanced security features but requires more setup. For most users, API Token authentication is simpler and sufficient.
+
+### Setup Steps
+
+1. Go to [Atlassian Developer Console](https://developer.atlassian.com/console/myapps/)
+2. Create an "OAuth 2.0 (3LO) integration" app
+3. Configure **Permissions** (scopes) for Jira/Confluence
+4. Set **Callback URL** (e.g., `http://localhost:8080/callback`)
+5. Run setup wizard:
+   ```bash
+   # Using uvx
+   uvx mcp-atlassian --oauth-setup -v
+
+   # Or using Docker
+   docker run --rm -i \
+     -p 8080:8080 \
+     -v "${HOME}/.mcp-atlassian:/home/app/.mcp-atlassian" \
+     ghcr.io/sooperset/mcp-atlassian:latest --oauth-setup -v
+   ```
+6. Follow prompts for `Client ID`, `Secret`, `URI`, and `Scope`
+7. Complete browser authorization
+8. Use the obtained credentials in your configuration
+
+**Environment variables (after setup):**
+```bash
+JIRA_URL=https://your-company.atlassian.net
+CONFLUENCE_URL=https://your-company.atlassian.net/wiki
+ATLASSIAN_OAUTH_CLOUD_ID=your_cloud_id_from_wizard
+ATLASSIAN_OAUTH_CLIENT_ID=your_oauth_client_id
+ATLASSIAN_OAUTH_CLIENT_SECRET=your_oauth_client_secret
+ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback
+ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-content.all write:confluence-content offline_access
+```
+
+> **Important**: Include `offline_access` in your scope to allow automatic token refresh.
+
+### Bring Your Own Token (BYOT)
+
+If you manage OAuth tokens externally (e.g., through a central identity provider), you can provide an access token directly:
+
+**Environment variables:**
+```bash
+ATLASSIAN_OAUTH_CLOUD_ID=your_cloud_id
+ATLASSIAN_OAUTH_ACCESS_TOKEN=your_pre_existing_access_token
+```
+
+**Important considerations:**
+- Token refresh is your responsibility - the server does not handle it
+- Standard OAuth client variables are not used and can be omitted
+- The `--oauth-setup` wizard is not applicable
+- No token cache volume mount is needed
+
+### Multi-Cloud OAuth
+
+For multi-tenant applications where users provide their own OAuth tokens:
+
+1. Enable minimal OAuth mode:
+   ```bash
+   # Using uvx
+   ATLASSIAN_OAUTH_ENABLE=true uvx mcp-atlassian --transport streamable-http --port 9000
+
+   # Or using Docker
+   docker run -e ATLASSIAN_OAUTH_ENABLE=true -p 9000:9000 \
+     ghcr.io/sooperset/mcp-atlassian:latest \
+     --transport streamable-http --port 9000
+   ```
+
+2. Users provide authentication via HTTP headers:
+   - `Authorization: Bearer <user_oauth_token>`
+   - `X-Atlassian-Cloud-Id: <user_cloud_id>`
+
+See [HTTP Transport](http-transport.md) for more details on multi-user authentication.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,269 @@
+# Configuration
+
+This guide covers IDE integration, environment variables, and advanced configuration options.
+
+## IDE Integration
+
+### Configuration File Locations
+
+| IDE | Location |
+|-----|----------|
+| Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Claude Desktop (Linux) | `~/.config/Claude/claude_desktop_config.json` |
+| Cursor | Settings → MCP → + Add new global MCP server |
+
+### Basic Configuration (uvx)
+
+The simplest configuration using uvx:
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+### Docker Configuration
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "JIRA_URL",
+        "-e", "JIRA_USERNAME",
+        "-e", "JIRA_API_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+### Docker with Environment File
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "--env-file", "/path/to/your/mcp-atlassian.env",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ]
+    }
+  }
+}
+```
+
+### Server/Data Center Configuration
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": {
+        "JIRA_URL": "https://jira.your-company.com",
+        "JIRA_PERSONAL_TOKEN": "your_pat",
+        "JIRA_SSL_VERIFY": "false",
+        "CONFLUENCE_URL": "https://confluence.your-company.com",
+        "CONFLUENCE_PERSONAL_TOKEN": "your_pat",
+        "CONFLUENCE_SSL_VERIFY": "false"
+      }
+    }
+  }
+}
+```
+
+### OAuth 2.0 Configuration
+
+For standard OAuth flow (after running setup wizard):
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-v", "/path/to/home/.mcp-atlassian:/home/app/.mcp-atlassian",
+        "-e", "JIRA_URL",
+        "-e", "CONFLUENCE_URL",
+        "-e", "ATLASSIAN_OAUTH_CLIENT_ID",
+        "-e", "ATLASSIAN_OAUTH_CLIENT_SECRET",
+        "-e", "ATLASSIAN_OAUTH_REDIRECT_URI",
+        "-e", "ATLASSIAN_OAUTH_SCOPE",
+        "-e", "ATLASSIAN_OAUTH_CLOUD_ID",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "ATLASSIAN_OAUTH_CLIENT_ID": "your_client_id",
+        "ATLASSIAN_OAUTH_CLIENT_SECRET": "your_client_secret",
+        "ATLASSIAN_OAUTH_REDIRECT_URI": "http://localhost:8080/callback",
+        "ATLASSIAN_OAUTH_SCOPE": "read:jira-work write:jira-work read:confluence-content.all write:confluence-content offline_access",
+        "ATLASSIAN_OAUTH_CLOUD_ID": "your_cloud_id"
+      }
+    }
+  }
+}
+```
+
+### Single Service Configuration
+
+**Confluence only:**
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": {
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "CONFLUENCE_USERNAME": "your.email@company.com",
+        "CONFLUENCE_API_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+**Jira only:**
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+### Connection Settings
+
+| Variable | Description |
+|----------|-------------|
+| `JIRA_URL` | Jira instance URL |
+| `JIRA_USERNAME` | Jira username (email for Cloud) |
+| `JIRA_API_TOKEN` | Jira API token (Cloud) |
+| `JIRA_PERSONAL_TOKEN` | Jira Personal Access Token (Server/DC) |
+| `JIRA_SSL_VERIFY` | SSL verification (`true`/`false`) |
+| `CONFLUENCE_URL` | Confluence instance URL |
+| `CONFLUENCE_USERNAME` | Confluence username (email for Cloud) |
+| `CONFLUENCE_API_TOKEN` | Confluence API token (Cloud) |
+| `CONFLUENCE_PERSONAL_TOKEN` | Confluence Personal Access Token (Server/DC) |
+| `CONFLUENCE_SSL_VERIFY` | SSL verification (`true`/`false`) |
+
+### Filtering Options
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `JIRA_PROJECTS_FILTER` | Limit to specific Jira projects | `PROJ,DEV,SUPPORT` |
+| `CONFLUENCE_SPACES_FILTER` | Limit to specific Confluence spaces | `DEV,TEAM,DOC` |
+| `ENABLED_TOOLS` | Enable only specific tools | `confluence_search,jira_get_issue` |
+
+### Server Options
+
+| Variable | Description |
+|----------|-------------|
+| `READ_ONLY_MODE` | Disable write operations (`true`/`false`) |
+| `MCP_VERBOSE` | Enable verbose logging (`true`/`false`) |
+| `MCP_VERY_VERBOSE` | Enable debug logging (`true`/`false`) |
+| `MCP_LOGGING_STDOUT` | Log to stdout instead of stderr (`true`/`false`) |
+
+See [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) for all available options.
+
+## Proxy Configuration
+
+MCP Atlassian supports routing API requests through HTTP/HTTPS/SOCKS proxies.
+
+| Variable | Description |
+|----------|-------------|
+| `HTTP_PROXY` | HTTP proxy URL |
+| `HTTPS_PROXY` | HTTPS proxy URL |
+| `SOCKS_PROXY` | SOCKS proxy URL |
+| `NO_PROXY` | Hosts to bypass proxy |
+| `JIRA_HTTPS_PROXY` | Jira-specific HTTPS proxy |
+| `CONFLUENCE_HTTPS_PROXY` | Confluence-specific HTTPS proxy |
+
+Service-specific variables override global ones.
+
+**Example:**
+```json
+{
+  "env": {
+    "HTTPS_PROXY": "http://proxy.internal:8080",
+    "NO_PROXY": "localhost,.your-company.com"
+  }
+}
+```
+
+## Custom HTTP Headers
+
+Add custom HTTP headers to all API requests. Useful in corporate environments requiring additional headers for security or routing.
+
+| Variable | Description |
+|----------|-------------|
+| `JIRA_CUSTOM_HEADERS` | Custom headers for Jira requests |
+| `CONFLUENCE_CUSTOM_HEADERS` | Custom headers for Confluence requests |
+
+**Format:** Comma-separated `key=value` pairs.
+
+**Example:**
+```bash
+JIRA_CUSTOM_HEADERS=X-Forwarded-User=service-account,X-Custom-Auth=token
+CONFLUENCE_CUSTOM_HEADERS=X-Service=mcp-integration,X-ALB-Token=secret
+```
+
+**Security notes:**
+- Header values are masked in debug logs
+- Avoid conflicts with standard HTTP or Atlassian API headers
+- Headers are sent with every API request
+
+## Tool Filtering
+
+Control which tools are available:
+
+1. **Enable specific tools:**
+   ```bash
+   ENABLED_TOOLS="confluence_search,jira_get_issue,jira_search"
+   ```
+
+2. **Read-only mode:** Disables all write operations regardless of `ENABLED_TOOLS`:
+   ```bash
+   READ_ONLY_MODE=true
+   ```
+
+Command-line alternative:
+```bash
+uvx mcp-atlassian --enabled-tools "confluence_search,jira_get_issue"
+```

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -1,0 +1,185 @@
+# HTTP Transport
+
+Instead of using `stdio`, you can run the server as a persistent HTTP service. This enables multi-user scenarios and remote deployment.
+
+## Transport Types
+
+| Transport | Endpoint | Use Case |
+|-----------|----------|----------|
+| `sse` | `/sse` | Server-Sent Events, good for streaming |
+| `streamable-http` | `/mcp` | HTTP-based, good for multi-user |
+
+## Basic Setup
+
+### SSE Transport
+
+```bash
+# Using uvx
+uvx mcp-atlassian --transport sse --port 9000 -vv
+
+# Or using Docker
+docker run --rm -p 9000:9000 \
+  --env-file /path/to/your/.env \
+  ghcr.io/sooperset/mcp-atlassian:latest \
+  --transport sse --port 9000 -vv
+```
+
+**IDE Configuration:**
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian-http": {
+      "url": "http://localhost:9000/sse"
+    }
+  }
+}
+```
+
+### Streamable-HTTP Transport
+
+```bash
+# Using uvx
+uvx mcp-atlassian --transport streamable-http --port 9000 -vv
+
+# Or using Docker
+docker run --rm -p 9000:9000 \
+  --env-file /path/to/your/.env \
+  ghcr.io/sooperset/mcp-atlassian:latest \
+  --transport streamable-http --port 9000 -vv
+```
+
+**IDE Configuration:**
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian-service": {
+      "url": "http://localhost:9000/mcp"
+    }
+  }
+}
+```
+
+## Multi-User Authentication
+
+Both transport types support per-request authentication where each user provides their own credentials.
+
+### Authentication Methods
+
+**Cloud (OAuth 2.0):**
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian-service": {
+      "url": "http://localhost:9000/mcp",
+      "headers": {
+        "Authorization": "Bearer <USER_OAUTH_ACCESS_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+**Server/Data Center (PAT):**
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian-service": {
+      "url": "http://localhost:9000/mcp",
+      "headers": {
+        "Authorization": "Token <USER_PERSONAL_ACCESS_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+### Server Setup for Multi-User
+
+1. Run the OAuth setup wizard first (if using OAuth):
+   ```bash
+   # Using uvx
+   uvx mcp-atlassian --oauth-setup -v
+
+   # Or using Docker
+   docker run --rm -i \
+     -p 8080:8080 \
+     -v "${HOME}/.mcp-atlassian:/home/app/.mcp-atlassian" \
+     ghcr.io/sooperset/mcp-atlassian:latest --oauth-setup -v
+   ```
+
+2. Start the server with HTTP transport:
+   ```bash
+   # Using uvx (with env vars set)
+   uvx mcp-atlassian --transport streamable-http --port 9000 -vv
+
+   # Or using Docker
+   docker run --rm -p 9000:9000 \
+     --env-file /path/to/your/.env \
+     ghcr.io/sooperset/mcp-atlassian:latest \
+     --transport streamable-http --port 9000 -vv
+   ```
+
+3. Required environment variables:
+   ```bash
+   JIRA_URL=https://your-company.atlassian.net
+   CONFLUENCE_URL=https://your-company.atlassian.net/wiki
+   ATLASSIAN_OAUTH_CLIENT_ID=your_oauth_app_client_id
+   ATLASSIAN_OAUTH_CLIENT_SECRET=your_oauth_app_client_secret
+   ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback
+   ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-content.all write:confluence-content offline_access
+   ATLASSIAN_OAUTH_CLOUD_ID=your_cloud_id_from_setup_wizard
+   ```
+
+### Multi-Cloud Support
+
+For multi-tenant applications where each user connects to their own Atlassian cloud instance:
+
+1. Enable minimal OAuth mode:
+   ```bash
+   # Using uvx
+   ATLASSIAN_OAUTH_ENABLE=true uvx mcp-atlassian --transport streamable-http --port 9000
+
+   # Or using Docker
+   docker run -e ATLASSIAN_OAUTH_ENABLE=true -p 9000:9000 \
+     ghcr.io/sooperset/mcp-atlassian:latest \
+     --transport streamable-http --port 9000
+   ```
+
+2. Users provide authentication via HTTP headers:
+   - `Authorization: Bearer <user_oauth_token>`
+   - `X-Atlassian-Cloud-Id: <user_cloud_id>`
+
+**Example (Python):**
+```python
+import asyncio
+from mcp.client.streamable_http import streamablehttp_client
+from mcp import ClientSession
+
+user_token = "user-specific-oauth-token"
+user_cloud_id = "user-specific-cloud-id"
+
+async def main():
+    async with streamablehttp_client(
+        "http://localhost:9000/mcp",
+        headers={
+            "Authorization": f"Bearer {user_token}",
+            "X-Atlassian-Cloud-Id": user_cloud_id
+        }
+    ) as (read_stream, write_stream, _):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                "jira_get_issue",
+                {"issue_key": "PROJ-123"}
+            )
+            print(result)
+
+asyncio.run(main())
+```
+
+### Notes
+
+- The server should have fallback authentication configured via environment variables
+- User tokens are isolated per request - no cross-tenant data leakage
+- Falls back to global `ATLASSIAN_OAUTH_CLOUD_ID` if header not provided
+- User tokens should have appropriate scopes for their needed operations

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,129 @@
+# Installation
+
+MCP Atlassian can be installed using several methods. Choose the one that best fits your workflow.
+
+## uvx (Recommended)
+
+The simplest way to run MCP Atlassian without permanent installation using [uvx](https://docs.astral.sh/uv/guides/tools/):
+
+```bash
+# Run directly (downloads on first use, cached for subsequent runs)
+uvx mcp-atlassian --help
+
+# Run with specific Python version (required for Python 3.14+)
+uvx --python=3.12 mcp-atlassian --help
+```
+
+### IDE Configuration with uvx
+
+**Claude Desktop / Cursor:**
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": {
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "CONFLUENCE_USERNAME": "your.email@company.com",
+        "CONFLUENCE_API_TOKEN": "your_confluence_api_token",
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_jira_api_token"
+      }
+    }
+  }
+}
+```
+
+> **Note**: Python 3.14 is not yet supported due to upstream pydantic-core/PyO3 limitations.
+> Use `["--python=3.12", "mcp-atlassian"]` as args if needed.
+
+## Docker
+
+Docker provides an isolated environment and is recommended for production deployments or when you need specific version control.
+
+```bash
+# Pull the latest image
+docker pull ghcr.io/sooperset/mcp-atlassian:latest
+
+# Run with environment variables
+docker run --rm -i \
+  -e JIRA_URL=https://your-company.atlassian.net \
+  -e JIRA_USERNAME=your.email@company.com \
+  -e JIRA_API_TOKEN=your_api_token \
+  ghcr.io/sooperset/mcp-atlassian:latest
+```
+
+### IDE Configuration with Docker
+
+**Claude Desktop / Cursor:**
+
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "CONFLUENCE_URL",
+        "-e", "CONFLUENCE_USERNAME",
+        "-e", "CONFLUENCE_API_TOKEN",
+        "-e", "JIRA_URL",
+        "-e", "JIRA_USERNAME",
+        "-e", "JIRA_API_TOKEN",
+        "ghcr.io/sooperset/mcp-atlassian:latest"
+      ],
+      "env": {
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "CONFLUENCE_USERNAME": "your.email@company.com",
+        "CONFLUENCE_API_TOKEN": "your_confluence_api_token",
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_jira_api_token"
+      }
+    }
+  }
+}
+```
+
+See [Configuration](configuration.md) for more Docker configuration options including environment files.
+
+## pip
+
+Install directly with pip for development or when you need the package in your Python environment:
+
+```bash
+pip install mcp-atlassian
+
+# Run the server
+mcp-atlassian --help
+```
+
+## uv
+
+If you're using [uv](https://docs.astral.sh/uv/) for package management:
+
+```bash
+# Add to your project
+uv add mcp-atlassian
+
+# Run
+uv run mcp-atlassian --help
+```
+
+## From Source
+
+For development or contributing:
+
+```bash
+git clone https://github.com/sooperset/mcp-atlassian.git
+cd mcp-atlassian
+uv sync --frozen --all-extras --dev
+uv run mcp-atlassian --help
+```
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for development setup details.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,0 +1,86 @@
+# Tools Reference
+
+MCP Atlassian provides tools for interacting with Jira and Confluence.
+
+## Key Tools
+
+### Jira
+
+| Tool | Description |
+|------|-------------|
+| `jira_get_issue` | Get details of a specific issue |
+| `jira_search` | Search issues using JQL |
+| `jira_create_issue` | Create a new issue |
+| `jira_update_issue` | Update an existing issue |
+| `jira_transition_issue` | Transition an issue to a new status |
+| `jira_add_comment` | Add a comment to an issue |
+
+### Confluence
+
+| Tool | Description |
+|------|-------------|
+| `confluence_search` | Search content using CQL |
+| `confluence_get_page` | Get content of a specific page |
+| `confluence_create_page` | Create a new page |
+| `confluence_update_page` | Update an existing page |
+
+## Complete Tool List
+
+| Operation | Jira Tools | Confluence Tools |
+|-----------|------------|------------------|
+| **Read** | `jira_search` | `confluence_search` |
+| | `jira_get_issue` | `confluence_get_page` |
+| | `jira_get_all_projects` | `confluence_get_page_children` |
+| | `jira_get_project_issues` | `confluence_get_comments` |
+| | `jira_get_worklog` | `confluence_get_labels` |
+| | `jira_get_transitions` | `confluence_search_user` |
+| | `jira_search_fields` | |
+| | `jira_get_agile_boards` | |
+| | `jira_get_board_issues` | |
+| | `jira_get_sprints_from_board` | |
+| | `jira_get_sprint_issues` | |
+| | `jira_get_issue_link_types` | |
+| | `jira_batch_get_changelogs`* | |
+| | `jira_get_user_profile` | |
+| | `jira_download_attachments` | |
+| | `jira_get_project_versions` | |
+| **Write** | `jira_create_issue` | `confluence_create_page` |
+| | `jira_update_issue` | `confluence_update_page` |
+| | `jira_delete_issue` | `confluence_delete_page` |
+| | `jira_batch_create_issues` | `confluence_add_label` |
+| | `jira_add_comment` | `confluence_add_comment` |
+| | `jira_transition_issue` | |
+| | `jira_add_worklog` | |
+| | `jira_link_to_epic` | |
+| | `jira_create_sprint` | |
+| | `jira_update_sprint` | |
+| | `jira_create_issue_link` | |
+| | `jira_remove_issue_link` | |
+| | `jira_create_version` | |
+| | `jira_batch_create_versions` | |
+
+\* Tool only available on Jira Cloud
+
+## Tool Access Control
+
+### Enable Specific Tools
+
+Use `ENABLED_TOOLS` environment variable or `--enabled-tools` flag:
+
+```bash
+# Environment variable
+ENABLED_TOOLS="confluence_search,jira_get_issue,jira_search"
+
+# Command line
+uvx mcp-atlassian --enabled-tools "confluence_search,jira_get_issue,jira_search"
+```
+
+### Read-Only Mode
+
+Disable all write operations:
+
+```bash
+READ_ONLY_MODE=true
+```
+
+When enabled, only read operations are available regardless of `ENABLED_TOOLS` setting.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,121 @@
+# Troubleshooting
+
+## Common Issues
+
+### Authentication Failures
+
+**Cloud:**
+- Ensure you're using API tokens, not your account password
+- Verify the token hasn't expired
+- Check that `JIRA_USERNAME` / `CONFLUENCE_USERNAME` is your email address
+
+**Server/Data Center:**
+- Verify your Personal Access Token is valid and not expired
+- For older Confluence servers, try basic auth with `CONFLUENCE_USERNAME` and `CONFLUENCE_API_TOKEN` (where token is your password)
+
+### SSL Certificate Issues
+
+For Server/Data Center with self-signed certificates:
+
+```bash
+JIRA_SSL_VERIFY=false
+CONFLUENCE_SSL_VERIFY=false
+```
+
+### Permission Errors
+
+Ensure your Atlassian account has sufficient permissions to access the spaces/projects you're targeting.
+
+### Python Version Issues
+
+Python 3.14 is not yet supported due to upstream pydantic-core/PyO3 limitations.
+
+**Workaround with uvx:**
+```bash
+uvx --python=3.12 mcp-atlassian
+```
+
+**In IDE configuration:**
+```json
+{
+  "args": ["--python=3.12", "mcp-atlassian"]
+}
+```
+
+## Debugging
+
+### Enable Verbose Logging
+
+```bash
+# Standard verbose
+MCP_VERBOSE=true
+
+# Debug level (includes request details)
+MCP_VERY_VERBOSE=true
+
+# Log to stdout instead of stderr
+MCP_LOGGING_STDOUT=true
+```
+
+### View Logs
+
+**macOS:**
+```bash
+tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
+```
+
+**Windows:**
+```cmd
+type %APPDATA%\Claude\logs\mcp*.log | more
+```
+
+### MCP Inspector
+
+Test your configuration interactively:
+
+```bash
+# With uvx
+npx @modelcontextprotocol/inspector uvx mcp-atlassian
+
+# With local development version
+npx @modelcontextprotocol/inspector uv --directory /path/to/mcp-atlassian run mcp-atlassian
+```
+
+## Debugging Custom Headers
+
+### Verify Headers Are Applied
+
+1. Enable debug logging:
+   ```bash
+   MCP_VERY_VERBOSE=true
+   MCP_LOGGING_STDOUT=true
+   ```
+
+2. Check logs for header confirmation:
+   ```
+   DEBUG Custom headers applied: {'X-Forwarded-User': '***', 'X-ALB-Token': '***'}
+   ```
+
+### Correct Header Format
+
+```bash
+# Correct
+JIRA_CUSTOM_HEADERS=X-Custom=value1,X-Other=value2
+
+# Incorrect (extra quotes)
+JIRA_CUSTOM_HEADERS="X-Custom=value1,X-Other=value2"
+
+# Incorrect (colon instead of equals)
+JIRA_CUSTOM_HEADERS=X-Custom: value1,X-Other: value2
+
+# Incorrect (spaces around equals)
+JIRA_CUSTOM_HEADERS=X-Custom = value1
+```
+
+**Note:** Header values containing sensitive information are automatically masked in logs.
+
+## Getting Help
+
+- Check [GitHub Issues](https://github.com/sooperset/mcp-atlassian/issues) for known problems
+- Review [SECURITY.md](../SECURITY.md) for security-related concerns
+- Open a new issue with debug logs if the problem persists


### PR DESCRIPTION
## Description

Restructure documentation from monolithic README (~880 lines) into a slim landing page (~105 lines) + docs/ folder. Makes uvx the primary quick-start method, addressing user request for uvx documentation.

Fixes: #641

## Changes

- Rewrite README.md as slim landing page with uvx quick start
- Create docs/installation.md (uvx, Docker, pip, from source)
- Create docs/authentication.md (API tokens, PAT, OAuth, BYOT)
- Create docs/configuration.md (IDE configs, env vars, filters)
- Create docs/http-transport.md (SSE, streamable-http, multi-user)
- Create docs/tools-reference.md (all Jira/Confluence tools)
- Create docs/troubleshooting.md (common issues, debugging)

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: Verified markdown renders correctly, all links work

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).