### PR TITLE
feat(auth): add OAuth 2.0 support for Atlassian Data Center

### DIFF
--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -49,14 +49,23 @@ class ConfluenceConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
-        # Multi-Cloud OAuth mode: URL might be None, but we use api.atlassian.com
+        # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
             and self.oauth_config
             and self.oauth_config.cloud_id
         ):
-            # OAuth with cloud_id uses api.atlassian.com which is always Cloud
             return True
+
+        # DC OAuth has base_url but no cloud_id — not Cloud
+        if (
+            self.auth_type == "oauth"
+            and self.oauth_config
+            and hasattr(self.oauth_config, "base_url")
+            and self.oauth_config.base_url
+            and not self.oauth_config.cloud_id
+        ):
+            return False
 
         # For other auth types, check the URL
         return is_atlassian_cloud_url(self.url) if self.url else False
@@ -94,8 +103,10 @@ class ConfluenceConfig:
         api_token = os.getenv("CONFLUENCE_API_TOKEN")
         personal_token = os.getenv("CONFLUENCE_PERSONAL_TOKEN")
 
-        # Check for OAuth configuration
-        oauth_config = get_oauth_config_from_env()
+        # Check for OAuth configuration (pass service info for DC detection)
+        oauth_config = get_oauth_config_from_env(
+            service_url=url, service_type="confluence"
+        )
         auth_type = None
 
         # Use the shared utility function directly
@@ -204,10 +215,26 @@ class ConfluenceConfig:
         """
         logger = logging.getLogger("mcp-atlassian.confluence.config")
         if self.auth_type == "oauth":
-            # Handle different OAuth configuration types
             if self.oauth_config:
-                # Full OAuth configuration (traditional mode)
+                # Minimal OAuth (user-provided tokens mode)
                 if isinstance(self.oauth_config, OAuthConfig):
+                    if (
+                        not self.oauth_config.client_id
+                        and not self.oauth_config.client_secret
+                    ):
+                        logger.debug(
+                            "Minimal OAuth config detected - "
+                            "expecting user-provided tokens via headers"
+                        )
+                        return True
+                    # DC OAuth: needs client_id + client_secret (no cloud_id needed)
+                    if hasattr(self.oauth_config, "is_data_center"):
+                        if self.oauth_config.is_data_center:
+                            return bool(
+                                self.oauth_config.client_id
+                                and self.oauth_config.client_secret
+                            )
+                    # Cloud OAuth: full set required
                     if (
                         self.oauth_config.client_id
                         and self.oauth_config.client_secret
@@ -216,23 +243,17 @@ class ConfluenceConfig:
                         and self.oauth_config.cloud_id
                     ):
                         return True
-                    # Minimal OAuth configuration (user-provided tokens mode)
-                    # This is valid if we have oauth_config but missing client credentials
-                    # In this case, we expect authentication to come from user-provided headers
-                    elif (
-                        not self.oauth_config.client_id
-                        and not self.oauth_config.client_secret
-                    ):
-                        logger.debug(
-                            "Minimal OAuth config detected - expecting user-provided tokens via headers"
-                        )
-                        return True
-                # Bring Your Own Access Token mode
+                # BYO Access Token mode
                 elif isinstance(self.oauth_config, BYOAccessTokenOAuthConfig):
-                    if self.oauth_config.cloud_id and self.oauth_config.access_token:
-                        return True
+                    if self.oauth_config.access_token:
+                        # DC BYO: access_token is enough
+                        if hasattr(self.oauth_config, "is_data_center"):
+                            if self.oauth_config.is_data_center:
+                                return True
+                        # Cloud BYO: needs cloud_id + access_token
+                        if self.oauth_config.cloud_id:
+                            return True
 
-            # Partial configuration is invalid
             logger.warning("Incomplete OAuth configuration detected")
             return False
         elif self.auth_type == "pat":

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -48,8 +48,17 @@ class JiraClient:
 
         # Initialize the Jira client based on auth type
         if self.config.auth_type == "oauth":
-            if not self.config.oauth_config or not self.config.oauth_config.cloud_id:
-                error_msg = "OAuth authentication requires a valid cloud_id"
+            if not self.config.oauth_config:
+                error_msg = "OAuth authentication requires oauth_config"
+                raise ValueError(error_msg)
+
+            # Determine Cloud vs Data Center OAuth
+            is_dc_oauth = (
+                getattr(self.config.oauth_config, "is_data_center", False) is True
+            )
+
+            if not is_dc_oauth and not self.config.oauth_config.cloud_id:
+                error_msg = "Cloud OAuth authentication requires a valid cloud_id"
                 raise ValueError(error_msg)
 
             # Create a session for OAuth
@@ -60,16 +69,20 @@ class JiraClient:
                 error_msg = "Failed to configure OAuth session"
                 raise MCPAtlassianAuthenticationError(error_msg)
 
-            # The Jira API URL with OAuth is different
-            api_url = (
-                f"https://api.atlassian.com/ex/jira/{self.config.oauth_config.cloud_id}"
-            )
+            if is_dc_oauth:
+                # Data Center: use the instance URL directly
+                api_url = self.config.url
+                is_cloud = False
+            else:
+                # Cloud: use the Atlassian Cloud API URL
+                api_url = f"https://api.atlassian.com/ex/jira/{self.config.oauth_config.cloud_id}"
+                is_cloud = True
 
             # Initialize Jira with the session
             self.jira = Jira(
                 url=api_url,
                 session=session,
-                cloud=True,  # OAuth is only for Cloud
+                cloud=is_cloud,
                 verify_ssl=self.config.ssl_verify,
                 timeout=self.config.timeout,
             )

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -125,14 +125,23 @@ class JiraConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
-        # Multi-Cloud OAuth mode: URL might be None, but we use api.atlassian.com
+        # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
             and self.oauth_config
             and self.oauth_config.cloud_id
         ):
-            # OAuth with cloud_id uses api.atlassian.com which is always Cloud
             return True
+
+        # DC OAuth has base_url but no cloud_id — not Cloud
+        if (
+            self.auth_type == "oauth"
+            and self.oauth_config
+            and hasattr(self.oauth_config, "base_url")
+            and self.oauth_config.base_url
+            and not self.oauth_config.cloud_id
+        ):
+            return False
 
         # For other auth types, check the URL
         return is_atlassian_cloud_url(self.url) if self.url else False
@@ -170,8 +179,8 @@ class JiraConfig:
         api_token = os.getenv("JIRA_API_TOKEN")
         personal_token = os.getenv("JIRA_PERSONAL_TOKEN")
 
-        # Check for OAuth configuration
-        oauth_config = get_oauth_config_from_env()
+        # Check for OAuth configuration (pass service info for DC detection)
+        oauth_config = get_oauth_config_from_env(service_url=url, service_type="jira")
         auth_type = None
 
         # Use the shared utility function directly
@@ -282,10 +291,26 @@ class JiraConfig:
         """
         logger = logging.getLogger("mcp-atlassian.jira.config")
         if self.auth_type == "oauth":
-            # Handle different OAuth configuration types
             if self.oauth_config:
-                # Full OAuth configuration (traditional mode)
+                # Minimal OAuth (user-provided tokens mode)
                 if isinstance(self.oauth_config, OAuthConfig):
+                    if (
+                        not self.oauth_config.client_id
+                        and not self.oauth_config.client_secret
+                    ):
+                        logger.debug(
+                            "Minimal OAuth config detected - "
+                            "expecting user-provided tokens via headers"
+                        )
+                        return True
+                    # DC OAuth: needs client_id + client_secret (no cloud_id needed)
+                    if hasattr(self.oauth_config, "is_data_center"):
+                        if self.oauth_config.is_data_center:
+                            return bool(
+                                self.oauth_config.client_id
+                                and self.oauth_config.client_secret
+                            )
+                    # Cloud OAuth: full set required
                     if (
                         self.oauth_config.client_id
                         and self.oauth_config.client_secret
@@ -294,23 +319,17 @@ class JiraConfig:
                         and self.oauth_config.cloud_id
                     ):
                         return True
-                    # Minimal OAuth configuration (user-provided tokens mode)
-                    # This is valid if we have oauth_config but missing client credentials
-                    # In this case, we expect authentication to come from user-provided headers
-                    elif (
-                        not self.oauth_config.client_id
-                        and not self.oauth_config.client_secret
-                    ):
-                        logger.debug(
-                            "Minimal OAuth config detected - expecting user-provided tokens via headers"
-                        )
-                        return True
-                # Bring Your Own Access Token mode
+                # BYO Access Token mode
                 elif isinstance(self.oauth_config, BYOAccessTokenOAuthConfig):
-                    if self.oauth_config.cloud_id and self.oauth_config.access_token:
-                        return True
+                    if self.oauth_config.access_token:
+                        # DC BYO: access_token is enough
+                        if hasattr(self.oauth_config, "is_data_center"):
+                            if self.oauth_config.is_data_center:
+                                return True
+                        # Cloud BYO: needs cloud_id + access_token
+                        if self.oauth_config.cloud_id:
+                            return True
 
-            # Partial configuration is invalid
             logger.warning("Incomplete OAuth configuration detected")
             return False
         elif self.auth_type == "pat":

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -18,31 +18,52 @@ def get_available_services(
     if confluence_url:
         is_cloud = is_atlassian_cloud_url(confluence_url)
 
-        # OAuth check (highest precedence, applies to Cloud)
+        # Cloud OAuth check (needs cloud_id)
         if all(
             [
-                os.getenv("ATLASSIAN_OAUTH_CLIENT_ID"),
-                os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET"),
-                os.getenv("ATLASSIAN_OAUTH_REDIRECT_URI"),
-                os.getenv("ATLASSIAN_OAUTH_SCOPE"),
-                os.getenv(
-                    "ATLASSIAN_OAUTH_CLOUD_ID"
-                ),  # CLOUD_ID is essential for OAuth client init
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_ID")
+                or os.getenv("CONFLUENCE_OAUTH_CLIENT_ID"),
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET")
+                or os.getenv("CONFLUENCE_OAUTH_CLIENT_SECRET"),
+                os.getenv("ATLASSIAN_OAUTH_CLOUD_ID"),
             ]
         ):
             confluence_is_setup = True
-            logger.info(
-                "Using Confluence OAuth 2.0 (3LO) authentication (Cloud-only features)"
+            logger.info("Using Confluence OAuth 2.0 (3LO) authentication (Cloud)")
+        # DC OAuth check (no cloud_id, but has client credentials + non-cloud URL)
+        elif (
+            not is_cloud
+            and (
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_ID")
+                or os.getenv("CONFLUENCE_OAUTH_CLIENT_ID")
             )
+            and (
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET")
+                or os.getenv("CONFLUENCE_OAUTH_CLIENT_SECRET")
+            )
+        ):
+            confluence_is_setup = True
+            logger.info("Using Confluence OAuth 2.0 authentication (Data Center)")
         elif all(
             [
-                os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN"),
+                os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN")
+                or os.getenv("CONFLUENCE_OAUTH_ACCESS_TOKEN"),
                 os.getenv("ATLASSIAN_OAUTH_CLOUD_ID"),
             ]
         ):
             confluence_is_setup = True
             logger.info(
-                "Using Confluence OAuth 2.0 (3LO) authentication (Cloud-only features) "
+                "Using Confluence OAuth 2.0 (3LO) authentication (Cloud) "
+                "with provided access token"
+            )
+        # DC BYO access token (no cloud_id, non-cloud URL)
+        elif not is_cloud and (
+            os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN")
+            or os.getenv("CONFLUENCE_OAUTH_ACCESS_TOKEN")
+        ):
+            confluence_is_setup = True
+            logger.info(
+                "Using Confluence OAuth 2.0 authentication (Data Center) "
                 "with provided access token"
             )
         elif is_cloud:  # Cloud non-OAuth
@@ -80,28 +101,52 @@ def get_available_services(
     jira_is_setup = False
     if jira_url:
         is_cloud = is_atlassian_cloud_url(jira_url)
+        # Cloud OAuth check (needs cloud_id)
         if all(
             [
-                os.getenv("ATLASSIAN_OAUTH_CLIENT_ID"),
-                os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET"),
-                os.getenv("ATLASSIAN_OAUTH_REDIRECT_URI"),
-                os.getenv("ATLASSIAN_OAUTH_SCOPE"),
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_ID")
+                or os.getenv("JIRA_OAUTH_CLIENT_ID"),
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET")
+                or os.getenv("JIRA_OAUTH_CLIENT_SECRET"),
                 os.getenv("ATLASSIAN_OAUTH_CLOUD_ID"),
             ]
         ):
             jira_is_setup = True
-            logger.info(
-                "Using Jira OAuth 2.0 (3LO) authentication (Cloud-only features)"
+            logger.info("Using Jira OAuth 2.0 (3LO) authentication (Cloud)")
+        # DC OAuth check (no cloud_id, but has client credentials + non-cloud URL)
+        elif (
+            not is_cloud
+            and (
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_ID")
+                or os.getenv("JIRA_OAUTH_CLIENT_ID")
             )
+            and (
+                os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET")
+                or os.getenv("JIRA_OAUTH_CLIENT_SECRET")
+            )
+        ):
+            jira_is_setup = True
+            logger.info("Using Jira OAuth 2.0 authentication (Data Center)")
         elif all(
             [
-                os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN"),
+                os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN")
+                or os.getenv("JIRA_OAUTH_ACCESS_TOKEN"),
                 os.getenv("ATLASSIAN_OAUTH_CLOUD_ID"),
             ]
         ):
             jira_is_setup = True
             logger.info(
-                "Using Jira OAuth 2.0 (3LO) authentication (Cloud-only features) "
+                "Using Jira OAuth 2.0 (3LO) authentication (Cloud) "
+                "with provided access token"
+            )
+        # DC BYO access token (no cloud_id, non-cloud URL)
+        elif not is_cloud and (
+            os.getenv("ATLASSIAN_OAUTH_ACCESS_TOKEN")
+            or os.getenv("JIRA_OAUTH_ACCESS_TOKEN")
+        ):
+            jira_is_setup = True
+            logger.info(
+                "Using Jira OAuth 2.0 authentication (Data Center) "
                 "with provided access token"
             )
         elif is_cloud:  # Cloud non-OAuth

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.utils.oauth import OAuthConfig
 
 
 def test_from_env_basic_auth():
@@ -289,3 +290,54 @@ def test_jira_config_timeout_default():
     ):
         config = JiraConfig.from_env()
         assert config.timeout == 75
+
+
+def test_jira_config_is_cloud_false_for_dc_oauth():
+    """Test is_cloud returns False when DC OAuth is configured."""
+    dc_oauth = OAuthConfig(
+        client_id="c",
+        client_secret="s",
+        redirect_uri="r",
+        scope="sc",
+        base_url="https://jira.corp.com",
+    )
+    config = JiraConfig(
+        url="https://jira.corp.com",
+        auth_type="oauth",
+        oauth_config=dc_oauth,
+    )
+    assert config.is_cloud is False
+
+
+def test_jira_config_is_cloud_true_for_cloud_oauth():
+    """Test is_cloud returns True when Cloud OAuth is configured."""
+    cloud_oauth = OAuthConfig(
+        client_id="c",
+        client_secret="s",
+        redirect_uri="r",
+        scope="sc",
+        cloud_id="cloud-123",
+    )
+    config = JiraConfig(
+        url="https://test.atlassian.net",
+        auth_type="oauth",
+        oauth_config=cloud_oauth,
+    )
+    assert config.is_cloud is True
+
+
+def test_jira_config_is_auth_configured_dc_oauth():
+    """Test is_auth_configured returns True for DC OAuth with client_id + secret."""
+    dc_oauth = OAuthConfig(
+        client_id="c",
+        client_secret="s",
+        redirect_uri="r",
+        scope="sc",
+        base_url="https://jira.corp.com",
+    )
+    config = JiraConfig(
+        url="https://jira.corp.com",
+        auth_type="oauth",
+        oauth_config=dc_oauth,
+    )
+    assert config.is_auth_configured() is True


### PR DESCRIPTION
## Summary

- Extends OAuth 2.0 authentication from Cloud-only to support **Atlassian Data Center / Server** instances
- Adds `base_url` field and `is_data_center` property to `OAuthConfig` with dynamic `token_url`/`authorize_url` properties (DC uses `/rest/oauth2/latest/*`)
- Adds mutual exclusivity validation: `cloud_id` and `base_url` cannot both be set
- DC token exchange does not require `refresh_token` (no `offline_access` scope needed)
- Service-specific env vars (`JIRA_OAUTH_CLIENT_ID`, `CONFLUENCE_OAUTH_CLIENT_ID`) override shared `ATLASSIAN_OAUTH_CLIENT_ID`
- Namespaces keyring token storage keys by `cloud_id` or `base_url` hash to prevent collisions
- Early return in `configure_oauth_session` when no tokens available (#858)
- Environment detection recognizes DC OAuth and DC BYO access token configurations

Closes #527

## Test plan

- [x] 32 new DC OAuth unit tests covering:
  - `is_data_center` property (3 cases)
  - Mutual exclusivity validation (2 cases)
  - Dynamic `token_url`/`authorize_url` (5 cases)
  - Keyring username namespacing (3 cases)
  - Authorization URL params (2 cases: DC no audience, Cloud has audience)
  - Token exchange (DC no refresh required, Cloud requires refresh)
  - `from_env` with service-specific env vars and DC detection (3 cases)
  - BYO DC config and from_env (2 cases)
  - `configure_oauth_session` no-tokens early return (1 case)
  - Token save includes `base_url` (1 case)
  - Client init DC OAuth uses base_url with cloud=False (2 cases)
  - Config `is_cloud` returns False for DC OAuth (3 cases)
  - Environment detection for DC OAuth (3 cases)
- [x] All 1443 existing tests pass (no regressions)
- [x] pre-commit clean (ruff, mypy)