### PR TITLE
Timeout support for Confluence and Jira clients

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -55,6 +55,7 @@ class ConfluenceClient:
                 session=session,
                 cloud=True,  # OAuth is only for Cloud
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         elif self.config.auth_type == "pat":
             logger.debug(
@@ -67,6 +68,7 @@ class ConfluenceClient:
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         else:  # basic auth
             logger.debug(
@@ -81,6 +83,7 @@ class ConfluenceClient:
                 password=self.config.api_token,  # API token is used as password
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
             logger.debug(
                 f"Confluence client initialized. "

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -39,6 +39,7 @@ class ConfluenceConfig:
     client_cert: str | None = None  # Client certificate file path (.pem)
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
+    timeout: int = 75  # Connection timeout in seconds
 
     @property
     def is_cloud(self) -> bool:
@@ -142,6 +143,14 @@ class ConfluenceConfig:
         client_key = os.getenv("CONFLUENCE_CLIENT_KEY")
         client_key_password = os.getenv("CONFLUENCE_CLIENT_KEY_PASSWORD")
 
+        # Timeout setting
+        timeout = 75  # Default timeout
+        if (
+            os.getenv("CONFLUENCE_TIMEOUT")
+            and os.getenv("CONFLUENCE_TIMEOUT").isdigit()
+        ):
+            timeout = int(os.getenv("CONFLUENCE_TIMEOUT"))
+
         return cls(
             url=url,
             auth_type=auth_type,
@@ -159,6 +168,7 @@ class ConfluenceConfig:
             client_cert=client_cert,
             client_key=client_key,
             client_key_password=client_key_password,
+            timeout=timeout,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -70,6 +70,7 @@ class JiraClient:
                 session=session,
                 cloud=True,  # OAuth is only for Cloud
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         elif self.config.auth_type == "pat":
             logger.debug(
@@ -82,6 +83,7 @@ class JiraClient:
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         else:  # basic auth
             logger.debug(
@@ -96,6 +98,7 @@ class JiraClient:
                 password=self.config.api_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
             logger.debug(
                 f"Jira client initialized. Session headers (Authorization masked): "

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -115,6 +115,7 @@ class JiraConfig:
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
     sla_config: SLAConfig | None = None  # Optional SLA configuration
+    timeout: int = 75  # Connection timeout in seconds
 
     @property
     def is_cloud(self) -> bool:
@@ -223,6 +224,11 @@ class JiraConfig:
         client_key = os.getenv("JIRA_CLIENT_KEY")
         client_key_password = os.getenv("JIRA_CLIENT_KEY_PASSWORD")
 
+        # Timeout setting
+        timeout = 75  # Default timeout
+        if os.getenv("JIRA_TIMEOUT") and os.getenv("JIRA_TIMEOUT").isdigit():
+            timeout = int(os.getenv("JIRA_TIMEOUT"))
+
         return cls(
             url=url,
             auth_type=auth_type,
@@ -241,6 +247,7 @@ class JiraConfig:
             client_cert=client_cert,
             client_key=client_key,
             client_key_password=client_key_password,
+            timeout=timeout,
         )
 
     def is_auth_configured(self) -> bool:

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -38,6 +38,7 @@ def test_init_with_basic_auth():
             password="test_token",
             cloud=True,
             verify_ssl=True,
+            timeout=75,
         )
         assert client.config == config
         assert client.confluence == mock_confluence.return_value
@@ -84,6 +85,7 @@ def test_init_with_token_auth():
             token="test_personal_token",
             cloud=False,
             verify_ssl=False,
+            timeout=75,
         )
         assert client.config == config
         assert client.confluence == mock_confluence.return_value

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -44,6 +44,7 @@ def test_init_with_basic_auth():
             password="test_token",
             cloud=True,
             verify_ssl=True,
+            timeout=75,
         )
 
         # Verify SSL verification was configured
@@ -85,6 +86,7 @@ def test_init_with_token_auth():
             token="test_personal_token",
             cloud=False,
             verify_ssl=False,
+            timeout=75,
         )
 
         # Verify SSL verification was configured with ssl_verify=False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Added timeout support for Confluence and Jira clients.

## Changes

<!-- Briefly list the key changes made. -->

- added timeout parameter to ConfluenceConfig and JiraConfig configurations
- support for setting timeout via environment variables CONFLUENCE_TIMEOUT and JIRA_TIMEOUT
- default timeout value set to 75 seconds

Related Issues:
- #539 
- #891 


