### PR TITLE
fix(jira): revert incorrect fields= kwarg in update_issue calls

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1091,7 +1091,9 @@ class IssuesMixin(
 
             # Update the issue fields
             if update_fields:
-                self.jira.update_issue(issue_key=issue_key, fields=update_fields)  # type: ignore[call-arg]
+                self.jira.update_issue(
+                    issue_key=issue_key, update={"fields": update_fields}
+                )
 
             # Handle attachments if provided
             if "attachments" in kwargs and kwargs["attachments"]:
@@ -1148,7 +1150,7 @@ class IssuesMixin(
 
         # First update any fields if needed
         if fields:
-            self.jira.update_issue(issue_key=issue_key, fields=fields)  # type: ignore[call-arg]
+            self.jira.update_issue(issue_key=issue_key, update={"fields": fields})
 
         # If no status change is requested, return the issue
         if not status:

--- a/tests/unit/jira/test_issues_markdown.py
+++ b/tests/unit/jira/test_issues_markdown.py
@@ -133,9 +133,11 @@ class TestIssuesMarkdownConversion:
         # Verify the converted description was passed to API
         issues_mixin.jira.update_issue.assert_called_once_with(
             issue_key="TEST-123",
-            fields={
-                "description": f"[CONVERTED] {markdown_description}",
-                "summary": "Updated Issue",
+            update={
+                "fields": {
+                    "description": f"[CONVERTED] {markdown_description}",
+                    "summary": "Updated Issue",
+                }
             },
         )
 
@@ -171,7 +173,7 @@ class TestIssuesMarkdownConversion:
         # Verify the converted description was passed to API
         issues_mixin.jira.update_issue.assert_called_once_with(
             issue_key="TEST-123",
-            fields={"description": f"[CONVERTED] {markdown_description}"},
+            update={"fields": {"description": f"[CONVERTED] {markdown_description}"}},
         )
 
         # Verify result
@@ -216,7 +218,7 @@ class TestIssuesMarkdownConversion:
             "description": f"[CONVERTED] {markdown_description}",
         }
         issues_mixin.jira.update_issue.assert_called_once_with(
-            issue_key="TEST-123", fields=expected_fields
+            issue_key="TEST-123", update={"fields": expected_fields}
         )
 
         # Verify result


### PR DESCRIPTION
## Summary

- PR #887 changed `update={"fields": update_fields}` to `fields=update_fields` in two call sites within `IssuesMixin.update_issue` and `IssuesMixin._update_issue_with_status`
- The `atlassian-python-api` library's `Jira.update_issue()` does not accept a `fields` keyword argument, causing all update operations to fail with `Jira.update_issue() got an unexpected keyword argument 'fields'`
- Restores the correct `update={"fields": ...}` structure in both call sites and removes the `# type: ignore[call-arg]` comments that were masking the type error
- Fixes all test assertions that were updated to match the broken behavior
- Adds a new test (`test_update_issue_with_status_and_fields`) covering the previously untested status+fields code path in `_update_issue_with_status`

Fixes #912

## Test plan

- [x] New test `test_update_issue_with_status_and_fields` fails before fix, passes after
- [x] All existing update_issue tests pass (assertions corrected to match library API)
- [x] Full unit test suite passes (1294 passed, 5 skipped)
- [x] Live verification: `jira_update_issue` with `additional_fields={"customfield_10814": 1}` succeeds against Jira Cloud