### PR TITLE
fix: prevent .netrc from overriding explicit PAT/OAuth credentials

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -92,6 +92,11 @@ class ConfluenceClient:
                 f"{get_masked_session_headers(dict(self.confluence._session.headers))}"
             )
 
+        # Disable trust_env for PAT and OAuth to prevent .netrc from overriding
+        # explicit credentials (#860). Basic auth can safely use .netrc.
+        if self.config.auth_type in ("pat", "oauth"):
+            self.confluence._session.trust_env = False
+
         # Configure SSL verification using the shared utility
         configure_ssl_verification(
             service_name="Confluence",

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -106,6 +106,11 @@ class JiraClient:
                 f"{get_masked_session_headers(dict(self.jira._session.headers))}"
             )
 
+        # Disable trust_env for PAT and OAuth to prevent .netrc from overriding
+        # explicit credentials (#860). Basic auth can safely use .netrc.
+        if self.config.auth_type in ("pat", "oauth"):
+            self.jira._session.trust_env = False
+
         # Configure SSL verification using the shared utility
         configure_ssl_verification(
             service_name="Jira",

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -296,6 +296,27 @@ def test_confluence_client_passes_timeout_to_constructor():
         )
 
 
+def test_confluence_client_pat_disables_trust_env():
+    """Test that PAT auth disables trust_env to prevent .netrc override (#860)."""
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        mock_session = MagicMock()
+        mock_session.trust_env = True
+        mock_confluence.return_value._session = mock_session
+
+        config = ConfluenceConfig(
+            url="https://confluence.example.com",
+            auth_type="pat",
+            personal_token="test_pat",
+        )
+        ConfluenceClient(config=config)
+
+        assert mock_session.trust_env is False
+
+
 # Phase 4: AttachmentsMixin Integration Tests
 def test_confluence_fetcher_has_attachments_mixin():
     """Test that ConfluenceFetcher includes AttachmentsMixin in inheritance."""


### PR DESCRIPTION
## Summary
- Sets `session.trust_env = False` when explicit PAT or OAuth credentials are configured
- Prevents `~/.netrc` from silently overriding the `Authorization` header
- Basic auth preserves `trust_env = True` since netrc is a valid credential source for that auth type
- Applied to both Jira and Confluence clients

Closes #860

## Test plan
- [x] `test_jira_client_pat_disables_trust_env` — PAT sets trust_env=False
- [x] `test_jira_client_oauth_disables_trust_env` — OAuth sets trust_env=False
- [x] `test_jira_client_basic_auth_preserves_trust_env` — Basic keeps trust_env=True
- [x] `test_confluence_client_pat_disables_trust_env` — Confluence PAT sets trust_env=False
- [x] Full unit test suite passes (1413 tests)
- [x] pre-commit (ruff + mypy) clean