### PR TITLE
docs: add JIRA_PERSONAL_TOKEN note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Add to your Claude Desktop or Cursor MCP configuration:
 
 > **Python 3.14 not yet supported.** Use `["--python=3.12", "mcp-atlassian"]` as args if needed.
 
+> **Server/Data Center users**: Use `JIRA_PERSONAL_TOKEN` instead of `JIRA_USERNAME` + `JIRA_API_TOKEN`. See [Authentication](https://personal-1d37018d.mintlify.app/docs/authentication) for details.
+
 ### 3. Start Using
 
 Ask your AI assistant to:


### PR DESCRIPTION
## Description

Add callout for Server/Data Center users to use `JIRA_PERSONAL_TOKEN` instead of username/token combination. Links to full authentication documentation.

Fixes: #635

## Changes

- Add callout note after the Quick Start config example
- Link to Authentication documentation for more details

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: Visual inspection of README rendering

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).