### PR TITLE
feat(jira): Add jira_get_issue_sla tool for SLA metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,28 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 # Optional: Comma-separated list of Jira project keys to limit searches and other operations to.
 #JIRA_PROJECTS_FILTER=PROJ,DEVOPS
 
+# --- SLA Metrics Configuration ---
+# Configure how SLA metrics are calculated for Jira issues.
+# Default metrics to calculate (comma-separated).
+# Available: cycle_time, lead_time, time_in_status, due_date_compliance, resolution_time, first_response_time
+#JIRA_SLA_METRICS=cycle_time,time_in_status
+
+# Enable working hours filtering (only count business hours, exclude weekends).
+#JIRA_SLA_WORKING_HOURS_ONLY=false
+
+# Working hours start time in 24-hour format (HH:MM).
+#JIRA_SLA_WORKING_HOURS_START=09:00
+
+# Working hours end time in 24-hour format (HH:MM).
+#JIRA_SLA_WORKING_HOURS_END=17:00
+
+# Working days as comma-separated integers (1=Monday, 7=Sunday).
+#JIRA_SLA_WORKING_DAYS=1,2,3,4,5
+
+# Timezone for SLA calculations (IANA timezone identifier).
+# Examples: UTC, America/New_York, Europe/London, Asia/Tokyo
+#JIRA_SLA_TIMEZONE=UTC
+
 # --- Proxy Configuration (Advanced) ---
 # Global proxy settings (applies to both Jira and Confluence unless overridden by service-specific proxy settings below).
 #HTTP_PROXY=http://proxy.example.com:8080

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_create_issue` - Create issues | `confluence_create_page` - Create pages |
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
-| | `confluence_get_page_views` - Get page view stats (Cloud only) |
+| `jira_get_issue_sla` - Calculate SLA metrics | `confluence_get_page_views` - Get page view stats (Cloud only) |
 
 See [Tools Reference](https://personal-1d37018d.mintlify.app/docs/tools-reference) for the complete list.
 

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -20,6 +20,7 @@ from .issues import IssuesMixin
 from .links import LinksMixin
 from .metrics import MetricsMixin
 from .projects import ProjectsMixin
+from .sla import SLAMixin
 from .search import SearchMixin
 from .sprints import SprintsMixin
 from .transitions import TransitionsMixin
@@ -43,6 +44,7 @@ class JiraFetcher(
     AttachmentsMixin,
     LinksMixin,
     MetricsMixin,
+    SLAMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -63,6 +65,7 @@ class JiraFetcher(
     - AttachmentsMixin: Attachment download operations
     - LinksMixin: Issue link operations
     - MetricsMixin: Issue metrics and date operations
+    - SLAMixin: SLA calculations
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.
@@ -71,4 +74,11 @@ class JiraFetcher(
     pass
 
 
-__all__ = ["JiraFetcher", "JiraConfig", "JiraClient", "Jira", "MetricsMixin"]
+__all__ = [
+    "JiraFetcher",
+    "JiraConfig",
+    "JiraClient",
+    "Jira",
+    "MetricsMixin",
+    "SLAMixin",
+]

--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -1,10 +1,13 @@
 """Module for Jira protocol definitions."""
 
 from abc import abstractmethod
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from ..models.jira import JiraIssue
 from ..models.jira.search import JiraSearchResult
+
+if TYPE_CHECKING:
+    from ..models.jira.metrics import IssueDatesResponse
 
 
 class AttachmentsOperationsProto(Protocol):
@@ -204,4 +207,35 @@ class UsersOperationsProto(Protocol):
 
         Raises:
             ValueError: If the account ID could not be found
+        """
+
+
+@runtime_checkable
+class MetricsOperationsProto(Protocol):
+    """Protocol defining metrics operations interface."""
+
+    @abstractmethod
+    def get_issue_dates(
+        self,
+        issue_key: str,
+        include_created: bool = True,
+        include_updated: bool = True,
+        include_due_date: bool = True,
+        include_resolution_date: bool = True,
+        include_status_changes: bool = True,
+        include_status_summary: bool = True,
+    ) -> "IssueDatesResponse":
+        """Get date information and status history for an issue.
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123')
+            include_created: Include created date
+            include_updated: Include updated date
+            include_due_date: Include due date
+            include_resolution_date: Include resolution date
+            include_status_changes: Include status change history
+            include_status_summary: Include time in status summary
+
+        Returns:
+            IssueDatesResponse with date information
         """

--- a/src/mcp_atlassian/jira/sla.py
+++ b/src/mcp_atlassian/jira/sla.py
@@ -1,0 +1,665 @@
+"""Module for Jira SLA calculations."""
+
+import logging
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from ..models.jira.metrics import IssueDatesResponse
+from ..models.jira.sla import (
+    CycleTimeMetric,
+    DueDateComplianceMetric,
+    FirstResponseTimeMetric,
+    IssueSLABatchResponse,
+    IssueSLAMetrics,
+    IssueSLAResponse,
+    LeadTimeMetric,
+    ResolutionTimeMetric,
+    TimeInStatusEntry,
+    TimeInStatusMetric,
+    WorkingHoursConfig,
+)
+from .client import JiraClient
+from .config import SLAConfig
+from .metrics import MetricsMixin
+from .protocols import MetricsOperationsProto
+
+logger = logging.getLogger("mcp-jira")
+
+# Available SLA metrics
+AVAILABLE_METRICS = [
+    "cycle_time",
+    "lead_time",
+    "time_in_status",
+    "due_date_compliance",
+    "resolution_time",
+    "first_response_time",
+]
+
+# Jira status category keys that indicate "in progress" work
+IN_PROGRESS_CATEGORY_KEY = "indeterminate"
+
+
+class SLAMixin(JiraClient, MetricsOperationsProto):
+    """Mixin for Jira SLA calculations."""
+
+    def get_issue_sla(
+        self,
+        issue_key: str,
+        metrics: list[str] | None = None,
+        working_hours_only: bool | None = None,
+        include_raw_dates: bool = False,
+    ) -> IssueSLAResponse:
+        """
+        Calculate SLA metrics for a single Jira issue.
+
+        Args:
+            issue_key: The issue key (e.g., PROJECT-123)
+            metrics: List of metrics to calculate (defaults to config)
+            working_hours_only: Whether to use working hours only (defaults to config)
+            include_raw_dates: Whether to include raw date values
+
+        Returns:
+            IssueSLAResponse with calculated metrics
+
+        Raises:
+            ValueError: If the issue cannot be found
+        """
+        # Get SLA config
+        sla_config = self._get_sla_config()
+
+        # Determine which metrics to calculate
+        if metrics is None:
+            metrics = sla_config.default_metrics
+        metrics = [m for m in metrics if m in AVAILABLE_METRICS]
+
+        # Determine working hours setting
+        if working_hours_only is None:
+            working_hours_only = sla_config.working_hours_only
+
+        # Get raw dates from the metrics mixin
+        issue_dates = self.get_issue_dates(
+            issue_key=issue_key,
+            include_created=True,
+            include_updated=True,
+            include_due_date=True,
+            include_resolution_date=True,
+            include_status_changes=True,
+            include_status_summary=True,
+        )
+
+        # Calculate requested metrics
+        sla_metrics = self._calculate_metrics(
+            issue_key=issue_key,
+            issue_dates=issue_dates,
+            metrics=metrics,
+            working_hours_only=working_hours_only,
+            sla_config=sla_config,
+        )
+
+        # Build raw dates if requested
+        raw_dates = None
+        if include_raw_dates:
+            # Build status changes with timestamps
+            status_changes_data = []
+            for change in issue_dates.status_changes:
+                change_entry = {
+                    "status": change.status,
+                    "entered_at": change.entered_at.isoformat(),
+                }
+                if change.exited_at:
+                    change_entry["exited_at"] = change.exited_at.isoformat()
+                if change.transitioned_by:
+                    change_entry["transitioned_by"] = change.transitioned_by
+                status_changes_data.append(change_entry)
+
+            raw_dates = {
+                "created": (
+                    issue_dates.created.isoformat() if issue_dates.created else None
+                ),
+                "updated": (
+                    issue_dates.updated.isoformat() if issue_dates.updated else None
+                ),
+                "due_date": (
+                    issue_dates.due_date.isoformat() if issue_dates.due_date else None
+                ),
+                "resolution_date": (
+                    issue_dates.resolution_date.isoformat()
+                    if issue_dates.resolution_date
+                    else None
+                ),
+                "current_status": issue_dates.current_status,
+                "status_changes": status_changes_data,
+            }
+
+        return IssueSLAResponse(
+            issue_key=issue_key,
+            metrics=sla_metrics,
+            raw_dates=raw_dates,
+        )
+
+    def batch_get_issue_sla(
+        self,
+        issue_keys: list[str],
+        metrics: list[str] | None = None,
+        working_hours_only: bool | None = None,
+        include_raw_dates: bool = False,
+    ) -> IssueSLABatchResponse:
+        """
+        Calculate SLA metrics for multiple Jira issues.
+
+        Args:
+            issue_keys: List of issue keys
+            metrics: List of metrics to calculate (defaults to config)
+            working_hours_only: Whether to use working hours only (defaults to config)
+            include_raw_dates: Whether to include raw date values
+
+        Returns:
+            IssueSLABatchResponse with results for all issues
+        """
+        # Get SLA config
+        sla_config = self._get_sla_config()
+
+        # Determine which metrics to calculate
+        if metrics is None:
+            metrics = sla_config.default_metrics
+        metrics = [m for m in metrics if m in AVAILABLE_METRICS]
+
+        # Determine working hours setting
+        if working_hours_only is None:
+            working_hours_only = sla_config.working_hours_only
+
+        issues: list[IssueSLAResponse] = []
+        errors: list[dict[str, str]] = []
+
+        for issue_key in issue_keys:
+            try:
+                issue_sla = self.get_issue_sla(
+                    issue_key=issue_key,
+                    metrics=metrics,
+                    working_hours_only=working_hours_only,
+                    include_raw_dates=include_raw_dates,
+                )
+                issues.append(issue_sla)
+            except Exception as e:
+                logger.warning(f"Error calculating SLA for {issue_key}: {str(e)}")
+                errors.append(
+                    {
+                        "issue_key": issue_key,
+                        "error": str(e),
+                    }
+                )
+
+        # Build working hours config if applied
+        working_config = None
+        if working_hours_only:
+            working_config = WorkingHoursConfig(
+                start=sla_config.working_hours_start,
+                end=sla_config.working_hours_end,
+                days=sla_config.working_days or [1, 2, 3, 4, 5],
+                timezone=sla_config.timezone,
+            )
+
+        return IssueSLABatchResponse(
+            issues=issues,
+            total_count=len(issue_keys),
+            success_count=len(issues),
+            error_count=len(errors),
+            errors=errors,
+            metrics_calculated=metrics,
+            working_hours_applied=working_hours_only,
+            working_hours_config=working_config,
+        )
+
+    def _get_sla_config(self) -> SLAConfig:
+        """Get SLA configuration from JiraConfig or create default."""
+        if self.config.sla_config:
+            return self.config.sla_config
+        return SLAConfig.from_env()
+
+    def _get_sla_timezone(self, sla_config: SLAConfig) -> ZoneInfo:
+        """Get timezone from SLA config with fallback to UTC."""
+        try:
+            return ZoneInfo(sla_config.timezone)
+        except Exception:
+            logger.warning(f"Invalid timezone {sla_config.timezone}, using UTC")
+            return ZoneInfo("UTC")
+
+    def _calculate_metrics(
+        self,
+        issue_key: str,
+        issue_dates: IssueDatesResponse,
+        metrics: list[str],
+        working_hours_only: bool,
+        sla_config: SLAConfig,
+    ) -> IssueSLAMetrics:
+        """
+        Calculate requested SLA metrics.
+
+        Args:
+            issue_key: The issue key (for fetching status categories)
+            issue_dates: Raw date information from get_issue_dates
+            metrics: List of metric IDs to calculate
+            working_hours_only: Whether to filter by working hours
+            sla_config: SLA configuration
+
+        Returns:
+            IssueSLAMetrics with calculated metrics
+        """
+        result = IssueSLAMetrics()
+
+        if "cycle_time" in metrics:
+            result.cycle_time = self._calculate_cycle_time(
+                issue_dates, working_hours_only, sla_config
+            )
+
+        if "lead_time" in metrics:
+            result.lead_time = self._calculate_lead_time(
+                issue_dates, working_hours_only, sla_config
+            )
+
+        if "time_in_status" in metrics:
+            result.time_in_status = self._calculate_time_in_status(
+                issue_dates, working_hours_only, sla_config
+            )
+
+        if "due_date_compliance" in metrics:
+            result.due_date_compliance = self._calculate_due_date_compliance(
+                issue_dates
+            )
+
+        if "resolution_time" in metrics:
+            result.resolution_time = self._calculate_resolution_time(
+                issue_key, issue_dates, working_hours_only, sla_config
+            )
+
+        if "first_response_time" in metrics:
+            result.first_response_time = self._calculate_first_response_time(
+                issue_dates, working_hours_only, sla_config
+            )
+
+        return result
+
+    def _calculate_cycle_time(
+        self,
+        issue_dates: IssueDatesResponse,
+        working_hours_only: bool,
+        sla_config: SLAConfig,
+    ) -> CycleTimeMetric:
+        """Calculate cycle time (created to resolved)."""
+        if not issue_dates.created or not issue_dates.resolution_date:
+            return CycleTimeMetric(
+                calculated=False,
+                reason="Issue not resolved"
+                if issue_dates.created
+                else "No created date",
+            )
+
+        minutes = self._calculate_duration(
+            issue_dates.created,
+            issue_dates.resolution_date,
+            working_hours_only,
+            sla_config,
+        )
+
+        return CycleTimeMetric(
+            value_minutes=minutes,
+            formatted=MetricsMixin._format_duration(self, minutes),
+            calculated=True,
+        )
+
+    def _calculate_lead_time(
+        self,
+        issue_dates: IssueDatesResponse,
+        working_hours_only: bool,
+        sla_config: SLAConfig,
+    ) -> LeadTimeMetric:
+        """Calculate lead time (created to now or resolved)."""
+        if not issue_dates.created:
+            return LeadTimeMetric(
+                value_minutes=0,
+                formatted="0m",
+                is_resolved=False,
+            )
+
+        # Use SLA config timezone for "now", not issue timezone
+        tz = self._get_sla_timezone(sla_config)
+        end_time = issue_dates.resolution_date or datetime.now(tz=tz)
+
+        minutes = self._calculate_duration(
+            issue_dates.created,
+            end_time,
+            working_hours_only,
+            sla_config,
+        )
+
+        return LeadTimeMetric(
+            value_minutes=minutes,
+            formatted=MetricsMixin._format_duration(self, minutes),
+            is_resolved=issue_dates.resolution_date is not None,
+        )
+
+    def _calculate_time_in_status(
+        self,
+        issue_dates: IssueDatesResponse,
+        working_hours_only: bool,
+        sla_config: SLAConfig,
+    ) -> TimeInStatusMetric:
+        """Calculate time spent in each status."""
+        if not issue_dates.status_summary:
+            return TimeInStatusMetric(statuses=[], total_minutes=0)
+
+        entries: list[TimeInStatusEntry] = []
+        total_minutes = 0
+
+        # Get SLA timezone for "now" calculations
+        tz = self._get_sla_timezone(sla_config)
+
+        for summary in issue_dates.status_summary:
+            # Recalculate with working hours if needed
+            if working_hours_only and issue_dates.status_changes:
+                # Find all entries for this status and recalculate
+                status_minutes = 0
+                visit_count = 0
+                for change in issue_dates.status_changes:
+                    if change.status == summary.status and change.exited_at:
+                        minutes = self._calculate_duration(
+                            change.entered_at,
+                            change.exited_at,
+                            working_hours_only,
+                            sla_config,
+                        )
+                        status_minutes += minutes
+                        visit_count += 1
+                    elif change.status == summary.status and not change.exited_at:
+                        # Current status - calculate to now using SLA timezone
+                        now = datetime.now(tz=tz)
+                        minutes = self._calculate_duration(
+                            change.entered_at,
+                            now,
+                            working_hours_only,
+                            sla_config,
+                        )
+                        status_minutes += minutes
+                        visit_count += 1
+
+                if status_minutes > 0 or visit_count > 0:
+                    total_minutes += status_minutes
+                    entries.append(
+                        TimeInStatusEntry(
+                            status=summary.status,
+                            value_minutes=status_minutes,
+                            formatted=MetricsMixin._format_duration(
+                                self, status_minutes
+                            ),
+                            percentage=0.0,  # Calculate after total
+                            visit_count=max(visit_count, summary.visit_count),
+                        )
+                    )
+            else:
+                # Use existing summary data
+                total_minutes += summary.total_duration_minutes
+                entries.append(
+                    TimeInStatusEntry(
+                        status=summary.status,
+                        value_minutes=summary.total_duration_minutes,
+                        formatted=summary.total_duration_formatted,
+                        percentage=0.0,  # Calculate after total
+                        visit_count=summary.visit_count,
+                    )
+                )
+
+        # Calculate percentages
+        if total_minutes > 0:
+            for entry in entries:
+                entry.percentage = (entry.value_minutes / total_minutes) * 100
+
+        # Sort by time descending
+        entries.sort(key=lambda x: x.value_minutes, reverse=True)
+
+        return TimeInStatusMetric(
+            statuses=entries,
+            total_minutes=total_minutes,
+        )
+
+    def _calculate_due_date_compliance(
+        self,
+        issue_dates: IssueDatesResponse,
+    ) -> DueDateComplianceMetric:
+        """Calculate due date compliance."""
+        if not issue_dates.due_date:
+            return DueDateComplianceMetric(status="no_due_date")
+
+        if not issue_dates.resolution_date:
+            return DueDateComplianceMetric(status="not_resolved")
+
+        # Compare resolution date to due date
+        # Due date is typically just a date (no time), so compare at end of day
+        due_datetime = datetime.combine(
+            issue_dates.due_date.date()
+            if isinstance(issue_dates.due_date, datetime)
+            else issue_dates.due_date,
+            time(23, 59, 59),
+            tzinfo=issue_dates.resolution_date.tzinfo,
+        )
+
+        margin_minutes = int(
+            (due_datetime - issue_dates.resolution_date).total_seconds() / 60
+        )
+
+        if margin_minutes >= 0:
+            return DueDateComplianceMetric(
+                status="met",
+                margin_minutes=margin_minutes,
+                formatted_margin=(
+                    f"{MetricsMixin._format_duration(self, margin_minutes)} early"
+                ),
+            )
+        else:
+            return DueDateComplianceMetric(
+                status="missed",
+                margin_minutes=margin_minutes,
+                formatted_margin=(
+                    f"{MetricsMixin._format_duration(self, abs(margin_minutes))} late"
+                ),
+            )
+
+    def _is_in_progress_status(self, issue_key: str, status_name: str) -> bool:
+        """
+        Check if a status represents "in progress" work using Jira status category.
+
+        Uses the Jira API to check the status category, which is more reliable
+        than hardcoding status names across different Jira instances.
+
+        Args:
+            issue_key: The issue key (used to get project context)
+            status_name: The status name to check
+
+        Returns:
+            True if the status is in the "In Progress" category
+        """
+        try:
+            # Get all statuses and find the matching one
+            statuses = self.jira.get_all_statuses()
+            for status in statuses:
+                if status.get("name", "").lower() == status_name.lower():
+                    category = status.get("statusCategory", {})
+                    return category.get("key") == IN_PROGRESS_CATEGORY_KEY
+        except Exception as e:
+            logger.debug(f"Could not fetch status category for {status_name}: {e}")
+
+        # Fallback to name-based check if API fails
+        return status_name.lower() in ("in progress", "in development", "working")
+
+    def _calculate_resolution_time(
+        self,
+        issue_key: str,
+        issue_dates: IssueDatesResponse,
+        working_hours_only: bool,
+        sla_config: SLAConfig,
+    ) -> ResolutionTimeMetric:
+        """Calculate resolution time (first in progress to resolved)."""
+        if not issue_dates.resolution_date:
+            return ResolutionTimeMetric(
+                calculated=False,
+                reason="Issue not resolved",
+            )
+
+        # Find first "In Progress" transition using status category
+        first_in_progress = None
+        for change in issue_dates.status_changes:
+            if self._is_in_progress_status(issue_key, change.status):
+                first_in_progress = change.entered_at
+                break
+
+        if not first_in_progress:
+            return ResolutionTimeMetric(
+                calculated=False,
+                reason="No 'In Progress' status found",
+            )
+
+        minutes = self._calculate_duration(
+            first_in_progress,
+            issue_dates.resolution_date,
+            working_hours_only,
+            sla_config,
+        )
+
+        return ResolutionTimeMetric(
+            value_minutes=minutes,
+            formatted=MetricsMixin._format_duration(self, minutes),
+            calculated=True,
+        )
+
+    def _calculate_first_response_time(
+        self,
+        issue_dates: IssueDatesResponse,
+        working_hours_only: bool,
+        sla_config: SLAConfig,
+    ) -> FirstResponseTimeMetric:
+        """Calculate first response time (created to first transition)."""
+        if not issue_dates.created:
+            return FirstResponseTimeMetric(calculated=False)
+
+        if not issue_dates.status_changes:
+            return FirstResponseTimeMetric(calculated=False)
+
+        # Find first transition (after the initial status)
+        first_transition = None
+        for i, change in enumerate(issue_dates.status_changes):
+            if i > 0:  # Skip the initial status
+                first_transition = change.entered_at
+                break
+
+        if not first_transition:
+            return FirstResponseTimeMetric(calculated=False)
+
+        minutes = self._calculate_duration(
+            issue_dates.created,
+            first_transition,
+            working_hours_only,
+            sla_config,
+        )
+
+        return FirstResponseTimeMetric(
+            value_minutes=minutes,
+            formatted=MetricsMixin._format_duration(self, minutes),
+            calculated=True,
+            response_type="transition",
+        )
+
+    def _calculate_duration(
+        self,
+        start: datetime,
+        end: datetime,
+        working_hours_only: bool,
+        sla_config: SLAConfig,
+    ) -> int:
+        """
+        Calculate duration in minutes, optionally filtering by working hours.
+
+        Args:
+            start: Start datetime
+            end: End datetime
+            working_hours_only: Whether to only count working hours
+            sla_config: SLA configuration with working hours settings
+
+        Returns:
+            Duration in minutes
+        """
+        if not working_hours_only:
+            # Simple calendar time calculation
+            delta = end - start
+            return max(0, int(delta.total_seconds() / 60))
+
+        # Working hours calculation
+        return self._calculate_working_minutes(start, end, sla_config)
+
+    def _calculate_working_minutes(
+        self,
+        start: datetime,
+        end: datetime,
+        sla_config: SLAConfig,
+    ) -> int:
+        """
+        Calculate working minutes between two timestamps.
+
+        Algorithm:
+        1. Convert times to configured timezone
+        2. Iterate day by day from start to end
+        3. For each day:
+           a. Skip if not in working_days
+           b. Calculate overlap with working hours
+           c. Add to total
+        4. Return total working minutes
+
+        Args:
+            start: Start datetime
+            end: End datetime
+            sla_config: SLA configuration
+
+        Returns:
+            Working minutes between start and end
+        """
+        if end <= start:
+            return 0
+
+        # Get timezone
+        tz = self._get_sla_timezone(sla_config)
+
+        # Convert to configured timezone
+        start_local = start.astimezone(tz)
+        end_local = end.astimezone(tz)
+
+        # Parse working hours
+        work_start_parts = sla_config.working_hours_start.split(":")
+        work_end_parts = sla_config.working_hours_end.split(":")
+        work_start_time = time(int(work_start_parts[0]), int(work_start_parts[1]))
+        work_end_time = time(int(work_end_parts[0]), int(work_end_parts[1]))
+
+        working_days = set(sla_config.working_days or [1, 2, 3, 4, 5])
+
+        total_minutes = 0
+        current_date = start_local.date()
+        end_date = end_local.date()
+
+        while current_date <= end_date:
+            # Check if it's a working day (isoweekday: 1=Mon, 7=Sun)
+            if current_date.isoweekday() not in working_days:
+                current_date += timedelta(days=1)
+                continue
+
+            # Calculate day boundaries
+            day_start = datetime.combine(current_date, work_start_time, tzinfo=tz)
+            day_end = datetime.combine(current_date, work_end_time, tzinfo=tz)
+
+            # Calculate overlap with actual time range
+            period_start = max(day_start, start_local)
+            period_end = min(day_end, end_local)
+
+            if period_end > period_start:
+                minutes = int((period_end - period_start).total_seconds() / 60)
+                total_minutes += minutes
+
+            current_date += timedelta(days=1)
+
+        return total_minutes

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -32,6 +32,19 @@ from .metrics import (
 )
 from .project import JiraProject
 from .search import JiraSearchResult
+from .sla import (
+    CycleTimeMetric,
+    DueDateComplianceMetric,
+    FirstResponseTimeMetric,
+    IssueSLABatchResponse,
+    IssueSLAMetrics,
+    IssueSLAResponse,
+    LeadTimeMetric,
+    ResolutionTimeMetric,
+    TimeInStatusEntry,
+    TimeInStatusMetric,
+    WorkingHoursConfig,
+)
 from .workflow import JiraTransition
 from .worklog import JiraWorklog
 
@@ -63,4 +76,16 @@ __all__ = [
     "IssueDatesBatchResponse",
     "StatusChangeEntry",
     "StatusTimeSummary",
+    # SLA models
+    "IssueSLAResponse",
+    "IssueSLABatchResponse",
+    "IssueSLAMetrics",
+    "CycleTimeMetric",
+    "LeadTimeMetric",
+    "TimeInStatusEntry",
+    "TimeInStatusMetric",
+    "DueDateComplianceMetric",
+    "ResolutionTimeMetric",
+    "FirstResponseTimeMetric",
+    "WorkingHoursConfig",
 ]

--- a/src/mcp_atlassian/models/jira/sla.py
+++ b/src/mcp_atlassian/models/jira/sla.py
@@ -1,0 +1,221 @@
+"""Models for Jira SLA calculations."""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class WorkingHoursConfig(BaseModel):
+    """Configuration for working hours."""
+
+    start: str  # Start time in HH:MM format
+    end: str  # End time in HH:MM format
+    days: list[int]  # Working days (1=Mon, 7=Sun)
+    timezone: str  # IANA timezone
+
+
+class CycleTimeMetric(BaseModel):
+    """Cycle time metric (created to resolved)."""
+
+    value_minutes: int | None = None
+    formatted: str | None = None
+    calculated: bool = False
+    reason: str | None = None
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        result: dict[str, Any] = {"calculated": self.calculated}
+        if self.calculated and self.value_minutes is not None:
+            result["value_minutes"] = self.value_minutes
+            result["formatted"] = self.formatted
+        if self.reason:
+            result["reason"] = self.reason
+        return result
+
+
+class LeadTimeMetric(BaseModel):
+    """Lead time metric (created to now or resolved)."""
+
+    value_minutes: int
+    formatted: str
+    is_resolved: bool = False
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        return {
+            "value_minutes": self.value_minutes,
+            "formatted": self.formatted,
+            "is_resolved": self.is_resolved,
+        }
+
+
+class TimeInStatusEntry(BaseModel):
+    """Time spent in a single status."""
+
+    status: str
+    value_minutes: int
+    formatted: str
+    percentage: float
+    visit_count: int
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        return {
+            "status": self.status,
+            "value_minutes": self.value_minutes,
+            "formatted": self.formatted,
+            "percentage": round(self.percentage, 2),
+            "visit_count": self.visit_count,
+        }
+
+
+class TimeInStatusMetric(BaseModel):
+    """Time in status breakdown."""
+
+    statuses: list[TimeInStatusEntry]
+    total_minutes: int
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        return {
+            "statuses": [s.to_simplified_dict() for s in self.statuses],
+            "total_minutes": self.total_minutes,
+        }
+
+
+class DueDateComplianceMetric(BaseModel):
+    """Due date compliance metric."""
+
+    status: str  # "met", "missed", "no_due_date", "not_resolved"
+    margin_minutes: int | None = None
+    formatted_margin: str | None = None
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        result: dict[str, Any] = {"status": self.status}
+        if self.margin_minutes is not None:
+            result["margin_minutes"] = self.margin_minutes
+            result["formatted_margin"] = self.formatted_margin
+        return result
+
+
+class ResolutionTimeMetric(BaseModel):
+    """Resolution time metric (first in progress to resolved)."""
+
+    value_minutes: int | None = None
+    formatted: str | None = None
+    calculated: bool = False
+    reason: str | None = None
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        result: dict[str, Any] = {"calculated": self.calculated}
+        if self.calculated and self.value_minutes is not None:
+            result["value_minutes"] = self.value_minutes
+            result["formatted"] = self.formatted
+        if self.reason:
+            result["reason"] = self.reason
+        return result
+
+
+class FirstResponseTimeMetric(BaseModel):
+    """First response time metric."""
+
+    value_minutes: int | None = None
+    formatted: str | None = None
+    calculated: bool = False
+    response_type: str | None = None  # "transition", "comment", etc.
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        result: dict[str, Any] = {"calculated": self.calculated}
+        if self.calculated and self.value_minutes is not None:
+            result["value_minutes"] = self.value_minutes
+            result["formatted"] = self.formatted
+            if self.response_type:
+                result["response_type"] = self.response_type
+        return result
+
+
+class IssueSLAMetrics(BaseModel):
+    """Container for all SLA metrics."""
+
+    cycle_time: CycleTimeMetric | None = None
+    lead_time: LeadTimeMetric | None = None
+    time_in_status: TimeInStatusMetric | None = None
+    due_date_compliance: DueDateComplianceMetric | None = None
+    resolution_time: ResolutionTimeMetric | None = None
+    first_response_time: FirstResponseTimeMetric | None = None
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        result: dict[str, Any] = {}
+        if self.cycle_time:
+            result["cycle_time"] = self.cycle_time.to_simplified_dict()
+        if self.lead_time:
+            result["lead_time"] = self.lead_time.to_simplified_dict()
+        if self.time_in_status:
+            result["time_in_status"] = self.time_in_status.to_simplified_dict()
+        if self.due_date_compliance:
+            result["due_date_compliance"] = (
+                self.due_date_compliance.to_simplified_dict()
+            )
+        if self.resolution_time:
+            result["resolution_time"] = self.resolution_time.to_simplified_dict()
+        if self.first_response_time:
+            result["first_response_time"] = (
+                self.first_response_time.to_simplified_dict()
+            )
+        return result
+
+
+class IssueSLAResponse(BaseModel):
+    """Response containing SLA metrics for a single issue."""
+
+    issue_key: str
+    metrics: IssueSLAMetrics
+    raw_dates: dict[str, Any] | None = None
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        result: dict[str, Any] = {
+            "issue_key": self.issue_key,
+            "metrics": self.metrics.to_simplified_dict(),
+        }
+        if self.raw_dates:
+            result["raw_dates"] = self.raw_dates
+        return result
+
+
+class IssueSLABatchResponse(BaseModel):
+    """Response containing SLA metrics for multiple issues."""
+
+    issues: list[IssueSLAResponse]
+    total_count: int
+    success_count: int
+    error_count: int
+    errors: list[dict[str, str]]
+    metrics_calculated: list[str]
+    working_hours_applied: bool
+    working_hours_config: WorkingHoursConfig | None = None
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary."""
+        result: dict[str, Any] = {
+            "issues": [i.to_simplified_dict() for i in self.issues],
+            "total_count": self.total_count,
+            "success_count": self.success_count,
+            "error_count": self.error_count,
+            "metrics_calculated": self.metrics_calculated,
+            "working_hours_applied": self.working_hours_applied,
+        }
+        if self.errors:
+            result["errors"] = self.errors
+        if self.working_hours_config:
+            result["working_hours_config"] = {
+                "start": self.working_hours_config.start,
+                "end": self.working_hours_config.end,
+                "days": self.working_hours_config.days,
+                "timezone": self.working_hours_config.timezone,
+            }
+        return result

--- a/tests/unit/jira/test_sla.py
+++ b/tests/unit/jira/test_sla.py
@@ -1,0 +1,563 @@
+"""Tests for the Jira SLA mixin."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.config import SLAConfig
+from mcp_atlassian.jira.sla import SLAMixin
+from mcp_atlassian.models.jira.metrics import (
+    IssueDatesResponse,
+    StatusChangeEntry,
+    StatusTimeSummary,
+)
+from mcp_atlassian.models.jira.sla import (
+    CycleTimeMetric,
+    DueDateComplianceMetric,
+    IssueSLABatchResponse,
+    IssueSLAMetrics,
+    IssueSLAResponse,
+    LeadTimeMetric,
+    TimeInStatusEntry,
+    WorkingHoursConfig,
+)
+
+
+class TestSLAConfig:
+    """Tests for SLAConfig dataclass."""
+
+    def test_default_working_days(self):
+        """Test default working days are Monday-Friday."""
+        config = SLAConfig(default_metrics=["cycle_time"])
+        assert config.working_days == [1, 2, 3, 4, 5]
+
+    def test_custom_working_days(self):
+        """Test custom working days."""
+        config = SLAConfig(
+            default_metrics=["cycle_time"],
+            working_days=[1, 2, 3],  # Mon-Wed
+        )
+        assert config.working_days == [1, 2, 3]
+
+    def test_invalid_working_days_low(self):
+        """Test validation rejects day 0."""
+        with pytest.raises(ValueError) as exc_info:
+            SLAConfig(default_metrics=["cycle_time"], working_days=[0, 1, 2])
+        assert "Invalid working days" in str(exc_info.value)
+        assert "0" in str(exc_info.value)
+
+    def test_invalid_working_days_high(self):
+        """Test validation rejects day 8."""
+        with pytest.raises(ValueError) as exc_info:
+            SLAConfig(default_metrics=["cycle_time"], working_days=[1, 2, 8])
+        assert "Invalid working days" in str(exc_info.value)
+        assert "8" in str(exc_info.value)
+
+    def test_invalid_working_days_multiple(self):
+        """Test validation rejects multiple invalid days."""
+        with pytest.raises(ValueError) as exc_info:
+            SLAConfig(default_metrics=["cycle_time"], working_days=[0, 8, 9])
+        assert "Invalid working days" in str(exc_info.value)
+
+    def test_from_env_defaults(self):
+        """Test from_env with defaults."""
+        with patch.dict("os.environ", {}, clear=True):
+            config = SLAConfig.from_env()
+            assert config.default_metrics == ["cycle_time", "time_in_status"]
+            assert config.working_hours_only is False
+            assert config.working_hours_start == "09:00"
+            assert config.working_hours_end == "17:00"
+            assert config.working_days == [1, 2, 3, 4, 5]
+            assert config.timezone == "UTC"
+
+    def test_from_env_custom_values(self):
+        """Test from_env with custom environment variables."""
+        env = {
+            "JIRA_SLA_METRICS": "lead_time,resolution_time",
+            "JIRA_SLA_WORKING_HOURS_ONLY": "true",
+            "JIRA_SLA_WORKING_HOURS_START": "08:00",
+            "JIRA_SLA_WORKING_HOURS_END": "18:00",
+            "JIRA_SLA_WORKING_DAYS": "1,2,3,4",
+            "JIRA_SLA_TIMEZONE": "America/New_York",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            config = SLAConfig.from_env()
+            assert config.default_metrics == ["lead_time", "resolution_time"]
+            assert config.working_hours_only is True
+            assert config.working_hours_start == "08:00"
+            assert config.working_hours_end == "18:00"
+            assert config.working_days == [1, 2, 3, 4]
+            assert config.timezone == "America/New_York"
+
+    def test_from_env_invalid_working_days(self):
+        """Test from_env raises error for invalid working days."""
+        env = {"JIRA_SLA_WORKING_DAYS": "0,8,9"}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                SLAConfig.from_env()
+            assert "Invalid JIRA_SLA_WORKING_DAYS" in str(exc_info.value)
+
+
+class TestSLAMixin:
+    """Tests for the SLAMixin class."""
+
+    @pytest.fixture
+    def sla_mixin(self, jira_fetcher: JiraFetcher) -> SLAMixin:
+        """Create an SLAMixin instance with mocked dependencies."""
+        return jira_fetcher
+
+    @pytest.fixture
+    def mock_issue_dates(self) -> IssueDatesResponse:
+        """Create mock issue dates response."""
+        return IssueDatesResponse(
+            issue_key="TEST-123",
+            created=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+            updated=datetime(2023, 1, 15, 12, 0, tzinfo=timezone.utc),
+            due_date=datetime(2023, 2, 1, 23, 59, tzinfo=timezone.utc),
+            resolution_date=datetime(2023, 1, 20, 10, 0, tzinfo=timezone.utc),
+            current_status="Done",
+            status_changes=[
+                StatusChangeEntry(
+                    status="Open",
+                    entered_at=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+                    exited_at=datetime(2023, 1, 2, 10, 0, tzinfo=timezone.utc),
+                    duration_minutes=1440,
+                ),
+                StatusChangeEntry(
+                    status="In Progress",
+                    entered_at=datetime(2023, 1, 2, 10, 0, tzinfo=timezone.utc),
+                    exited_at=datetime(2023, 1, 10, 10, 0, tzinfo=timezone.utc),
+                    duration_minutes=11520,
+                ),
+                StatusChangeEntry(
+                    status="Done",
+                    entered_at=datetime(2023, 1, 10, 10, 0, tzinfo=timezone.utc),
+                    exited_at=None,
+                    duration_minutes=None,
+                ),
+            ],
+            status_summary=[
+                StatusTimeSummary(
+                    status="Open",
+                    total_duration_minutes=1440,
+                    total_duration_formatted="1d 0h 0m",
+                    visit_count=1,
+                ),
+                StatusTimeSummary(
+                    status="In Progress",
+                    total_duration_minutes=11520,
+                    total_duration_formatted="8d 0h 0m",
+                    visit_count=1,
+                ),
+            ],
+        )
+
+    def test_get_issue_sla_basic(
+        self, sla_mixin: SLAMixin, mock_issue_dates: IssueDatesResponse
+    ):
+        """Test basic SLA calculation."""
+        # Mock get_issue_dates to return our fixture
+        sla_mixin.get_issue_dates = MagicMock(return_value=mock_issue_dates)
+
+        result = sla_mixin.get_issue_sla(
+            issue_key="TEST-123",
+            metrics=["cycle_time", "lead_time"],
+            working_hours_only=False,
+        )
+
+        assert isinstance(result, IssueSLAResponse)
+        assert result.issue_key == "TEST-123"
+        assert result.metrics.cycle_time is not None
+        assert result.metrics.lead_time is not None
+
+    def test_cycle_time_calculation(
+        self, sla_mixin: SLAMixin, mock_issue_dates: IssueDatesResponse
+    ):
+        """Test cycle time calculation (created to resolved)."""
+        sla_mixin.get_issue_dates = MagicMock(return_value=mock_issue_dates)
+
+        result = sla_mixin.get_issue_sla(
+            issue_key="TEST-123",
+            metrics=["cycle_time"],
+            working_hours_only=False,
+        )
+
+        assert result.metrics.cycle_time is not None
+        assert result.metrics.cycle_time.calculated is True
+        # 19 days from Jan 1 to Jan 20 = 27360 minutes
+        assert result.metrics.cycle_time.value_minutes == 27360
+
+    def test_cycle_time_not_resolved(self, sla_mixin: SLAMixin):
+        """Test cycle time when issue not resolved."""
+        issue_dates = IssueDatesResponse(
+            issue_key="TEST-123",
+            created=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+            resolution_date=None,  # Not resolved
+            current_status="In Progress",
+        )
+        sla_mixin.get_issue_dates = MagicMock(return_value=issue_dates)
+
+        result = sla_mixin.get_issue_sla(
+            issue_key="TEST-123",
+            metrics=["cycle_time"],
+            working_hours_only=False,
+        )
+
+        assert result.metrics.cycle_time.calculated is False
+        assert "not resolved" in result.metrics.cycle_time.reason.lower()
+
+    def test_due_date_compliance_met(
+        self, sla_mixin: SLAMixin, mock_issue_dates: IssueDatesResponse
+    ):
+        """Test due date compliance when deadline met."""
+        sla_mixin.get_issue_dates = MagicMock(return_value=mock_issue_dates)
+
+        result = sla_mixin.get_issue_sla(
+            issue_key="TEST-123",
+            metrics=["due_date_compliance"],
+            working_hours_only=False,
+        )
+
+        assert result.metrics.due_date_compliance is not None
+        assert result.metrics.due_date_compliance.status == "met"
+        assert "early" in result.metrics.due_date_compliance.formatted_margin
+
+    def test_due_date_compliance_missed(self, sla_mixin: SLAMixin):
+        """Test due date compliance when deadline missed."""
+        issue_dates = IssueDatesResponse(
+            issue_key="TEST-123",
+            created=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+            due_date=datetime(2023, 1, 15, 23, 59, tzinfo=timezone.utc),
+            resolution_date=datetime(2023, 1, 20, 10, 0, tzinfo=timezone.utc),
+            current_status="Done",
+        )
+        sla_mixin.get_issue_dates = MagicMock(return_value=issue_dates)
+
+        result = sla_mixin.get_issue_sla(
+            issue_key="TEST-123",
+            metrics=["due_date_compliance"],
+            working_hours_only=False,
+        )
+
+        assert result.metrics.due_date_compliance.status == "missed"
+        assert "late" in result.metrics.due_date_compliance.formatted_margin
+
+    def test_time_in_status(
+        self, sla_mixin: SLAMixin, mock_issue_dates: IssueDatesResponse
+    ):
+        """Test time in status calculation."""
+        sla_mixin.get_issue_dates = MagicMock(return_value=mock_issue_dates)
+
+        result = sla_mixin.get_issue_sla(
+            issue_key="TEST-123",
+            metrics=["time_in_status"],
+            working_hours_only=False,
+        )
+
+        assert result.metrics.time_in_status is not None
+        assert len(result.metrics.time_in_status.statuses) >= 1
+
+    def test_batch_get_issue_sla(
+        self, sla_mixin: SLAMixin, mock_issue_dates: IssueDatesResponse
+    ):
+        """Test batch SLA calculation."""
+        sla_mixin.get_issue_dates = MagicMock(return_value=mock_issue_dates)
+
+        result = sla_mixin.batch_get_issue_sla(
+            issue_keys=["TEST-1", "TEST-2", "TEST-3"],
+            metrics=["cycle_time"],
+            working_hours_only=False,
+        )
+
+        assert isinstance(result, IssueSLABatchResponse)
+        assert result.total_count == 3
+        assert result.success_count == 3
+        assert result.error_count == 0
+
+    def test_batch_get_issue_sla_with_errors(self, sla_mixin: SLAMixin):
+        """Test batch SLA calculation with some errors."""
+
+        def mock_get_dates(issue_key, **kwargs):
+            if issue_key == "TEST-2":
+                raise ValueError("Issue not found")
+            return IssueDatesResponse(
+                issue_key=issue_key,
+                created=datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc),
+                resolution_date=datetime(2023, 1, 20, 10, 0, tzinfo=timezone.utc),
+                current_status="Done",
+            )
+
+        sla_mixin.get_issue_dates = MagicMock(side_effect=mock_get_dates)
+
+        result = sla_mixin.batch_get_issue_sla(
+            issue_keys=["TEST-1", "TEST-2", "TEST-3"],
+            metrics=["cycle_time"],
+            working_hours_only=False,
+        )
+
+        assert result.total_count == 3
+        assert result.success_count == 2
+        assert result.error_count == 1
+        assert result.errors[0]["issue_key"] == "TEST-2"
+
+
+class TestSLATimezones:
+    """Tests for SLA timezone handling."""
+
+    @pytest.fixture
+    def sla_mixin(self, jira_fetcher: JiraFetcher) -> SLAMixin:
+        """Create an SLAMixin instance with mocked dependencies."""
+        return jira_fetcher
+
+    def test_timezone_utc(self, sla_mixin: SLAMixin):
+        """Test SLA calculation with UTC timezone."""
+        sla_config = SLAConfig(
+            default_metrics=["lead_time"],
+            timezone="UTC",
+        )
+        tz = sla_mixin._get_sla_timezone(sla_config)
+        assert str(tz) == "UTC"
+
+    def test_timezone_new_york(self, sla_mixin: SLAMixin):
+        """Test SLA calculation with America/New_York timezone."""
+        sla_config = SLAConfig(
+            default_metrics=["lead_time"],
+            timezone="America/New_York",
+        )
+        tz = sla_mixin._get_sla_timezone(sla_config)
+        assert str(tz) == "America/New_York"
+
+    def test_timezone_asia_seoul(self, sla_mixin: SLAMixin):
+        """Test SLA calculation with Asia/Seoul timezone."""
+        sla_config = SLAConfig(
+            default_metrics=["lead_time"],
+            timezone="Asia/Seoul",
+        )
+        tz = sla_mixin._get_sla_timezone(sla_config)
+        assert str(tz) == "Asia/Seoul"
+
+    def test_timezone_invalid_fallback(self, sla_mixin: SLAMixin):
+        """Test invalid timezone falls back to UTC."""
+        sla_config = SLAConfig(
+            default_metrics=["lead_time"],
+            timezone="Invalid/Timezone",
+        )
+        tz = sla_mixin._get_sla_timezone(sla_config)
+        assert str(tz) == "UTC"
+
+
+class TestSLAWorkingHours:
+    """Tests for SLA working hours calculation."""
+
+    @pytest.fixture
+    def sla_mixin(self, jira_fetcher: JiraFetcher) -> SLAMixin:
+        """Create an SLAMixin instance with mocked dependencies."""
+        return jira_fetcher
+
+    def test_working_minutes_weekday(self, sla_mixin: SLAMixin):
+        """Test working minutes on a single weekday."""
+        sla_config = SLAConfig(
+            default_metrics=["cycle_time"],
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+            working_days=[1, 2, 3, 4, 5],
+            timezone="UTC",
+        )
+
+        # Monday 9am to 5pm = 8 hours = 480 minutes
+        start = datetime(2023, 1, 2, 9, 0, tzinfo=timezone.utc)  # Monday
+        end = datetime(2023, 1, 2, 17, 0, tzinfo=timezone.utc)
+
+        result = sla_mixin._calculate_working_minutes(start, end, sla_config)
+        assert result == 480
+
+    def test_working_minutes_excludes_weekend(self, sla_mixin: SLAMixin):
+        """Test working minutes excludes weekend days."""
+        sla_config = SLAConfig(
+            default_metrics=["cycle_time"],
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+            working_days=[1, 2, 3, 4, 5],
+            timezone="UTC",
+        )
+
+        # Friday 9am to Monday 5pm should only count Friday and Monday
+        start = datetime(2023, 1, 6, 9, 0, tzinfo=timezone.utc)  # Friday
+        end = datetime(2023, 1, 9, 17, 0, tzinfo=timezone.utc)  # Monday
+
+        result = sla_mixin._calculate_working_minutes(start, end, sla_config)
+        # 8 hours Friday + 8 hours Monday = 960 minutes
+        assert result == 960
+
+    def test_working_minutes_partial_day(self, sla_mixin: SLAMixin):
+        """Test working minutes for partial day."""
+        sla_config = SLAConfig(
+            default_metrics=["cycle_time"],
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+            working_days=[1, 2, 3, 4, 5],
+            timezone="UTC",
+        )
+
+        # Monday 10am to 2pm = 4 hours = 240 minutes
+        start = datetime(2023, 1, 2, 10, 0, tzinfo=timezone.utc)  # Monday
+        end = datetime(2023, 1, 2, 14, 0, tzinfo=timezone.utc)
+
+        result = sla_mixin._calculate_working_minutes(start, end, sla_config)
+        assert result == 240
+
+    def test_working_minutes_outside_hours(self, sla_mixin: SLAMixin):
+        """Test working minutes when entirely outside working hours."""
+        sla_config = SLAConfig(
+            default_metrics=["cycle_time"],
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+            working_days=[1, 2, 3, 4, 5],
+            timezone="UTC",
+        )
+
+        # Monday 6pm to 8pm = 0 minutes (after working hours)
+        start = datetime(2023, 1, 2, 18, 0, tzinfo=timezone.utc)  # Monday
+        end = datetime(2023, 1, 2, 20, 0, tzinfo=timezone.utc)
+
+        result = sla_mixin._calculate_working_minutes(start, end, sla_config)
+        assert result == 0
+
+
+class TestSLAModels:
+    """Tests for SLA Pydantic models."""
+
+    def test_cycle_time_metric_calculated(self):
+        """Test CycleTimeMetric serialization when calculated."""
+        metric = CycleTimeMetric(
+            value_minutes=1440,
+            formatted="1d 0h 0m",
+            calculated=True,
+        )
+
+        result = metric.to_simplified_dict()
+
+        assert result["calculated"] is True
+        assert result["value_minutes"] == 1440
+        assert result["formatted"] == "1d 0h 0m"
+
+    def test_cycle_time_metric_not_calculated(self):
+        """Test CycleTimeMetric serialization when not calculated."""
+        metric = CycleTimeMetric(
+            calculated=False,
+            reason="Issue not resolved",
+        )
+
+        result = metric.to_simplified_dict()
+
+        assert result["calculated"] is False
+        assert result["reason"] == "Issue not resolved"
+        assert "value_minutes" not in result
+
+    def test_lead_time_metric(self):
+        """Test LeadTimeMetric serialization."""
+        metric = LeadTimeMetric(
+            value_minutes=2880,
+            formatted="2d 0h 0m",
+            is_resolved=True,
+        )
+
+        result = metric.to_simplified_dict()
+
+        assert result["value_minutes"] == 2880
+        assert result["formatted"] == "2d 0h 0m"
+        assert result["is_resolved"] is True
+
+    def test_time_in_status_entry(self):
+        """Test TimeInStatusEntry serialization."""
+        entry = TimeInStatusEntry(
+            status="In Progress",
+            value_minutes=1440,
+            formatted="1d 0h 0m",
+            percentage=50.0,
+            visit_count=2,
+        )
+
+        result = entry.to_simplified_dict()
+
+        assert result["status"] == "In Progress"
+        assert result["value_minutes"] == 1440
+        assert result["percentage"] == 50.0
+        assert result["visit_count"] == 2
+
+    def test_due_date_compliance_met(self):
+        """Test DueDateComplianceMetric serialization when met."""
+        metric = DueDateComplianceMetric(
+            status="met",
+            margin_minutes=1440,
+            formatted_margin="1d 0h 0m early",
+        )
+
+        result = metric.to_simplified_dict()
+
+        assert result["status"] == "met"
+        assert result["margin_minutes"] == 1440
+        assert result["formatted_margin"] == "1d 0h 0m early"
+
+    def test_due_date_compliance_no_due_date(self):
+        """Test DueDateComplianceMetric when no due date."""
+        metric = DueDateComplianceMetric(status="no_due_date")
+
+        result = metric.to_simplified_dict()
+
+        assert result["status"] == "no_due_date"
+        assert "margin_minutes" not in result
+
+    def test_issue_sla_response(self):
+        """Test IssueSLAResponse serialization."""
+        response = IssueSLAResponse(
+            issue_key="TEST-123",
+            metrics=IssueSLAMetrics(
+                cycle_time=CycleTimeMetric(
+                    value_minutes=1440,
+                    formatted="1d 0h 0m",
+                    calculated=True,
+                )
+            ),
+        )
+
+        result = response.to_simplified_dict()
+
+        assert result["issue_key"] == "TEST-123"
+        assert "metrics" in result
+        assert result["metrics"]["cycle_time"]["calculated"] is True
+
+    def test_issue_sla_batch_response(self):
+        """Test IssueSLABatchResponse serialization."""
+        response = IssueSLABatchResponse(
+            issues=[
+                IssueSLAResponse(
+                    issue_key="TEST-1",
+                    metrics=IssueSLAMetrics(),
+                )
+            ],
+            total_count=2,
+            success_count=1,
+            error_count=1,
+            errors=[{"issue_key": "TEST-2", "error": "Not found"}],
+            metrics_calculated=["cycle_time"],
+            working_hours_applied=True,
+            working_hours_config=WorkingHoursConfig(
+                start="09:00",
+                end="17:00",
+                days=[1, 2, 3, 4, 5],
+                timezone="UTC",
+            ),
+        )
+
+        result = response.to_simplified_dict()
+
+        assert result["total_count"] == 2
+        assert result["success_count"] == 1
+        assert result["error_count"] == 1
+        assert len(result["issues"]) == 1
+        assert len(result["errors"]) == 1
+        assert result["working_hours_applied"] is True
+        assert result["working_hours_config"]["start"] == "09:00"


### PR DESCRIPTION
## Description

  Add `jira_get_issue_sla` tool to calculate SLA metrics for Jira issues including cycle time, lead time, and time in status.

  **New Tool:**
  - `jira_get_issue_sla` - Calculate cycle time, lead time, time in status, due date compliance

  **Features:**
  - Working hours filtering (exclude weekends/non-business hours)
  - Configurable start/end times and timezone
  - Batch operations for multiple issues
  - Uses status category API for reliable status detection

  **Configuration:**
  ```bash
  JIRA_SLA_WORKING_HOURS_ONLY=true
  JIRA_SLA_WORKING_HOURS_START=09:00
  JIRA_SLA_WORKING_HOURS_END=17:00
  JIRA_SLA_TIMEZONE=America/New_York
``` 

  This is part 2 of 3 PRs splitting the original #823.
  Depends on: PR for jira_get_issue_dates (MetricsMixin)

  Changes

  - Add jira/sla.py - SLAMixin for SLA calculations
  - Add jira/config.py - SLAConfig with validation
  - Add jira/protocols.py - MetricsOperationsProto
  - Add models/jira/sla.py - Pydantic models for SLA responses
  - Update servers/jira.py - Register jira_get_issue_sla tool
  - Add comprehensive unit tests including timezone and DST edge cases
  - Update .env.example and README.md

  Testing

 - [x] Unit tests added (including timezone, DST, validation tests)
 - [x] All tests pass locally
 - [x] Manual testing with real Jira instance

  Checklist

 - [x] Code follows project style guidelines
 - [x] Tests added for changes
 - [x] All tests pass locally
 - [x] Documentation updated

