### PR TITLE
fix(jira): use ASCII transliteration for user lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "keyring>=25.6.0",
     "cachetools>=5.0.0",
     "types-cachetools>=5.5.0.20240820",
+    "unidecode>=1.3.0",
 ]
 [[project.authors]]
 name = "sooperset"

--- a/uv.lock
+++ b/uv.lock
@@ -1035,6 +1035,7 @@ dependencies = [
     { name = "trio" },
     { name = "types-cachetools" },
     { name = "types-python-dateutil" },
+    { name = "unidecode" },
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
@@ -1075,6 +1076,7 @@ requires-dist = [
     { name = "trio", specifier = ">=0.29.0" },
     { name = "types-cachetools", specifier = ">=5.5.0.20240820" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20241206" },
+    { name = "unidecode", specifier = ">=1.3.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "uvicorn", specifier = ">=0.27.1" },
 ]
@@ -2308,6 +2310,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "unidecode"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/7d/a8a765761bbc0c836e397a2e48d498305a865b70a8600fd7a942e85dcf63/Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23", size = 200149, upload-time = "2025-04-24T08:45:03.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/b7/559f59d57d18b44c6d1250d2eeaa676e028b9c527431f5d0736478a73ba1/Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021", size = 235837, upload-time = "2025-04-24T08:45:01.609Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Use `unidecode` for ASCII transliteration in `_lookup_user_directly()` to handle display names with diacritics like Polish "ł" or German "ü".

## Problem

The `_lookup_user_directly` function uses string comparison to match users returned by the Jira API. When a user's display name contains Unicode characters (e.g., "Paweł Kowalczyk"), searching with ASCII approximations (e.g., "Pawel Kowalczyk") fails despite the API finding the correct user.

### Root Cause

The previous implementation used `casefold()` which only handles case normalization, not character transliteration:

```python
"Paweł".casefold()  # → "paweł" (ł preserved)
"Pawel".casefold()  # → "pawel"
# These don't match!
```

### Reproduction

```python
# API correctly returns the user with fuzzy matching
curl "https://INSTANCE.atlassian.net/rest/api/3/user/search?query=Pawel%20Kowalczyk"
# Returns: [{"displayName": "Paweł Kowalczyk", "accountId": "712020:..."}]

# But MCP tool fails because comparison fails
jira_get_user_profile(user_identifier="Pawel Kowalczyk")
# {"success": false, "error": "Could not determine how to look up user..."}

# Unicode name works
jira_get_user_profile(user_identifier="Paweł Kowalczyk")
# {"success": true, ...}
```

## Solution

Use `unidecode` library to transliterate Unicode to ASCII before comparison:

```python
from unidecode import unidecode

def normalize_text(text: str) -> str:
    if not text:
        return ""
    return unidecode(text).casefold()
```

This converts:
- Polish: ł → l, ó → o, ą → a
- German: ü → u, ö → o, ß → ss
- And many other character sets

## Changes

- Add `unidecode>=1.3.0` to dependencies
- Update `normalize_text()` in `jira/users.py` to use unidecode
- Existing tests pass, ASCII approximations now work