### PR TITLE
fix(jira): allow components field updates via update_issue

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -822,8 +822,11 @@ class IssuesMixin(
         # Process each kwarg
         # Iterate over a copy to allow modification of the original kwargs if needed elsewhere
         for key, value in kwargs.copy().items():
-            # Skip keys used internally for epic/parent handling or explicitly handled args like assignee/components
-            if key.startswith("__epic_") or key in ("parent", "assignee", "components"):
+            # Skip fields handled explicitly in create_issue()/update_issue()
+            # (e.g., assignee requires account ID lookup via _get_account_id).
+            # Other array fields like components, fixVersions, etc. flow through
+            # _format_field_value_for_write() which handles their formatting.
+            if key.startswith("__epic_") or key in ("parent", "assignee"):
                 continue
 
             normalized_key = key.lower()

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -660,6 +660,98 @@ class TestIssuesMixin:
         assert not issues_mixin._get_account_id.called
         assert document.key == "TEST-123"
 
+    def test_update_issue_components(self, issues_mixin: IssuesMixin):
+        """Test updating an issue's components field."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._generate_field_map = MagicMock(  # type: ignore[assignment]
+            return_value={"components": "components"}
+        )
+        issues_mixin.get_field_by_id = MagicMock(  # type: ignore[assignment]
+            return_value={"id": "components", "name": "Components"}
+        )
+
+        document = issues_mixin.update_issue(
+            issue_key="TEST-123", components=["Backend", "Frontend"]
+        )
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123",
+            fields={"components": [{"name": "Backend"}, {"name": "Frontend"}]},
+        )
+        assert document.key == "TEST-123"
+
+    def test_update_issue_components_with_dict_format(self, issues_mixin: IssuesMixin):
+        """Test updating components with pre-formatted dict values."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._generate_field_map = MagicMock(  # type: ignore[assignment]
+            return_value={"components": "components"}
+        )
+        issues_mixin.get_field_by_id = MagicMock(  # type: ignore[assignment]
+            return_value={"id": "components", "name": "Components"}
+        )
+
+        document = issues_mixin.update_issue(
+            issue_key="TEST-123",
+            components=[{"id": "10001"}, {"name": "API"}],
+        )
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123",
+            fields={"components": [{"id": "10001"}, {"name": "API"}]},
+        )
+        assert document.key == "TEST-123"
+
+    def test_update_issue_components_clear(self, issues_mixin: IssuesMixin):
+        """Test clearing an issue's components with an empty list."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._generate_field_map = MagicMock(  # type: ignore[assignment]
+            return_value={"components": "components"}
+        )
+        issues_mixin.get_field_by_id = MagicMock(  # type: ignore[assignment]
+            return_value={"id": "components", "name": "Components"}
+        )
+
+        document = issues_mixin.update_issue(issue_key="TEST-123", components=[])
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123",
+            fields={"components": []},
+        )
+        assert document.key == "TEST-123"
+
     def test_delete_issue(self, issues_mixin: IssuesMixin):
         """Test deleting an issue."""
         # Call the method


### PR DESCRIPTION
## Summary

Fixes #770 — `update_issue()` silently drops `components` field updates. Supersedes #870.

## Root Cause

In commit de58988 (May 2025), the `_process_additional_fields()` refactoring added `"components"` to a skip list alongside `"parent"` and `"assignee"`. While `parent` and `assignee` genuinely need special handling (e.g., account ID lookup via `_get_account_id()`), `components` does not — it is already fully supported by `_format_field_value_for_write()`, which converts string arrays to `[{"name": "..."}]` format.

This caused `components` passed via kwargs (the path used by the MCP tool) to be silently skipped, making component updates appear successful while doing nothing.

## Fix

- Remove `"components"` from the skip list in `_process_additional_fields()`, allowing it to flow through `_format_field_value_for_write()` which already handles the formatting correctly
- Add a clarifying comment explaining *why* `parent` and `assignee` remain skipped (they require special handling), so this regression doesn't recur

## Test Coverage

Three new test cases:
- **String array format**: `["Backend", "Frontend"]` → correctly formatted as `[{"name": "Backend"}, {"name": "Frontend"}]`
- **Pre-formatted dict format**: `[{"id": "10001"}, {"name": "API"}]` → passed through as-is
- **Clearing components**: `[]` → empty list preserved (not silently dropped)

All tests mock `_generate_field_map` and `get_field_by_id` to exercise the full `_process_additional_fields()` → `_format_field_value_for_write()` pipeline.