### PR TITLE
fix(confluence): remove double /wiki prefix in Cloud URLs

### DIFF
--- a/src/mcp_atlassian/confluence/analytics.py
+++ b/src/mcp_atlassian/confluence/analytics.py
@@ -130,7 +130,7 @@ class AnalyticsMixin:
         Raises:
             HTTPError: If the API request fails
         """
-        url = f"{self.confluence.url}/wiki/rest/api/analytics/content/{page_id}/views"
+        url = f"{self.confluence.url}/rest/api/analytics/content/{page_id}/views"
         response = self.confluence._session.get(url)
         response.raise_for_status()
         return response.json()

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -739,7 +739,7 @@ class ConfluenceV2Adapter:
         """
         try:
             # Use the Analytics API endpoint
-            url = f"{self.base_url}/wiki/rest/api/analytics/content/{page_id}/views"
+            url = f"{self.base_url}/rest/api/analytics/content/{page_id}/views"
 
             response = self.session.get(url)
             response.raise_for_status()
@@ -795,7 +795,7 @@ class ConfluenceV2Adapter:
             ValueError: If page not found or other errors
         """
         try:
-            url = f"{self.base_url}/wiki/api/v2/pages/{page_id}/attachments"
+            url = f"{self.base_url}/api/v2/pages/{page_id}/attachments"
             params: dict[str, Any] = {"start": start, "limit": limit}
 
             if filename:
@@ -847,7 +847,7 @@ class ConfluenceV2Adapter:
             ValueError: If attachment not found or other errors
         """
         try:
-            url = f"{self.base_url}/wiki/api/v2/attachments/{attachment_id}"
+            url = f"{self.base_url}/api/v2/attachments/{attachment_id}"
 
             response = self.session.get(url)
             response.raise_for_status()
@@ -883,7 +883,7 @@ class ConfluenceV2Adapter:
             ValueError: If attachment not found or deletion fails
         """
         try:
-            url = f"{self.base_url}/wiki/api/v2/attachments/{attachment_id}"
+            url = f"{self.base_url}/api/v2/attachments/{attachment_id}"
 
             response = self.session.delete(url)
             response.raise_for_status()


### PR DESCRIPTION
## Summary

- Fix double `/wiki` prefix in Confluence Cloud URL construction causing 404 errors for analytics, attachments, and attachment operations
- `base_url` / `self.confluence.url` already includes `/wiki` for Cloud (auto-appended by `atlassian-python-api`), so 5 URLs were producing paths like `.../wiki/wiki/rest/api/...`
- Affected: `v2_adapter.py` (4 URLs: analytics views, page attachments, get/delete attachment) and `analytics.py` (1 URL: direct page views)

## Test plan

- [x] Regression tests added for all 5 fixed URLs (parametrized in `test_v2_adapter.py`, explicit in `test_analytics.py`)
- [x] Unit + integration tests pass (1805 passed)
- [x] DC E2E tests pass (60 passed)
- [x] Cloud E2E tests pass (34 passed) — `test_get_page_views` validates the analytics fix against live Cloud
- [x] Pre-commit (ruff + mypy) clean

Closes #962