### PR TITLE
fix(confluence): resolve Vertex AI schema validation error in confluence_get_page

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -126,7 +126,7 @@ async def search(
 async def get_page(
     ctx: Context,
     page_id: Annotated[
-        str | int | None,
+        str | None,
         Field(
             description=(
                 "Confluence page ID (numeric ID, can be found in the page URL). "
@@ -136,6 +136,7 @@ async def get_page(
             ),
             default=None,
         ),
+        BeforeValidator(lambda x: str(x) if x is not None else None),
     ] = None,
     title: Annotated[
         str | None,

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -608,6 +608,21 @@ async def test_update_page_with_string_parent_id(client, mock_confluence_fetcher
     assert result_data["page"]["title"] == "Test Page Mock Title"
 
 
+@pytest.mark.anyio
+async def test_get_page_with_numeric_id(client, mock_confluence_fetcher):
+    """Test get_page with numeric page_id (integer) - should convert to string."""
+    response = await client.call_tool("confluence_get_page", {"page_id": 123456})
+
+    # Verify the page_id was converted to string when calling the underlying method
+    mock_confluence_fetcher.get_page_content.assert_called_once_with(
+        "123456", convert_to_markdown=True
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert "metadata" in result_data
+    assert result_data["metadata"]["id"] == "123456"
+
+
 # Phase 5: MCP Attachment Tools Tests (TDD RED Phase)
 @pytest.mark.anyio
 async def test_upload_attachment(client, mock_confluence_fetcher):


### PR DESCRIPTION
## Description

This PR fixes a schema validation error when using `mcp-atlassian` with Google Vertex AI. The `confluence_get_page` tool previously used a union type `str | int | None` for the `page_id` parameter, which failed to translate to a valid JSON Schema for Vertex AI (resulting in a `400 INVALID_ARGUMENT` error).

Fixes: #885

## Changes

- Updated `page_id` type hint in `get_page` tool from `str | int | None` to `str | None` in [`src/mcp_atlassian/servers/confluence.py`](src/mcp_atlassian/servers/confluence.py:122).
- Added a `BeforeValidator` to `page_id` to automatically convert integer inputs to strings, ensuring backward compatibility for numeric IDs.
- Added a regression test `test_get_page_with_numeric_id` in [`tests/unit/servers/test_confluence_server.py`](tests/unit/servers/test_confluence_server.py:538).

## Testing

- [x] Unit tests added/updated: Added `test_get_page_with_numeric_id` to verify integer-to-string conversion.
- [x] Manual checks performed: Verified that the tool still accepts both string and integer IDs through the FastMCP interface.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).