### PR TITLE
Add regression tests for OAuth refresh token failure (#858)

### DIFF
--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -1080,3 +1080,21 @@ class TestResolveBearerAuthType:
         )
         result = _resolve_bearer_auth_type(config, "oauth")
         assert result == "pat"
+
+    def test_minimal_oauth_config_bearer_fallback_to_pat(self):
+        """Regression: ATLASSIAN_OAUTH_ENABLE=true with no cloud_id creates
+        minimal OAuth config. Bearer token should fall back to PAT (#858)."""
+        # Minimal OAuth config: empty strings, no cloud_id, no base_url
+        minimal_oauth = OAuthConfig(
+            client_id="",
+            client_secret="",
+            redirect_uri="",
+            scope="",
+        )
+        config = JiraConfig(
+            url="https://jira.corp.example.com",
+            auth_type="oauth",
+            oauth_config=minimal_oauth,
+        )
+        result = _resolve_bearer_auth_type(config, "oauth")
+        assert result == "pat"

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -1137,6 +1137,26 @@ class TestDataCenterOAuth:
         mock_logger.warning.assert_called_once()
         assert "No access_token or refresh_token" in str(mock_logger.warning.call_args)
 
+    @patch("mcp_atlassian.utils.oauth.logger")
+    def test_configure_oauth_session_minimal_oauth_no_tokens(self, mock_logger):
+        """Regression: minimal OAuth config (ATLASSIAN_OAUTH_ENABLE=true) with no
+        tokens should return False with clear warning, not crash (#858)."""
+        session = requests.Session()
+        # Minimal config: empty client_id/secret, as created by ATLASSIAN_OAUTH_ENABLE=true
+        config = OAuthConfig(
+            client_id="",
+            client_secret="",
+            redirect_uri="",
+            scope="",
+        )
+
+        result = configure_oauth_session(session, config)
+
+        assert result is False
+        assert "Authorization" not in session.headers
+        mock_logger.warning.assert_called_once()
+        assert "per-request auth" in str(mock_logger.warning.call_args)
+
     # --- _save_tokens includes base_url ---
 
     @patch("keyring.set_password")


### PR DESCRIPTION
## Summary
- Add regression tests verifying the fix for the OAuth refresh token failure when a server has `ATLASSIAN_OAUTH_ENABLE=true` globally but receives per-request PAT/Bearer tokens
- The actual fixes were delivered in PR #952 (early return in `configure_oauth_session`) and PR #953 (bearer disambiguation fallback to PAT)
- This PR adds targeted regression tests for the #858 scenario to prevent regressions

## Test plan
- [x] `test_configure_oauth_session_minimal_oauth_no_tokens` — verifies early return when no tokens available
- [x] `test_minimal_oauth_config_bearer_fallback_to_pat` — verifies Bearer falls back to PAT when OAuth config has no tokens
- [x] All 1451 existing tests pass
- [x] Pre-commit clean