### PR TITLE
Add Basic Auth multi-user support for MCP gateway

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -1,5 +1,6 @@
 """Main FastMCP server setup for Atlassian integration."""
 
+import base64
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -508,14 +509,50 @@ class UserTokenMiddleware:
                     f"...{mask_sensitive(token, 8)}"
                 )
 
+        elif auth_header.startswith("Basic "):
+            encoded = auth_header[6:].strip()
+            if not encoded:
+                scope["state"]["auth_validation_error"] = (
+                    "Unauthorized: Empty Basic auth credentials"
+                )
+                return
+            try:
+                decoded = base64.b64decode(encoded).decode("utf-8")
+            except (ValueError, UnicodeDecodeError) as e:
+                logger.warning(f"Failed to decode Basic auth: {e}")
+                scope["state"]["auth_validation_error"] = (
+                    "Unauthorized: Invalid Basic auth encoding"
+                )
+                return
+            if ":" not in decoded:
+                scope["state"]["auth_validation_error"] = (
+                    "Unauthorized: Invalid Basic auth format. "
+                    "Expected 'email:api_token'"
+                )
+                return
+            email, api_token = decoded.split(":", 1)
+            if not email or not api_token:
+                scope["state"]["auth_validation_error"] = (
+                    "Unauthorized: Email or API token is empty"
+                )
+                return
+            scope["state"]["user_atlassian_email"] = email
+            scope["state"]["user_atlassian_api_token"] = api_token
+            scope["state"]["user_atlassian_auth_type"] = "basic"
+            scope["state"]["user_atlassian_token"] = None
+            logger.debug(
+                f"UserTokenMiddleware: Basic auth extracted for email: {email}"
+            )
+
         elif auth_header.strip():
             # Non-empty but unsupported auth type
             auth_value = auth_header.strip()
             auth_type = auth_value.split(" ", 1)[0] if " " in auth_value else auth_value
             logger.warning(f"Unsupported Authorization type: {auth_type}")
             scope["state"]["auth_validation_error"] = (
-                "Unauthorized: Only 'Bearer <OAuthToken>' or "
-                "'Token <PAT>' types are supported."
+                "Unauthorized: Only 'Bearer <OAuthToken>', "
+                "'Token <PAT>', or 'Basic <base64(email:api_token)>' "
+                "types are supported."
             )
         else:
             # Empty or whitespace-only


### PR DESCRIPTION
## Summary
- Add HTTP Basic authentication (`email:api_token`) support for multi-user scenarios in the MCP gateway
- Each user can authenticate with their own Atlassian Cloud credentials via the `Authorization: Basic <base64(email:api_token)>` header
- Enables building multi-tenant MCP gateway servers where each request is authenticated with the user's own Atlassian API token

## Changes
- **Middleware** (`servers/main.py`): Parse `Authorization: Basic` header, decode base64, validate email:token format
- **Dependencies** (`servers/dependencies.py`): Handle `basic` auth type in config creation and fetcher injection
- **Tests**: 13 new tests covering middleware parsing (valid credentials, malformed base64, missing colon, empty email/token) and dependency injection (config creation, fetcher creation for Jira/Confluence, missing credentials)

## Usage

```bash
# Generate credentials
echo -n "user@example.com:your_api_token" | base64

# IDE config
{
  "mcpServers": {
    "mcp-atlassian": {
      "url": "http://localhost:9000/mcp",
      "headers": {
        "Authorization": "Basic dXNlckBleGFtcGxlLmNvbTp5b3VyX2FwaV90b2tlbg=="
      }
    }
  }
}
```

Based on the approach from PR #739 by @kangis89. Closes #380.

## Test plan
- [x] Valid Basic auth header extracts email + api_token correctly
- [x] Malformed base64 → 401
- [x] Missing colon separator → 401
- [x] Empty email or token → 401
- [x] User-specific JiraFetcher created with basic auth credentials
- [x] User-specific ConfluenceFetcher created with basic auth credentials
- [x] All 1464 existing tests pass
- [x] Pre-commit clean (ruff + mypy)