### PR TITLE
fix: ASGI protocol violations in UserTokenMiddleware

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -11,9 +11,9 @@ from fastmcp.tools import Tool as FastMCPTool
 from mcp.types import Tool as MCPTool
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.config import ConfluenceConfig
@@ -207,123 +207,166 @@ token_validation_cache: TTLCache[
 ] = TTLCache(maxsize=100, ttl=300)
 
 
-class UserTokenMiddleware(BaseHTTPMiddleware):
-    """Middleware to extract Atlassian user tokens/credentials from Authorization headers."""
+class UserTokenMiddleware:
+    """ASGI-compliant middleware to extract Atlassian user tokens/credentials.
+
+    Based on PR #700 by @isaacpalomero - fixes ASGI protocol violations that caused
+    server crashes when MCP clients disconnect during HTTP requests.
+    """
 
     def __init__(
-        self, app: Any, mcp_server_ref: Optional["AtlassianMCP"] = None
+        self, app: ASGIApp, mcp_server_ref: Optional["AtlassianMCP"] = None
     ) -> None:
-        super().__init__(app)
+        self.app = app
         self.mcp_server_ref = mcp_server_ref
         if not self.mcp_server_ref:
             logger.warning(
-                "UserTokenMiddleware initialized without mcp_server_ref. Path matching for MCP endpoint might fail if settings are needed."
+                "UserTokenMiddleware initialized without mcp_server_ref. "
+                "Path matching for MCP endpoint might fail if settings are needed."
             )
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> JSONResponse:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Pass through non-HTTP requests directly per ASGI spec
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # According to ASGI spec, middleware should copy scope when modifying it
+        scope_copy: Scope = dict(scope)
+
+        # Ensure state exists in scope - this is where Starlette stores request state
+        if "state" not in scope_copy:
+            scope_copy["state"] = {}
+
+        # Initialize default authentication state
+        scope_copy["state"]["user_atlassian_token"] = None
+        scope_copy["state"]["user_atlassian_auth_type"] = None
+        scope_copy["state"]["user_atlassian_email"] = None
+        scope_copy["state"]["user_atlassian_cloud_id"] = None
+        scope_copy["state"]["auth_validation_error"] = None
+
         logger.debug(
-            f"UserTokenMiddleware.dispatch: ENTERED for request path='{request.url.path}', method='{request.method}'"
+            f"UserTokenMiddleware: Processing {scope_copy.get('method', 'UNKNOWN')} "
+            f"{scope_copy.get('path', 'UNKNOWN')}"
         )
-        mcp_server_instance = self.mcp_server_ref
-        if mcp_server_instance is None:
-            logger.debug(
-                "UserTokenMiddleware.dispatch: self.mcp_server_ref is None. Skipping MCP auth logic."
-            )
-            return await call_next(request)
 
-        mcp_path = mcp_server_instance.settings.streamable_http_path.rstrip("/")
-        request_path = request.url.path.rstrip("/")
-        logger.debug(
-            f"UserTokenMiddleware.dispatch: Comparing request_path='{request_path}' with mcp_path='{mcp_path}'. Request method='{request.method}'"
-        )
-        if request_path == mcp_path and request.method == "POST":
-            auth_header = request.headers.get("Authorization")
-            cloud_id_header = request.headers.get("X-Atlassian-Cloud-Id")
+        # Only process authentication for our MCP endpoint
+        if self.mcp_server_ref and self._should_process_auth(scope_copy):
+            self._process_authentication_headers(scope_copy)
 
-            token_for_log = mask_sensitive(
-                auth_header.split(" ", 1)[1].strip()
-                if auth_header and " " in auth_header
-                else auth_header
-            )
-            logger.debug(
-                f"UserTokenMiddleware: Path='{request.url.path}', AuthHeader='{mask_sensitive(auth_header)}', ParsedToken(masked)='{token_for_log}', CloudId='{cloud_id_header}'"
-            )
-
-            # Extract and save cloudId if provided
-            if cloud_id_header and cloud_id_header.strip():
-                request.state.user_atlassian_cloud_id = cloud_id_header.strip()
+        # Create wrapped send function to handle client disconnections gracefully
+        async def safe_send(message: Message) -> None:
+            try:
+                await send(message)
+            except (ConnectionResetError, BrokenPipeError, OSError) as e:
+                # Client disconnected - log but don't propagate to avoid ASGI violations
                 logger.debug(
-                    f"UserTokenMiddleware: Extracted cloudId from header: {cloud_id_header.strip()}"
+                    f"Client disconnected during response: {type(e).__name__}: {e}"
+                )
+                # Don't re-raise - this prevents the ASGI protocol violation
+                return
+            except Exception:
+                # Re-raise unexpected errors
+                raise
+
+        # Call the next application with modified scope and safe send wrapper
+        await self.app(scope_copy, receive, safe_send)
+
+    def _should_process_auth(self, scope: Scope) -> bool:
+        """Check if this request should be processed for authentication."""
+        if not self.mcp_server_ref or scope.get("method") != "POST":
+            return False
+
+        try:
+            mcp_path = self.mcp_server_ref.settings.streamable_http_path.rstrip("/")
+            request_path = scope.get("path", "").rstrip("/")
+            return request_path == mcp_path
+        except (AttributeError, ValueError) as e:
+            logger.warning(f"Error checking auth path: {e}")
+            return False
+
+    def _process_authentication_headers(self, scope: Scope) -> None:
+        """Process authentication headers and store in scope state."""
+        try:
+            # Parse headers from scope (headers are byte tuples per ASGI spec)
+            headers = dict(scope.get("headers", []))
+            auth_header = headers.get(b"authorization")
+            cloud_id_header = headers.get(b"x-atlassian-cloud-id")
+
+            # Convert bytes to strings (ASGI headers are always bytes)
+            auth_header_str = auth_header.decode("latin-1") if auth_header else None
+            cloud_id_str = (
+                cloud_id_header.decode("latin-1") if cloud_id_header else None
+            )
+
+            logger.debug(
+                f"UserTokenMiddleware: Processing auth for {scope.get('path')}, "
+                f"AuthHeader present: {bool(auth_header_str)}, "
+                f"CloudId present: {bool(cloud_id_str)}"
+            )
+
+            # Process Cloud ID
+            if cloud_id_str and cloud_id_str.strip():
+                scope["state"]["user_atlassian_cloud_id"] = cloud_id_str.strip()
+                logger.debug(
+                    f"UserTokenMiddleware: Extracted cloudId: {cloud_id_str.strip()}"
+                )
+
+            # Process Authorization header
+            if auth_header_str:
+                self._parse_auth_header(auth_header_str, scope)
+            else:
+                logger.debug("UserTokenMiddleware: No Authorization header provided")
+
+        except Exception as e:
+            logger.error(f"Error processing authentication headers: {e}", exc_info=True)
+            scope["state"]["auth_validation_error"] = "Authentication processing error"
+
+    def _parse_auth_header(self, auth_header: str, scope: Scope) -> None:
+        """Parse the Authorization header and store credentials in scope state."""
+        auth_header = auth_header.strip()
+
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:].strip()  # Remove "Bearer " prefix
+            if not token:
+                scope["state"]["auth_validation_error"] = (
+                    "Unauthorized: Empty Bearer token"
                 )
             else:
-                request.state.user_atlassian_cloud_id = None
+                scope["state"]["user_atlassian_token"] = token
+                scope["state"]["user_atlassian_auth_type"] = "oauth"
                 logger.debug(
-                    "UserTokenMiddleware: No cloudId header provided, will use global config"
+                    "UserTokenMiddleware: Bearer token extracted (masked): "
+                    f"...{mask_sensitive(token, 8)}"
                 )
 
-            # Check for mcp-session-id header for debugging
-            mcp_session_id = request.headers.get("mcp-session-id")
-            if mcp_session_id:
-                logger.debug(
-                    f"UserTokenMiddleware: MCP-Session-ID header found: {mcp_session_id}"
-                )
-            if auth_header and auth_header.startswith("Bearer "):
-                token = auth_header.split(" ", 1)[1].strip()
-                if not token:
-                    return JSONResponse(
-                        {"error": "Unauthorized: Empty Bearer token"},
-                        status_code=401,
-                    )
-                logger.debug(
-                    f"UserTokenMiddleware.dispatch: Bearer token extracted (masked): ...{mask_sensitive(token, 8)}"
-                )
-                request.state.user_atlassian_token = token
-                request.state.user_atlassian_auth_type = "oauth"
-                request.state.user_atlassian_email = None
-                logger.debug(
-                    f"UserTokenMiddleware.dispatch: Set request.state (pre-validation): "
-                    f"auth_type='{getattr(request.state, 'user_atlassian_auth_type', 'N/A')}', "
-                    f"token_present={bool(getattr(request.state, 'user_atlassian_token', None))}"
-                )
-            elif auth_header and auth_header.startswith("Token "):
-                token = auth_header.split(" ", 1)[1].strip()
-                if not token:
-                    return JSONResponse(
-                        {"error": "Unauthorized: Empty Token (PAT)"},
-                        status_code=401,
-                    )
-                logger.debug(
-                    f"UserTokenMiddleware.dispatch: PAT (Token scheme) extracted (masked): ...{mask_sensitive(token, 8)}"
-                )
-                request.state.user_atlassian_token = token
-                request.state.user_atlassian_auth_type = "pat"
-                request.state.user_atlassian_email = (
-                    None  # PATs don't carry email in the token itself
-                )
-                logger.debug(
-                    "UserTokenMiddleware.dispatch: Set request.state for PAT auth."
-                )
-            elif auth_header:
-                logger.warning(
-                    f"Unsupported Authorization type for {request.url.path}: {auth_header.split(' ', 1)[0] if ' ' in auth_header else 'UnknownType'}"
-                )
-                return JSONResponse(
-                    {
-                        "error": "Unauthorized: Only 'Bearer <OAuthToken>' or 'Token <PAT>' types are supported."
-                    },
-                    status_code=401,
+        elif auth_header.startswith("Token "):
+            token = auth_header[6:].strip()  # Remove "Token " prefix
+            if not token:
+                scope["state"]["auth_validation_error"] = (
+                    "Unauthorized: Empty Token (PAT)"
                 )
             else:
+                scope["state"]["user_atlassian_token"] = token
+                scope["state"]["user_atlassian_auth_type"] = "pat"
                 logger.debug(
-                    f"No Authorization header provided for {request.url.path}. Will proceed with global/fallback server configuration if applicable."
+                    "UserTokenMiddleware: PAT token extracted (masked): "
+                    f"...{mask_sensitive(token, 8)}"
                 )
-        response = await call_next(request)
-        logger.debug(
-            f"UserTokenMiddleware.dispatch: EXITED for request path='{request.url.path}'"
-        )
-        return response
+
+        elif auth_header:
+            auth_type = (
+                auth_header.split(" ", 1)[0] if " " in auth_header else "Unknown"
+            )
+            logger.warning(f"Unsupported Authorization type: {auth_type}")
+            scope["state"]["auth_validation_error"] = (
+                "Unauthorized: Only 'Bearer <OAuthToken>' or "
+                "'Token <PAT>' types are supported."
+            )
+        else:
+            scope["state"]["auth_validation_error"] = (
+                "Unauthorized: Empty Authorization header"
+            )
 
 
 main_mcp = AtlassianMCP(name="Atlassian MCP", lifespan=main_lifespan)


### PR DESCRIPTION
## Description

Replace `BaseHTTPMiddleware` with pure ASGI-compliant implementation to fix server crashes when MCP clients disconnect during HTTP requests.

This is a critical stability fix for users running the server with HTTP/SSE transport in Docker or LangChain environments.

Fixes: #695

Based on PR #700 by @isaacpalomero - thank you for the excellent fix!

## Changes

- Replace `BaseHTTPMiddleware` with pure ASGI `__call__(scope, receive, send)` pattern
- Add `safe_send()` wrapper to gracefully handle client disconnection errors (`ConnectionResetError`, `BrokenPipeError`, `OSError`)
- Process headers as byte tuples per ASGI specification
- Use proper Starlette types (`Scope`, `Receive`, `Send`, `Message`, `ASGIApp`)
- Update tests to use ASGI-style fixtures

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `pre-commit run --all-files`, `pyright type checking`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).