### PR TITLE
fix(jira): add components param to update_issue and fix datetime timezone format

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1061,6 +1061,16 @@ async def update_issue(
             default=None,
         ),
     ] = None,
+    components: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated list of component names "
+                "(e.g., 'Frontend,API')"
+            ),
+            default=None,
+        ),
+    ] = None,
     attachments: Annotated[
         str | None,
         Field(
@@ -1079,6 +1089,7 @@ async def update_issue(
         issue_key: Jira issue key.
         fields: Dictionary of fields to update. Text fields like 'description' should use Markdown format.
         additional_fields: Optional dictionary or JSON string of additional fields.
+        components: Comma-separated list of component names.
         attachments: Optional JSON array string or comma-separated list of file paths.
 
     Returns:
@@ -1090,6 +1101,13 @@ async def update_issue(
     jira = await get_jira_fetcher(ctx)
     # Use fields directly as dict
     update_fields = fields
+
+    # Parse components from comma-separated string to list
+    components_list = None
+    if components and isinstance(components, str):
+        components_list = [
+            comp.strip() for comp in components.split(",") if comp.strip()
+        ]
 
     extra_fields = _parse_additional_fields(additional_fields)
 
@@ -1115,6 +1133,8 @@ async def update_issue(
 
     # Combine fields and additional_fields
     all_updates = {**update_fields, **extra_fields}
+    if components_list:
+        all_updates["components"] = components_list
     if attachment_paths:
         all_updates["attachments"] = attachment_paths
 


### PR DESCRIPTION
## Description

Two related fixes improving `jira_update_issue` usability and fixing a blocking bug with datetime custom fields.

1. **Components UX gap**: `jira_create_issue` has a convenient `components` CSV parameter, but `jira_update_issue` required users to pass components through `additional_fields` JSON. This adds parity.

2. **DateTime timezone format** (#863): Custom `datetime` fields fail on create/update because Python's `dt.isoformat()` produces `+HH:MM` (extended format) but Jira REST API requires `+HHMM` (basic format). Issues with required datetime custom fields **cannot be created at all** — no workaround exists.

Fixes: #863

## Changes

- Add explicit `components` CSV parameter to `jira_update_issue` tool, matching `jira_create_issue` UX
- Fix datetime custom field timezone format: use `isoformat(timespec="milliseconds")` and strip colon from tz offset (`±HH:MM` → `±HHMM`)
- Add 8 parametrized datetime timezone tests covering basic, extended, naive, date-only, negative offset, and passthrough cases
- Add 5 component update tests covering multi, single, empty, None, and precedence over `additional_fields`

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `uv run pytest tests/unit/ -x (1371 passed), pre-commit run --all-files (all passed)`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).