### PR TITLE
fix(jira): pass through array-type checklist fields unchanged

### DIFF
--- a/src/mcp_atlassian/jira/fields.py
+++ b/src/mcp_atlassian/jira/fields.py
@@ -465,6 +465,8 @@ class FieldsMixin(JiraClient, EpicOperationsProto, UsersOperationsProto):
 
         # --- 0. Check custom field plugins (before system/schema dispatch) ---
         if schema_custom and "checklist" in schema_custom.lower():
+            if schema_type == "array":
+                return value  # Array-type checklist (Server/DC): pass through
             return self._format_checklist_value(value)
 
         # --- 1. Dispatch on system field ID (reliable, not display name) ---

--- a/tests/unit/jira/conftest.py
+++ b/tests/unit/jira/conftest.py
@@ -158,6 +158,17 @@ def session_jira_field_definitions():
                 "customId": 11003,
             },
         },
+        # Checklist plugin (Okapya) — Server/DC array variant
+        {
+            "id": "customfield_11004",
+            "name": "Checklist",
+            "schema": {
+                "type": "array",
+                "items": "checklist-item",
+                "custom": "com.okapya.jira.checklist:checklist",
+                "customId": 11004,
+            },
+        },
     ]
 
 

--- a/tests/unit/jira/test_fields.py
+++ b/tests/unit/jira/test_fields.py
@@ -918,6 +918,17 @@ class TestChecklistFieldFormatting:
         },
     }
 
+    CHECKLIST_ARRAY_FIELD_DEF = {
+        "id": "customfield_11004",
+        "name": "Checklist",
+        "schema": {
+            "type": "array",
+            "items": "checklist-item",
+            "custom": "com.okapya.jira.checklist:checklist",
+            "customId": 11004,
+        },
+    }
+
     @pytest.fixture
     def mixin(self, jira_fetcher: "JiraFetcher") -> FieldsMixin:
         """Create a FieldsMixin instance with mocked dependencies."""
@@ -965,6 +976,42 @@ class TestChecklistFieldFormatting:
         """Checklist fields should be converted to markdown string format."""
         result = mixin._format_field_value_for_write(
             "customfield_11003", value, self.CHECKLIST_FIELD_DEF
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "test_id, value, expected",
+        [
+            pytest.param(
+                "array_dict_list_passthrough",
+                [{"name": "A", "checked": True}, {"name": "B", "checked": False}],
+                [{"name": "A", "checked": True}, {"name": "B", "checked": False}],
+                id="array_dict_list_passthrough",
+            ),
+            pytest.param(
+                "array_string_list_passthrough",
+                ["Task A", "Task B"],
+                ["Task A", "Task B"],
+                id="array_string_list_passthrough",
+            ),
+            pytest.param(
+                "array_string_passthrough",
+                "* [x] done\n* todo",
+                "* [x] done\n* todo",
+                id="array_string_passthrough",
+            ),
+            pytest.param(
+                "array_empty_list_passthrough",
+                [],
+                [],
+                id="array_empty_list_passthrough",
+            ),
+        ],
+    )
+    def test_checklist_array_passthrough(self, mixin, test_id, value, expected):
+        """Array-type checklist fields (Server/DC) should pass through unchanged."""
+        result = mixin._format_field_value_for_write(
+            "customfield_11004", value, self.CHECKLIST_ARRAY_FIELD_DEF
         )
         assert result == expected
 


### PR DESCRIPTION
## Summary
- Array-type checklist fields (Server/DC Okapya plugin) are now passed through unchanged instead of being converted to markdown strings
- String-type checklist fields (Cloud) continue to use markdown conversion as before
- Added 4 parametrized tests for array-type passthrough behavior

Closes #972

## Test plan
- [x] 4 new parametrized tests for array-type checklist passthrough
- [x] Existing 5 Cloud checklist tests still pass (regression)
- [x] Full unit test suite passes (1979 passed)
- [x] pre-commit (ruff + mypy) clean