### PR TITLE
fix(jira): fix double-prefix SLA tool name and sprint date comparison crash

### DIFF
--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -162,6 +162,8 @@ class SprintsMixin(JiraClient):
             raise ValueError("Start date is required.")
 
         # validate start date is not in the past
+        if parsed_start_date.tzinfo is None:
+            parsed_start_date = parsed_start_date.replace(tzinfo=datetime.timezone.utc)
         if parsed_start_date < datetime.datetime.now(datetime.timezone.utc):
             raise ValueError("Start date cannot be in the past.")
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2295,7 +2295,7 @@ async def get_issue_dates(
     tags={"jira", "read", "metrics", "sla"},
     annotations={"title": "Get Issue SLA", "readOnlyHint": True},
 )
-async def jira_get_issue_sla(
+async def get_issue_sla(
     ctx: Context,
     issue_key: Annotated[
         str,


### PR DESCRIPTION
## Summary

Found via end-to-end testing against real Atlassian Cloud (soomiles21).

### Bug 1: `jira_jira_get_issue_sla` double-prefix tool name

`jira_get_issue_sla` in `servers/jira.py` was defined as `async def jira_get_issue_sla(...)`. FastMCP prepends the server name (`jira_`) to the function name, resulting in the tool being registered as `jira_jira_get_issue_sla` instead of `jira_get_issue_sla`. All other SLA/date tools use unprefixed function names (e.g., `get_issue_dates`).

**Fix**: renamed to `async def get_issue_sla(...)` — same pattern as PR #927 applied to `get_issue_dates` and `confluence_get_page_views`.

### Bug 2: `jira_create_sprint` crashes on date-only strings

When a user passes a date-only string (e.g., `"2026-03-01"`) as `start_date`, `parse_date()` returns a naive `datetime` (no timezone). The validation then compares it to `datetime.now(timezone.utc)` (aware), raising:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

**Fix**: localize the naive datetime to UTC before comparison in `create_sprint`.

## Testing

- 1367 passed, 159 skipped (no regressions)
- `pre-commit run --all-files` clean
- E2E verified: `jira_get_issue_sla` now registers as correct name; `create_sprint` with `"2026-03-01"` no longer crashes