### PR TITLE
fix(server): allowlisted domains bypass DNS resolution check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,7 +200,9 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # Optional: Comma-separated list of allowed URL domains for header-based authentication.
 # When set, only URLs matching these domains (exact or subdomain) are accepted
 # from X-Atlassian-Jira-Url and X-Atlassian-Confluence-Url headers.
-# Example: MCP_ALLOWED_URL_DOMAINS=atlassian.net,jira.example.com
+# Allowlisted domains bypass DNS resolution checks, so internal/private-IP hosts
+# are permitted. Only list domains you trust.
+# Example: MCP_ALLOWED_URL_DOMAINS=atlassian.net,jira.corp.example.com
 #MCP_ALLOWED_URL_DOMAINS=
 
 # --- Custom HTTP Headers (Advanced) ---

--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -88,6 +88,7 @@ def validate_url_for_ssrf(url: str) -> str | None:
     if allowlist is not None:
         if not _hostname_matches_allowlist(hostname, allowlist):
             return f"Hostname {hostname} not in allowed domains"
+        return None  # explicitly allowlisted — skip DNS check
 
     # DNS resolution check - resolve hostname and check all IPs
     dns_error = _check_dns_resolution(hostname)


### PR DESCRIPTION
## Summary
- When `MCP_ALLOWED_URL_DOMAINS` is set, domains matching the allowlist now return early from `validate_url_for_ssrf()` before the DNS resolution check
- Previously, internal hosts resolving to private IPs (e.g. `10.x.x.x`) were blocked even when explicitly allowlisted, breaking the documented use case for corporate Jira/Confluence instances
- Hard-blocked hostnames (`localhost`, `metadata.google.internal`) and IP literal checks remain enforced before the allowlist

Closes #1002

## Test plan
- [x] Added 5 new tests covering allowlisted domains with private IPs, non-matching domains, no-allowlist behavior, and DNS failure bypass
- [x] Key regression test: DNS failure on allowlisted domain is accepted (proves DNS is truly bypassed, not just tolerant)
- [x] All 2045 unit tests pass
- [x] pre-commit clean (ruff + mypy)

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/personal-1d37018d/personal-1d37018d/editor/worktree-issue-1002?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->