### PR TITLE
fix(docs): move docs.json to root with docs/ prefixed paths

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "MCP Atlassian",
-  "favicon": "/favicon.svg",
+  "favicon": "/docs/favicon.svg",
   "colors": {
     "primary": "#0052CC",
     "light": "#4C9AFF",
@@ -38,23 +38,23 @@
           {
             "group": "Getting Started",
             "pages": [
-              "index",
-              "installation",
-              "authentication"
+              "docs/index",
+              "docs/installation",
+              "docs/authentication"
             ]
           },
           {
             "group": "Usage",
             "pages": [
-              "configuration",
-              "tools-reference",
-              "http-transport"
+              "docs/configuration",
+              "docs/tools-reference",
+              "docs/http-transport"
             ]
           },
           {
             "group": "Help",
             "pages": [
-              "troubleshooting"
+              "docs/troubleshooting"
             ]
           }
         ]


### PR DESCRIPTION
## Description

Fix Mintlify deployment - it requires docs.json at repository root.

## Changes

- Move `docs/docs.json` back to root as `docs.json`
- Update navigation paths to include `docs/` prefix
- Update favicon path to `/docs/favicon.svg`

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [ ] Manual checks performed: Verify Mintlify deployment

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).