### PR TITLE
fix(docker): remove HEALTHCHECK that breaks stdio transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Authorization: Bearer <your_oauth_token>
 # X-Atlassian-Cloud-Id: <your_cloud_id>
 
-# Health check for HTTP transport modes (SSE/Streamable HTTP)
-# This check is only relevant when using --transport sse or --transport streamable-http
-# For stdio mode (default), this check will fail but can be safely ignored
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('127.0.0.1', 8000)); s.close()" || exit 1
-
 ENTRYPOINT ["mcp-atlassian"]


### PR DESCRIPTION
## Description

Remove Docker HEALTHCHECK that was added in #755. The HEALTHCHECK assumes HTTP transport but the default is stdio, causing containers to be marked unhealthy and restarted by container orchestrators.

Fixes: #755 (follow-up)

## Changes

- Remove HEALTHCHECK directive from Dockerfile (lines 55-59)
- Remove associated comments explaining the health check

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Docker build succeeds, no HEALTHCHECK in final image

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).

---

## Why Remove?

The HEALTHCHECK added in #755 checks port 8000, but:
- Default transport is `stdio` (no network listener)
- HEALTHCHECK failures cause Docker to mark container as `unhealthy`
- Container orchestrators (k8s, Swarm) restart unhealthy containers
- This causes a restart loop for most users

## Future Consideration

If HEALTHCHECK support is desired, it should be conditional on transport mode:
- Only enable when `MCP_TRANSPORT=sse` or `MCP_TRANSPORT=streamable-http`
- Could use a separate `Dockerfile.http` for HTTP deployments