### PR TITLE
fix(docs): remove duplicate page headers and update docs domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![PePy - Total Downloads](https://static.pepy.tech/personalized-badge/mcp-atlassian?period=total&units=international_system&left_color=grey&right_color=blue&left_text=Total%20Downloads)
 [![Run Tests](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml/badge.svg)](https://github.com/sooperset/mcp-atlassian/actions/workflows/tests.yml)
 ![License](https://img.shields.io/github/license/sooperset/mcp-atlassian)
-[![Docs](https://img.shields.io/badge/docs-mintlify-blue)](https://personal-1d37018d.mintlify.app)
+[![Docs](https://img.shields.io/badge/docs-mintlify-blue)](https://mcp-atlassian.soomiles.com)
 
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.
 
@@ -24,7 +24,7 @@ https://github.com/user-attachments/assets/7fe9c488-ad0c-4876-9b54-120b666bb785
 
 Go to https://id.atlassian.com/manage-profile/security/api-tokens and create a token.
 
-> For Server/Data Center, use a Personal Access Token instead. See [Authentication](https://personal-1d37018d.mintlify.app/docs/authentication).
+> For Server/Data Center, use a Personal Access Token instead. See [Authentication](https://mcp-atlassian.soomiles.com/docs/authentication).
 
 ### 2. Configure Your IDE
 
@@ -49,7 +49,7 @@ Add to your Claude Desktop or Cursor MCP configuration:
 }
 ```
 
-> **Server/Data Center users**: Use `JIRA_PERSONAL_TOKEN` instead of `JIRA_USERNAME` + `JIRA_API_TOKEN`. See [Authentication](https://personal-1d37018d.mintlify.app/docs/authentication) for details.
+> **Server/Data Center users**: Use `JIRA_PERSONAL_TOKEN` instead of `JIRA_USERNAME` + `JIRA_API_TOKEN`. See [Authentication](https://mcp-atlassian.soomiles.com/docs/authentication) for details.
 
 ### 3. Start Using
 
@@ -61,20 +61,20 @@ Ask your AI assistant to:
 
 ## Documentation
 
-Full documentation is available at **[personal-1d37018d.mintlify.app](https://personal-1d37018d.mintlify.app)**.
+Full documentation is available at **[mcp-atlassian.soomiles.com](https://mcp-atlassian.soomiles.com)**.
 
 Documentation is also available in [llms.txt format](https://llmstxt.org/), which LLMs can consume easily:
-- [`llms.txt`](https://personal-1d37018d.mintlify.app/llms.txt) — documentation sitemap
-- [`llms-full.txt`](https://personal-1d37018d.mintlify.app/llms-full.txt) — complete documentation
+- [`llms.txt`](https://mcp-atlassian.soomiles.com/llms.txt) — documentation sitemap
+- [`llms-full.txt`](https://mcp-atlassian.soomiles.com/llms-full.txt) — complete documentation
 
 | Topic | Description |
 |-------|-------------|
-| [Installation](https://personal-1d37018d.mintlify.app/docs/installation) | uvx, Docker, pip, from source |
-| [Authentication](https://personal-1d37018d.mintlify.app/docs/authentication) | API tokens, PAT, OAuth 2.0 |
-| [Configuration](https://personal-1d37018d.mintlify.app/docs/configuration) | IDE setup, environment variables |
-| [HTTP Transport](https://personal-1d37018d.mintlify.app/docs/http-transport) | SSE, streamable-http, multi-user |
-| [Tools Reference](https://personal-1d37018d.mintlify.app/docs/tools-reference) | All Jira & Confluence tools |
-| [Troubleshooting](https://personal-1d37018d.mintlify.app/docs/troubleshooting) | Common issues & debugging |
+| [Installation](https://mcp-atlassian.soomiles.com/docs/installation) | uvx, Docker, pip, from source |
+| [Authentication](https://mcp-atlassian.soomiles.com/docs/authentication) | API tokens, PAT, OAuth 2.0 |
+| [Configuration](https://mcp-atlassian.soomiles.com/docs/configuration) | IDE setup, environment variables |
+| [HTTP Transport](https://mcp-atlassian.soomiles.com/docs/http-transport) | SSE, streamable-http, multi-user |
+| [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) | All Jira & Confluence tools |
+| [Troubleshooting](https://mcp-atlassian.soomiles.com/docs/troubleshooting) | Common issues & debugging |
 
 ## Compatibility
 
@@ -101,7 +101,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_get_proforma_form_details` - Get form details | |
 | `jira_update_proforma_form_answers` - Update form answers | |
 
-See [Tools Reference](https://personal-1d37018d.mintlify.app/docs/tools-reference) for the complete list.
+See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -3,8 +3,6 @@ title: "Authentication"
 description: "Configure authentication for MCP Atlassian - API tokens, PATs, and OAuth 2.0"
 ---
 
-# Authentication
-
 MCP Atlassian supports three authentication methods depending on your Atlassian deployment type.
 
 ## API Token (Cloud) - Recommended

--- a/docs/compatibility.mdx
+++ b/docs/compatibility.mdx
@@ -3,8 +3,6 @@ title: "AI Platform Compatibility"
 description: "Compatibility status across AI platforms, clients, and gateways"
 ---
 
-# AI Platform Compatibility
-
 MCP Atlassian works with any MCP-compatible client. This page documents platform-specific notes and known issues.
 
 ## Compatibility Matrix

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -3,8 +3,6 @@ title: "Configuration"
 description: "IDE integration, environment variables, and advanced configuration options"
 ---
 
-# Configuration
-
 This guide covers IDE integration, environment variables, and advanced configuration options.
 
 ## IDE Integration

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -3,8 +3,6 @@ title: "HTTP Transport"
 description: "Run MCP Atlassian as an HTTP service for multi-user scenarios"
 ---
 
-# HTTP Transport
-
 Instead of using `stdio`, you can run the server as a persistent HTTP service. This enables multi-user scenarios and remote deployment.
 
 ## Transport Types

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,8 +3,6 @@ title: "MCP Atlassian"
 description: "Model Context Protocol server for Jira and Confluence"
 ---
 
-# MCP Atlassian
-
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.
 
 <CardGroup cols={2}>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -3,8 +3,6 @@ title: "Installation"
 description: "Install MCP Atlassian using uvx, Docker, pip, or from source"
 ---
 
-# Installation
-
 MCP Atlassian can be installed using several methods. Choose the one that best fits your workflow.
 
 ## uvx (Recommended)

--- a/docs/sigpipe-analysis.mdx
+++ b/docs/sigpipe-analysis.mdx
@@ -3,8 +3,6 @@ title: "SIGPIPE Analysis"
 description: "Critical SIGPIPE signal handling requirement for MCP servers on Unix/Linux"
 ---
 
-# SIGPIPE Analysis: Critical MCP Server Requirement
-
 **Date**: 2026-01-31
 **Discovery Phase**: Phase 4.6 - Technical Debt Removal
 **Impact**: CRITICAL for Unix/Linux MCP server stability

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -3,8 +3,6 @@ title: "Tools Reference"
 description: "All available MCP Atlassian tools for Jira and Confluence"
 ---
 
-# Tools Reference
-
 MCP Atlassian provides tools for interacting with Jira and Confluence.
 
 ## Key Tools

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -3,8 +3,6 @@ title: "Troubleshooting"
 description: "Common issues and debugging tips for MCP Atlassian"
 ---
 
-# Troubleshooting
-
 ## Common Issues
 
 <AccordionGroup>


### PR DESCRIPTION
## Summary

- **Remove duplicate H1 headings** from all 9 MDX documentation files. Mintlify's frontmatter `title` field already renders as the page H1, so the additional `# Title` on line 6 of each file created a visible duplicate header.
- **Update documentation domain** in README.md: replace all 13 occurrences of `personal-1d37018d.mintlify.app` with `mcp-atlassian.soomiles.com` (including display text and URLs).

## Files changed

- `docs/index.mdx`, `docs/installation.mdx`, `docs/authentication.mdx`, `docs/configuration.mdx`, `docs/tools-reference.mdx`, `docs/http-transport.mdx`, `docs/compatibility.mdx`, `docs/troubleshooting.mdx`, `docs/sigpipe-analysis.mdx` — removed duplicate H1 + trailing blank line
- `README.md` — replaced old Mintlify domain with custom domain

## Verification

```
$ grep -c 'personal-1d37018d' README.md
0

$ grep -c 'mcp-atlassian.soomiles.com' README.md
13
```

No standalone H1 headings remain in MDX files — all `# ` matches are inside code blocks (bash/python comments), not Markdown headings.