### PR TITLE
fix(auth): prioritize PAT over OAuth for Server/DC instances

### DIFF
--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -96,20 +96,27 @@ class JiraConfig:
         # Use the shared utility function directly
         is_cloud = is_atlassian_cloud_url(url)
 
-        if oauth_config:
-            # OAuth is available - could be full config or minimal config for user-provided tokens
-            auth_type = "oauth"
-        elif is_cloud:
-            if username and api_token:
+        if is_cloud:
+            # Cloud: OAuth takes priority, then basic auth
+            if oauth_config:
+                auth_type = "oauth"
+            elif username and api_token:
                 auth_type = "basic"
             else:
                 error_msg = "Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN, or OAuth configuration (set ATLASSIAN_OAUTH_ENABLE=true for user-provided tokens)"
                 raise ValueError(error_msg)
         else:  # Server/Data Center
+            # Server/DC: PAT takes priority over OAuth (fixes #824)
             if personal_token:
+                if oauth_config:
+                    logger = logging.getLogger("mcp-atlassian.jira.config")
+                    logger.warning(
+                        "Both PAT and OAuth configured for Server/DC. Using PAT."
+                    )
                 auth_type = "pat"
+            elif oauth_config:
+                auth_type = "oauth"
             elif username and api_token:
-                # Allow basic auth for Server/DC too
                 auth_type = "basic"
             else:
                 error_msg = "Server/Data Center authentication requires JIRA_PERSONAL_TOKEN or JIRA_USERNAME and JIRA_API_TOKEN"

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -183,3 +183,21 @@ def test_is_cloud_oauth_with_cloud_id():
         oauth_config=oauth_config,
     )
     assert config.is_cloud is True
+
+
+def test_from_env_pat_priority_over_oauth(caplog):
+    """Test that PAT takes priority over OAuth for Server/DC (fixes #824)."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",  # Server/DC URL
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+            "ATLASSIAN_OAUTH_ENABLE": "true",  # OAuth also enabled
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.auth_type == "pat"
+        assert config.personal_token == "test_pat"
+        # Verify warning is logged when both are configured
+        assert "Both PAT and OAuth configured for Server/DC. Using PAT." in caplog.text


### PR DESCRIPTION
## Description

When using PAT authentication with Jira/Confluence Data Center, the code was checking OAuth first. If `ATLASSIAN_OAUTH_ENABLE=true` was set (even without full OAuth config), it returned a "minimal OAuth config" which then failed because OAuth wasn't properly configured for Server/DC.

Fixes: #824

## Changes

- Reorder auth priority in `JiraConfig.from_env()` so PAT is checked before OAuth for Server/DC URLs
- Reorder auth priority in `ConfluenceConfig.from_env()` with the same fix
- Cloud instances continue to check OAuth first (intended behavior)
- Add regression tests for both Jira and Confluence configs

## Testing

- [x] Unit tests added/updated
- [x] All tests pass locally
- [x] Manual verification: `pre-commit run --all-files` passes

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed). N/A - behavior fix, no doc changes needed.