### PR TITLE
feat(jira): add ADF write support for Jira Cloud

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1456,7 +1456,7 @@ class IssuesMixin(
 
                 # Add optional fields
                 if description:
-                    fields["description"] = description
+                    fields["description"] = self._markdown_to_jira(description)
 
                 # Add assignee if provided
                 if assignee:

--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -94,9 +94,7 @@ class WorklogMixin(JiraClient):
 
             # Convert Markdown comment to Jira format if provided
             if comment:
-                # Check if _markdown_to_jira is available (from CommentsMixin)
-                if hasattr(self, "_markdown_to_jira"):
-                    comment = self._markdown_to_jira(comment)
+                comment = self._markdown_to_jira(comment)
 
             # Step 1: Update original estimate if provided (separate API call)
             original_estimate_updated = False

--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -5,6 +5,7 @@ import re
 from typing import Any
 
 from ..models import JiraWorklog
+from ..models.jira.adf import adf_to_text
 from ..utils import parse_date
 from .client import JiraClient
 
@@ -138,9 +139,15 @@ class WorklogMixin(JiraClient):
                 raise TypeError(msg)
 
             # Format and return the result
+            comment_raw = result.get("comment", "")
+            comment_text = (
+                adf_to_text(comment_raw)
+                if isinstance(comment_raw, dict)
+                else comment_raw
+            )
             return {
                 "id": result.get("id"),
-                "comment": self._clean_text(result.get("comment", "")),
+                "comment": self._clean_text(comment_text or ""),
                 "created": str(parse_date(result.get("created", ""))),
                 "updated": str(parse_date(result.get("updated", ""))),
                 "started": str(parse_date(result.get("started", ""))),

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -1,10 +1,236 @@
 """
 Atlassian Document Format (ADF) utilities.
 
-This module provides utilities for parsing ADF content from Jira Cloud.
+This module provides utilities for converting between ADF and other formats.
+Supports both ADF → plain text (for reading) and Markdown → ADF (for writing).
 """
 
+import re
 from datetime import datetime, timezone
+from typing import Any
+
+
+def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
+    """Parse inline Markdown formatting into ADF inline nodes.
+
+    Handles: bold (**), italic (*), inline code (`), links ([text](url)),
+    and strikethrough (~~).
+
+    Args:
+        text: Raw text potentially containing inline Markdown formatting.
+
+    Returns:
+        List of ADF inline nodes (text nodes with optional marks).
+    """
+    if not text:
+        return []
+
+    nodes: list[dict[str, Any]] = []
+    # Pattern order matters: bold before italic, code before others
+    inline_re = re.compile(
+        r"`(?P<code_inner>[^`]+)`"
+        r"|\*\*(?P<bold_inner>.+?)\*\*"
+        r"|~~(?P<strike_inner>.+?)~~"
+        r"|\[(?P<link_text>[^\]]+)\]\((?P<link_href>[^)]+)\)"
+        r"|(?<!\*)\*(?!\*)(?P<italic_inner>.+?)(?<!\*)\*(?!\*)"
+    )
+
+    pos = 0
+    for m in inline_re.finditer(text):
+        # Add any plain text before this match
+        if m.start() > pos:
+            plain = text[pos : m.start()]
+            if plain:
+                nodes.append({"type": "text", "text": plain})
+
+        if m.group("code_inner") is not None:
+            nodes.append(
+                {
+                    "type": "text",
+                    "text": m.group("code_inner"),
+                    "marks": [{"type": "code"}],
+                }
+            )
+        elif m.group("bold_inner") is not None:
+            nodes.append(
+                {
+                    "type": "text",
+                    "text": m.group("bold_inner"),
+                    "marks": [{"type": "strong"}],
+                }
+            )
+        elif m.group("strike_inner") is not None:
+            nodes.append(
+                {
+                    "type": "text",
+                    "text": m.group("strike_inner"),
+                    "marks": [{"type": "strike"}],
+                }
+            )
+        elif m.group("link_text") is not None:
+            nodes.append(
+                {
+                    "type": "text",
+                    "text": m.group("link_text"),
+                    "marks": [
+                        {
+                            "type": "link",
+                            "attrs": {"href": m.group("link_href")},
+                        }
+                    ],
+                }
+            )
+        elif m.group("italic_inner") is not None:
+            nodes.append(
+                {
+                    "type": "text",
+                    "text": m.group("italic_inner"),
+                    "marks": [{"type": "em"}],
+                }
+            )
+
+        pos = m.end()
+
+    # Remaining plain text after last match
+    if pos < len(text):
+        remaining = text[pos:]
+        if remaining:
+            nodes.append({"type": "text", "text": remaining})
+
+    # If no patterns matched, return the whole thing as plain text
+    if not nodes and text:
+        nodes.append({"type": "text", "text": text})
+
+    return nodes
+
+
+def _make_paragraph(text: str) -> dict[str, Any]:
+    """Create an ADF paragraph node from text with inline formatting."""
+    content = _parse_inline_formatting(text)
+    if not content:
+        content = [{"type": "text", "text": ""}]
+    return {"type": "paragraph", "content": content}
+
+
+def _make_list_item(text: str) -> dict[str, Any]:
+    """Create an ADF listItem node wrapping a paragraph."""
+    return {"type": "listItem", "content": [_make_paragraph(text)]}
+
+
+def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
+    """Convert Markdown text to ADF (Atlassian Document Format) document.
+
+    Implements a line-by-line parser that handles common Markdown constructs.
+    No external dependencies required.
+
+    Args:
+        markdown_text: Markdown-formatted text to convert.
+
+    Returns:
+        ADF document dict with version, type, and content keys.
+    """
+    doc: dict[str, Any] = {"version": 1, "type": "doc", "content": []}
+
+    if not markdown_text:
+        doc["content"].append({"type": "paragraph", "content": []})
+        return doc
+
+    lines = markdown_text.split("\n")
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        # --- Fenced code block ---
+        if line.startswith("```"):
+            lang = line[3:].strip()
+            code_lines: list[str] = []
+            i += 1
+            while i < len(lines) and not lines[i].startswith("```"):
+                code_lines.append(lines[i])
+                i += 1
+            # Skip closing ```
+            if i < len(lines):
+                i += 1
+            cb: dict[str, Any] = {
+                "type": "codeBlock",
+                "attrs": {"language": lang} if lang else {},
+                "content": [{"type": "text", "text": "\n".join(code_lines)}],
+            }
+            doc["content"].append(cb)
+            continue
+
+        # --- Horizontal rule ---
+        stripped = line.strip()
+        if stripped in ("---", "***", "___") or (
+            len(stripped) >= 3
+            and all(c == stripped[0] for c in stripped)
+            and stripped[0] in "-*_"
+        ):
+            # Make sure it's not a list item like "- --"
+            if not line.startswith("- ") and not line.startswith("* "):
+                doc["content"].append({"type": "rule"})
+                i += 1
+                continue
+
+        # --- Heading ---
+        heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if heading_match:
+            level = len(heading_match.group(1))
+            text = heading_match.group(2)
+            heading_node: dict[str, Any] = {
+                "type": "heading",
+                "attrs": {"level": level},
+                "content": _parse_inline_formatting(text),
+            }
+            doc["content"].append(heading_node)
+            i += 1
+            continue
+
+        # --- Blockquote ---
+        if line.startswith("> "):
+            quote_lines: list[str] = []
+            while i < len(lines) and lines[i].startswith("> "):
+                quote_lines.append(lines[i][2:])
+                i += 1
+            bq_content = [_make_paragraph(ln) for ln in quote_lines]
+            doc["content"].append({"type": "blockquote", "content": bq_content})
+            continue
+
+        # --- Unordered list ---
+        if re.match(r"^[-*]\s+", line):
+            items: list[dict[str, Any]] = []
+            while i < len(lines) and re.match(r"^[-*]\s+", lines[i]):
+                item_text = re.sub(r"^[-*]\s+", "", lines[i])
+                items.append(_make_list_item(item_text))
+                i += 1
+            doc["content"].append({"type": "bulletList", "content": items})
+            continue
+
+        # --- Ordered list ---
+        if re.match(r"^\d+\.\s+", line):
+            items_ol: list[dict[str, Any]] = []
+            while i < len(lines) and re.match(r"^\d+\.\s+", lines[i]):
+                item_text = re.sub(r"^\d+\.\s+", "", lines[i])
+                items_ol.append(_make_list_item(item_text))
+                i += 1
+            doc["content"].append({"type": "orderedList", "content": items_ol})
+            continue
+
+        # --- Empty line (skip) ---
+        if not stripped:
+            i += 1
+            continue
+
+        # --- Paragraph (default) ---
+        doc["content"].append(_make_paragraph(line))
+        i += 1
+
+    # Ensure at least one content node
+    if not doc["content"]:
+        doc["content"].append({"type": "paragraph", "content": []})
+
+    return doc
 
 
 def adf_to_text(adf_content: dict | list | str | None) -> str | None:

--- a/tests/unit/jira/test_format_conversion.py
+++ b/tests/unit/jira/test_format_conversion.py
@@ -153,12 +153,12 @@ class TestFormatConversionIntegration:
         # Verify ADF was converted to plain text
         assert result.description == "This is ADF content"
 
-    def test_create_issue_converts_markdown_description_to_jira(
+    def test_create_issue_converts_markdown_description_to_adf_on_cloud(
         self, jira_fetcher_with_real_preprocessor
     ):
-        """Test that creating an issue converts Markdown description to Jira wiki markup.
+        """Test that creating an issue converts Markdown description to ADF on Cloud.
 
-        This verifies the write path: Markdown → Jira wiki markup.
+        This verifies the write path: Markdown → ADF (Cloud).
         """
         # Mock API response
         jira_fetcher_with_real_preprocessor.jira.create_issue.return_value = {
@@ -168,17 +168,7 @@ class TestFormatConversionIntegration:
         }
 
         # Create issue with Markdown description
-        markdown_description = """## Summary
-
-This is **bold** and *italic* text.
-
-1. First item
-2. Second item
-
-| Header 1 | Header 2 |
-|----------|----------|
-| Cell 1   | Cell 2   |
-"""
+        markdown_description = "## Summary\n\nThis is **bold** and *italic* text."
 
         result = jira_fetcher_with_real_preprocessor.create_issue(
             project_key="TEST",
@@ -187,22 +177,21 @@ This is **bold** and *italic* text.
             description=markdown_description,
         )
 
-        # Verify create_issue was called with Jira wiki markup
+        # Verify create_issue was called with ADF dict (Cloud)
         call_args = jira_fetcher_with_real_preprocessor.jira.create_issue.call_args
         sent_fields = call_args[1]["fields"]
         sent_description = sent_fields["description"]
 
-        # Should be converted to Jira wiki markup
-        assert "h2. Summary" in sent_description  # ## → h2.
-        assert "*bold*" in sent_description  # **bold** → *bold*
-        assert "_italic_" in sent_description  # *italic* → _italic_
-        assert "# First item" in sent_description  # 1. → #
-        assert "# Second item" in sent_description  # 2. → #
-        assert "||" in sent_description  # | Header | → || Header ||
+        # On Cloud, description should be an ADF dict
+        assert isinstance(sent_description, dict)
+        assert sent_description["version"] == 1
+        assert sent_description["type"] == "doc"
+        assert isinstance(sent_description["content"], list)
 
-        # Should NOT contain Markdown
-        assert "**bold**" not in sent_description
-        assert "1. First" not in sent_description
+        # Verify ADF contains the expected heading and formatting
+        heading = sent_description["content"][0]
+        assert heading["type"] == "heading"
+        assert heading["attrs"]["level"] == 2
 
     def test_numbered_list_not_converted_to_heading(
         self, jira_fetcher_with_real_preprocessor

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -272,14 +272,19 @@ class TestIssuesMixin:
             description="This is a test issue",
         )
 
-        # Verify API calls
-        expected_fields = {
-            "project": {"key": "TEST"},
-            "summary": "Test Issue",
-            "issuetype": {"name": "Bug"},
-            "description": "This is a test issue",
-        }
-        issues_mixin.jira.create_issue.assert_called_once_with(fields=expected_fields)
+        # Verify API calls — description is ADF dict on Cloud, use ANY
+        issues_mixin.jira.create_issue.assert_called_once_with(
+            fields={
+                "project": {"key": "TEST"},
+                "summary": "Test Issue",
+                "issuetype": {"name": "Bug"},
+                "description": ANY,
+            }
+        )
+        # Verify description is ADF on Cloud
+        sent = issues_mixin.jira.create_issue.call_args[1]["fields"]["description"]
+        assert isinstance(sent, dict)
+        assert sent["version"] == 1
         issues_mixin.jira.get_issue.assert_called_once_with("TEST-123")
 
         # Verify issue
@@ -306,14 +311,15 @@ class TestIssuesMixin:
             components=None,
         )
 
-        # Verify API calls
-        expected_fields = {
-            "project": {"key": "TEST"},
-            "summary": "Test Issue",
-            "issuetype": {"name": "Bug"},
-            "description": "This is a test issue",
-        }
-        issues_mixin.jira.create_issue.assert_called_once_with(fields=expected_fields)
+        # Verify API calls — description is ADF on Cloud
+        issues_mixin.jira.create_issue.assert_called_once_with(
+            fields={
+                "project": {"key": "TEST"},
+                "summary": "Test Issue",
+                "issuetype": {"name": "Bug"},
+                "description": ANY,
+            }
+        )
 
         # Verify 'components' is not in the fields
         assert "components" not in issues_mixin.jira.create_issue.call_args[1]["fields"]
@@ -340,15 +346,16 @@ class TestIssuesMixin:
             components=["UI"],
         )
 
-        # Verify API calls
-        expected_fields = {
-            "project": {"key": "TEST"},
-            "summary": "Test Issue",
-            "issuetype": {"name": "Bug"},
-            "description": "This is a test issue",
-            "components": [{"name": "UI"}],
-        }
-        issues_mixin.jira.create_issue.assert_called_once_with(fields=expected_fields)
+        # Verify API calls — description is ADF on Cloud
+        issues_mixin.jira.create_issue.assert_called_once_with(
+            fields={
+                "project": {"key": "TEST"},
+                "summary": "Test Issue",
+                "issuetype": {"name": "Bug"},
+                "description": ANY,
+                "components": [{"name": "UI"}],
+            }
+        )
 
         # Verify the components field was passed correctly
         assert issues_mixin.jira.create_issue.call_args[1]["fields"]["components"] == [
@@ -377,15 +384,16 @@ class TestIssuesMixin:
             components=["UI", "API"],
         )
 
-        # Verify API calls
-        expected_fields = {
-            "project": {"key": "TEST"},
-            "summary": "Test Issue",
-            "issuetype": {"name": "Bug"},
-            "description": "This is a test issue",
-            "components": [{"name": "UI"}, {"name": "API"}],
-        }
-        issues_mixin.jira.create_issue.assert_called_once_with(fields=expected_fields)
+        # Verify API calls — description is ADF on Cloud
+        issues_mixin.jira.create_issue.assert_called_once_with(
+            fields={
+                "project": {"key": "TEST"},
+                "summary": "Test Issue",
+                "issuetype": {"name": "Bug"},
+                "description": ANY,
+                "components": [{"name": "UI"}, {"name": "API"}],
+            }
+        )
 
         # Verify the components field was passed correctly
         assert issues_mixin.jira.create_issue.call_args[1]["fields"]["components"] == [
@@ -415,15 +423,16 @@ class TestIssuesMixin:
             components=["Valid", "", None, "  Backend  "],
         )
 
-        # Verify API calls
-        expected_fields = {
-            "project": {"key": "TEST"},
-            "summary": "Test Issue",
-            "issuetype": {"name": "Bug"},
-            "description": "This is a test issue",
-            "components": [{"name": "Valid"}, {"name": "Backend"}],
-        }
-        issues_mixin.jira.create_issue.assert_called_once_with(fields=expected_fields)
+        # Verify API calls — description is ADF on Cloud
+        issues_mixin.jira.create_issue.assert_called_once_with(
+            fields={
+                "project": {"key": "TEST"},
+                "summary": "Test Issue",
+                "issuetype": {"name": "Bug"},
+                "description": ANY,
+                "components": [{"name": "Valid"}, {"name": "Backend"}],
+            }
+        )
 
         # Verify the components field was passed correctly, with invalid entries filtered out
         assert issues_mixin.jira.create_issue.call_args[1]["fields"]["components"] == [
@@ -897,7 +906,9 @@ class TestIssuesMixin:
         assert fields["project"]["key"] == "TEST"
         assert fields["summary"] == "Test Issue"
         assert fields["issuetype"]["name"] == "Bug"
-        assert fields["description"] == "This is a test issue"
+        # Description is ADF dict on Cloud
+        assert isinstance(fields["description"], dict)
+        assert fields["description"]["version"] == 1
         assert "fixVersions" in fields
         assert fields["fixVersions"] == [{"name": "1.0.0"}]
 

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -507,7 +507,11 @@ class TestTransitionsMixin:
         assert "update" in transition_data
         assert "comment" in transition_data["update"]
         assert len(transition_data["update"]["comment"]) == 1
-        assert transition_data["update"]["comment"][0]["add"]["body"] == "Test comment"
+        # On Cloud, body is ADF dict (not plain string)
+        body = transition_data["update"]["comment"][0]["add"]["body"]
+        assert isinstance(body, dict)
+        assert body["version"] == 1
+        assert body["type"] == "doc"
 
     def test_add_comment_to_transition_data_with_non_string(
         self, transitions_mixin: TransitionsMixin
@@ -519,8 +523,10 @@ class TestTransitionsMixin:
         # Call the method with int
         transitions_mixin._add_comment_to_transition_data(transition_data, 123)
 
-        # Verify comment was converted to string
-        assert transition_data["update"]["comment"][0]["add"]["body"] == "123"
+        # On Cloud, converted "123" becomes ADF dict
+        body = transition_data["update"]["comment"][0]["add"]["body"]
+        assert isinstance(body, dict)
+        assert body["version"] == 1
 
     def test_add_comment_to_transition_data_with_markdown_to_jira(
         self, transitions_mixin


### PR DESCRIPTION
## Summary
- Added `markdown_to_adf()` converter for Markdown → ADF (Atlassian Document Format)
- `_markdown_to_jira()` now returns ADF dicts on Cloud, wiki markup on Server/DC
- Removed duplicate `_markdown_to_jira()` from `CommentsMixin`
- Fixed missing `_markdown_to_jira()` call in `batch_create_issues()`
- Added ADF response normalization in comment/worklog response handling

Closes #864
Based on the approach from #865 by @TerminalGravity.

## Test plan
- [x] 16+ parametrized tests for `markdown_to_adf()` conversion
- [x] Cloud/Server dispatch tests for `_markdown_to_jira()`
- [x] Updated existing tests for Cloud ADF behavior
- [x] Full unit test suite passes (2003 tests)
- [x] pre-commit (ruff + mypy) clean