### PR TITLE
feat(jira): Add jira_get_issue_dates tool for date extraction

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -8,6 +8,8 @@ This module provides various Jira API client implementations.
 # Re-export the Jira class for backward compatibility
 from atlassian.jira import Jira
 
+from .attachments import AttachmentsMixin
+from .boards import BoardsMixin
 from .client import JiraClient
 from .comments import CommentsMixin
 from .config import JiraConfig
@@ -16,14 +18,13 @@ from .fields import FieldsMixin
 from .formatting import FormattingMixin
 from .issues import IssuesMixin
 from .links import LinksMixin
+from .metrics import MetricsMixin
 from .projects import ProjectsMixin
 from .search import SearchMixin
 from .sprints import SprintsMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
 from .worklog import WorklogMixin
-from .boards import BoardsMixin
-from .attachments import AttachmentsMixin
 
 
 class JiraFetcher(
@@ -41,6 +42,7 @@ class JiraFetcher(
     SprintsMixin,
     AttachmentsMixin,
     LinksMixin,
+    MetricsMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -60,6 +62,7 @@ class JiraFetcher(
     - SprintsMixin: Sprint operations
     - AttachmentsMixin: Attachment download operations
     - LinksMixin: Issue link operations
+    - MetricsMixin: Issue metrics and date operations
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.
@@ -68,4 +71,4 @@ class JiraFetcher(
     pass
 
 
-__all__ = ["JiraFetcher", "JiraConfig", "JiraClient", "Jira"]
+__all__ = ["JiraFetcher", "JiraConfig", "JiraClient", "Jira", "MetricsMixin"]

--- a/src/mcp_atlassian/jira/metrics.py
+++ b/src/mcp_atlassian/jira/metrics.py
@@ -1,0 +1,408 @@
+"""Module for Jira issue metrics and date operations."""
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from ..models.jira.common import JiraChangelog
+from ..models.jira.metrics import (
+    IssueDatesBatchResponse,
+    IssueDatesResponse,
+    StatusChangeEntry,
+    StatusTimeSummary,
+)
+from ..utils import parse_date
+from .client import JiraClient
+from .protocols import IssueOperationsProto
+
+logger = logging.getLogger("mcp-jira")
+
+
+class MetricsMixin(JiraClient, IssueOperationsProto):
+    """Mixin for Jira issue metrics and date operations."""
+
+    def get_issue_dates(
+        self,
+        issue_key: str,
+        include_created: bool = True,
+        include_updated: bool = True,
+        include_due_date: bool = True,
+        include_resolution_date: bool = True,
+        include_status_changes: bool = True,
+        include_status_summary: bool = True,
+    ) -> IssueDatesResponse:
+        """
+        Get raw date information for a single Jira issue.
+
+        Args:
+            issue_key: The issue key (e.g., PROJECT-123)
+            include_created: Include the created date
+            include_updated: Include the updated date
+            include_due_date: Include the due date
+            include_resolution_date: Include the resolution date
+            include_status_changes: Include status change history
+            include_status_summary: Include aggregated time per status
+
+        Returns:
+            IssueDatesResponse with the requested date information
+
+        Raises:
+            ValueError: If the issue cannot be found
+            Exception: If there is an error retrieving the issue
+        """
+        try:
+            # Build fields list based on what we need
+            fields_needed = ["status"]
+            if include_created:
+                fields_needed.append("created")
+            if include_updated:
+                fields_needed.append("updated")
+            if include_due_date:
+                fields_needed.append("duedate")
+            if include_resolution_date:
+                fields_needed.append("resolutiondate")
+
+            # Get issue with changelog if status changes are needed
+            expand = None
+            if include_status_changes or include_status_summary:
+                expand = "changelog"
+
+            issue = self.jira.get_issue(
+                issue_key,
+                expand=expand,
+                fields=",".join(fields_needed),
+            )
+
+            if not issue:
+                raise ValueError(f"Issue {issue_key} not found")
+            if not isinstance(issue, dict):
+                raise TypeError(f"Unexpected return type: {type(issue)}")
+
+            fields = issue.get("fields", {}) or {}
+
+            # Parse dates
+            created = None
+            updated = None
+            due_date = None
+            resolution_date = None
+            current_status = None
+
+            if include_created and "created" in fields:
+                created = parse_date(fields["created"])
+
+            if include_updated and "updated" in fields:
+                updated = parse_date(fields["updated"])
+
+            if include_due_date and "duedate" in fields and fields["duedate"]:
+                due_date = parse_date(fields["duedate"])
+
+            if include_resolution_date and "resolutiondate" in fields:
+                if fields["resolutiondate"]:
+                    resolution_date = parse_date(fields["resolutiondate"])
+
+            # Get current status
+            status_field = fields.get("status", {})
+            if status_field:
+                current_status = status_field.get("name")
+
+            # Parse changelog for status changes
+            status_changes: list[StatusChangeEntry] = []
+            status_summary: list[StatusTimeSummary] = []
+
+            if include_status_changes or include_status_summary:
+                changelog_data = issue.get("changelog", {})
+                if changelog_data:
+                    histories = changelog_data.get("histories", [])
+                    changelogs = [JiraChangelog.from_api_response(h) for h in histories]
+
+                    if include_status_changes:
+                        status_changes = self._parse_changelog_to_status_changes(
+                            issue_key, changelogs, created
+                        )
+
+                    if include_status_summary:
+                        status_summary = self._aggregate_status_times(status_changes)
+
+            return IssueDatesResponse(
+                issue_key=issue_key,
+                created=created,
+                updated=updated,
+                due_date=due_date,
+                resolution_date=resolution_date,
+                current_status=current_status,
+                status_changes=status_changes,
+                status_summary=status_summary,
+            )
+
+        except Exception as e:
+            logger.error(f"Error getting dates for issue {issue_key}: {str(e)}")
+            raise
+
+    def batch_get_issue_dates(
+        self,
+        issue_keys: list[str],
+        include_created: bool = True,
+        include_updated: bool = True,
+        include_due_date: bool = True,
+        include_resolution_date: bool = True,
+        include_status_changes: bool = True,
+        include_status_summary: bool = True,
+    ) -> IssueDatesBatchResponse:
+        """
+        Get raw date information for multiple Jira issues.
+
+        Args:
+            issue_keys: List of issue keys (e.g., ['PROJECT-123', 'PROJECT-456'])
+            include_created: Include the created date
+            include_updated: Include the updated date
+            include_due_date: Include the due date
+            include_resolution_date: Include the resolution date
+            include_status_changes: Include status change history
+            include_status_summary: Include aggregated time per status
+
+        Returns:
+            IssueDatesBatchResponse with results for all issues
+        """
+        issues: list[IssueDatesResponse] = []
+        errors: list[dict[str, str]] = []
+
+        for issue_key in issue_keys:
+            try:
+                issue_dates = self.get_issue_dates(
+                    issue_key=issue_key,
+                    include_created=include_created,
+                    include_updated=include_updated,
+                    include_due_date=include_due_date,
+                    include_resolution_date=include_resolution_date,
+                    include_status_changes=include_status_changes,
+                    include_status_summary=include_status_summary,
+                )
+                issues.append(issue_dates)
+            except Exception as e:
+                logger.warning(f"Error getting dates for {issue_key}: {str(e)}")
+                errors.append(
+                    {
+                        "issue_key": issue_key,
+                        "error": str(e),
+                    }
+                )
+
+        return IssueDatesBatchResponse(
+            issues=issues,
+            total_count=len(issue_keys),
+            success_count=len(issues),
+            error_count=len(errors),
+            errors=errors,
+        )
+
+    def _parse_changelog_to_status_changes(
+        self,
+        issue_key: str,
+        changelogs: list[JiraChangelog],
+        created_date: datetime | None,
+    ) -> list[StatusChangeEntry]:
+        """
+        Parse changelog to extract status transitions.
+
+        Algorithm:
+        1. Filter changelog items where field == "status"
+        2. Sort by timestamp ascending
+        3. For each status change, record:
+           - status name (to_string)
+           - entered_at (changelog.created)
+           - exited_at (next changelog.created or None if current)
+           - transitioned_by (changelog.author)
+        4. Calculate duration_minutes for each entry
+
+        Args:
+            issue_key: The issue key for logging
+            changelogs: List of JiraChangelog objects
+            created_date: The issue creation date (for initial status)
+
+        Returns:
+            List of StatusChangeEntry objects in chronological order
+        """
+        # Collect all status changes from changelog
+        status_transitions: list[dict[str, Any]] = []
+
+        for changelog in changelogs:
+            if not changelog.created:
+                continue
+
+            for item in changelog.items:
+                if item.field.lower() == "status":
+                    author_name = None
+                    if changelog.author:
+                        author_name = changelog.author.display_name
+
+                    status_transitions.append(
+                        {
+                            "from_status": item.from_string,
+                            "to_status": item.to_string,
+                            "timestamp": changelog.created,
+                            "transitioned_by": author_name,
+                        }
+                    )
+
+        # Sort by timestamp ascending
+        status_transitions.sort(key=lambda x: x["timestamp"])
+
+        # Build status change entries
+        entries: list[StatusChangeEntry] = []
+
+        # Add initial status if we have a created date and status transitions
+        if created_date and status_transitions:
+            first_transition = status_transitions[0]
+            initial_status = first_transition.get("from_status")
+            if initial_status:
+                first_timestamp = first_transition["timestamp"]
+                duration_minutes = self._calculate_duration_minutes(
+                    created_date, first_timestamp
+                )
+                entries.append(
+                    StatusChangeEntry(
+                        status=initial_status,
+                        entered_at=created_date,
+                        exited_at=first_timestamp,
+                        duration_minutes=duration_minutes,
+                        duration_formatted=self._format_duration(duration_minutes),
+                        transitioned_by=None,  # Created by, not transitioned
+                    )
+                )
+
+        # Process each status transition
+        for i, transition in enumerate(status_transitions):
+            to_status = transition.get("to_status")
+            if not to_status:
+                continue
+
+            entered_at = transition["timestamp"]
+
+            # Determine exit time (next transition or None if current)
+            exited_at = None
+            if i + 1 < len(status_transitions):
+                exited_at = status_transitions[i + 1]["timestamp"]
+
+            # Calculate duration
+            duration_minutes = None
+            duration_formatted = None
+            if exited_at:
+                duration_minutes = self._calculate_duration_minutes(
+                    entered_at, exited_at
+                )
+                duration_formatted = self._format_duration(duration_minutes)
+
+            entries.append(
+                StatusChangeEntry(
+                    status=to_status,
+                    entered_at=entered_at,
+                    exited_at=exited_at,
+                    duration_minutes=duration_minutes,
+                    duration_formatted=duration_formatted,
+                    transitioned_by=transition.get("transitioned_by"),
+                )
+            )
+
+        return entries
+
+    def _aggregate_status_times(
+        self,
+        status_changes: list[StatusChangeEntry],
+    ) -> list[StatusTimeSummary]:
+        """
+        Aggregate time spent in each status across all visits.
+
+        Args:
+            status_changes: List of StatusChangeEntry objects
+
+        Returns:
+            List of StatusTimeSummary objects, one per unique status
+        """
+        # Aggregate by status name
+        status_times: defaultdict[str, dict[str, int]] = defaultdict(
+            lambda: {"total_minutes": 0, "visit_count": 0}
+        )
+
+        for entry in status_changes:
+            if entry.duration_minutes is not None:
+                status_times[entry.status]["total_minutes"] += entry.duration_minutes
+                status_times[entry.status]["visit_count"] += 1
+            elif entry.exited_at is None:
+                # Current status - count the visit but don't add duration
+                status_times[entry.status]["visit_count"] += 1
+
+        # Build summary list
+        summaries: list[StatusTimeSummary] = []
+        for status_name, data in status_times.items():
+            summaries.append(
+                StatusTimeSummary(
+                    status=status_name,
+                    total_duration_minutes=data["total_minutes"],
+                    total_duration_formatted=self._format_duration(
+                        data["total_minutes"]
+                    ),
+                    visit_count=data["visit_count"],
+                )
+            )
+
+        # Sort by total duration descending
+        summaries.sort(key=lambda x: x.total_duration_minutes, reverse=True)
+
+        return summaries
+
+    def _calculate_duration_minutes(
+        self,
+        start: datetime,
+        end: datetime,
+    ) -> int:
+        """
+        Calculate duration in minutes between two timestamps.
+
+        Args:
+            start: Start datetime
+            end: End datetime
+
+        Returns:
+            Duration in minutes (rounded)
+        """
+        delta = end - start
+        return int(delta.total_seconds() / 60)
+
+    def _format_duration(self, minutes: int) -> str:
+        """
+        Format minutes into human-readable string.
+
+        Examples:
+        - 90 -> "1h 30m"
+        - 1500 -> "1d 1h 0m"
+        - 0 -> "0m"
+
+        Rules:
+        - 1 day = 24 hours (calendar time)
+        - 1 hour = 60 minutes
+        - Always show minutes
+        - Omit days/hours if zero (except "0m")
+
+        Args:
+            minutes: Duration in minutes
+
+        Returns:
+            Formatted duration string
+        """
+        if minutes <= 0:
+            return "0m"
+
+        days = minutes // (24 * 60)
+        remaining = minutes % (24 * 60)
+        hours = remaining // 60
+        mins = remaining % 60
+
+        parts = []
+        if days > 0:
+            parts.append(f"{days}d")
+        if hours > 0 or days > 0:  # Show hours if days are shown
+            parts.append(f"{hours}h")
+        parts.append(f"{mins}m")
+
+        return " ".join(parts)

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -24,6 +24,12 @@ from .link import (
     JiraLinkedIssue,
     JiraLinkedIssueFields,
 )
+from .metrics import (
+    IssueDatesBatchResponse,
+    IssueDatesResponse,
+    StatusChangeEntry,
+    StatusTimeSummary,
+)
 from .project import JiraProject
 from .search import JiraSearchResult
 from .workflow import JiraTransition
@@ -52,4 +58,9 @@ __all__ = [
     "JiraIssueLink",
     "JiraLinkedIssue",
     "JiraLinkedIssueFields",
+    # Metrics models
+    "IssueDatesResponse",
+    "IssueDatesBatchResponse",
+    "StatusChangeEntry",
+    "StatusTimeSummary",
 ]

--- a/src/mcp_atlassian/models/jira/metrics.py
+++ b/src/mcp_atlassian/models/jira/metrics.py
@@ -1,0 +1,231 @@
+"""
+Metrics data models for Jira issue dates and status changes.
+
+This module provides Pydantic models for issue date information,
+status change history, and aggregated time tracking data.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import Field
+
+from ..base import ApiModel
+
+
+class StatusChangeEntry(ApiModel):
+    """
+    Model representing a single status transition for an issue.
+
+    Tracks when an issue entered and exited a specific status,
+    including duration spent in that status.
+    """
+
+    status: str = Field(description="The name of the status")
+    entered_at: datetime = Field(description="When the issue entered this status")
+    exited_at: datetime | None = Field(
+        default=None,
+        description="When the issue exited this status (None if current status)",
+    )
+    duration_minutes: int | None = Field(
+        default=None, description="Total minutes spent in this status"
+    )
+    duration_formatted: str | None = Field(
+        default=None, description="Human-readable duration (e.g., '2d 3h 15m')"
+    )
+    transitioned_by: str | None = Field(
+        default=None, description="Display name of the user who made the transition"
+    )
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "StatusChangeEntry":
+        """Create a StatusChangeEntry from data."""
+        return cls(**data)
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "status": self.status,
+            "entered_at": self.entered_at.isoformat(),
+        }
+        if self.exited_at:
+            result["exited_at"] = self.exited_at.isoformat()
+        if self.duration_minutes is not None:
+            result["duration_minutes"] = self.duration_minutes
+        if self.duration_formatted:
+            result["duration_formatted"] = self.duration_formatted
+        if self.transitioned_by:
+            result["transitioned_by"] = self.transitioned_by
+        return result
+
+
+class StatusTimeSummary(ApiModel):
+    """
+    Model representing aggregated time spent in a specific status.
+
+    Used to provide a summary of total time an issue has spent
+    in each status across all transitions.
+    """
+
+    status: str = Field(description="The name of the status")
+    total_duration_minutes: int = Field(
+        description="Total minutes spent in this status across all visits"
+    )
+    total_duration_formatted: str = Field(description="Human-readable total duration")
+    visit_count: int = Field(
+        default=1, description="Number of times the issue was in this status"
+    )
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "StatusTimeSummary":
+        """Create a StatusTimeSummary from data."""
+        return cls(**data)
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        return {
+            "status": self.status,
+            "total_duration_minutes": self.total_duration_minutes,
+            "total_duration_formatted": self.total_duration_formatted,
+            "visit_count": self.visit_count,
+        }
+
+
+class IssueDatesResponse(ApiModel):
+    """
+    Model representing raw date information for a single issue.
+
+    This is the response model for the jira_get_issue_dates tool,
+    providing both core dates and optional status change history.
+    """
+
+    issue_key: str = Field(description="The Jira issue key (e.g., 'PROJ-123')")
+    created: datetime | None = Field(
+        default=None, description="When the issue was created"
+    )
+    updated: datetime | None = Field(
+        default=None, description="When the issue was last updated"
+    )
+    due_date: datetime | None = Field(
+        default=None, description="The due date for the issue"
+    )
+    resolution_date: datetime | None = Field(
+        default=None, description="When the issue was resolved"
+    )
+    current_status: str | None = Field(
+        default=None, description="The current status of the issue"
+    )
+    status_changes: list[StatusChangeEntry] = Field(
+        default_factory=list, description="History of status transitions"
+    )
+    status_summary: list[StatusTimeSummary] = Field(
+        default_factory=list, description="Aggregated time spent in each status"
+    )
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "IssueDatesResponse":
+        """Create an IssueDatesResponse from data."""
+        status_changes = [
+            StatusChangeEntry.from_api_response(sc)
+            for sc in data.get("status_changes", [])
+        ]
+        status_summary = [
+            StatusTimeSummary.from_api_response(ss)
+            for ss in data.get("status_summary", [])
+        ]
+        return cls(
+            issue_key=data["issue_key"],
+            created=data.get("created"),
+            updated=data.get("updated"),
+            due_date=data.get("due_date"),
+            resolution_date=data.get("resolution_date"),
+            current_status=data.get("current_status"),
+            status_changes=status_changes,
+            status_summary=status_summary,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "issue_key": self.issue_key,
+        }
+
+        if self.created:
+            result["created"] = self.created.isoformat()
+        if self.updated:
+            result["updated"] = self.updated.isoformat()
+        if self.due_date:
+            result["due_date"] = self.due_date.isoformat()
+        if self.resolution_date:
+            result["resolution_date"] = self.resolution_date.isoformat()
+        if self.current_status:
+            result["current_status"] = self.current_status
+
+        if self.status_changes:
+            result["status_changes"] = [
+                sc.to_simplified_dict() for sc in self.status_changes
+            ]
+        if self.status_summary:
+            result["status_summary"] = [
+                ss.to_simplified_dict() for ss in self.status_summary
+            ]
+
+        return result
+
+
+class IssueDatesBatchResponse(ApiModel):
+    """
+    Model representing batch response for multiple issues.
+
+    Wraps multiple IssueDatesResponse objects with metadata
+    about the batch operation.
+    """
+
+    issues: list[IssueDatesResponse] = Field(
+        default_factory=list, description="List of issue date responses"
+    )
+    total_count: int = Field(default=0, description="Total number of issues processed")
+    success_count: int = Field(
+        default=0, description="Number of issues successfully processed"
+    )
+    error_count: int = Field(
+        default=0, description="Number of issues that failed to process"
+    )
+    errors: list[dict[str, str]] = Field(
+        default_factory=list, description="List of errors for failed issues"
+    )
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "IssueDatesBatchResponse":
+        """Create an IssueDatesBatchResponse from data."""
+        issues = [
+            IssueDatesResponse.from_api_response(issue)
+            for issue in data.get("issues", [])
+        ]
+        return cls(
+            issues=issues,
+            total_count=data.get("total_count", len(issues)),
+            success_count=data.get("success_count", len(issues)),
+            error_count=data.get("error_count", 0),
+            errors=data.get("errors", []),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "total_count": self.total_count,
+            "success_count": self.success_count,
+            "error_count": self.error_count,
+            "issues": [issue.to_simplified_dict() for issue in self.issues],
+        }
+        if self.errors:
+            result["errors"] = self.errors
+        return result

--- a/tests/unit/jira/test_metrics.py
+++ b/tests/unit/jira/test_metrics.py
@@ -1,0 +1,348 @@
+"""Tests for the Jira Metrics mixin."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.metrics import MetricsMixin
+from mcp_atlassian.models.jira.metrics import (
+    IssueDatesBatchResponse,
+    IssueDatesResponse,
+    StatusChangeEntry,
+    StatusTimeSummary,
+)
+
+
+class TestMetricsMixin:
+    """Tests for the MetricsMixin class."""
+
+    @pytest.fixture
+    def metrics_mixin(self, jira_fetcher: JiraFetcher) -> MetricsMixin:
+        """Create a MetricsMixin instance with mocked dependencies."""
+        return jira_fetcher
+
+    def test_format_duration_zero_minutes(self, metrics_mixin: MetricsMixin):
+        """Test formatting zero minutes."""
+        result = metrics_mixin._format_duration(0)
+        assert result == "0m"
+
+    def test_format_duration_negative_minutes(self, metrics_mixin: MetricsMixin):
+        """Test formatting negative minutes."""
+        result = metrics_mixin._format_duration(-10)
+        assert result == "0m"
+
+    def test_format_duration_minutes_only(self, metrics_mixin: MetricsMixin):
+        """Test formatting when only minutes are present."""
+        result = metrics_mixin._format_duration(45)
+        assert result == "45m"
+
+    def test_format_duration_hours_and_minutes(self, metrics_mixin: MetricsMixin):
+        """Test formatting hours and minutes."""
+        result = metrics_mixin._format_duration(90)  # 1h 30m
+        assert result == "1h 30m"
+
+    def test_format_duration_days_hours_minutes(self, metrics_mixin: MetricsMixin):
+        """Test formatting days, hours, and minutes."""
+        result = metrics_mixin._format_duration(1500)  # 1d 1h 0m
+        assert result == "1d 1h 0m"
+
+    def test_format_duration_multiple_days(self, metrics_mixin: MetricsMixin):
+        """Test formatting multiple days."""
+        result = metrics_mixin._format_duration(4320)  # 3 days
+        assert result == "3d 0h 0m"
+
+    def test_calculate_duration_minutes(self, metrics_mixin: MetricsMixin):
+        """Test calculating duration between two timestamps."""
+        start = datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2023, 1, 1, 11, 30, 0, tzinfo=timezone.utc)
+
+        result = metrics_mixin._calculate_duration_minutes(start, end)
+        assert result == 90  # 1.5 hours = 90 minutes
+
+    def test_get_issue_dates_basic(self, metrics_mixin: MetricsMixin):
+        """Test getting basic date information for an issue."""
+        # Mock the API response
+        metrics_mixin.jira.get_issue.return_value = {
+            "id": "10001",
+            "key": "TEST-123",
+            "fields": {
+                "created": "2023-01-01T00:00:00.000+0000",
+                "updated": "2023-01-15T12:00:00.000+0000",
+                "duedate": "2023-02-01",
+                "resolutiondate": "2023-01-20T10:00:00.000+0000",
+                "status": {"name": "Done"},
+            },
+        }
+
+        result = metrics_mixin.get_issue_dates("TEST-123")
+
+        assert isinstance(result, IssueDatesResponse)
+        assert result.issue_key == "TEST-123"
+        assert result.created is not None
+        assert result.updated is not None
+        assert result.current_status == "Done"
+
+    def test_get_issue_dates_with_changelog(self, metrics_mixin: MetricsMixin):
+        """Test getting date information with changelog."""
+        # Mock the API response with changelog
+        metrics_mixin.jira.get_issue.return_value = {
+            "id": "10001",
+            "key": "TEST-123",
+            "fields": {
+                "created": "2023-01-01T00:00:00.000+0000",
+                "updated": "2023-01-15T12:00:00.000+0000",
+                "status": {"name": "In Progress"},
+            },
+            "changelog": {
+                "histories": [
+                    {
+                        "id": "1001",
+                        "created": "2023-01-02T10:00:00.000+0000",
+                        "author": {"displayName": "Test User"},
+                        "items": [
+                            {
+                                "field": "status",
+                                "fieldtype": "jira",
+                                "fromString": "Open",
+                                "toString": "In Progress",
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+
+        result = metrics_mixin.get_issue_dates("TEST-123")
+
+        assert isinstance(result, IssueDatesResponse)
+        assert result.issue_key == "TEST-123"
+        assert result.current_status == "In Progress"
+        assert len(result.status_changes) >= 1
+        # Should have the transition from Open to In Progress
+
+    def test_get_issue_dates_excludes_optional_fields(
+        self, metrics_mixin: MetricsMixin
+    ):
+        """Test getting dates with some fields excluded."""
+        metrics_mixin.jira.get_issue.return_value = {
+            "id": "10001",
+            "key": "TEST-123",
+            "fields": {
+                "created": "2023-01-01T00:00:00.000+0000",
+                "status": {"name": "Open"},
+            },
+        }
+
+        result = metrics_mixin.get_issue_dates(
+            "TEST-123",
+            include_created=True,
+            include_updated=False,
+            include_due_date=False,
+            include_resolution_date=False,
+            include_status_changes=False,
+            include_status_summary=False,
+        )
+
+        assert isinstance(result, IssueDatesResponse)
+        assert result.created is not None
+        assert result.status_changes == []
+        assert result.status_summary == []
+
+    def test_batch_get_issue_dates(self, metrics_mixin: MetricsMixin):
+        """Test batch getting dates for multiple issues."""
+
+        def mock_get_issue(issue_key, **kwargs):
+            return {
+                "id": f"1000{issue_key[-1]}",
+                "key": issue_key,
+                "fields": {
+                    "created": "2023-01-01T00:00:00.000+0000",
+                    "updated": "2023-01-15T12:00:00.000+0000",
+                    "status": {"name": "Open"},
+                },
+            }
+
+        metrics_mixin.jira.get_issue.side_effect = mock_get_issue
+
+        result = metrics_mixin.batch_get_issue_dates(
+            ["TEST-1", "TEST-2", "TEST-3"],
+            include_status_changes=False,
+            include_status_summary=False,
+        )
+
+        assert isinstance(result, IssueDatesBatchResponse)
+        assert result.total_count == 3
+        assert result.success_count == 3
+        assert result.error_count == 0
+        assert len(result.issues) == 3
+
+    def test_batch_get_issue_dates_with_errors(self, metrics_mixin: MetricsMixin):
+        """Test batch operation handling errors gracefully."""
+
+        def mock_get_issue(issue_key, **kwargs):
+            if issue_key == "TEST-2":
+                raise ValueError("Issue not found")
+            return {
+                "id": f"1000{issue_key[-1]}",
+                "key": issue_key,
+                "fields": {
+                    "created": "2023-01-01T00:00:00.000+0000",
+                    "status": {"name": "Open"},
+                },
+            }
+
+        metrics_mixin.jira.get_issue.side_effect = mock_get_issue
+
+        result = metrics_mixin.batch_get_issue_dates(
+            ["TEST-1", "TEST-2", "TEST-3"],
+            include_status_changes=False,
+            include_status_summary=False,
+        )
+
+        assert isinstance(result, IssueDatesBatchResponse)
+        assert result.total_count == 3
+        assert result.success_count == 2
+        assert result.error_count == 1
+        assert len(result.errors) == 1
+        assert result.errors[0]["issue_key"] == "TEST-2"
+
+    def test_aggregate_status_times(self, metrics_mixin: MetricsMixin):
+        """Test aggregating time spent in each status."""
+        status_changes = [
+            StatusChangeEntry(
+                status="Open",
+                entered_at=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+                exited_at=datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc),
+                duration_minutes=120,
+            ),
+            StatusChangeEntry(
+                status="In Progress",
+                entered_at=datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc),
+                exited_at=datetime(2023, 1, 2, 12, 0, tzinfo=timezone.utc),
+                duration_minutes=1440,
+            ),
+            StatusChangeEntry(
+                status="Open",
+                entered_at=datetime(2023, 1, 2, 12, 0, tzinfo=timezone.utc),
+                exited_at=datetime(2023, 1, 2, 13, 0, tzinfo=timezone.utc),
+                duration_minutes=60,
+            ),
+        ]
+
+        result = metrics_mixin._aggregate_status_times(status_changes)
+
+        assert len(result) == 2  # Open and In Progress
+
+        # Find the Open status summary
+        open_summary = next((s for s in result if s.status == "Open"), None)
+        assert open_summary is not None
+        assert open_summary.total_duration_minutes == 180  # 120 + 60
+        assert open_summary.visit_count == 2
+
+        # Find the In Progress status summary
+        in_progress_summary = next(
+            (s for s in result if s.status == "In Progress"), None
+        )
+        assert in_progress_summary is not None
+        assert in_progress_summary.total_duration_minutes == 1440
+        assert in_progress_summary.visit_count == 1
+
+
+class TestMetricsModels:
+    """Tests for the metrics Pydantic models."""
+
+    def test_status_change_entry_to_simplified_dict(self):
+        """Test StatusChangeEntry serialization."""
+        entry = StatusChangeEntry(
+            status="In Progress",
+            entered_at=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+            exited_at=datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc),
+            duration_minutes=120,
+            duration_formatted="2h 0m",
+            transitioned_by="Test User",
+        )
+
+        result = entry.to_simplified_dict()
+
+        assert result["status"] == "In Progress"
+        assert "entered_at" in result
+        assert "exited_at" in result
+        assert result["duration_minutes"] == 120
+        assert result["duration_formatted"] == "2h 0m"
+        assert result["transitioned_by"] == "Test User"
+
+    def test_status_change_entry_without_exit(self):
+        """Test StatusChangeEntry for current status (no exit)."""
+        entry = StatusChangeEntry(
+            status="In Progress",
+            entered_at=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+            exited_at=None,
+        )
+
+        result = entry.to_simplified_dict()
+
+        assert result["status"] == "In Progress"
+        assert "entered_at" in result
+        assert "exited_at" not in result
+
+    def test_status_time_summary_to_simplified_dict(self):
+        """Test StatusTimeSummary serialization."""
+        summary = StatusTimeSummary(
+            status="In Progress",
+            total_duration_minutes=2880,
+            total_duration_formatted="2d 0h 0m",
+            visit_count=3,
+        )
+
+        result = summary.to_simplified_dict()
+
+        assert result["status"] == "In Progress"
+        assert result["total_duration_minutes"] == 2880
+        assert result["total_duration_formatted"] == "2d 0h 0m"
+        assert result["visit_count"] == 3
+
+    def test_issue_dates_response_to_simplified_dict(self):
+        """Test IssueDatesResponse serialization."""
+        response = IssueDatesResponse(
+            issue_key="TEST-123",
+            created=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+            updated=datetime(2023, 1, 15, 12, 0, tzinfo=timezone.utc),
+            current_status="Done",
+        )
+
+        result = response.to_simplified_dict()
+
+        assert result["issue_key"] == "TEST-123"
+        assert "created" in result
+        assert "updated" in result
+        assert result["current_status"] == "Done"
+
+    def test_issue_dates_batch_response_to_simplified_dict(self):
+        """Test IssueDatesBatchResponse serialization."""
+        issues = [
+            IssueDatesResponse(
+                issue_key="TEST-1",
+                current_status="Open",
+            ),
+            IssueDatesResponse(
+                issue_key="TEST-2",
+                current_status="Done",
+            ),
+        ]
+
+        response = IssueDatesBatchResponse(
+            issues=issues,
+            total_count=3,
+            success_count=2,
+            error_count=1,
+            errors=[{"issue_key": "TEST-3", "error": "Not found"}],
+        )
+
+        result = response.to_simplified_dict()
+
+        assert result["total_count"] == 3
+        assert result["success_count"] == 2
+        assert result["error_count"] == 1
+        assert len(result["issues"]) == 2
+        assert len(result["errors"]) == 1


### PR DESCRIPTION
## Description

  Add `jira_get_issue_dates` tool to extract date information and status transition history from Jira issues.

  **New Tool:**
  - `jira_get_issue_dates` - Extract created, updated, due date, resolution date, and status change history

  **Capabilities:**
  - Get all relevant dates from a Jira issue
  - Track status transitions with timestamps
  - Calculate time spent in each status
  - Support for both Cloud and Server/Data Center

  This is part 1 of 3 PRs splitting the original #823.

  ## Changes

  - Add `jira/metrics.py` - MetricsMixin for date extraction
  - Add `models/jira/metrics.py` - Pydantic models for responses
  - Update `jira/__init__.py` - Export MetricsMixin
  - Update `servers/jira.py` - Register jira_get_issue_dates tool
  - Add unit tests

  ## Testing

  - [x] Unit tests added
  - [x] All tests pass locally
  - [x] Manual testing with real Jira instance

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Tests added for changes
  - [x] All tests pass locally
