### PR TITLE
fix(docker): add PYTHONUNBUFFERED for proper stdio communication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ COPY --from=uv --chown=app:app /app/.venv /app/.venv
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Disable Python output buffering for proper stdio communication
+ENV PYTHONUNBUFFERED=1
+
 # For minimal OAuth setup without environment variables, use:
 # docker run -e ATLASSIAN_OAUTH_ENABLE=true -p 8000:8000 your-image
 # Then provide authentication via headers:


### PR DESCRIPTION
## Description

Add `ENV PYTHONUNBUFFERED=1` to disable Python output buffering when running in Docker containers without TTY. This ensures proper JSON-RPC communication via stdin/stdout.

Fixes: #697

## Changes

- Add `ENV PYTHONUNBUFFERED=1` to Dockerfile final stage
- This ensures unbuffered output for proper MCP protocol communication

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: Docker build verification

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).