### PR TITLE
feat(jira): add custom field options discovery for select fields

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -15,6 +15,7 @@ from .comments import CommentsMixin
 from .config import JiraConfig
 from .development import DevelopmentMixin
 from .epics import EpicsMixin
+from .field_options import FieldOptionsMixin
 from .fields import FieldsMixin
 from .forms_api import FormsApiMixin  # Forms REST API
 from .formatting import FormattingMixin
@@ -33,6 +34,7 @@ from .worklog import WorklogMixin
 class JiraFetcher(
     ProjectsMixin,
     FieldsMixin,
+    FieldOptionsMixin,
     FormsApiMixin,  # Use new Forms REST API instead of FormsMixin
     FormattingMixin,
     TransitionsMixin,

--- a/src/mcp_atlassian/jira/field_options.py
+++ b/src/mcp_atlassian/jira/field_options.py
@@ -1,0 +1,210 @@
+"""Module for Jira custom field options operations."""
+
+import logging
+
+from ..models.jira.field_option import FieldContext, FieldOption
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class FieldOptionsMixin(JiraClient):
+    """Mixin for Jira custom field options operations.
+
+    Provides methods to discover available options for custom fields
+    (select, multi-select, radio, checkbox, cascading select).
+
+    Cloud uses the Field Configuration Context API.
+    Server/DC falls back to createmeta allowedValues.
+    """
+
+    def get_field_contexts(self, field_id: str) -> list[FieldContext]:
+        """Get contexts for a custom field.
+
+        Contexts define which projects/issue types a field applies to.
+        Cloud only — Server/DC does not support this endpoint.
+
+        Args:
+            field_id: The custom field ID (e.g., 'customfield_10001')
+
+        Returns:
+            List of FieldContext objects (empty on Server/DC)
+        """
+        if not self.config.is_cloud:
+            return []
+
+        try:
+            response = self.jira.get(
+                f"rest/api/3/field/{field_id}/context",
+                params={"maxResults": 100},
+            )
+
+            if not isinstance(response, dict):
+                return []
+
+            return [
+                FieldContext.from_api_response(ctx)
+                for ctx in response.get("values", [])
+                if isinstance(ctx, dict)
+            ]
+        except Exception as e:
+            logger.error(f"Error getting field contexts for {field_id}: {e}")
+            return []
+
+    def get_field_options(
+        self,
+        field_id: str,
+        context_id: str | None = None,
+        project_key: str | None = None,
+        issue_type: str | None = None,
+    ) -> list[FieldOption]:
+        """Get allowed option values for a custom field.
+
+        Cloud: Uses the Field Context Option API with pagination.
+            If context_id is not provided, auto-resolves by fetching
+            contexts and using the global context.
+        Server/DC: Uses createmeta to get allowedValues.
+            Requires project_key and issue_type parameters.
+
+        Args:
+            field_id: The custom field ID (e.g., 'customfield_10001')
+            context_id: Context ID (Cloud only, auto-resolved if None)
+            project_key: Project key (required for Server/DC)
+            issue_type: Issue type name (required for Server/DC)
+
+        Returns:
+            List of FieldOption objects
+
+        Raises:
+            ValueError: If Server/DC and project_key/issue_type missing
+        """
+        if self.config.is_cloud:
+            return self._get_field_options_cloud(field_id, context_id)
+        else:
+            return self._get_field_options_server(field_id, project_key, issue_type)
+
+    def _get_field_options_cloud(
+        self, field_id: str, context_id: str | None
+    ) -> list[FieldOption]:
+        """Get field options via Cloud API with pagination.
+
+        Args:
+            field_id: The custom field ID
+            context_id: Context ID (auto-resolved if None)
+
+        Returns:
+            List of FieldOption objects
+        """
+        # Auto-resolve context if not provided
+        if context_id is None:
+            contexts = self.get_field_contexts(field_id)
+            if not contexts:
+                logger.warning(
+                    f"No contexts found for field {field_id}. "
+                    "Cannot retrieve options without a context."
+                )
+                return []
+
+            # Prefer global context
+            global_ctx = next((c for c in contexts if c.is_global_context), None)
+            context_id = global_ctx.id if global_ctx else contexts[0].id
+
+        # Paginate through all options
+        all_options: list[FieldOption] = []
+        start_at = 0
+        max_results = 100
+
+        while True:
+            try:
+                response = self.jira.get(
+                    f"rest/api/3/field/{field_id}/context/{context_id}/option",
+                    params={"startAt": start_at, "maxResults": max_results},
+                )
+
+                if not isinstance(response, dict):
+                    break
+
+                values = response.get("values", [])
+                for item in values:
+                    if isinstance(item, dict):
+                        all_options.append(FieldOption.from_api_response(item))
+
+                total = response.get("total", len(values))
+                start_at += len(values)
+
+                if start_at >= total or not values:
+                    break
+
+            except Exception as e:
+                logger.error(
+                    f"Error getting options for {field_id} context {context_id}: {e}"
+                )
+                break
+
+        return all_options
+
+    def _get_field_options_server(
+        self,
+        field_id: str,
+        project_key: str | None,
+        issue_type: str | None,
+    ) -> list[FieldOption]:
+        """Get field options via Server/DC createmeta.
+
+        Args:
+            field_id: The custom field ID
+            project_key: Project key (required)
+            issue_type: Issue type name (required)
+
+        Returns:
+            List of FieldOption objects
+
+        Raises:
+            ValueError: If project_key or issue_type is missing
+        """
+        if not project_key or not issue_type:
+            msg = (
+                "Server/DC requires project_key and issue_type "
+                "parameters to retrieve field options. "
+                "Example: get_field_options('customfield_10001', "
+                "project_key='PROJ', issue_type='Bug')"
+            )
+            raise ValueError(msg)
+
+        try:
+            response = self.jira.get(
+                "rest/api/2/issue/createmeta",
+                params={
+                    "projectKeys": project_key,
+                    "issuetypeNames": issue_type,
+                    "expand": "projects.issuetypes.fields",
+                },
+            )
+
+            if not isinstance(response, dict):
+                return []
+
+            # Navigate: projects[0].issuetypes[0].fields.{field_id}.allowedValues
+            projects = response.get("projects", [])
+            if not projects:
+                return []
+
+            issue_types = projects[0].get("issuetypes", [])
+            if not issue_types:
+                return []
+
+            fields = issue_types[0].get("fields", {})
+            field_data = fields.get(field_id, {})
+            allowed_values = field_data.get("allowedValues", [])
+
+            return [
+                FieldOption.from_api_response(item)
+                for item in allowed_values
+                if isinstance(item, dict)
+            ]
+
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting options for {field_id} via createmeta: {e}")
+            return []

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -17,6 +17,7 @@ from .common import (
     JiraTimetracking,
     JiraUser,
 )
+from .field_option import FieldContext, FieldOption
 from .forms import ProFormaForm, ProFormaFormField, ProFormaFormState
 from .issue import JiraIssue
 from .link import (
@@ -50,6 +51,9 @@ from .workflow import JiraTransition
 from .worklog import JiraWorklog
 
 __all__ = [
+    # Field option models
+    "FieldContext",
+    "FieldOption",
     # Common models
     "JiraUser",
     "JiraStatusCategory",

--- a/src/mcp_atlassian/models/jira/field_option.py
+++ b/src/mcp_atlassian/models/jira/field_option.py
@@ -1,0 +1,105 @@
+"""
+Jira custom field option models.
+
+This module provides Pydantic models for Jira custom field contexts
+and options, used for discovering allowed values for select, radio,
+checkbox, and cascading select fields.
+"""
+
+from typing import Any
+
+from pydantic import Field
+
+from ..base import ApiModel
+
+
+class FieldContext(ApiModel):
+    """Model representing a custom field context in Jira Cloud."""
+
+    id: str
+    name: str
+    description: str = ""
+    is_global_context: bool = False
+    is_any_issue_type: bool = False
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldContext":
+        """Create a FieldContext from a Jira API response.
+
+        Args:
+            data: The context data from the Jira API
+
+        Returns:
+            A FieldContext instance
+        """
+        if not data or not isinstance(data, dict):
+            return cls(id="", name="")
+
+        return cls(
+            id=str(data.get("id", "")),
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            is_global_context=data.get("isGlobalContext", False),
+            is_any_issue_type=data.get("isAnyIssueType", False),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+        }
+        if self.description:
+            result["description"] = self.description
+        if self.is_global_context:
+            result["is_global_context"] = True
+        return result
+
+
+class FieldOption(ApiModel):
+    """Model representing a custom field option value."""
+
+    id: str
+    value: str
+    disabled: bool = False
+    child_options: list["FieldOption"] = Field(default_factory=list)
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldOption":
+        """Create a FieldOption from a Jira API response.
+
+        Args:
+            data: The option data from the Jira API
+
+        Returns:
+            A FieldOption instance
+        """
+        if not data or not isinstance(data, dict):
+            return cls(id="", value="")
+
+        children = [
+            cls.from_api_response(c)
+            for c in data.get("cascadingOptions", [])
+            if isinstance(c, dict)
+        ]
+
+        return cls(
+            id=str(data.get("id", data.get("optionId", ""))),
+            value=data.get("value", ""),
+            disabled=data.get("disabled", False),
+            child_options=children,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "id": self.id,
+            "value": self.value,
+        }
+        if self.disabled:
+            result["disabled"] = True
+        if self.child_options:
+            result["child_options"] = [
+                child.to_simplified_dict() for child in self.child_options
+            ]
+        return result

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -344,6 +344,74 @@ async def search_fields(
 
 @jira_mcp.tool(
     tags={"jira", "read"},
+    annotations={"title": "Get Field Options", "readOnlyHint": True},
+)
+async def get_field_options(
+    ctx: Context,
+    field_id: Annotated[
+        str,
+        Field(
+            description="Custom field ID (e.g., 'customfield_10001'). "
+            "Use jira_search_fields to find field IDs."
+        ),
+    ],
+    context_id: Annotated[
+        str | None,
+        Field(
+            description="Field context ID (Cloud only). "
+            "If omitted, auto-resolves to the global context.",
+            default=None,
+        ),
+    ] = None,
+    project_key: Annotated[
+        str | None,
+        Field(
+            description="Project key (required for Server/DC). Example: 'PROJ'",
+            default=None,
+        ),
+    ] = None,
+    issue_type: Annotated[
+        str | None,
+        Field(
+            description="Issue type name (required for Server/DC). Example: 'Bug'",
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Get allowed option values for a custom field.
+
+    Returns the list of valid options for select, multi-select, radio,
+    checkbox, and cascading select custom fields.
+
+    Cloud: Uses the Field Context Option API. If context_id is not provided,
+    automatically resolves to the global context.
+
+    Server/DC: Uses createmeta to get allowedValues. Requires project_key
+    and issue_type parameters.
+
+    Args:
+        ctx: The FastMCP context.
+        field_id: The custom field ID.
+        context_id: Field context ID (Cloud only, auto-resolved if omitted).
+        project_key: Project key (required for Server/DC).
+        issue_type: Issue type name (required for Server/DC).
+
+    Returns:
+        JSON string with the list of available options.
+    """
+    jira = await get_jira_fetcher(ctx)
+    options = jira.get_field_options(
+        field_id=field_id,
+        context_id=context_id,
+        project_key=project_key,
+        issue_type=issue_type,
+    )
+    result = [opt.to_simplified_dict() for opt in options]
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read"},
     annotations={"title": "Get Project Issues", "readOnlyHint": True},
 )
 async def get_project_issues(

--- a/tests/unit/jira/test_field_options.py
+++ b/tests/unit/jira/test_field_options.py
@@ -1,0 +1,412 @@
+"""Tests for custom field options tooling."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.field_options import FieldOptionsMixin
+from mcp_atlassian.models.jira.field_option import FieldContext, FieldOption
+
+# ============================================================================
+# Model Tests
+# ============================================================================
+
+
+class TestFieldContextModel:
+    """Tests for FieldContext.from_api_response."""
+
+    @pytest.mark.parametrize(
+        "test_id, data, expected_id, expected_name, expected_global",
+        [
+            (
+                "basic",
+                {"id": "10001", "name": "Default", "description": "Global context"},
+                "10001",
+                "Default",
+                False,
+            ),
+            (
+                "global_context",
+                {
+                    "id": "10002",
+                    "name": "Global",
+                    "isGlobalContext": True,
+                    "isAnyIssueType": True,
+                },
+                "10002",
+                "Global",
+                True,
+            ),
+            (
+                "empty_data",
+                {},
+                "",
+                "",
+                False,
+            ),
+            (
+                "none_data",
+                None,
+                "",
+                "",
+                False,
+            ),
+        ],
+    )
+    def test_from_api_response(
+        self, test_id, data, expected_id, expected_name, expected_global
+    ):
+        ctx = FieldContext.from_api_response(data)
+        assert ctx.id == expected_id
+        assert ctx.name == expected_name
+        assert ctx.is_global_context == expected_global
+
+    def test_to_simplified_dict(self):
+        ctx = FieldContext(
+            id="10001",
+            name="Default",
+            description="Global context",
+            is_global_context=True,
+        )
+        simplified = ctx.to_simplified_dict()
+        assert simplified["id"] == "10001"
+        assert simplified["name"] == "Default"
+        assert simplified["description"] == "Global context"
+        assert simplified["is_global_context"] is True
+
+    def test_to_simplified_dict_no_extras(self):
+        ctx = FieldContext(id="1", name="Basic")
+        simplified = ctx.to_simplified_dict()
+        assert "description" not in simplified
+        assert "is_global_context" not in simplified
+
+
+class TestFieldOptionModel:
+    """Tests for FieldOption.from_api_response."""
+
+    @pytest.mark.parametrize(
+        "test_id, data, expected_id, expected_value, expected_disabled",
+        [
+            (
+                "basic",
+                {"id": "10100", "value": "High", "disabled": False},
+                "10100",
+                "High",
+                False,
+            ),
+            (
+                "disabled",
+                {"id": "10101", "value": "Deprecated", "disabled": True},
+                "10101",
+                "Deprecated",
+                True,
+            ),
+            (
+                "option_id_fallback",
+                {"optionId": "10102", "value": "Low"},
+                "10102",
+                "Low",
+                False,
+            ),
+            (
+                "empty_data",
+                {},
+                "",
+                "",
+                False,
+            ),
+        ],
+    )
+    def test_from_api_response(
+        self, test_id, data, expected_id, expected_value, expected_disabled
+    ):
+        opt = FieldOption.from_api_response(data)
+        assert opt.id == expected_id
+        assert opt.value == expected_value
+        assert opt.disabled == expected_disabled
+
+    def test_cascading_options(self):
+        data = {
+            "id": "10200",
+            "value": "North America",
+            "cascadingOptions": [
+                {"id": "10201", "value": "United States"},
+                {"id": "10202", "value": "Canada"},
+            ],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.value == "North America"
+        assert len(opt.child_options) == 2
+        assert opt.child_options[0].value == "United States"
+        assert opt.child_options[1].value == "Canada"
+
+    def test_to_simplified_dict_with_children(self):
+        opt = FieldOption(
+            id="1",
+            value="Parent",
+            child_options=[
+                FieldOption(id="2", value="Child A"),
+                FieldOption(id="3", value="Child B"),
+            ],
+        )
+        simplified = opt.to_simplified_dict()
+        assert simplified["id"] == "1"
+        assert simplified["value"] == "Parent"
+        assert "disabled" not in simplified
+        assert len(simplified["child_options"]) == 2
+
+    def test_to_simplified_dict_disabled(self):
+        opt = FieldOption(id="1", value="Old", disabled=True)
+        simplified = opt.to_simplified_dict()
+        assert simplified["disabled"] is True
+
+
+# ============================================================================
+# Mixin Tests
+# ============================================================================
+
+
+class TestFieldOptionsMixin:
+    """Tests for FieldOptionsMixin methods."""
+
+    @pytest.fixture
+    def mixin(self, jira_fetcher: JiraFetcher) -> FieldOptionsMixin:
+        """Create a mixin instance with mocked dependencies."""
+        fetcher = jira_fetcher
+        fetcher.config = MagicMock()
+        fetcher.config.is_cloud = True
+        return fetcher
+
+    # -- get_field_contexts -------------------------------------------------
+
+    def test_contexts_cloud(self, mixin):
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [
+                    {
+                        "id": "10001",
+                        "name": "Default Configuration Scheme",
+                        "isGlobalContext": True,
+                        "isAnyIssueType": True,
+                    },
+                    {
+                        "id": "10002",
+                        "name": "Bug context",
+                        "isGlobalContext": False,
+                    },
+                ],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 2,
+            }
+        )
+
+        result = mixin.get_field_contexts("customfield_10001")
+        assert len(result) == 2
+        assert result[0].id == "10001"
+        assert result[0].is_global_context is True
+        assert result[1].name == "Bug context"
+
+    def test_contexts_server_returns_empty(self, mixin):
+        mixin.config.is_cloud = False
+        result = mixin.get_field_contexts("customfield_10001")
+        assert result == []
+
+    # -- get_field_options (Cloud) ------------------------------------------
+
+    def test_options_cloud_with_context(self, mixin):
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [
+                    {"id": "10100", "value": "High", "disabled": False},
+                    {"id": "10101", "value": "Medium", "disabled": False},
+                    {"id": "10102", "value": "Low", "disabled": False},
+                ],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 3,
+            }
+        )
+
+        result = mixin.get_field_options("customfield_10001", context_id="10001")
+        assert len(result) == 3
+        assert result[0].value == "High"
+        assert result[2].value == "Low"
+
+    def test_options_cloud_auto_context(self, mixin):
+        """When context_id is None, auto-resolve via get_field_contexts."""
+        mixin.config.is_cloud = True
+        # First call returns contexts, second returns options
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # get_field_contexts response
+                {
+                    "values": [
+                        {"id": "10001", "name": "Global", "isGlobalContext": True},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # get_field_options response
+                {
+                    "values": [{"id": "1", "value": "Option A"}],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10001")
+        assert len(result) == 1
+        assert result[0].value == "Option A"
+
+    def test_options_cloud_disabled(self, mixin):
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [
+                    {"id": "1", "value": "Active", "disabled": False},
+                    {"id": "2", "value": "Deprecated", "disabled": True},
+                ],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 2,
+            }
+        )
+
+        result = mixin.get_field_options("customfield_10001", context_id="10001")
+        assert result[1].disabled is True
+
+    def test_options_cloud_pagination(self, mixin):
+        """Pagination: two pages of results."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                {
+                    "values": [
+                        {"id": "1", "value": "A"},
+                        {"id": "2", "value": "B"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+                {
+                    "values": [{"id": "3", "value": "C"}],
+                    "startAt": 2,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10001", context_id="10001")
+        assert len(result) == 3
+        assert [o.value for o in result] == ["A", "B", "C"]
+
+    def test_options_cloud_empty(self, mixin):
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 0,
+            }
+        )
+
+        result = mixin.get_field_options("customfield_10001", context_id="10001")
+        assert result == []
+
+    def test_options_cloud_cascading(self, mixin):
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [
+                    {
+                        "id": "10200",
+                        "value": "Americas",
+                        "cascadingOptions": [
+                            {"id": "10201", "value": "US"},
+                            {"id": "10202", "value": "Canada"},
+                        ],
+                    }
+                ],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 1,
+            }
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 2
+
+    # -- get_field_options (Server/DC) --------------------------------------
+
+    def test_options_server_with_params(self, mixin):
+        mixin.config.is_cloud = False
+        mixin.jira.get = MagicMock(
+            return_value={
+                "projects": [
+                    {
+                        "issuetypes": [
+                            {
+                                "fields": {
+                                    "customfield_10001": {
+                                        "allowedValues": [
+                                            {"id": "1", "value": "High"},
+                                            {"id": "2", "value": "Low"},
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        result = mixin.get_field_options(
+            "customfield_10001", project_key="TEST", issue_type="Bug"
+        )
+        assert len(result) == 2
+        assert result[0].value == "High"
+
+    def test_options_server_missing_params(self, mixin):
+        mixin.config.is_cloud = False
+        with pytest.raises(ValueError, match="project_key.*issue_type"):
+            mixin.get_field_options("customfield_10001")
+
+    def test_options_server_field_not_found(self, mixin):
+        mixin.config.is_cloud = False
+        mixin.jira.get = MagicMock(
+            return_value={
+                "projects": [
+                    {
+                        "issuetypes": [
+                            {
+                                "fields": {
+                                    "customfield_99999": {
+                                        "allowedValues": [
+                                            {"id": "1", "value": "X"},
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
+        result = mixin.get_field_options(
+            "customfield_10001", project_key="TEST", issue_type="Bug"
+        )
+        assert result == []


### PR DESCRIPTION
## Description

Add `FieldOptionsMixin` with `get_field_contexts()` and `get_field_options()` methods to discover allowed values for custom select, multi-select, radio, checkbox, and cascading select fields.

This is a common pain point when building automations: users need to know valid option values before setting custom fields. The new `jira_get_field_options` tool provides this capability.

Fixes: #686

## Changes

- New `FieldOptionsMixin` (`jira/field_options.py`) with Cloud/Server dispatch:
  - **Cloud**: Uses Field Context API (`/rest/api/3/field/{id}/context/{ctxId}/option`) with auto-resolution of context ID and full pagination support
  - **Server/DC**: Falls back to `createmeta` `allowedValues` (requires `project_key` + `issue_type`)
- New Pydantic models (`models/jira/field_option.py`): `FieldContext` and `FieldOption` with cascading child option support
- New read-only server tool `jira_get_field_options` for MCP clients
- Added `FieldOptionsMixin` to `JiraFetcher` MRO

## Testing

- [x] Unit tests added/updated (24 new tests)
- [ ] Integration tests passed
- [x] Manual checks performed: `pre-commit run --all-files` passes, all 1403 unit tests pass

### Test coverage

- **Model tests**: `FieldContext.from_api_response` (4 parametrized cases), `FieldOption.from_api_response` (4 parametrized), cascading options, `to_simplified_dict` variants
- **Mixin tests**: Cloud contexts, Server returns empty, Cloud options with/without context, auto-context resolution, disabled options, pagination (multi-page), empty results, cascading select, Server with params, Server missing params (ValueError), Server field not found

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).