### PR TITLE
fix(docs): add required favicon for Mintlify deployment

### DIFF
--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0052CC"/>
+  <text x="16" y="23" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">A</text>
+</svg>

--- a/mint.json
+++ b/mint.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://mintlify.com/schema.json",
   "name": "MCP Atlassian",
+  "favicon": "/favicon.svg",
   "colors": {
     "primary": "#0052CC",
     "light": "#4C9AFF",


### PR DESCRIPTION
## Description

Fix Mintlify deployment error: "Invalid mint.json: #.favicon: This field is required"

## Changes

- Add `favicon.svg` with Atlassian blue color scheme
- Add `favicon` field to `mint.json`

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Mintlify deployment should succeed after this fix

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).