### PR TITLE
chore: track CLAUDE.md and .claude/settings.json, add .worktreeinclude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Edit:*",
+      "Write:*",
+      "MultiEdit:*",
+      "Bash:*"
+    ],
+    "defaultMode": "acceptEdits"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,8 @@ playground/
 .cursor*
 
 # Claude
-.claude/
+.claude/worktrees/
+.claude/settings.local.json
+
+# Dev docs (local task documents)
+dev/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+.env
+.env.*
+!.env.example
+dev/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Track `CLAUDE.md` and `.claude/settings.json` so worktrees and contributors get them automatically
- Selectively gitignore `.claude/worktrees/` and `settings.local.json` instead of the entire `.claude/` directory
- Add `.worktreeinclude` for automatic `.env` and `dev/` copying into worktrees
- Add `dev/` to `.gitignore` (local task documents)

## Test plan
- [ ] Verify `CLAUDE.md` and `.claude/settings.json` are tracked: `git ls-files CLAUDE.md .claude/settings.json`
- [ ] Verify `.claude/worktrees/` is ignored: `git check-ignore .claude/worktrees/`
- [ ] Verify `.claude/settings.local.json` is ignored: `git check-ignore .claude/settings.local.json`
- [ ] Verify `dev/` is ignored: `git check-ignore dev/`
- [ ] Verify worktree gets `.env` and `dev/` via `.worktreeinclude`: `claude -w test-verify`