### PR TITLE
Fix high CPU usage on Windows by using SelectorEventLoop

### DIFF
--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -7,6 +7,13 @@ from importlib.metadata import PackageNotFoundError, version
 import click
 from dotenv import load_dotenv
 
+# Fix high CPU usage on Windows - use SelectorEventLoop instead of ProactorEventLoop
+# ProactorEventLoop uses IOCP which can cause busy-waiting when combined with
+# synchronous libraries (like requests) that use select() for socket operations.
+# This reduces idle CPU usage from ~3-5% per process to near zero.
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 from mcp_atlassian.utils.env import is_env_truthy
 from mcp_atlassian.utils.lifecycle import (
     ensure_clean_exit,


### PR DESCRIPTION
Fixes #820

## Problem

On Windows, the MCP server consumes approximately 3-5% CPU per process even when completely idle. With multiple Claude Code instances running, this adds up to significant CPU usage (e.g., 4 instances = ~5 CPU cores constantly active).

## Root Cause

Python's default `ProactorEventLoop` on Windows uses IOCP (I/O Completion Ports), which can cause busy-waiting when combined with synchronous HTTP libraries like `requests` (used by `atlassian-python-api`) that internally use `select()` for socket operations.

Profiling with `py-spy` showed the issue in the Windows asyncio event loop polling:
```
ZwWaitForSingleObject (ntdll.dll)
select (WS2_32.dll)
windows_events.py:322
```

## Solution

Switch to `WindowsSelectorEventLoopPolicy` on Windows, which uses the traditional selector-based approach. This is more efficient when the server is idle and is compatible with libraries that expect a selector-based event loop.

```python
if sys.platform == "win32":
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

## Results

- **Before**: ~3-5% CPU usage per idle MCP server process
- **After**: Near 0% CPU usage when idle

## Testing

Tested on Windows 11 with Python 3.13. The fix is applied early in module initialization and only affects Windows systems.