### PR TITLE
feat(jira): add Jira Service Desk queue read support (Server/DC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_create_issue` - Create issues | `confluence_create_page` - Create pages |
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
+| `jira_get_queue_issues` - Read JSM queue items | |
 | `jira_get_issue_sla` - Calculate SLA metrics | `confluence_get_page_history` - Get historical page versions |
 | `jira_get_issue_development_info` - Get linked PRs, branches, commits | `confluence_get_page_views` - Get page view stats (Cloud only) |
 | `jira_get_issue_proforma_forms` - Get ProForma forms | |

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -55,6 +55,9 @@ MCP Atlassian provides tools for interacting with Jira and Confluence.
 | | `jira_get_issue_development_info` | |
 | | `jira_get_issues_development_info` | |
 | | `jira_get_project_components` | |
+| | `jira_get_service_desk_for_project` | |
+| | `jira_get_service_desk_queues` | |
+| | `jira_get_queue_issues` | |
 | **Write** | `jira_create_issue` | `confluence_create_page` |
 | | `jira_update_issue` | `confluence_update_page` |
 | | `jira_delete_issue` | `confluence_delete_page` |

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -23,6 +23,7 @@ from .issues import IssuesMixin
 from .links import LinksMixin
 from .metrics import MetricsMixin
 from .projects import ProjectsMixin
+from .queues import QueuesMixin
 from .sla import SLAMixin
 from .search import SearchMixin
 from .sprints import SprintsMixin
@@ -46,6 +47,7 @@ class JiraFetcher(
     UsersMixin,
     BoardsMixin,
     SprintsMixin,
+    QueuesMixin,
     AttachmentsMixin,
     LinksMixin,
     MetricsMixin,

--- a/src/mcp_atlassian/jira/queues.py
+++ b/src/mcp_atlassian/jira/queues.py
@@ -1,0 +1,218 @@
+"""Module for Jira Service Management queue read operations."""
+
+import logging
+
+from ..models.jira import (
+    JiraQueue,
+    JiraQueueIssuesResult,
+    JiraServiceDesk,
+    JiraServiceDeskQueuesResult,
+)
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class QueuesMixin(JiraClient):
+    """Mixin for Jira Service Management queue read operations."""
+
+    def _ensure_server_mode(self) -> None:
+        """Ensure queue endpoints are used only on Server/Data Center in v1."""
+        if self.config.is_cloud:
+            raise NotImplementedError(
+                "Jira Service Desk queue read endpoints are currently implemented "
+                "for Server/Data Center in v1."
+            )
+
+    def get_service_desk_for_project(self, project_key: str) -> JiraServiceDesk | None:
+        """
+        Get the Jira Service Desk associated with a project key.
+
+        Args:
+            project_key: The Jira project key (e.g. 'SUP')
+
+        Returns:
+            Matched JiraServiceDesk model or None if not found
+        """
+        if not project_key or not project_key.strip():
+            raise ValueError("Project key is required")
+
+        self._ensure_server_mode()
+
+        normalized_project_key = project_key.strip().upper()
+        start = 0
+        limit = 50
+
+        try:
+            while True:
+                response = self.jira.get(
+                    "rest/servicedeskapi/servicedesk",
+                    params={"start": start, "limit": limit},
+                )
+                if not isinstance(response, dict):
+                    logger.error(
+                        "Unexpected response type from servicedesk list endpoint: %s",
+                        type(response),
+                    )
+                    return None
+
+                service_desks = response.get("values", [])
+                if not isinstance(service_desks, list):
+                    logger.error(
+                        "Unexpected service desk list payload type: %s",
+                        type(service_desks),
+                    )
+                    return None
+
+                for service_desk_data in service_desks:
+                    if not isinstance(service_desk_data, dict):
+                        continue
+                    current_key = str(service_desk_data.get("projectKey", "")).upper()
+                    if current_key == normalized_project_key:
+                        return JiraServiceDesk.from_api_response(service_desk_data)
+
+                if response.get("isLastPage", True) or not service_desks:
+                    break
+                start += len(service_desks)
+
+            return None
+        except Exception as e:
+            logger.error(
+                "Error getting service desk for project %s: %s", project_key, str(e)
+            )
+            return None
+
+    def get_service_desk_queues(
+        self,
+        service_desk_id: str,
+        start_at: int = 0,
+        limit: int = 50,
+        include_count: bool = True,
+    ) -> JiraServiceDeskQueuesResult:
+        """
+        Get queues for a specific service desk.
+
+        Args:
+            service_desk_id: The service desk ID (e.g. '4')
+            start_at: Starting index for pagination
+            limit: Maximum number of queues to return
+            include_count: Whether to request queue issue counts from API
+
+        Returns:
+            JiraServiceDeskQueuesResult with queues and pagination metadata
+        """
+        if not service_desk_id or not service_desk_id.strip():
+            raise ValueError("Service desk ID is required")
+        if start_at < 0:
+            raise ValueError("start_at must be >= 0")
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
+
+        self._ensure_server_mode()
+
+        try:
+            response = self.jira.get(
+                f"rest/servicedeskapi/servicedesk/{service_desk_id}/queue",
+                params={
+                    "start": start_at,
+                    "limit": limit,
+                    "includeCount": str(include_count).lower(),
+                },
+            )
+            if not isinstance(response, dict):
+                logger.error(
+                    "Unexpected response type from queue list endpoint: %s",
+                    type(response),
+                )
+                return JiraServiceDeskQueuesResult(service_desk_id=service_desk_id)
+
+            return JiraServiceDeskQueuesResult.from_api_response(
+                response, service_desk_id=service_desk_id
+            )
+        except Exception as e:
+            logger.error(
+                "Error getting queues for service desk %s: %s", service_desk_id, str(e)
+            )
+            return JiraServiceDeskQueuesResult(service_desk_id=service_desk_id)
+
+    def get_queue_issues(
+        self,
+        service_desk_id: str,
+        queue_id: str,
+        start_at: int = 0,
+        limit: int = 50,
+    ) -> JiraQueueIssuesResult:
+        """
+        Get issues from a specific service desk queue.
+
+        Args:
+            service_desk_id: The service desk ID (e.g. '4')
+            queue_id: The queue ID (e.g. '47')
+            start_at: Starting index for pagination
+            limit: Maximum number of issues to return
+
+        Returns:
+            JiraQueueIssuesResult containing queue metadata and queue issues
+        """
+        if not service_desk_id or not service_desk_id.strip():
+            raise ValueError("Service desk ID is required")
+        if not queue_id or not queue_id.strip():
+            raise ValueError("Queue ID is required")
+        if start_at < 0:
+            raise ValueError("start_at must be >= 0")
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
+
+        self._ensure_server_mode()
+
+        queue_model: JiraQueue | None = None
+
+        try:
+            queue_response = self.jira.get(
+                f"rest/servicedeskapi/servicedesk/{service_desk_id}/queue/{queue_id}",
+                params={"includeCount": "true"},
+            )
+            if isinstance(queue_response, dict):
+                queue_model = JiraQueue.from_api_response(queue_response)
+        except Exception as e:
+            logger.debug(
+                "Unable to fetch queue metadata for service desk %s queue %s: %s",
+                service_desk_id,
+                queue_id,
+                str(e),
+            )
+
+        try:
+            response = self.jira.get(
+                f"rest/servicedeskapi/servicedesk/{service_desk_id}/queue/{queue_id}/issue",
+                params={"start": start_at, "limit": limit},
+            )
+            if not isinstance(response, dict):
+                logger.error(
+                    "Unexpected response type from queue issues endpoint: %s",
+                    type(response),
+                )
+                return JiraQueueIssuesResult(
+                    service_desk_id=service_desk_id,
+                    queue_id=queue_id,
+                    queue=queue_model,
+                )
+
+            return JiraQueueIssuesResult.from_api_response(
+                response,
+                service_desk_id=service_desk_id,
+                queue_id=queue_id,
+                queue=queue_model,
+            )
+        except Exception as e:
+            logger.error(
+                "Error getting queue issues for service desk %s queue %s: %s",
+                service_desk_id,
+                queue_id,
+                str(e),
+            )
+            return JiraQueueIssuesResult(
+                service_desk_id=service_desk_id,
+                queue_id=queue_id,
+                queue=queue_model,
+            )

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -33,6 +33,12 @@ from .metrics import (
     StatusTimeSummary,
 )
 from .project import JiraProject
+from .queue import (
+    JiraQueue,
+    JiraQueueIssuesResult,
+    JiraServiceDesk,
+    JiraServiceDeskQueuesResult,
+)
 from .search import JiraSearchResult
 from .sla import (
     CycleTimeMetric,
@@ -72,6 +78,10 @@ __all__ = [
     "JiraSprint",
     "JiraIssue",
     "JiraSearchResult",
+    "JiraServiceDesk",
+    "JiraQueue",
+    "JiraServiceDeskQueuesResult",
+    "JiraQueueIssuesResult",
     "JiraIssueLinkType",
     "JiraIssueLink",
     "JiraLinkedIssue",

--- a/src/mcp_atlassian/models/jira/queue.py
+++ b/src/mcp_atlassian/models/jira/queue.py
@@ -1,0 +1,246 @@
+"""
+Jira Service Management queue models.
+
+This module provides Pydantic models for Jira Service Management
+service desks, queues, and queue issue responses.
+"""
+
+from typing import Any
+
+from pydantic import Field
+
+from ..base import ApiModel
+from ..constants import EMPTY_STRING
+
+
+class JiraServiceDesk(ApiModel):
+    """Model representing a Jira Service Management service desk."""
+
+    id: str = EMPTY_STRING
+    project_id: str | None = None
+    project_key: str = EMPTY_STRING
+    project_name: str = EMPTY_STRING
+    name: str | None = None
+    links: dict[str, Any] | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraServiceDesk":
+        """Create a JiraServiceDesk model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls()
+
+        service_desk_id = data.get("id")
+        project_id = data.get("projectId")
+
+        return cls(
+            id=str(service_desk_id) if service_desk_id is not None else EMPTY_STRING,
+            project_id=str(project_id) if project_id is not None else None,
+            project_key=str(data.get("projectKey", EMPTY_STRING)),
+            project_name=str(data.get("projectName", EMPTY_STRING)),
+            name=data.get("name"),
+            links=data.get("_links") if isinstance(data.get("_links"), dict) else None,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "id": self.id,
+            "project_key": self.project_key,
+            "project_name": self.project_name,
+        }
+
+        if self.project_id:
+            result["project_id"] = self.project_id
+        if self.name:
+            result["name"] = self.name
+        if self.links:
+            result["links"] = self.links
+
+        return result
+
+
+class JiraQueue(ApiModel):
+    """Model representing a Jira Service Management queue."""
+
+    id: str = EMPTY_STRING
+    name: str = EMPTY_STRING
+    issue_count: int | None = None
+    jql: str | None = None
+    fields: list[str] = Field(default_factory=list)
+    links: dict[str, Any] | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraQueue":
+        """Create a JiraQueue model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls()
+
+        queue_id = data.get("id")
+        raw_issue_count = data.get("issueCount")
+        issue_count = None
+        if raw_issue_count is not None:
+            try:
+                issue_count = int(raw_issue_count)
+            except (TypeError, ValueError):
+                issue_count = None
+
+        raw_fields = data.get("fields")
+        fields: list[str] = []
+        if isinstance(raw_fields, list):
+            fields = [str(field) for field in raw_fields if field is not None]
+
+        return cls(
+            id=str(queue_id) if queue_id is not None else EMPTY_STRING,
+            name=str(data.get("name", EMPTY_STRING)),
+            issue_count=issue_count,
+            jql=data.get("jql"),
+            fields=fields,
+            links=data.get("_links") if isinstance(data.get("_links"), dict) else None,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+        }
+
+        if self.issue_count is not None:
+            result["issue_count"] = self.issue_count
+        if self.jql:
+            result["jql"] = self.jql
+        if self.fields:
+            result["fields"] = self.fields
+        if self.links:
+            result["links"] = self.links
+
+        return result
+
+
+class JiraServiceDeskQueuesResult(ApiModel):
+    """Model representing queue listing results for a service desk."""
+
+    service_desk_id: str = EMPTY_STRING
+    start: int = 0
+    limit: int = 50
+    size: int = 0
+    is_last_page: bool = True
+    queues: list[JiraQueue] = Field(default_factory=list)
+    links: dict[str, Any] | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraServiceDeskQueuesResult":
+        """Create a JiraServiceDeskQueuesResult model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls(service_desk_id=str(kwargs.get("service_desk_id", EMPTY_STRING)))
+
+        raw_queues = data.get("values", [])
+        queues: list[JiraQueue] = []
+        if isinstance(raw_queues, list):
+            queues = [
+                JiraQueue.from_api_response(queue_data)
+                for queue_data in raw_queues
+                if isinstance(queue_data, dict)
+            ]
+
+        def _to_int(value: Any, default: int) -> int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        service_desk_id = kwargs.get("service_desk_id", EMPTY_STRING)
+
+        return cls(
+            service_desk_id=str(service_desk_id),
+            start=_to_int(data.get("start"), 0),
+            limit=_to_int(data.get("limit"), 50),
+            size=_to_int(data.get("size"), len(queues)),
+            is_last_page=bool(data.get("isLastPage", True)),
+            queues=queues,
+            links=data.get("_links") if isinstance(data.get("_links"), dict) else None,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "service_desk_id": self.service_desk_id,
+            "start": self.start,
+            "limit": self.limit,
+            "size": self.size,
+            "is_last_page": self.is_last_page,
+            "queues": [queue.to_simplified_dict() for queue in self.queues],
+        }
+        if self.links:
+            result["links"] = self.links
+        return result
+
+
+class JiraQueueIssuesResult(ApiModel):
+    """Model representing queue issues results."""
+
+    service_desk_id: str = EMPTY_STRING
+    queue_id: str = EMPTY_STRING
+    queue: JiraQueue | None = None
+    start: int = 0
+    limit: int = 50
+    size: int = 0
+    is_last_page: bool = True
+    issues: list[dict[str, Any]] = Field(default_factory=list)
+    links: dict[str, Any] | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraQueueIssuesResult":
+        """Create a JiraQueueIssuesResult model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls(
+                service_desk_id=str(kwargs.get("service_desk_id", EMPTY_STRING)),
+                queue_id=str(kwargs.get("queue_id", EMPTY_STRING)),
+                queue=kwargs.get("queue"),
+            )
+
+        raw_issues = data.get("values", [])
+        issues: list[dict[str, Any]] = []
+        if isinstance(raw_issues, list):
+            issues = [issue for issue in raw_issues if isinstance(issue, dict)]
+
+        def _to_int(value: Any, default: int) -> int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        return cls(
+            service_desk_id=str(kwargs.get("service_desk_id", EMPTY_STRING)),
+            queue_id=str(kwargs.get("queue_id", EMPTY_STRING)),
+            queue=kwargs.get("queue"),
+            start=_to_int(data.get("start"), 0),
+            limit=_to_int(data.get("limit"), 50),
+            size=_to_int(data.get("size"), len(issues)),
+            is_last_page=bool(data.get("isLastPage", True)),
+            issues=issues,
+            links=data.get("_links") if isinstance(data.get("_links"), dict) else None,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "service_desk_id": self.service_desk_id,
+            "queue_id": self.queue_id,
+            "start": self.start,
+            "limit": self.limit,
+            "size": self.size,
+            "is_last_page": self.is_last_page,
+            "issues": self.issues,
+        }
+        if self.queue:
+            result["queue"] = self.queue.to_simplified_dict()
+        if self.links:
+            result["links"] = self.links
+        return result

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2015,6 +2015,129 @@ async def get_all_projects(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read"},
+    annotations={
+        "title": "Get Service Desk For Project",
+        "readOnlyHint": True,
+    },
+)
+async def get_service_desk_for_project(
+    ctx: Context,
+    project_key: Annotated[
+        str,
+        Field(
+            description="Jira project key (e.g., 'SUP')",
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+) -> str:
+    """
+    Get the Jira Service Desk associated with a project key.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key.
+
+    Returns:
+        JSON string with project key and service desk data (or null if not found).
+    """
+    jira = await get_jira_fetcher(ctx)
+    service_desk = jira.get_service_desk_for_project(project_key=project_key)
+    result = {
+        "project_key": project_key.upper(),
+        "service_desk": service_desk.to_simplified_dict() if service_desk else None,
+    }
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read"},
+    annotations={"title": "Get Service Desk Queues", "readOnlyHint": True},
+)
+async def get_service_desk_queues(
+    ctx: Context,
+    service_desk_id: Annotated[
+        str,
+        Field(description="Service desk ID (e.g., '4')"),
+    ],
+    start_at: Annotated[
+        int,
+        Field(description="Starting index for pagination (0-based)", default=0, ge=0),
+    ] = 0,
+    limit: Annotated[
+        int,
+        Field(description="Maximum number of results (1-50)", default=50, ge=1, le=50),
+    ] = 50,
+) -> str:
+    """
+    Get queues for a Jira Service Desk.
+
+    Args:
+        ctx: The FastMCP context.
+        service_desk_id: Service desk ID.
+        start_at: Starting index for pagination.
+        limit: Maximum number of queues to return.
+
+    Returns:
+        JSON string with queue list and pagination metadata.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_service_desk_queues(
+        service_desk_id=service_desk_id,
+        start_at=start_at,
+        limit=limit,
+        include_count=True,
+    )
+    return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read"},
+    annotations={"title": "Get Queue Issues", "readOnlyHint": True},
+)
+async def get_queue_issues(
+    ctx: Context,
+    service_desk_id: Annotated[
+        str,
+        Field(description="Service desk ID (e.g., '4')"),
+    ],
+    queue_id: Annotated[
+        str,
+        Field(description="Queue ID (e.g., '47')"),
+    ],
+    start_at: Annotated[
+        int,
+        Field(description="Starting index for pagination (0-based)", default=0, ge=0),
+    ] = 0,
+    limit: Annotated[
+        int,
+        Field(description="Maximum number of results (1-50)", default=50, ge=1),
+    ] = 50,
+) -> str:
+    """
+    Get issues from a Jira Service Desk queue.
+
+    Args:
+        ctx: The FastMCP context.
+        service_desk_id: Service desk ID.
+        queue_id: Queue ID.
+        start_at: Starting index for pagination.
+        limit: Maximum number of issues to return.
+
+    Returns:
+        JSON string with queue metadata, issues, and pagination metadata.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_queue_issues(
+        service_desk_id=service_desk_id,
+        queue_id=queue_id,
+        start_at=start_at,
+        limit=limit,
+    )
+    return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "write"},
     annotations={"title": "Create Version", "destructiveHint": True},
 )

--- a/tests/unit/jira/test_queues.py
+++ b/tests/unit/jira/test_queues.py
@@ -1,0 +1,160 @@
+"""Tests for Jira Service Management queue read operations."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.models.jira import JiraQueueIssuesResult, JiraServiceDeskQueuesResult
+
+
+@pytest.fixture
+def queues_fetcher(jira_fetcher: JiraFetcher) -> JiraFetcher:
+    """Create a Jira fetcher configured for queue endpoint testing."""
+    fetcher = jira_fetcher
+    fetcher.config = MagicMock()
+    fetcher.config.is_cloud = False
+    return fetcher
+
+
+def test_get_service_desk_for_project_found_on_second_page(queues_fetcher: JiraFetcher):
+    """Service desk lookup should paginate until a matching project key is found."""
+    queues_fetcher.jira.get = MagicMock(
+        side_effect=[
+            {
+                "start": 0,
+                "limit": 1,
+                "isLastPage": False,
+                "values": [
+                    {
+                        "id": "1",
+                        "projectKey": "TIC",
+                        "projectId": "10001",
+                        "projectName": "Ticketing",
+                    }
+                ],
+            },
+            {
+                "start": 1,
+                "limit": 1,
+                "isLastPage": True,
+                "values": [
+                    {
+                        "id": "4",
+                        "projectKey": "SUP",
+                        "projectId": "10400",
+                        "projectName": "support",
+                        "_links": {"self": "https://test/rest/servicedeskapi/4"},
+                    }
+                ],
+            },
+        ]
+    )
+
+    result = queues_fetcher.get_service_desk_for_project("sup")
+
+    assert result is not None
+    assert result.id == "4"
+    assert result.project_key == "SUP"
+    assert result.project_name == "support"
+    assert queues_fetcher.jira.get.call_count == 2
+
+
+def test_get_service_desk_for_project_not_found(queues_fetcher: JiraFetcher):
+    """Service desk lookup should return None when project key has no service desk."""
+    queues_fetcher.jira.get = MagicMock(
+        return_value={"start": 0, "limit": 50, "isLastPage": True, "values": []}
+    )
+
+    result = queues_fetcher.get_service_desk_for_project("NOTFOUND")
+
+    assert result is None
+
+
+def test_get_service_desk_queues_success(queues_fetcher: JiraFetcher):
+    """Queue listing should parse queues and pagination metadata."""
+    queues_fetcher.jira.get = MagicMock(
+        return_value={
+            "start": 0,
+            "limit": 50,
+            "size": 2,
+            "isLastPage": True,
+            "_links": {"self": "https://test/rest/servicedeskapi/servicedesk/4/queue"},
+            "values": [
+                {"id": "47", "name": "Support Team", "issueCount": 11},
+                {"id": "48", "name": "Waiting for customer", "issueCount": 33},
+            ],
+        }
+    )
+
+    result = queues_fetcher.get_service_desk_queues("4", start_at=0, limit=50)
+
+    assert isinstance(result, JiraServiceDeskQueuesResult)
+    assert result.service_desk_id == "4"
+    assert result.size == 2
+    assert len(result.queues) == 2
+    assert result.queues[0].id == "47"
+    assert result.queues[0].issue_count == 11
+
+
+def test_get_queue_issues_success(queues_fetcher: JiraFetcher):
+    """Queue issues call should include queue metadata and issue payloads."""
+    queues_fetcher.jira.get = MagicMock(
+        side_effect=[
+            {
+                "id": "47",
+                "name": "Support Team",
+                "issueCount": 11,
+                "_links": {"self": "https://test/rest/servicedeskapi/servicedesk/4/47"},
+            },
+            {
+                "start": 0,
+                "limit": 2,
+                "size": 2,
+                "isLastPage": True,
+                "values": [
+                    {"id": "1", "key": "SUP-1", "fields": {"summary": "Issue 1"}},
+                    {"id": "2", "key": "SUP-2", "fields": {"summary": "Issue 2"}},
+                ],
+            },
+        ]
+    )
+
+    result = queues_fetcher.get_queue_issues("4", "47", start_at=0, limit=2)
+
+    assert isinstance(result, JiraQueueIssuesResult)
+    assert result.service_desk_id == "4"
+    assert result.queue_id == "47"
+    assert result.queue is not None
+    assert result.queue.name == "Support Team"
+    assert result.size == 2
+    assert len(result.issues) == 2
+    assert result.issues[0]["key"] == "SUP-1"
+
+
+def test_get_queue_issues_invalid_payload_returns_safe_default(
+    queues_fetcher: JiraFetcher,
+):
+    """Invalid queue-issues payload should return an empty safe default."""
+    queues_fetcher.jira.get = MagicMock(
+        side_effect=[
+            {"id": "47", "name": "Support Team", "issueCount": 11},
+            "invalid-payload",
+        ]
+    )
+
+    result = queues_fetcher.get_queue_issues("4", "47", start_at=0, limit=2)
+
+    assert isinstance(result, JiraQueueIssuesResult)
+    assert result.queue is not None
+    assert result.queue.id == "47"
+    assert result.issues == []
+    assert result.size == 0
+
+
+def test_queue_endpoints_are_server_only_in_v1(queues_fetcher: JiraFetcher):
+    """Cloud mode should raise NotImplementedError in v1."""
+    queues_fetcher.config.is_cloud = True
+
+    with pytest.raises(NotImplementedError):
+        queues_fetcher.get_service_desk_for_project("SUP")

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -250,6 +250,46 @@ def mock_jira_fetcher():
 
     mock_get_user_profile.side_effect = side_effect_func
     mock_fetcher.get_user_profile_by_identifier = mock_get_user_profile
+
+    mock_service_desk = MagicMock()
+    mock_service_desk.to_simplified_dict.return_value = {
+        "id": "4",
+        "project_id": "10400",
+        "project_key": "SUP",
+        "project_name": "support",
+        "links": {"self": "https://test.atlassian.net/rest/servicedeskapi/4"},
+    }
+    mock_fetcher.get_service_desk_for_project.return_value = mock_service_desk
+
+    mock_service_desk_queues = MagicMock()
+    mock_service_desk_queues.to_simplified_dict.return_value = {
+        "service_desk_id": "4",
+        "start": 0,
+        "limit": 50,
+        "size": 2,
+        "is_last_page": True,
+        "queues": [
+            {"id": "47", "name": "Support Team", "issue_count": 11},
+            {"id": "48", "name": "Waiting for customer", "issue_count": 33},
+        ],
+    }
+    mock_fetcher.get_service_desk_queues.return_value = mock_service_desk_queues
+
+    mock_queue_issues = MagicMock()
+    mock_queue_issues.to_simplified_dict.return_value = {
+        "service_desk_id": "4",
+        "queue_id": "47",
+        "start": 0,
+        "limit": 2,
+        "size": 2,
+        "is_last_page": True,
+        "queue": {"id": "47", "name": "Support Team", "issue_count": 11},
+        "issues": [
+            {"id": "1", "key": "SUP-1"},
+            {"id": "2", "key": "SUP-2"},
+        ],
+    }
+    mock_fetcher.get_queue_issues.return_value = mock_queue_issues
     return mock_fetcher
 
 
@@ -304,6 +344,9 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         get_project_components,
         get_project_issues,
         get_project_versions,
+        get_queue_issues,
+        get_service_desk_for_project,
+        get_service_desk_queues,
         get_sprint_issues,
         get_sprints_from_board,
         get_transitions,
@@ -326,6 +369,9 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(get_project_versions)
     jira_sub_mcp.add_tool(get_project_components)
     jira_sub_mcp.add_tool(get_all_projects)
+    jira_sub_mcp.add_tool(get_service_desk_for_project)
+    jira_sub_mcp.add_tool(get_service_desk_queues)
+    jira_sub_mcp.add_tool(get_queue_issues)
     jira_sub_mcp.add_tool(get_transitions)
     jira_sub_mcp.add_tool(get_worklog)
     jira_sub_mcp.add_tool(download_attachments)
@@ -475,6 +521,83 @@ async def test_search(jira_client, mock_jira_fetcher):
         start=0,
         projects_filter=None,
         expand=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_service_desk_for_project(jira_client, mock_jira_fetcher):
+    """Test service desk lookup by project key."""
+    response = await jira_client.call_tool(
+        "jira_get_service_desk_for_project", {"project_key": "SUP"}
+    )
+    assert hasattr(response, "content")
+    assert len(response.content) > 0
+
+    content = json.loads(response.content[0].text)
+    assert content["project_key"] == "SUP"
+    assert content["service_desk"]["id"] == "4"
+    assert content["service_desk"]["project_key"] == "SUP"
+    mock_jira_fetcher.get_service_desk_for_project.assert_called_once_with(
+        project_key="SUP"
+    )
+
+
+@pytest.mark.anyio
+async def test_get_service_desk_for_project_not_found(jira_client, mock_jira_fetcher):
+    """Test service desk lookup returns null payload when not found."""
+    mock_jira_fetcher.get_service_desk_for_project.return_value = None
+
+    response = await jira_client.call_tool(
+        "jira_get_service_desk_for_project", {"project_key": "SUP"}
+    )
+    content = json.loads(response.content[0].text)
+
+    assert content["project_key"] == "SUP"
+    assert content["service_desk"] is None
+
+
+@pytest.mark.anyio
+async def test_get_service_desk_queues(jira_client, mock_jira_fetcher):
+    """Test queue listing for a service desk."""
+    response = await jira_client.call_tool(
+        "jira_get_service_desk_queues",
+        {"service_desk_id": "4", "start_at": 0, "limit": 50},
+    )
+    assert hasattr(response, "content")
+    assert len(response.content) > 0
+
+    content = json.loads(response.content[0].text)
+    assert content["service_desk_id"] == "4"
+    assert content["size"] == 2
+    assert content["queues"][0]["id"] == "47"
+    mock_jira_fetcher.get_service_desk_queues.assert_called_once_with(
+        service_desk_id="4",
+        start_at=0,
+        limit=50,
+        include_count=True,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_queue_issues(jira_client, mock_jira_fetcher):
+    """Test queue issue retrieval."""
+    response = await jira_client.call_tool(
+        "jira_get_queue_issues",
+        {"service_desk_id": "4", "queue_id": "47", "start_at": 0, "limit": 2},
+    )
+    assert hasattr(response, "content")
+    assert len(response.content) > 0
+
+    content = json.loads(response.content[0].text)
+    assert content["service_desk_id"] == "4"
+    assert content["queue_id"] == "47"
+    assert content["size"] == 2
+    assert content["issues"][0]["key"] == "SUP-1"
+    mock_jira_fetcher.get_queue_issues.assert_called_once_with(
+        service_desk_id="4",
+        queue_id="47",
+        start_at=0,
+        limit=2,
     )
 
 


### PR DESCRIPTION
Merge of community PR #971 by @ilgaur with conflict resolution.

Adds 3 new read-only MCP tools for Jira Service Desk queue support on Server/DC:
- `jira_get_service_desk_for_project` — Get Service Desk associated with a project
- `jira_get_service_desk_queues` — List queues for a Service Desk
- `jira_get_queue_issues` — Get issues from a specific queue

Includes new `QueuesMixin`, 4 Pydantic models, and comprehensive unit tests.

Closes #971