### PR TITLE
Add OAuth 2.0 support for Atlassian Data Center

### DIFF
--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -48,17 +48,20 @@ class ConfluenceConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
-        # Multi-Cloud OAuth mode: URL might be None, but we use api.atlassian.com
+        # If OAuth with cloud_id is set, it's always Cloud
+        # (cloud_id is specific to Atlassian Cloud)
         if (
             self.auth_type == "oauth"
             and self.oauth_config
             and self.oauth_config.cloud_id
         ):
-            # OAuth with cloud_id uses api.atlassian.com which is always Cloud
             return True
 
-        # For other auth types, check the URL
-        return is_atlassian_cloud_url(self.url) if self.url else False
+        # Check the URL
+        if self.url:
+            return is_atlassian_cloud_url(self.url)
+
+        return False
 
     @property
     def verify_ssl(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -47,30 +47,55 @@ class JiraClient:
 
         # Initialize the Jira client based on auth type
         if self.config.auth_type == "oauth":
-            if not self.config.oauth_config or not self.config.oauth_config.cloud_id:
-                error_msg = "OAuth authentication requires a valid cloud_id"
+            if not self.config.oauth_config:
+                error_msg = "OAuth authentication requires oauth_config"
                 raise ValueError(error_msg)
 
             # Create a session for OAuth
             session = Session()
 
-            # Configure the session with OAuth authentication
+            # Configure the session with OAuth authentication (sets Bearer token)
             if not configure_oauth_session(session, self.config.oauth_config):
                 error_msg = "Failed to configure OAuth session"
                 raise MCPAtlassianAuthenticationError(error_msg)
 
-            # The Jira API URL with OAuth is different
-            api_url = (
-                f"https://api.atlassian.com/ex/jira/{self.config.oauth_config.cloud_id}"
-            )
+            # Determine if this is Cloud or Data Center OAuth
+            has_cloud_id = bool(self.config.oauth_config.cloud_id)
+            is_cloud_url = self.config.url and "atlassian.net" in self.config.url
+            is_dc_url = self.config.url and "atlassian.net" not in self.config.url
 
-            # Initialize Jira with the session
-            self.jira = Jira(
-                url=api_url,
-                session=session,
-                cloud=True,  # OAuth is only for Cloud
-                verify_ssl=self.config.ssl_verify,
-            )
+            # Cloud OAuth (URL is Cloud or no URL) requires cloud_id
+            if (is_cloud_url or not self.config.url) and not has_cloud_id:
+                error_msg = "Cloud OAuth authentication requires a valid cloud_id"
+                raise ValueError(error_msg)
+
+            if has_cloud_id:
+                # Cloud OAuth: use api.atlassian.com endpoint
+                api_url = f"https://api.atlassian.com/ex/jira/{self.config.oauth_config.cloud_id}"
+                logger.debug(
+                    f"Initializing Jira client with OAuth (Cloud). API URL: {api_url}"
+                )
+                self.jira = Jira(
+                    url=api_url,
+                    session=session,
+                    cloud=True,
+                    verify_ssl=self.config.ssl_verify,
+                )
+            else:
+                # Data Center OAuth: use configured URL directly with Bearer token
+                if not self.config.url:
+                    error_msg = "Data Center OAuth requires JIRA_URL to be set"
+                    raise ValueError(error_msg)
+                logger.debug(
+                    f"Initializing Jira client with OAuth (Data Center). "
+                    f"URL: {self.config.url}"
+                )
+                self.jira = Jira(
+                    url=self.config.url,
+                    session=session,
+                    cloud=False,
+                    verify_ssl=self.config.ssl_verify,
+                )
         elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Jira client with Token (PAT) auth. "

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -51,17 +51,20 @@ class JiraConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
-        # Multi-Cloud OAuth mode: URL might be None, but we use api.atlassian.com
+        # If OAuth with cloud_id is set, it's always Cloud
+        # (cloud_id is specific to Atlassian Cloud)
         if (
             self.auth_type == "oauth"
             and self.oauth_config
             and self.oauth_config.cloud_id
         ):
-            # OAuth with cloud_id uses api.atlassian.com which is always Cloud
             return True
 
-        # For other auth types, check the URL
-        return is_atlassian_cloud_url(self.url) if self.url else False
+        # Check the URL
+        if self.url:
+            return is_atlassian_cloud_url(self.url)
+
+        return False
 
     @property
     def verify_ssl(self) -> bool:

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -51,13 +51,23 @@ def get_available_services() -> dict[str, bool | None]:
             ):
                 confluence_is_setup = True
                 logger.info("Using Confluence Cloud Basic Authentication (API Token)")
-        else:  # Server/Data Center non-OAuth
+        else:  # Server/Data Center
             if os.getenv("CONFLUENCE_PERSONAL_TOKEN") or (
                 os.getenv("CONFLUENCE_USERNAME") and os.getenv("CONFLUENCE_API_TOKEN")
             ):
                 confluence_is_setup = True
                 logger.info(
                     "Using Confluence Server/Data Center authentication (PAT or Basic Auth)"
+                )
+            elif os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+                "true",
+                "1",
+                "yes",
+            ):
+                # Data Center with per-request bearer tokens
+                confluence_is_setup = True
+                logger.info(
+                    "Using Confluence Data Center OAuth - expecting user-provided tokens via headers"
                 )
     elif os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in ("true", "1", "yes"):
         confluence_is_setup = True
@@ -104,13 +114,23 @@ def get_available_services() -> dict[str, bool | None]:
             ):
                 jira_is_setup = True
                 logger.info("Using Jira Cloud Basic Authentication (API Token)")
-        else:  # Server/Data Center non-OAuth
+        else:  # Server/Data Center
             if os.getenv("JIRA_PERSONAL_TOKEN") or (
                 os.getenv("JIRA_USERNAME") and os.getenv("JIRA_API_TOKEN")
             ):
                 jira_is_setup = True
                 logger.info(
                     "Using Jira Server/Data Center authentication (PAT or Basic Auth)"
+                )
+            elif os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+                "true",
+                "1",
+                "yes",
+            ):
+                # Data Center with per-request bearer tokens
+                jira_is_setup = True
+                logger.info(
+                    "Using Jira Data Center OAuth - expecting user-provided tokens via headers"
                 )
     elif os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in ("true", "1", "yes"):
         jira_is_setup = True

--- a/tests/unit/confluence/test_client_oauth.py
+++ b/tests/unit/confluence/test_client_oauth.py
@@ -136,23 +136,23 @@ class TestConfluenceClientOAuth:
             assert client.preprocessor == mock_preprocessor.return_value
 
     def test_init_with_byo_oauth_missing_cloud_id(self):
-        """Test initializing the client with BYO OAuth but missing cloud_id."""
+        """Test initializing the client with BYO OAuth and Cloud URL but missing cloud_id."""
         # Create a mock BYO OAuth config without cloud_id
         byo_oauth_config = BYOAccessTokenOAuthConfig(
             access_token="test-byo-access-token",
             cloud_id="",  # Explicitly empty or None
         )
 
-        # Create a Confluence config with BYO OAuth
+        # Create a Confluence config with BYO OAuth and Cloud URL - requires cloud_id
         config = ConfluenceConfig(
             url="https://test.atlassian.net/wiki",
             auth_type="oauth",
             oauth_config=byo_oauth_config,
         )
 
-        # Verify error is raised by ConfluenceClient's validation
+        # Verify error is raised for Cloud URL without cloud_id
         with pytest.raises(
-            ValueError, match="OAuth authentication requires a valid cloud_id"
+            ValueError, match="Cloud OAuth authentication requires a valid cloud_id"
         ):
             ConfluenceClient(config=config)
 
@@ -218,7 +218,7 @@ class TestConfluenceClientOAuth:
                 ConfluenceClient(config=config)
 
     def test_init_with_oauth_missing_cloud_id(self):
-        """Test initializing the client with OAuth but missing cloud_id."""
+        """Test initializing the client with Cloud OAuth but missing cloud_id."""
         # Create a mock OAuth config without cloud_id
         oauth_config = OAuthConfig(
             client_id="test-client-id",
@@ -229,16 +229,16 @@ class TestConfluenceClientOAuth:
             access_token="test-access-token",
         )
 
-        # Create a Confluence config with OAuth
+        # Create a Confluence config with OAuth and Cloud URL - requires cloud_id
         config = ConfluenceConfig(
             url="https://test.atlassian.net/wiki",
             auth_type="oauth",
             oauth_config=oauth_config,
         )
 
-        # Verify error is raised
+        # Verify error is raised for Cloud URL without cloud_id
         with pytest.raises(
-            ValueError, match="OAuth authentication requires a valid cloud_id"
+            ValueError, match="Cloud OAuth authentication requires a valid cloud_id"
         ):
             ConfluenceClient(config=config)
 

--- a/tests/unit/jira/test_client_oauth.py
+++ b/tests/unit/jira/test_client_oauth.py
@@ -77,7 +77,7 @@ class TestJiraClientOAuth:
             mock_configure_ssl.assert_called_once()
 
     def test_init_with_oauth_missing_cloud_id(self):
-        """Test initializing the client with OAuth but missing cloud_id."""
+        """Test initializing the client with Cloud OAuth but missing cloud_id."""
         # Create a mock OAuth config without cloud_id
         oauth_config = OAuthConfig(
             client_id="test-client-id",
@@ -88,16 +88,16 @@ class TestJiraClientOAuth:
             access_token="test-access-token",
         )
 
-        # Create a Jira config with OAuth
+        # Create a Jira config with OAuth and Cloud URL - requires cloud_id
         config = JiraConfig(
             url="https://test.atlassian.net",
             auth_type="oauth",
             oauth_config=oauth_config,
         )
 
-        # Verify error is raised
+        # Verify error is raised for Cloud URL without cloud_id
         with pytest.raises(
-            ValueError, match="OAuth authentication requires a valid cloud_id"
+            ValueError, match="Cloud OAuth authentication requires a valid cloud_id"
         ):
             JiraClient(config=config)
 
@@ -201,22 +201,22 @@ class TestJiraClientOAuth:
             mock_configure_ssl.assert_called_once()
 
     def test_init_with_byo_oauth_missing_cloud_id(self):
-        """Test initializing with BYO OAuth but missing cloud_id."""
+        """Test initializing with BYO OAuth and Cloud URL but missing cloud_id."""
         # Create a mock BYO OAuth config with an empty cloud_id
         byo_oauth_config = BYOAccessTokenOAuthConfig(
             cloud_id="", access_token="my-byo-token"
         )
 
-        # Create a Jira config with OAuth
+        # Create a Jira config with OAuth and Cloud URL - requires cloud_id
         config = JiraConfig(
             url="https://test.atlassian.net",
             auth_type="oauth",
             oauth_config=byo_oauth_config,
         )
 
-        # Verify error is raised
+        # Verify error is raised for Cloud URL without cloud_id
         with pytest.raises(
-            ValueError, match="OAuth authentication requires a valid cloud_id"
+            ValueError, match="Cloud OAuth authentication requires a valid cloud_id"
         ):
             JiraClient(config=config)
 


### PR DESCRIPTION
## Description

  Add full OAuth 2.0 (3LO) authentication support for Atlassian Data Center instances, complementing the existing Cloud OAuth support. This enables users with on-premise Data Center deployments to use OAuth authentication instead of just PAT or basic auth.

  Tested on a local Data Center instance.

  ## Changes

  - Add Data Center OAuth endpoints (`/rest/oauth2/latest/*`)
  - Add `base_url` parameter to `OAuthConfig` for DC instance URL
  - Add `is_data_center` property to detect DC vs Cloud configuration
  - Update client initialization to handle both Cloud and DC OAuth
  - Cloud OAuth requires `cloud_id`; DC OAuth requires `base_url`
  - DC does not require `offline_access` scope for refresh tokens
  - Update `oauth_setup` wizard to support Data Center configuration
  - Fix `is_cloud` detection to treat OAuth with `cloud_id` as Cloud regardless of URL

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests passed
  - [x] Manual checks performed: Tested OAuth flow on local Atlassian Data Center instance

  ## Checklist

  - [x] Code follows project style guidelines (linting passes).
  - [x] Tests added/updated for changes.
  - [x] All tests pass locally.
  - [ ] Documentation updated (if needed).