### PR TITLE
test(jira): add security regression tests for path traversal and JQL sanitization

### DIFF
--- a/tests/unit/jira/test_jql_utils.py
+++ b/tests/unit/jira/test_jql_utils.py
@@ -36,6 +36,8 @@ class TestJQLQuoting:
             ('my"key', '"my\\"key"'),
             # Internal backslash escaping
             ("my\\key", '"my\\\\key"'),
+            # Both backslash and double-quote (PR #949 regression)
+            ('my\\"key', '"my\\\\\\"key"'),
         ],
         ids=[
             "reserved-IF",
@@ -54,6 +56,7 @@ class TestJQLQuoting:
             "digit-start-1ABC",
             "internal-quote",
             "internal-backslash",
+            "internal-backslash-and-quote",
         ],
     )
     def test_quoting(self, identifier: str, expected: str) -> None:


### PR DESCRIPTION
## Summary
- Add regression tests for security hardening introduced in PR #949
- Path traversal rejection tests for `download_attachment` (absolute and relative paths) and `download_issue_attachments` (ValueError propagation)
- JQL value escaping unit tests verifying the inline `replace("\\", "\\\\").replace('"', '\\"')` logic, including the critical backslash-then-quote ordering
- Integration tests confirming `search_issues` handles malicious `projects_filter` values without errors (both Cloud and Server/DC)
- New `backslash-and-quote` combined test case for `quote_jql_identifier_if_needed`

## Test plan
- [x] `pre-commit run --all-files` passes (Ruff + mypy)
- [x] All 701 jira unit tests pass (`uv run pytest tests/unit/jira/ -x`)
- [x] New tests specifically exercise the PR #949 guards

Follow-up to #949.