### PR TITLE
fix(jira): assign issue post-creation to prevent silent assignee drop

### DIFF
--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -508,9 +508,14 @@ class TestIssuesMixin:
         # Verify _get_account_id was called with the correct username
         issues_mixin._get_account_id.assert_called_once_with("testuser")
 
-        # Verify the assignee was properly set for Cloud (accountId)
+        # Verify assignee is in create fields (belt & suspenders)
         fields = issues_mixin.jira.create_issue.call_args[1]["fields"]
         assert fields["assignee"] == {"accountId": "cloud-account-id"}
+
+        # Verify assign_issue was also called post-creation as a safety net
+        issues_mixin.jira.assign_issue.assert_called_once_with(
+            "TEST-123", "cloud-account-id"
+        )
 
     def test_create_issue_with_assignee_server(self, issues_mixin: IssuesMixin):
         """Test creating an issue with an assignee in Jira Server/DC."""
@@ -541,9 +546,14 @@ class TestIssuesMixin:
         # Verify _get_account_id was called with the correct username
         issues_mixin._get_account_id.assert_called_once_with("testuser")
 
-        # Verify the assignee was properly set for Server/DC (name)
+        # Verify assignee is in create fields (belt & suspenders)
         fields = issues_mixin.jira.create_issue.call_args[1]["fields"]
         assert fields["assignee"] == {"name": "server-user"}
+
+        # Verify assign_issue was also called post-creation as a safety net
+        issues_mixin.jira.assign_issue.assert_called_once_with(
+            "TEST-456", "server-user"
+        )
 
     def test_create_epic(self, issues_mixin: IssuesMixin):
         """Test creating an epic."""


### PR DESCRIPTION
## Description

Fixes the assignee being silently ignored when creating issues via `jira_create_issue`.

The `create_issue()` method adds the assignee to the `fields` dict passed to the Jira REST API's create endpoint, but certain Jira Server/DC configurations don't honor this field during creation. The issue gets created as "Unassigned" with no error.

This adds a post-creation `jira.assign_issue()` call as a safety net — a dedicated REST API endpoint (`PUT /rest/api/2/issue/{key}/assignee`) that reliably works across all Jira instance types. The assignee is kept in the create fields (belt & suspenders) so there's zero regression risk for Cloud users where it already works. This follows the same two-step pattern already used for epic field updates.

Fixes #924

## Changes

- Add post-creation `assign_issue()` call as a safety net for configs where create-time assignee is silently dropped
- Keep assignee in the create `fields` dict (no regression for Cloud or configs where it already works)
- Update existing tests to verify both the create-time field and the post-creation assignment

## Testing

- [x] Unit tests updated and passing (44/44)
- [ ] Integration tests
- [x] Manual testing (confirmed on Jira Server/DC)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests have been added/updated
- [x] All tests pass
- [x] Documentation updated (if applicable)