### PR TITLE
feat: add configurable HTTP timeout for Jira and Confluence clients

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -56,6 +56,7 @@ class ConfluenceClient:
                 session=session,
                 cloud=True,  # OAuth is only for Cloud
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         elif self.config.auth_type == "pat":
             logger.debug(
@@ -68,6 +69,7 @@ class ConfluenceClient:
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         else:  # basic auth
             logger.debug(
@@ -82,6 +84,7 @@ class ConfluenceClient:
                 password=self.config.api_token,  # API token is used as password
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
             logger.debug(
                 f"Confluence client initialized. "

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -39,6 +39,7 @@ class ConfluenceConfig:
     client_cert: str | None = None  # Client certificate file path (.pem)
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
+    timeout: int = 75  # Connection timeout in seconds
 
     @property
     def is_cloud(self) -> bool:
@@ -167,6 +168,14 @@ class ConfluenceConfig:
         client_key = os.getenv("CONFLUENCE_CLIENT_KEY")
         client_key_password = os.getenv("CONFLUENCE_CLIENT_KEY_PASSWORD")
 
+        # Timeout setting
+        timeout = 75  # Default timeout
+        if (
+            os.getenv("CONFLUENCE_TIMEOUT")
+            and os.getenv("CONFLUENCE_TIMEOUT", "").isdigit()
+        ):
+            timeout = int(os.getenv("CONFLUENCE_TIMEOUT", "75"))
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -184,6 +193,7 @@ class ConfluenceConfig:
             client_cert=client_cert,
             client_key=client_key,
             client_key_password=client_key_password,
+            timeout=timeout,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -71,6 +71,7 @@ class JiraClient:
                 session=session,
                 cloud=True,  # OAuth is only for Cloud
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         elif self.config.auth_type == "pat":
             logger.debug(
@@ -83,6 +84,7 @@ class JiraClient:
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
         else:  # basic auth
             logger.debug(
@@ -97,6 +99,7 @@ class JiraClient:
                 password=self.config.api_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
             )
             logger.debug(
                 f"Jira client initialized. Session headers (Authorization masked): "

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -115,6 +115,7 @@ class JiraConfig:
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
     sla_config: SLAConfig | None = None  # Optional SLA configuration
+    timeout: int = 75  # Connection timeout in seconds
 
     @property
     def is_cloud(self) -> bool:
@@ -247,6 +248,11 @@ class JiraConfig:
         client_key = os.getenv("JIRA_CLIENT_KEY")
         client_key_password = os.getenv("JIRA_CLIENT_KEY_PASSWORD")
 
+        # Timeout setting
+        timeout = 75  # Default timeout
+        if os.getenv("JIRA_TIMEOUT") and os.getenv("JIRA_TIMEOUT", "").isdigit():
+            timeout = int(os.getenv("JIRA_TIMEOUT", "75"))
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -265,6 +271,7 @@ class JiraConfig:
             client_cert=client_cert,
             client_key=client_key,
             client_key_password=client_key_password,
+            timeout=timeout,
         )
 
     def is_auth_configured(self) -> bool:

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -38,6 +38,7 @@ def test_init_with_basic_auth():
             password="test_token",
             cloud=True,
             verify_ssl=True,
+            timeout=75,
         )
         assert client.config == config
         assert client.confluence == mock_confluence.return_value
@@ -84,6 +85,7 @@ def test_init_with_token_auth():
             token="test_personal_token",
             cloud=False,
             verify_ssl=False,
+            timeout=75,
         )
         assert client.config == config
         assert client.confluence == mock_confluence.return_value
@@ -266,6 +268,32 @@ def test_init_no_proxies(monkeypatch):
     )
     client = ConfluenceClient(config=config)
     assert mock_session.proxies == {}
+
+
+def test_confluence_client_passes_timeout_to_constructor():
+    """Test that ConfluenceClient passes custom timeout to Confluence constructor."""
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        config = ConfluenceConfig(
+            url="https://test.atlassian.net/wiki",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+            timeout=120,
+        )
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://test.atlassian.net/wiki",
+            username="test_user",
+            password="test_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=120,
+        )
 
 
 # Phase 4: AttachmentsMixin Integration Tests

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -240,3 +240,32 @@ def test_from_env_without_client_cert():
         assert config.client_cert is None
         assert config.client_key is None
         assert config.client_key_password is None
+
+
+def test_confluence_config_timeout_from_env():
+    """Test that timeout is read from CONFLUENCE_TIMEOUT env var."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+            "CONFLUENCE_TIMEOUT": "120",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.timeout == 120
+
+
+def test_confluence_config_timeout_default():
+    """Test that timeout defaults to 75 when no env var is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.timeout == 75

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -44,6 +44,7 @@ def test_init_with_basic_auth():
             password="test_token",
             cloud=True,
             verify_ssl=True,
+            timeout=75,
         )
 
         # Verify SSL verification was configured
@@ -85,6 +86,7 @@ def test_init_with_token_auth():
             token="test_personal_token",
             cloud=False,
             verify_ssl=False,
+            timeout=75,
         )
 
         # Verify SSL verification was configured with ssl_verify=False
@@ -295,3 +297,28 @@ def test_init_no_proxies(monkeypatch):
     )
     client = JiraClient(config=config)
     assert mock_session.proxies == {}
+
+
+def test_jira_client_passes_timeout_to_constructor():
+    """Test that JiraClient passes custom timeout to Jira constructor."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+            timeout=120,
+        )
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://test.atlassian.net",
+            username="test_user",
+            password="test_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=120,
+        )

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -260,3 +260,32 @@ def test_from_env_without_client_cert():
         assert config.client_cert is None
         assert config.client_key is None
         assert config.client_key_password is None
+
+
+def test_jira_config_timeout_from_env():
+    """Test that timeout is read from JIRA_TIMEOUT env var."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+            "JIRA_TIMEOUT": "120",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.timeout == 120
+
+
+def test_jira_config_timeout_default():
+    """Test that timeout defaults to 75 when no env var is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.timeout == 75


### PR DESCRIPTION
## Summary
- Adds `timeout` field to `JiraConfig` and `ConfluenceConfig` dataclasses (default: 75 seconds)
- Reads from `JIRA_TIMEOUT` and `CONFLUENCE_TIMEOUT` environment variables
- Propagates timeout to `atlassian-python-api` client constructors for all auth types (basic, PAT, OAuth)

Closes #891
Based on PR #895 by @ckaytev — thank you for the contribution!

## Test plan
- [x] `test_jira_config_timeout_from_env` — reads custom timeout from env
- [x] `test_jira_config_timeout_default` — defaults to 75s
- [x] `test_confluence_config_timeout_from_env` — reads custom timeout from env
- [x] `test_confluence_config_timeout_default` — defaults to 75s
- [x] `test_jira_client_passes_timeout_to_constructor` — verifies constructor propagation
- [x] `test_confluence_client_passes_timeout_to_constructor` — verifies constructor propagation
- [x] Full unit test suite passes (1409 tests)
- [x] pre-commit (ruff + mypy) clean