### PR TITLE
Add Jira Cloud search pagination (nextPageToken)

### DIFF
--- a/src/mcp_atlassian/models/jira/search.py
+++ b/src/mcp_atlassian/models/jira/search.py
@@ -23,6 +23,9 @@ class JiraSearchResult(ApiModel):
     total: int = 0
     start_at: int = 0
     max_results: int = 0
+    # Jira Cloud enhanced search paging
+    next_page_token: str | None = None
+    is_last: bool | None = None
     issues: list[JiraIssue] = Field(default_factory=list)
 
     @classmethod
@@ -61,6 +64,8 @@ class JiraSearchResult(ApiModel):
         raw_total = data.get("total")
         raw_start_at = data.get("startAt")
         raw_max_results = data.get("maxResults")
+        next_page_token = data.get("nextPageToken")
+        is_last = data.get("isLast")
 
         try:
             total = int(raw_total) if raw_total is not None else -1
@@ -81,6 +86,8 @@ class JiraSearchResult(ApiModel):
             total=total,
             start_at=start_at,
             max_results=max_results,
+            next_page_token=str(next_page_token) if next_page_token else None,
+            is_last=bool(is_last) if is_last is not None else None,
             issues=issues,
         )
 
@@ -103,5 +110,7 @@ class JiraSearchResult(ApiModel):
             "total": self.total,
             "start_at": self.start_at,
             "max_results": self.max_results,
+            "next_page_token": self.next_page_token,
+            "is_last": self.is_last,
             "issues": [issue.to_simplified_dict() for issue in self.issues],
         }


### PR DESCRIPTION
Problem: The existing jira_search tool exposes start_at/limit like the legacy offset-based API, but Jira Cloud /rest/api/3/search/jql ignores startAt and requires nextPageToken. With no page token exposed (and the tool’s limit capped), callers could not iterate past the first page, so plain search was not enough to fetch all matching issues.

Fix: Add a page-based search tool that returns next_page_token/is_last (and accepts page_token/page_size) so clients can reliably page through all results on Jira Cloud.

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
