### PR TITLE
fix: improve actionable error messages for common failure scenarios

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -5,6 +5,7 @@ import os
 
 from atlassian import Confluence
 from requests import Session
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from ..exceptions import MCPAtlassianAuthenticationError
 from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
@@ -154,6 +155,13 @@ class ConfluenceClient:
                     "Confluence authentication test returned None - "
                     "this may indicate an issue"
                 )
+        except RequestsConnectionError as e:
+            error_msg = (
+                f"Could not connect to Confluence at {self.config.url}. "
+                "Check that CONFLUENCE_URL is correct and the instance is reachable."
+            )
+            logger.error(error_msg)
+            raise MCPAtlassianAuthenticationError(error_msg) from e
         except Exception as e:
             error_msg = f"Confluence authentication validation failed: {e}"
             logger.error(error_msg)

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 from atlassian import Jira
 from requests import Session
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.preprocessing import JiraPreprocessor
@@ -171,6 +172,13 @@ class JiraClient:
                     "Jira authentication test returned empty user info - "
                     "this may indicate an issue"
                 )
+        except RequestsConnectionError as e:
+            error_msg = (
+                f"Could not connect to Jira at {self.config.url}. "
+                "Check that JIRA_URL is correct and the instance is reachable."
+            )
+            logger.error(error_msg)
+            raise MCPAtlassianAuthenticationError(error_msg) from e
         except Exception as e:
             error_msg = f"Jira authentication validation failed: {e}"
             logger.error(error_msg)


### PR DESCRIPTION
## Summary
- Improve Jira and Confluence auth/config validation errors to include missing environment variables and concrete remediation steps.
- Add actionable Jira connection failure messages for authentication validation and issue retrieval when the API is unreachable.
- Improve Jira issue retrieval errors for 404 (issue not found) and 429 (rate limit hit), and clarify required field errors in issue creation.

## Areas Improved
- Auth/config validation (`JiraConfig.from_env`, `ConfluenceConfig.from_env`)
- API unreachable handling (`JiraClient._validate_authentication`, `ConfluenceClient._validate_authentication`, `IssuesMixin.get_issue`)
- Missing required fields (`IssuesMixin.create_issue`)
- Issue not found and rate limiting (`IssuesMixin.get_issue`)

## Verification
- `uv run pre-commit run --all-files` ✅
- `uv run pytest -q` ❌ (fails in this worktree due unrelated pre-existing failures in `tests/unit/servers/test_main_server.py` and existing local changes outside this commit)
- Targeted tests for updated auth/config error paths pass:
  - `tests/unit/jira/test_config.py::test_from_env_missing_cloud_auth`
  - `tests/unit/jira/test_config.py::test_from_env_missing_server_auth`
  - `tests/unit/jira/test_client_oauth.py::TestJiraClientOAuth::test_from_env_with_no_oauth_config_found`
  - `tests/unit/confluence/test_config.py::test_from_env_missing_cloud_auth`
  - `tests/unit/confluence/test_config.py::test_from_env_missing_server_auth`
  - `tests/unit/confluence/test_client_oauth.py::TestConfluenceClientOAuth::test_from_env_with_no_oauth_config_found`