### PR TITLE
fix(docs): add required theme field to docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
   "name": "MCP Atlassian",
   "favicon": "/favicon.svg",
   "colors": {


### PR DESCRIPTION
## Description

Fix Mintlify deployment error: `Invalid docs.json: #.theme: Invalid discriminator value`

## Changes

- Add `"theme": "mint"` to docs.json (required field)

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [ ] Manual checks performed: Verify Mintlify deployment succeeds

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).