### PR TITLE
refactor(tests): remove dead code and consolidate mock utilities

### DIFF
--- a/tests/integration/test_content_processing.py
+++ b/tests/integration/test_content_processing.py
@@ -5,32 +5,12 @@ special character preservation, and performance with large content.
 """
 
 import time
-from typing import Any
 
 import pytest
 
 from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
 from mcp_atlassian.preprocessing.jira import JiraPreprocessor
-
-
-class MockConfluenceClient:
-    """Mock Confluence client for testing user lookups."""
-
-    def get_user_details_by_accountid(self, account_id: str) -> dict[str, Any]:
-        """Mock user details by account ID."""
-        return {
-            "displayName": f"User {account_id}",
-            "accountType": "atlassian",
-            "accountStatus": "active",
-        }
-
-    def get_user_details_by_username(self, username: str) -> dict[str, Any]:
-        """Mock user details by username (Server/DC compatibility)."""
-        return {
-            "displayName": f"User {username}",
-            "accountType": "atlassian",
-            "accountStatus": "active",
-        }
+from tests.utils.mocks import MockConfluenceClient
 
 
 @pytest.fixture
@@ -434,10 +414,10 @@ def process():
         )
 
         # Verify all user mentions are processed
-        assert "@User user123" in processed_markdown
-        assert "@User user456" in processed_markdown
-        assert "@User user789" in processed_markdown
-        assert "@User admin" in processed_markdown
+        assert "@Test Useruser123" in processed_markdown
+        assert "@Test Useruser456" in processed_markdown
+        assert "@Test Useruser789" in processed_markdown
+        assert "@Test Useradmin" in processed_markdown
 
     def test_confluence_markdown_roundtrip(self, confluence_preprocessor):
         """Test Markdown to Confluence storage format and processing."""
@@ -640,7 +620,7 @@ def function_{i}():
         assert (
             "function" in processed_markdown
         )  # Function names might have escaped underscores
-        assert "@User user10" in processed_markdown
+        assert "@Test Useruser10" in processed_markdown
 
     def test_confluence_nested_structures(self, confluence_preprocessor):
         """Test handling of deeply nested structures."""

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -4,16 +4,7 @@ from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
 from mcp_atlassian.preprocessing.jira import JiraPreprocessor
 from tests.fixtures.confluence_mocks import MOCK_COMMENTS_RESPONSE, MOCK_PAGE_RESPONSE
 from tests.fixtures.jira_mocks import MOCK_JIRA_ISSUE_RESPONSE
-
-
-class MockConfluenceClient:
-    def get_user_details_by_accountid(self, account_id):
-        # Mock user details response based on the format in MOCK_PAGE_RESPONSE
-        return {
-            "displayName": f"Test User {account_id}",
-            "accountType": "atlassian",
-            "accountStatus": "active",
-        }
+from tests.utils.mocks import MockConfluenceClient
 
 
 @pytest.fixture

--- a/tests/unit/confluence/conftest.py
+++ b/tests/unit/confluence/conftest.py
@@ -179,25 +179,6 @@ def mock_config(confluence_config_factory):
 
 
 @pytest.fixture
-def mock_env_vars():
-    """
-    Mock environment variables for testing.
-
-    Note: This fixture is maintained for backward compatibility.
-    Consider using the environment fixtures from root conftest.py.
-    """
-    with patch.dict(
-        "os.environ",
-        {
-            "CONFLUENCE_URL": "https://example.atlassian.net/wiki",
-            "CONFLUENCE_USERNAME": "test_user",
-            "CONFLUENCE_API_TOKEN": "test_token",
-        },
-    ):
-        yield
-
-
-@pytest.fixture
 def confluence_auth_environment():
     """
     Fixture providing Confluence-specific authentication environment.

--- a/tests/unit/jira/conftest.py
+++ b/tests/unit/jira/conftest.py
@@ -289,26 +289,6 @@ def mock_config(jira_config_factory):
 
 
 @pytest.fixture
-def mock_env_vars():
-    """
-    Mock environment variables for testing.
-
-    Note: This fixture is maintained for backward compatibility.
-    Consider using the environment fixtures from root conftest.py.
-    """
-    with patch.dict(
-        os.environ,
-        {
-            "JIRA_URL": "https://test.atlassian.net",
-            "JIRA_USERNAME": "test_username",
-            "JIRA_API_TOKEN": "test_token",
-        },
-        clear=True,  # Clear existing environment variables
-    ):
-        yield
-
-
-@pytest.fixture
 def jira_auth_environment():
     """
     Fixture providing Jira-specific authentication environment.

--- a/tests/unit/models/test_jira_models.py
+++ b/tests/unit/models/test_jira_models.py
@@ -11,14 +11,20 @@ import re
 from datetime import datetime, timezone
 
 import pytest
+from atlassian import Jira
 
-from src.mcp_atlassian.models.constants import (
+from mcp_atlassian.jira import JiraConfig, JiraFetcher
+from mcp_atlassian.jira.issues import IssuesMixin
+from mcp_atlassian.jira.projects import ProjectsMixin
+from mcp_atlassian.jira.transitions import TransitionsMixin
+from mcp_atlassian.jira.worklog import WorklogMixin
+from mcp_atlassian.models.constants import (
     EMPTY_STRING,
     JIRA_DEFAULT_ID,
     JIRA_DEFAULT_PROJECT,
     UNKNOWN,
 )
-from src.mcp_atlassian.models.jira import (
+from mcp_atlassian.models.jira import (
     JiraComment,
     JiraIssue,
     JiraIssueLink,
@@ -37,57 +43,7 @@ from src.mcp_atlassian.models.jira import (
     JiraUser,
     JiraWorklog,
 )
-from src.mcp_atlassian.models.jira.common import JiraChangelog
-
-# Optional: Import real API client for optional real-data testing
-try:
-    from atlassian import Jira
-
-    from src.mcp_atlassian.jira import JiraConfig, JiraFetcher
-    from src.mcp_atlassian.jira.issues import IssuesMixin
-    from src.mcp_atlassian.jira.projects import ProjectsMixin
-    from src.mcp_atlassian.jira.transitions import TransitionsMixin
-    from src.mcp_atlassian.jira.worklog import WorklogMixin
-
-    real_api_available = True
-except ImportError:
-    real_api_available = False
-
-    # Create a module-level namespace for dummy classes
-    class _DummyClasses:
-        """Namespace for dummy classes when real imports fail."""
-
-        class JiraFetcher:
-            pass
-
-        class JiraConfig:
-            @staticmethod
-            def from_env():
-                return None
-
-        class IssuesMixin:
-            pass
-
-        class ProjectsMixin:
-            pass
-
-        class TransitionsMixin:
-            pass
-
-        class WorklogMixin:
-            pass
-
-        class Jira:
-            pass
-
-    # Assign dummy classes to module namespace
-    JiraFetcher = _DummyClasses.JiraFetcher
-    JiraConfig = _DummyClasses.JiraConfig
-    IssuesMixin = _DummyClasses.IssuesMixin
-    ProjectsMixin = _DummyClasses.ProjectsMixin
-    TransitionsMixin = _DummyClasses.TransitionsMixin
-    WorklogMixin = _DummyClasses.WorklogMixin
-    Jira = _DummyClasses.Jira
+from mcp_atlassian.models.jira.common import JiraChangelog
 
 
 class TestJiraUser:
@@ -1728,8 +1684,6 @@ class TestRealJiraData:
 
     # Helper to get client/config
     def _get_client(self) -> IssuesMixin | None:
-        if not real_api_available:
-            return None
         try:
             config = JiraConfig.from_env()
             return JiraFetcher(config=config)
@@ -1738,8 +1692,6 @@ class TestRealJiraData:
             return None
 
     def _get_project_client(self) -> ProjectsMixin | None:
-        if not real_api_available:
-            return None
         try:
             config = JiraConfig.from_env()
 
@@ -1749,8 +1701,6 @@ class TestRealJiraData:
             return None
 
     def _get_transition_client(self) -> TransitionsMixin | None:
-        if not real_api_available:
-            return None
         try:
             config = JiraConfig.from_env()
             return JiraFetcher(config=config)
@@ -1759,8 +1709,6 @@ class TestRealJiraData:
             return None
 
     def _get_worklog_client(self) -> WorklogMixin | None:
-        if not real_api_available:
-            return None
         try:
             config = JiraConfig.from_env()
             return JiraFetcher(config=config)
@@ -1769,8 +1717,6 @@ class TestRealJiraData:
             return None
 
     def _get_base_jira_client(self) -> Jira | None:
-        if not real_api_available:
-            return None
         try:
             config = JiraConfig.from_env()
             if config.auth_type == "basic":

--- a/tests/utils/mocks.py
+++ b/tests/utils/mocks.py
@@ -193,3 +193,27 @@ class MockPreprocessor:
         preprocessor = MagicMock()
         preprocessor.process.return_value = "<h1>HTML Content</h1>"
         return preprocessor
+
+
+class MockConfluenceClient:
+    """Mock Confluence client for testing user lookups.
+
+    Provides both Cloud (account ID) and Server/DC (username) user
+    detail methods so tests can exercise either code path.
+    """
+
+    def get_user_details_by_accountid(self, account_id: str) -> dict[str, str]:
+        """Mock user details by account ID (Cloud)."""
+        return {
+            "displayName": f"Test User {account_id}",
+            "accountType": "atlassian",
+            "accountStatus": "active",
+        }
+
+    def get_user_details_by_username(self, username: str) -> dict[str, str]:
+        """Mock user details by username (Server/DC)."""
+        return {
+            "displayName": f"Test User {username}",
+            "accountType": "atlassian",
+            "accountStatus": "active",
+        }


### PR DESCRIPTION
## Summary

- Remove dead import guard (`_DummyClasses` + `real_api_available`) in `test_jira_models.py`
- Normalize `src.mcp_atlassian` imports to `mcp_atlassian`
- Extract duplicate `MockConfluenceClient` to `tests/utils/mocks.py`
- Remove dead `mock_env_vars` fixtures from jira and confluence conftest files
- Update `test_content_processing.py` to use shared `MockConfluenceClient`

## Test plan

- [x] `pre-commit run --all-files` passes (lint + mypy)
- [x] `uv run pytest tests/ -x` passes (all 2,371 tests)
- [x] No `real_api_available` or `_DummyClasses` in codebase
- [x] Single `MockConfluenceClient` definition in `tests/utils/mocks.py`