### PR TITLE
docs: improve AGENTS.md with architecture, gotchas, and accurate metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
-# AGENTS
+# MCP Atlassian
 
 > **Audience**: LLM-driven engineering agents
-
-This file provides guidance for autonomous coding agents working inside the **MCP Atlassian** repository.
 
 ---
 
@@ -10,70 +8,75 @@ This file provides guidance for autonomous coding agents working inside the **MC
 
 | Path | Purpose |
 | --- | --- |
-| `src/mcp_atlassian/` | Library source code (Python ≥ 3.10) |
-| `  ├─ jira/` | Jira client, mixins, and operations |
-| `  ├─ confluence/` | Confluence client, mixins, and operations |
-| `  ├─ models/` | Pydantic data models for API responses |
-| `  ├─ servers/` | FastMCP server implementations |
-| `  └─ utils/` | Shared utilities (auth, logging, SSL) |
-| `tests/` | Pytest test suite with fixtures |
+| `src/mcp_atlassian/` | Library source (Python ≥ 3.10) |
+| `  ├─ jira/` | Jira client + 16 mixins (issues, search, SLA, metrics, …) |
+| `  ├─ confluence/` | Confluence client + 7 mixins (pages, search, analytics, …) |
+| `  ├─ models/` | Pydantic v2 data models (`ApiModel` base) |
+| `  ├─ servers/` | FastMCP server instances (`jira_mcp`, `confluence_mcp`) |
+| `  ├─ preprocessing/` | Content conversion (ADF/Storage → Markdown) |
+| `  └─ utils/` | Shared utilities (auth, logging, SSL, decorators) |
+| `tests/` | Pytest suite — unit, integration, real-API validation |
 | `scripts/` | OAuth setup and testing scripts |
 
 ---
 
-## Mandatory dev workflow
+## Architecture
+
+- **Mixin composition**: `JiraFetcher` composes 16 mixins, `ConfluenceFetcher` composes 7. Client inheritance is transitive through mixins.
+- **FastMCP servers**: `servers/main.py` → lifespan → dependency injection via `get_jira_fetcher(ctx)` / `get_confluence_fetcher(ctx)`.
+- **Tool naming**: `{service}_{action}_{target}` (e.g., `jira_create_issue`, `confluence_get_page`).
+- **Config**: Environment-based `from_env()` factory on `JiraConfig` / `ConfluenceConfig` dataclasses.
+- **Auth**: Basic (Cloud), PAT (Server/DC), OAuth 2.0 (Cloud) — with multi-tenant header support.
+- **Models**: All extend `ApiModel` → `from_api_response()` + `to_simplified_dict()`.
+
+---
+
+## Dev workflow
 
 ```bash
 uv sync --frozen --all-extras --dev  # install dependencies
 pre-commit install                    # setup hooks
-pre-commit run --all-files           # Ruff + Prettier + Pyright
-uv run pytest                        # run full test suite
+pre-commit run --all-files           # Ruff + mypy
+uv run pytest -xvs                   # full test suite
+uv run pytest tests/unit/ -xvs       # unit tests only
+uv run pytest tests/integration/     # integration tests
+uv run pytest --cov=src/mcp_atlassian --cov-report=term-missing  # coverage
 ```
 
 *Tests must pass* and *lint/typing must be clean* before committing.
 
 ---
 
-## Core MCP patterns
-
-**Tool naming**: `{service}_{action}` (e.g., `jira_create_issue`)
-
-**Architecture**:
-- **Mixins**: Functionality split into focused mixins extending base clients
-- **Models**: All data structures extend `ApiModel` base class
-- **Auth**: Supports API tokens, PAT tokens, and OAuth 2.0
-
----
-
-## Development rules
+## Rules
 
 1. **Package management**: ONLY use `uv`, NEVER `pip`
 2. **Branching**: NEVER work on `main`, always create feature branches
 3. **Type safety**: All functions require type hints
 4. **Testing**: New features need tests, bug fixes need regression tests
 5. **Commits**: Use trailers for attribution, never mention tools/AI
+6. **Commit types**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `ci` — scopes: `jira`, `confluence`, `server`, `auth`, `docker`, `docs`
+7. **File hygiene**: Prefer editing existing files over creating new ones
 
 ---
 
 ## Code conventions
 
-* **Language**: Python ≥ 3.10
-* **Line length**: 88 characters maximum
-* **Imports**: Absolute imports, sorted by ruff
-* **Naming**: `snake_case` functions, `PascalCase` classes
-* **Docstrings**: Google-style for all public APIs
-* **Error handling**: Specific exceptions only
+- **Language**: Python ≥ 3.10
+- **Line length**: 88 characters maximum
+- **Imports**: Absolute imports, sorted by Ruff
+- **Naming**: `snake_case` functions, `PascalCase` classes
+- **Docstrings**: Google-style for all public APIs
+- **Error handling**: Specific exceptions only
 
 ---
 
-## Development guidelines
+## Gotchas
 
-1. Do what has been asked; nothing more, nothing less
-2. NEVER create files unless absolutely necessary
-3. Always prefer editing existing files
-4. Follow established patterns and maintain consistency
-5. Run `pre-commit run --all-files` before committing
-6. Fix bugs immediately when reported
+- **Cloud vs Server/DC**: API endpoints, field names, and auth methods differ. Always check `is_cloud` before assuming behavior.
+- **OAuth = Cloud only**, PAT = Server/DC only. Basic auth (user + API token) works on Cloud.
+- **Read-only mode**: `READ_ONLY_MODE=true` blocks all write tools at server level.
+- **Type checking**: pre-commit runs **mypy** (strict mode).
+- **Environment**: See `.env.example` for all configuration options (auth, proxy, SLA, filtering).
 
 ---
 
@@ -91,3 +94,4 @@ git checkout -b fix/issue-description # Bug fix
 git commit --trailer "Reported-by:<name>"      # Attribution
 git commit --trailer "Github-Issue:#<number>"  # Issue reference
 ```
+


### PR DESCRIPTION
## Description

Rewrites `AGENTS.md` to provide better orientation for LLM agents working in this codebase. The previous version was missing architectural context, had outdated references (Pyright instead of mypy), duplicate sections, and incomplete repository mapping.

## Changes

- Add **Architecture** section documenting mixin composition, FastMCP servers, config pattern, auth model, and data models
- Add **Gotchas** section covering Cloud vs Server/DC differences, OAuth/PAT scope, read-only mode, and environment config
- Add `preprocessing/` to repository map
- Fix `Ruff + Prettier + Pyright` → `Ruff + mypy` in dev workflow comment
- Add unit/integration/coverage test commands to dev workflow
- Add conventional commit types (`feat`, `fix`, `docs`, etc.) and scopes to rules
- Add file hygiene rule (prefer editing existing files)
- Remove redundant "Development guidelines" section (merged useful items into Rules)
- Remove "Core MCP patterns" section (merged into new Architecture section)
- Update mixin counts (16 Jira, 7 Confluence) and server instance names (`jira_mcp`, `confluence_mcp`)

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: verified line count (~97), confirmed all referenced paths exist, confirmed no stale "Pyright" references remain

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).