### PR TITLE
fix: add US Government Cloud URL detection

### DIFF
--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -31,9 +31,12 @@ def is_atlassian_cloud_url(url: str) -> bool:
         return False
 
     # The standard check for Atlassian cloud domains
+    # Includes US Government cloud domains (FedRAMP Moderate/High)
     return (
         ".atlassian.net" in hostname
         or ".jira.com" in hostname
         or ".jira-dev.com" in hostname
         or "api.atlassian.com" in hostname
+        or ".atlassian-us-gov-mod.net" in hostname  # US Gov Moderate (FedRAMP)
+        or ".atlassian-us-gov.net" in hostname  # US Gov (FedRAMP)
     )

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -37,6 +37,24 @@ def test_is_atlassian_cloud_url_multi_cloud_oauth():
     assert is_atlassian_cloud_url("https://api.atlassian.com") is True
 
 
+def test_is_atlassian_cloud_url_us_gov():
+    """Test that is_atlassian_cloud_url returns True for US Government Cloud URLs."""
+    # Test US Government Moderate (FedRAMP) Cloud URLs
+    assert is_atlassian_cloud_url("https://company.atlassian-us-gov-mod.net") is True
+    assert (
+        is_atlassian_cloud_url("https://company.atlassian-us-gov-mod.net/wiki") is True
+    )
+    assert (
+        is_atlassian_cloud_url("https://subdomain.atlassian-us-gov-mod.net/jira")
+        is True
+    )
+    assert is_atlassian_cloud_url("http://other.atlassian-us-gov-mod.net") is True
+
+    # Test US Government (FedRAMP) Cloud URLs
+    assert is_atlassian_cloud_url("https://company.atlassian-us-gov.net") is True
+    assert is_atlassian_cloud_url("https://company.atlassian-us-gov.net/wiki") is True
+
+
 def test_is_atlassian_cloud_url_server():
     """Test that is_atlassian_cloud_url returns False for Atlassian Server/Data Center URLs."""
     # Test with various server/data center domains


### PR DESCRIPTION
## Description

Add support for Atlassian US Government Cloud instances (FedRAMP) in the `is_atlassian_cloud_url()` function.

Without this fix, US Gov Cloud URLs like `*.atlassian-us-gov-mod.net` are incorrectly identified as Server/Data Center deployments, causing the library to use deprecated v2 APIs instead of the v3 Cloud APIs.

## Problem

After the Jira v2 search API deprecation (PR #769), US Government Cloud customers experience HTTP 410 errors when using `jira_search`:

```
The requested API has been removed. Please migrate to the /rest/api/3/search/jql API.
```

This happens because `is_atlassian_cloud_url()` only checks for `.atlassian.net` domains, not the US Gov domains.

## Solution

Added support for US Government Cloud domains:
- `*.atlassian-us-gov-mod.net` (US Gov Moderate - FedRAMP)
- `*.atlassian-us-gov.net` (US Gov - FedRAMP)

## Changes

- `src/mcp_atlassian/utils/urls.py`: Added US Gov domain checks
- `tests/unit/utils/test_urls.py`: Added test cases for US Gov URLs

## Testing

- All existing tests pass
- Added new test `test_is_atlassian_cloud_url_us_gov()` covering both US Gov domain patterns

Made with [Cursor](https://cursor.com)