### PR TITLE
fix: allow components field to be updated via jira_update_issue

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -813,8 +813,8 @@ class IssuesMixin(
         # Process each kwarg
         # Iterate over a copy to allow modification of the original kwargs if needed elsewhere
         for key, value in kwargs.copy().items():
-            # Skip keys used internally for epic/parent handling or explicitly handled args like assignee/components
-            if key.startswith("__epic_") or key in ("parent", "assignee", "components"):
+            # Skip keys used internally for epic/parent handling or explicitly handled args like assignee
+            if key.startswith("__epic_") or key in ("parent", "assignee"):
                 continue
 
             normalized_key = key.lower()

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -714,6 +714,72 @@ class TestIssuesMixin:
         assert not issues_mixin._get_account_id.called
         assert document.key == "TEST-123"
 
+    def test_update_issue_components(self, issues_mixin: IssuesMixin):
+        """Test updating an issue's components field."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+                "components": [{"name": "Backend"}],
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._generate_field_map = MagicMock(
+            return_value={"components": "components"}
+        )
+        issues_mixin.get_field_by_id = MagicMock(
+            return_value={"name": "Components", "schema": {"type": "array"}}
+        )
+
+        document = issues_mixin.update_issue(
+            issue_key="TEST-123", components=["Backend", "Frontend"]
+        )
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123",
+            update={
+                "fields": {"components": [{"name": "Backend"}, {"name": "Frontend"}]}
+            },
+        )
+        assert document.key == "TEST-123"
+
+    def test_update_issue_components_with_dict_format(self, issues_mixin: IssuesMixin):
+        """Test updating components with pre-formatted dict values."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+                "components": [],
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._generate_field_map = MagicMock(
+            return_value={"components": "components"}
+        )
+        issues_mixin.get_field_by_id = MagicMock(
+            return_value={"name": "Components", "schema": {"type": "array"}}
+        )
+
+        document = issues_mixin.update_issue(
+            issue_key="TEST-123", components=[{"id": "10001"}, {"name": "API"}]
+        )
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123",
+            update={"fields": {"components": [{"id": "10001"}, {"name": "API"}]}},
+        )
+        assert document.key == "TEST-123"
+
     def test_delete_issue(self, issues_mixin: IssuesMixin):
         """Test deleting an issue."""
         # Call the method


### PR DESCRIPTION
## Description

The `components` field was explicitly skipped in `_process_additional_fields()`, causing `jira_update_issue` to return "Issue updated successfully" while silently ignoring the components change. This blocked automation workflows on Jira Server/Data Center.

Fixes: #770

## Changes

- Remove `components` from the skip list in `_process_additional_fields()`
- Add unit tests for updating components with string array format
- Add unit tests for updating components with pre-formatted dict values

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Verified clear and set operations on Jira Server/DC instance

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).