### PR TITLE
fix(server): add SSRF protection for header-based URL validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,6 +196,13 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 #CONFLUENCE_SOCKS_PROXY=socks5://confluence-proxy.example.com:1080
 #CONFLUENCE_NO_PROXY=localhost,127.0.0.1,.internal.confluence.com
 
+# --- SSRF Protection (Advanced) ---
+# Optional: Comma-separated list of allowed URL domains for header-based authentication.
+# When set, only URLs matching these domains (exact or subdomain) are accepted
+# from X-Atlassian-Jira-Url and X-Atlassian-Confluence-Url headers.
+# Example: MCP_ALLOWED_URL_DOMAINS=atlassian.net,jira.example.com
+#MCP_ALLOWED_URL_DOMAINS=
+
 # --- Custom HTTP Headers (Advanced) ---
 # Jira-specific custom headers.
 #JIRA_CUSTOM_HEADERS=X-Jira-Service=mcp-integration,X-Custom-Auth=jira-token,X-Forwarded-User=service-account

--- a/src/mcp_atlassian/utils/__init__.py
+++ b/src/mcp_atlassian/utils/__init__.py
@@ -16,7 +16,7 @@ from .logging import setup_logging
 # Export OAuth utilities
 from .oauth import OAuthConfig, configure_oauth_session
 from .ssl import SSLIgnoreAdapter, configure_ssl_verification
-from .urls import is_atlassian_cloud_url
+from .urls import is_atlassian_cloud_url, validate_url_for_ssrf
 
 # Export all utility functions for backward compatibility
 __all__ = [
@@ -32,4 +32,5 @@ __all__ = [
     "configure_oauth_session",
     "setup_signal_handlers",
     "ensure_clean_exit",
+    "validate_url_for_ssrf",
 ]

--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -1,6 +1,9 @@
 """URL-related utility functions for MCP Atlassian."""
 
+import ipaddress
+import os
 import re
+import socket
 from urllib.parse import urlparse
 
 
@@ -40,3 +43,142 @@ def is_atlassian_cloud_url(url: str) -> bool:
         or ".atlassian-us-gov-mod.net" in hostname  # US Gov Moderate (FedRAMP)
         or ".atlassian-us-gov.net" in hostname  # US Gov (FedRAMP)
     )
+
+
+def validate_url_for_ssrf(url: str) -> str | None:
+    """Validate a URL to prevent SSRF attacks.
+
+    Returns None if the URL is safe, or an error message string
+    describing why it was blocked.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        None if safe, error message string if blocked.
+    """
+    if not url or not url.strip():
+        return "Empty URL"
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return f"Invalid URL: {url}"
+
+    # Scheme check
+    if parsed.scheme not in ("http", "https"):
+        return f"Blocked scheme: {parsed.scheme} (only http/https allowed)"
+
+    hostname = parsed.hostname
+    if not hostname:
+        return "No hostname in URL"
+
+    # Check blocked hostnames
+    blocked_hostnames = {"localhost", "metadata.google.internal"}
+    if hostname.lower() in blocked_hostnames:
+        return f"Blocked hostname: {hostname}"
+
+    # Check if hostname is an IP address
+    ip_error = _check_ip_address(hostname)
+    if ip_error:
+        return ip_error
+
+    # Domain allowlist check
+    allowlist = _get_domain_allowlist()
+    if allowlist is not None:
+        if not _hostname_matches_allowlist(hostname, allowlist):
+            return f"Hostname {hostname} not in allowed domains"
+
+    # DNS resolution check - resolve hostname and check all IPs
+    dns_error = _check_dns_resolution(hostname)
+    if dns_error:
+        return dns_error
+
+    return None
+
+
+def _check_ip_address(hostname: str) -> str | None:
+    """Check if hostname is a blocked IP address.
+
+    Args:
+        hostname: The hostname to check.
+
+    Returns:
+        None if safe, error message string if blocked.
+    """
+    try:
+        addr = ipaddress.ip_address(hostname)
+    except ValueError:
+        return None  # Not an IP literal - skip
+
+    # Handle IPv4-mapped IPv6 (e.g., ::ffff:127.0.0.1)
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+        addr = addr.ipv4_mapped
+
+    if not addr.is_global:
+        return f"Blocked IP address: {hostname} (non-global)"
+
+    return None
+
+
+def _get_domain_allowlist() -> list[str] | None:
+    """Get domain allowlist from environment variable.
+
+    Returns:
+        List of allowed domain strings, or None if not set.
+    """
+    raw = os.environ.get("MCP_ALLOWED_URL_DOMAINS", "").strip()
+    if not raw:
+        return None
+    return [d.strip().lower() for d in raw.split(",") if d.strip()]
+
+
+def _hostname_matches_allowlist(
+    hostname: str,
+    allowlist: list[str],
+) -> bool:
+    """Check if hostname matches any entry in the allowlist.
+
+    Args:
+        hostname: The hostname to check.
+        allowlist: List of allowed domain strings.
+
+    Returns:
+        True if hostname matches, False otherwise.
+    """
+    hostname_lower = hostname.lower()
+    for domain in allowlist:
+        if hostname_lower == domain or hostname_lower.endswith(f".{domain}"):
+            return True
+    return False
+
+
+def _check_dns_resolution(hostname: str) -> str | None:
+    """Resolve hostname via DNS and check if any IP is non-global.
+
+    Args:
+        hostname: The hostname to resolve and check.
+
+    Returns:
+        None if safe, error message string if blocked.
+    """
+    try:
+        results = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return f"DNS resolution failed for {hostname}"
+    except (OSError, UnicodeError):
+        return f"DNS resolution error for {hostname}"
+
+    for _family, _type, _proto, _canonname, sockaddr in results:
+        ip_str = sockaddr[0]
+        try:
+            addr = ipaddress.ip_address(ip_str)
+            # Handle IPv4-mapped IPv6
+            if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+                addr = addr.ipv4_mapped
+            if not addr.is_global:
+                return f"DNS for {hostname} resolves to non-global IP: {ip_str}"
+        except ValueError:
+            continue
+
+    return None


### PR DESCRIPTION
## Summary
- Add `validate_url_for_ssrf()` to `utils/urls.py` -- checks scheme, blocks private/loopback/link-local IPs, DNS resolution verification, optional domain allowlist via `MCP_ALLOWED_URL_DOMAINS`
- Validate `X-Atlassian-*-Url` headers in ASGI middleware (`_process_authentication_headers`) before fetcher creation
- Add redirect SSRF hook on header-based fetcher sessions (blocks 302 redirects to internal targets)
- Comprehensive unit tests for all SSRF attack vectors (28 URL tests + 6 dependency tests)

## Security
Fixes GHSA-7r34-79r5-rcc9 (High, CVSS 8.2) -- SSRF via unvalidated `X-Atlassian-*-Url` headers in HTTP middleware.

### Attack vectors blocked
- Direct IP literals: `127.0.0.1`, `10.x.x.x`, `172.16.x.x`, `192.168.x.x`, `169.254.169.254`, `::1`, `::ffff:127.0.0.1`
- Reserved hostnames: `localhost`, `metadata.google.internal`
- DNS rebinding: hostname resolving to private IPs
- Non-HTTP schemes: `file://`, `ftp://`, `gopher://`
- Redirect-based SSRF: 302 redirect from valid host to internal target

### Defense layers
1. **Middleware validation** (pre-fetcher): blocks malicious URLs before any HTTP client is created
2. **DNS resolution check**: resolves hostname and validates all IPs are globally routable
3. **Redirect hook** (post-fetcher): blocks 302 redirects to internal targets on header-based sessions
4. **Domain allowlist** (optional): `MCP_ALLOWED_URL_DOMAINS` env var restricts accepted domains

## Test plan
- [x] `validate_url_for_ssrf` unit tests (20 tests covering all attack vectors)
- [x] Redirect hook regression tests (3 tests: block/allow/passthrough)
- [x] SSRF validation regression tests in test_dependencies.py (3 tests)
- [x] `pre-commit run --all-files` clean (Ruff + mypy strict)
- [x] Full unit test suite: 1944 passed, 5 skipped