### PR TITLE
Add optional compatibility argument to jira_get_link_types

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -727,11 +727,24 @@ async def get_sprint_issues(
     tags={"jira", "read"},
     annotations={"title": "Get Link Types", "readOnlyHint": True},
 )
-async def get_link_types(ctx: Context) -> str:
+async def get_link_types(
+    ctx: Context,
+    dummy: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "(Optional) Compatibility argument. Ignored by the server. "
+                "Use only when an inference gateway requires non-empty tool arguments."
+            ),
+        ),
+    ] = None,
+) -> str:
     """Get all available issue link types.
 
     Args:
         ctx: The FastMCP context.
+        dummy: Optional compatibility argument. Ignored.
 
     Returns:
         JSON string representing a list of issue link type objects.


### PR DESCRIPTION
## Description

This PR makes `jira_get_link_types` resilient to inference gateways that silently drop empty-argument tool calls.

In some OpenAI-compatible/LiteLLM paths, no-arg tools can fail to execute reliably when the model emits `{}` arguments. A common workaround is to send a non-empty compatibility argument. Before this change, `jira_get_link_types` rejected that with a Pydantic `unexpected_keyword_argument` error.  
This PR adds an optional ignored compatibility argument so both empty and non-empty compatibility invocations succeed.

Fixes: added dummy input argument in `jira_get_link_types`.

## Changes

- Updated `jira_get_link_types` in `src/mcp_atlassian/servers/jira.py` to accept optional `dummy: str | None = None`.
- Documented `dummy` as a compatibility-only argument that is ignored by server behavior.
- Preserved existing behavior and output for standard calls with empty arguments.

## Testing

- N/A: Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `Validated MCP tools/call for jira_get_link_types with arguments {} and {"dummy":"x"}; both returned normal link-types payloads after restart.`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- N/A: Tests added/updated for changes.
- [x] All tests pass locally.
- N/A: Documentation updated (if needed).
