### PR TITLE
fix(jira): add proper optional type hints to comment visibility params

### DIFF
--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -53,7 +53,7 @@ class CommentsMixin(JiraClient):
             raise Exception(f"Error getting comments: {str(e)}") from e
 
     def add_comment(
-        self, issue_key: str, comment: str, visibility: dict[str, str] = None
+        self, issue_key: str, comment: str, visibility: dict[str, str] | None = None
     ) -> dict[str, Any]:
         """
         Add a comment to an issue.
@@ -96,7 +96,7 @@ class CommentsMixin(JiraClient):
         issue_key: str,
         comment_id: str,
         comment: str,
-        visibility: dict[str, str] = None,
+        visibility: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """
         Edit an existing comment on an issue.

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1043,7 +1043,7 @@ async def add_comment(
     issue_key: Annotated[str, Field(description="Jira issue key (e.g., 'PROJ-123')")],
     comment: Annotated[str, Field(description="Comment text in Markdown format")],
     visibility: Annotated[
-        dict[str, str],
+        dict[str, str] | None,
         Field(
             description="""(Optional) Comment visibility (e.g. {"type":"group","value":"jira-users"})"""
         ),
@@ -1082,7 +1082,7 @@ async def edit_comment(
         str, Field(description="Updated comment text in Markdown format")
     ],
     visibility: Annotated[
-        dict[str, str],
+        dict[str, str] | None,
         Field(
             description="""(Optional) Comment visibility (e.g. {"type":"group","value":"jira-users"})"""
         ),


### PR DESCRIPTION
## Description

Fixes type hints for the `visibility` parameter in `add_comment` and `edit_comment` functions.

The parameter was typed as `dict[str, str]` with a `None` default value, which is technically incorrect since `None` is not assignable to `dict[str, str]`. Changed to `dict[str, str] | None` to properly express the optional nature.

## Changes

- `src/mcp_atlassian/jira/comments.py`: Fix type hints for `add_comment` and `edit_comment` visibility params
- `src/mcp_atlassian/servers/jira.py`: Fix type hints in Annotated types for both tool functions

## Testing

- [x] Pre-commit hooks pass (ruff, mypy)
- [x] No functional changes, type hints only

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] All tests pass locally.