### PR TITLE
fix: return descriptive error messages from tool handlers

### DIFF
--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -675,53 +675,50 @@ async def test_create_issue_accepts_json_string(jira_client, mock_jira_fetcher):
 
 @pytest.mark.anyio
 async def test_create_issue_additional_fields_empty_string(jira_client):
-    """Test that empty string additional_fields returns a JSON error."""
-    response = await jira_client.call_tool(
-        "jira_create_issue",
-        {
-            "project_key": "TEST",
-            "summary": "Test issue",
-            "issue_type": "Task",
-            "additional_fields": "",
-        },
-    )
-    result = json.loads(response.content[0].text)
-    assert "error" in result
-    assert "not valid JSON" in result["error"]
+    """Test that empty string additional_fields raises ToolError."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_create_issue",
+            {
+                "project_key": "TEST",
+                "summary": "Test issue",
+                "issue_type": "Task",
+                "additional_fields": "",
+            },
+        )
+    assert "not valid JSON" in str(excinfo.value)
 
 
 @pytest.mark.anyio
 async def test_create_issue_additional_fields_invalid_json(jira_client):
-    """Test that invalid JSON additional_fields returns a JSON error."""
-    response = await jira_client.call_tool(
-        "jira_create_issue",
-        {
-            "project_key": "TEST",
-            "summary": "Test issue",
-            "issue_type": "Task",
-            "additional_fields": "{invalid json",
-        },
-    )
-    result = json.loads(response.content[0].text)
-    assert "error" in result
-    assert "not valid JSON" in result["error"]
+    """Test that invalid JSON additional_fields raises ToolError."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_create_issue",
+            {
+                "project_key": "TEST",
+                "summary": "Test issue",
+                "issue_type": "Task",
+                "additional_fields": "{invalid json",
+            },
+        )
+    assert "not valid JSON" in str(excinfo.value)
 
 
 @pytest.mark.anyio
 async def test_create_issue_additional_fields_non_dict_json(jira_client):
-    """Test that JSON array additional_fields returns a JSON error."""
-    response = await jira_client.call_tool(
-        "jira_create_issue",
-        {
-            "project_key": "TEST",
-            "summary": "Test issue",
-            "issue_type": "Task",
-            "additional_fields": '["item1", "item2"]',
-        },
-    )
-    result = json.loads(response.content[0].text)
-    assert "error" in result
-    assert "not a JSON object" in result["error"]
+    """Test that JSON array additional_fields raises ToolError."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_create_issue",
+            {
+                "project_key": "TEST",
+                "summary": "Test issue",
+                "issue_type": "Task",
+                "additional_fields": '["item1", "item2"]',
+            },
+        )
+    assert "not a JSON object" in str(excinfo.value)
 
 
 @pytest.mark.anyio
@@ -766,12 +763,12 @@ async def test_batch_create_issues(jira_client, mock_jira_fetcher):
 @pytest.mark.anyio
 async def test_batch_create_issues_invalid_json(jira_client):
     """Test error handling for invalid JSON in batch issue creation."""
-    response = await jira_client.call_tool(
-        "jira_batch_create_issues",
-        {"issues": "{invalid json", "validate_only": False},
-    )
-    result = json.loads(response.content[0].text)
-    assert "error" in result
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_batch_create_issues",
+            {"issues": "{invalid json", "validate_only": False},
+        )
+    assert "Invalid JSON" in str(excinfo.value)
 
 
 @pytest.mark.anyio
@@ -1582,50 +1579,47 @@ async def test_update_issue_accepts_json_string_additional_fields(
 
 @pytest.mark.anyio
 async def test_update_issue_additional_fields_invalid_json(jira_client):
-    """Test that invalid JSON additional_fields returns a JSON error."""
-    response = await jira_client.call_tool(
-        "jira_update_issue",
-        {
-            "issue_key": "TEST-123",
-            "fields": '{"summary": "Updated"}',
-            "additional_fields": "{invalid",
-        },
-    )
-    result = json.loads(response.content[0].text)
-    assert "error" in result
-    assert "not valid JSON" in result["error"]
+    """Test that invalid JSON additional_fields raises ToolError."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_update_issue",
+            {
+                "issue_key": "TEST-123",
+                "fields": '{"summary": "Updated"}',
+                "additional_fields": "{invalid",
+            },
+        )
+    assert "not valid JSON" in str(excinfo.value)
 
 
 @pytest.mark.anyio
 async def test_update_issue_additional_fields_non_dict_json(jira_client):
-    """Test that JSON array additional_fields returns a JSON error."""
-    response = await jira_client.call_tool(
-        "jira_update_issue",
-        {
-            "issue_key": "TEST-123",
-            "fields": '{"summary": "Updated"}',
-            "additional_fields": '["a","b"]',
-        },
-    )
-    result = json.loads(response.content[0].text)
-    assert "error" in result
-    assert "not a JSON object" in result["error"]
+    """Test that JSON array additional_fields raises ToolError."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_update_issue",
+            {
+                "issue_key": "TEST-123",
+                "fields": '{"summary": "Updated"}',
+                "additional_fields": '["a","b"]',
+            },
+        )
+    assert "not a JSON object" in str(excinfo.value)
 
 
 @pytest.mark.anyio
 async def test_update_issue_additional_fields_empty_string(jira_client):
-    """Test that empty string additional_fields returns a JSON error."""
-    response = await jira_client.call_tool(
-        "jira_update_issue",
-        {
-            "issue_key": "TEST-123",
-            "fields": '{"summary": "Updated"}',
-            "additional_fields": "",
-        },
-    )
-    result = json.loads(response.content[0].text)
-    assert "error" in result
-    assert "not valid JSON" in result["error"]
+    """Test that empty string additional_fields raises ToolError."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_update_issue",
+            {
+                "issue_key": "TEST-123",
+                "fields": '{"summary": "Updated"}',
+                "additional_fields": "",
+            },
+        )
+    assert "not valid JSON" in str(excinfo.value)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes #1009

When tool handlers raise exceptions, FastMCP's `mask_error_details` setting (if enabled) strips the original error message, producing generic errors like `"Error calling tool 'create_issue'"` with no actionable details.

This PR adds a `handle_tool_errors` decorator that catches exceptions and re-raises them as `ToolError`. Since `ToolError` bypasses FastMCP's error masking, descriptive error messages always reach MCP clients regardless of server configuration.

## Changes

- **`handle_tool_errors` decorator** — Catches non-`ToolError` exceptions, logs them, and re-raises as `ToolError(str(e))` with `isError=true` properly set in the MCP response
- **Integrated into `check_write_access`** — All write tools automatically get error handling via decorator composition
- **Tool name captured before `@wraps`** — Ensures correct tool name in log messages
- **New unit tests** — Tests for exception wrapping, `ToolError` passthrough, and normal return value preservation

## Test plan

- [x] All 2113 existing tests pass
- [x] New `handle_tool_errors` decorator tests cover exception wrapping, `ToolError` passthrough, and normal return
- [x] `check_write_access` tests verify read-only mode raises `ToolError`
- [x] Jira server tests verify invalid JSON inputs raise `ToolError` with descriptive messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)