### PR TITLE
revert: remove incorrect block=True fix for CPU issue (#825)

### DIFF
--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -49,7 +49,7 @@ class SSLIgnoreAdapter(HTTPAdapter):
         self.poolmanager = PoolManager(
             num_pools=connections,
             maxsize=maxsize,
-            block=True,  # Force blocking to prevent CPU busy-wait (#820)
+            block=block,
             ssl_context=context,
             **pool_kwargs,
         )


### PR DESCRIPTION
## Description

Reverts PR #825 which was incorrectly identified as the fix for #820.

## Why PR #825 was wrong

The `SSLIgnoreAdapter` fix only applies when `ssl_verify=False`:
- Original reporter used **Jira Cloud** with default settings
- SSL verification is **enabled** by default
- The `SSLIgnoreAdapter` code was **never executed**

## Correct fix

PR #821 (`WindowsSelectorEventLoopPolicy`) targets the actual issue - the Windows asyncio event loop which is always running.

## Changes

- Revert `block=True` back to `block=block` in `SSLIgnoreAdapter.init_poolmanager()`

Reverts sooperset/mcp-atlassian#825