### PR TITLE
security: add pip>=25.3 to fix CVE-2025-8869

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "keyring>=25.6.0",
     "cachetools>=5.0.0",
     "types-cachetools>=5.5.0.20240820",
+    "pip>=25.3",
 ]
 [[project.authors]]
 name = "sooperset"


### PR DESCRIPTION
## Security Fix: Add pip>=25.3 dependency constraint

### Summary
Adds `pip>=25.3` to `pyproject.toml` dependencies to fix CVE-2025-8869.

### Vulnerability Details
- **CVE**: CVE-2025-8869
- **Severity**: Medium (CVSS 5.9)
- **Affected Range**: pip <=25.2
- **Fixed Version**: pip 25.3
- **Description**: Improper Link Resolution Before File Access ('Link Following')

### Changes
- Added `pip>=25.3` to `pyproject.toml` dependencies

### Impact
- Ensures pip is at a secure version that fixes the vulnerability
- Low risk change (version constraint only)
- No breaking changes

### Testing
- ✅ Dependency constraint added successfully
- ✅ Compatible with existing Python versions (3.10+)

### References
- https://scout.docker.com/v/CVE-2025-8869
- https://github.com/pypa/pip/security/advisories