### PR TITLE
docs(auth): update documentation for Phase 3 auth changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,11 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 # =============================================
 # mcp-atlassian will attempt to auto-detect the auth method based on the credentials you provide below.
 # Precedence for auto-detection:
-#   1. Username/API Token (Basic Auth) - Recommended for Cloud
-#   2. Personal Access Token (if URL is Server/DC and PAT is set)
-#   3. OAuth BYOT (if ATLASSIAN_OAUTH_CLOUD_ID and ATLASSIAN_OAUTH_ACCESS_TOKEN are set)
-#   4. OAuth Standard (if OAuth Client ID/Secret are set)
+#   1. OAuth Standard (if Client ID/Secret are set — Cloud with cloud_id, DC without)
+#   2. OAuth BYOT (if access token is set — Cloud with cloud_id, DC without)
+#   3. Username/API Token (Basic Auth) - Recommended for Cloud
+#   4. Personal Access Token (if URL is Server/DC and PAT is set)
+#   5. ATLASSIAN_OAUTH_ENABLE=true (minimal BYOT — tokens provided per-request)
 
 # --- METHOD 1: API TOKEN (Recommended for Atlassian Cloud) ---
 # Get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
@@ -46,9 +47,11 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #CONFLUENCE_USERNAME=your_server_dc_username
 #CONFLUENCE_API_TOKEN=your_confluence_server_dc_password
 
-# --- METHOD 4: OAUTH 2.0 (Advanced - Atlassian Cloud Only) ---
+# --- METHOD 4: OAUTH 2.0 (Advanced - Cloud and Data Center) ---
 # OAuth 2.0 provides enhanced security but is more complex to set up.
 # For most users, Method 1 (API Token) is simpler and sufficient.
+#
+# --- Cloud OAuth 2.0 (3LO) ---
 # 1. Create an OAuth 2.0 (3LO) app in Atlassian Developer Console:
 #    https://developer.atlassian.com/console/myapps/
 # 2. Set the Callback/Redirect URI in your app (e.g., http://localhost:8080/callback).
@@ -66,12 +69,30 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # Required for the server AFTER running --oauth-setup (this ID is printed by the setup wizard):
 #ATLASSIAN_OAUTH_CLOUD_ID=your_atlassian_cloud_id_from_oauth_setup
 
-# --- METHOD 5: BRING YOUR OWN TOKEN (BYOT) OAUTH (Advanced - Atlassian Cloud Only) ---
+# --- Data Center OAuth 2.0 ---
+# For Server/DC instances, configure OAuth via your instance's Application Links.
+# Service-specific env vars override the global ATLASSIAN_OAUTH_* vars.
+#JIRA_OAUTH_CLIENT_ID=your_jira_dc_oauth_client_id
+#JIRA_OAUTH_CLIENT_SECRET=your_jira_dc_oauth_client_secret
+#CONFLUENCE_OAUTH_CLIENT_ID=your_confluence_dc_oauth_client_id
+#CONFLUENCE_OAUTH_CLIENT_SECRET=your_confluence_dc_oauth_client_secret
+
+# --- METHOD 5: BRING YOUR OWN TOKEN (BYOT) OAUTH (Advanced) ---
 # Use this method when you have an externally managed OAuth access token.
 # This is useful for integration with larger systems (e.g., MCP Gateway) that manage OAuth tokens.
 # No token refresh will be performed - the external system is responsible for token management.
+#
+# Cloud BYOT (requires cloud_id):
 #ATLASSIAN_OAUTH_CLOUD_ID=your_atlassian_cloud_id
 #ATLASSIAN_OAUTH_ACCESS_TOKEN=your_pre_existing_oauth_access_token
+#
+# Data Center BYOT (uses instance URL from JIRA_URL/CONFLUENCE_URL):
+#JIRA_OAUTH_ACCESS_TOKEN=your_dc_oauth_access_token
+#CONFLUENCE_OAUTH_ACCESS_TOKEN=your_dc_oauth_access_token
+#
+# Minimal BYOT mode — enables OAuth without any credentials or URLs.
+# The external system (e.g., MCP Gateway) provides tokens per-request via headers.
+#ATLASSIAN_OAUTH_ENABLE=true
 
 # =============================================
 # SERVER/DATA CENTER SPECIFIC SETTINGS
@@ -106,6 +127,11 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #PORT=8000
 # Host for 'sse' transport. Default is '0.0.0.0'.
 #HOST=0.0.0.0
+
+# --- HTTP Timeout ---
+# Timeout in seconds for HTTP requests to Atlassian APIs. Default is 75 seconds.
+#JIRA_TIMEOUT=75
+#CONFLUENCE_TIMEOUT=75
 
 # --- Read-Only Mode ---
 # Disables all write operations (create, update, delete). Default is false.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 - **FastMCP servers**: `servers/main.py` → lifespan → dependency injection via `get_jira_fetcher(ctx)` / `get_confluence_fetcher(ctx)`.
 - **Tool naming**: `{service}_{action}_{target}` (e.g., `jira_create_issue`, `confluence_get_page`).
 - **Config**: Environment-based `from_env()` factory on `JiraConfig` / `ConfluenceConfig` dataclasses.
-- **Auth**: Basic (Cloud), PAT (Server/DC), OAuth 2.0 (Cloud) — with multi-tenant header support.
+- **Auth**: Basic (Cloud + Server/DC), PAT (Server/DC), OAuth 2.0 (Cloud + Server/DC) — with multi-tenant header support.
 - **Models**: All extend `ApiModel` → `from_api_response()` + `to_simplified_dict()`.
 
 ---
@@ -73,7 +73,7 @@ uv run pytest --cov=src/mcp_atlassian --cov-report=term-missing  # coverage
 ## Gotchas
 
 - **Cloud vs Server/DC**: API endpoints, field names, and auth methods differ. Always check `is_cloud` before assuming behavior.
-- **OAuth = Cloud only**, PAT = Server/DC only. Basic auth (user + API token) works on Cloud.
+- **OAuth 2.0**: Supported on both Cloud and Server/Data Center. PAT is also available for Server/DC. Basic auth (user + API token) works on both Cloud and Server/DC.
 - **Read-only mode**: `READ_ONLY_MODE=true` blocks all write tools at server level.
 - **Type checking**: pre-commit runs **mypy** (strict mode).
 - **Environment**: See `.env.example` for all configuration options (auth, proxy, SLA, filtering).

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -241,9 +241,9 @@ def main(
 
     Supports both Atlassian Cloud and Jira Server/Data Center deployments.
     Authentication methods supported:
-    - Username and API token (Cloud)
+    - Username and API token (Cloud and Server/Data Center)
     - Personal Access Token (Server/Data Center)
-    - OAuth 2.0 (Cloud only)
+    - OAuth 2.0 (Cloud and Data Center)
     """
     # Logging level logic
     if verbose == 1:


### PR DESCRIPTION
## Summary

- **AGENTS.md**: Updated auth descriptions — OAuth 2.0 now listed as Cloud + Data Center, Basic Auth listed for both Cloud + Server/DC
- **CLI help text** (`__init__.py`): Updated "OAuth 2.0 (Cloud only)" → "OAuth 2.0 (Cloud and Data Center)"
- **.env.example**: 
  - Added Data Center OAuth 2.0 section with service-specific env vars (`JIRA_OAUTH_CLIENT_ID`, etc.)
  - Updated BYOT OAuth section to cover both Cloud and DC modes, including `ATLASSIAN_OAUTH_ENABLE`
  - Added HTTP timeout configuration (`JIRA_TIMEOUT`, `CONFLUENCE_TIMEOUT`)
  - Updated auth precedence documentation to match actual detection order

## Test plan

- [x] `pre-commit run --all-files` passes
- [ ] Verify `.env.example` comments are accurate against the codebase