### PR TITLE
Support BYOT OAuth mode without requiring service URLs

### DIFF
--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -83,10 +83,16 @@ def get_available_services(
                 logger.info(
                     "Using Confluence Server/Data Center authentication (PAT or Basic Auth)"
                 )
-    elif os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in ("true", "1", "yes"):
+
+    if not confluence_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+        "true",
+        "1",
+        "yes",
+    ):
         confluence_is_setup = True
         logger.info(
-            "Using Confluence minimal OAuth configuration - expecting user-provided tokens via headers"
+            "Using Confluence minimal OAuth configuration "
+            "- expecting user-provided tokens via headers"
         )
 
     if not confluence_is_setup:
@@ -166,10 +172,16 @@ def get_available_services(
                 logger.info(
                     "Using Jira Server/Data Center authentication (PAT or Basic Auth)"
                 )
-    elif os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in ("true", "1", "yes"):
+
+    if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+        "true",
+        "1",
+        "yes",
+    ):
         jira_is_setup = True
         logger.info(
-            "Using Jira minimal OAuth configuration - expecting user-provided tokens via headers"
+            "Using Jira minimal OAuth configuration "
+            "- expecting user-provided tokens via headers"
         )
 
     if not jira_is_setup:

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -269,3 +269,63 @@ def test_confluence_config_timeout_default():
     ):
         config = ConfluenceConfig.from_env()
         assert config.timeout == 75
+
+
+def test_from_env_oauth_enable_no_url():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true without URL."""
+    with patch.dict(
+        os.environ,
+        {"ATLASSIAN_OAUTH_ENABLE": "true"},
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.auth_type == "oauth"
+        assert config.url == ""
+        assert config.is_cloud is False
+
+
+def test_from_env_oauth_enable_no_url_with_cloud_id():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true with cloud_id but no URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+            "ATLASSIAN_OAUTH_CLOUD_ID": "test-cloud-id",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.auth_type == "oauth"
+        assert config.is_cloud is True
+
+
+def test_from_env_oauth_enable_with_cloud_url():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true with Cloud URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.url == "https://test.atlassian.net/wiki"
+        assert config.auth_type == "oauth"
+        assert config.is_cloud is True
+
+
+def test_from_env_oauth_enable_with_server_url():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true with Server URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+            "CONFLUENCE_URL": "https://confluence.example.com",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.url == "https://confluence.example.com"
+        assert config.auth_type == "oauth"
+        assert config.is_cloud is False

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -341,3 +341,63 @@ def test_jira_config_is_auth_configured_dc_oauth():
         oauth_config=dc_oauth,
     )
     assert config.is_auth_configured() is True
+
+
+def test_from_env_oauth_enable_no_url():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true without URL."""
+    with patch.dict(
+        os.environ,
+        {"ATLASSIAN_OAUTH_ENABLE": "true"},
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.auth_type == "oauth"
+        assert config.url == ""
+        assert config.is_cloud is False
+
+
+def test_from_env_oauth_enable_no_url_with_cloud_id():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true with cloud_id but no URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+            "ATLASSIAN_OAUTH_CLOUD_ID": "test-cloud-id",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.auth_type == "oauth"
+        assert config.is_cloud is True
+
+
+def test_from_env_oauth_enable_with_cloud_url():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true with Cloud URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+            "JIRA_URL": "https://test.atlassian.net",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.url == "https://test.atlassian.net"
+        assert config.auth_type == "oauth"
+        assert config.is_cloud is True
+
+
+def test_from_env_oauth_enable_with_server_url():
+    """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true with Server URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+            "JIRA_URL": "https://jira.example.com",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.url == "https://jira.example.com"
+        assert config.auth_type == "oauth"
+        assert config.is_cloud is False


### PR DESCRIPTION
## Summary
- Fix service detection to recognize `ATLASSIAN_OAUTH_ENABLE=true` as a fallback when URL-based auth detection fails
- Previously, the check was inside an `elif` branch only reached when no service URL was set
- Now it acts as a fallback regardless of URL presence, enabling BYOT mode with or without service URLs

## Changes
- **environment.py**: Move `ATLASSIAN_OAUTH_ENABLE` check from `elif` to `if not _is_setup` fallback
- **test_config.py** (Jira + Confluence): 8 new BYOT config tests (no URL, cloud_id, Cloud URL, Server URL)
- **test_environment.py**: 13 new service detection tests (BYOT without URLs, with URLs, value variations)

Based on the approach from PR #699 by @nealedj. Fixes #698.

## Test plan
- [x] BYOT without URLs: services detected, config loads correctly
- [x] BYOT with Cloud URL but no credentials: services detected
- [x] BYOT with cloud_id: `is_cloud == True`
- [x] BYOT with Server URL: `is_cloud == False`
- [x] Value variations (true/True/1/yes) all work
- [x] Disabled values (false/0/no) don't enable BYOT
- [x] All 1485 existing tests pass
- [x] Pre-commit clean