### PR TITLE
fix(jira): add Server/DC-only docs and expand queue tests

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -73,6 +73,7 @@ class JiraFetcher(
     - AttachmentsMixin: Attachment download operations
     - LinksMixin: Issue link operations
     - MetricsMixin: Issue metrics and date operations
+    - QueuesMixin: Service Desk queue read operations (Server/DC)
     - SLAMixin: SLA calculations
 
     The class structure is designed to maintain backward compatibility while

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2034,12 +2034,17 @@ async def get_service_desk_for_project(
     """
     Get the Jira Service Desk associated with a project key.
 
+    Server/Data Center only. Not available on Jira Cloud.
+
     Args:
         ctx: The FastMCP context.
         project_key: Jira project key.
 
     Returns:
         JSON string with project key and service desk data (or null if not found).
+
+    Raises:
+        NotImplementedError: If connected to Jira Cloud (Server/DC only).
     """
     jira = await get_jira_fetcher(ctx)
     service_desk = jira.get_service_desk_for_project(project_key=project_key)
@@ -2072,6 +2077,8 @@ async def get_service_desk_queues(
     """
     Get queues for a Jira Service Desk.
 
+    Server/Data Center only. Not available on Jira Cloud.
+
     Args:
         ctx: The FastMCP context.
         service_desk_id: Service desk ID.
@@ -2080,6 +2087,9 @@ async def get_service_desk_queues(
 
     Returns:
         JSON string with queue list and pagination metadata.
+
+    Raises:
+        NotImplementedError: If connected to Jira Cloud (Server/DC only).
     """
     jira = await get_jira_fetcher(ctx)
     result = jira.get_service_desk_queues(
@@ -2117,6 +2127,8 @@ async def get_queue_issues(
     """
     Get issues from a Jira Service Desk queue.
 
+    Server/Data Center only. Not available on Jira Cloud.
+
     Args:
         ctx: The FastMCP context.
         service_desk_id: Service desk ID.
@@ -2126,6 +2138,9 @@ async def get_queue_issues(
 
     Returns:
         JSON string with queue metadata, issues, and pagination metadata.
+
+    Raises:
+        NotImplementedError: If connected to Jira Cloud (Server/DC only).
     """
     jira = await get_jira_fetcher(ctx)
     result = jira.get_queue_issues(


### PR DESCRIPTION
## Summary

Follow-up to community PR #971:

- Add "Server/Data Center only. Not available on Jira Cloud." to all 3 queue tool docstrings so LLM clients know these tools won't work on Cloud
- Add `Raises: NotImplementedError` to the docstrings' Raises section
- Expand Cloud-rejection tests to cover all 3 queue methods using `@pytest.mark.parametrize` (previously only tested `get_service_desk_for_project`)
- Add `QueuesMixin` to the `JiraFetcher` class docstring's mixin list

## Test plan

- [x] `pre-commit run --all-files` passes (Ruff + mypy clean)
- [x] `uv run pytest tests/unit/jira/test_queues.py -xvs` — 8 tests pass (3 new parametrized Cloud-rejection tests)