### PR TITLE
fix(tests): correct assertion strings in content processing tests

### DIFF
--- a/tests/integration/test_content_processing.py
+++ b/tests/integration/test_content_processing.py
@@ -414,10 +414,10 @@ def process():
         )
 
         # Verify all user mentions are processed
-        assert "@Test Useruser123" in processed_markdown
-        assert "@Test Useruser456" in processed_markdown
-        assert "@Test Useruser789" in processed_markdown
-        assert "@Test Useradmin" in processed_markdown
+        assert "@Test User user123" in processed_markdown
+        assert "@Test User user456" in processed_markdown
+        assert "@Test User user789" in processed_markdown
+        assert "@Test User admin" in processed_markdown
 
     def test_confluence_markdown_roundtrip(self, confluence_preprocessor):
         """Test Markdown to Confluence storage format and processing."""
@@ -620,7 +620,7 @@ def function_{i}():
         assert (
             "function" in processed_markdown
         )  # Function names might have escaped underscores
-        assert "@Test Useruser10" in processed_markdown
+        assert "@Test User user10" in processed_markdown
 
     def test_confluence_nested_structures(self, confluence_preprocessor):
         """Test handling of deeply nested structures."""


### PR DESCRIPTION
## Summary

Fixes broken assertion strings introduced in #1006. The bulk `replace_all` of `"@User "` to `"@Test User"` consumed the space between the display name and the user identifier.

Before: `assert "@Test Useruser123"` (missing space, always passes vacuously since these tests require `--integration`)
After: `assert "@Test User user123"` (correct)

## Test plan

- [x] `uv run pytest tests/ -x` passes (2,371 tests)
- [x] All 5 affected assertions corrected

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/personal-1d37018d/personal-1d37018d/editor/fix%2Ftest-assertion-spacing?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->