### PR TITLE
feat(docs): add JQL/CQL guides, workflow recipes, and tool examples

### DIFF
--- a/docs/_overrides/confluence_add_comment.yaml
+++ b/docs/_overrides/confluence_add_comment.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"page_id": "12345678", "body": "Great documentation! Consider adding examples for the API section."}
+tips: |
+  Supports Markdown formatting. Comments are added to the page's comment section.

--- a/docs/_overrides/confluence_create_page.yaml
+++ b/docs/_overrides/confluence_create_page.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"space_key": "DEV", "title": "Architecture Decision Record", "content": "## Context\n\nWe need to decide...", "parent_id": "98765432"}
+tips: |
+  Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.

--- a/docs/_overrides/confluence_get_attachments.yaml
+++ b/docs/_overrides/confluence_get_attachments.yaml
@@ -1,0 +1,6 @@
+example: |
+  {"content_id": "12345678", "media_type": "application/octet-stream"}
+tips: |
+  Use `media_type="application/octet-stream"` for binary files (Confluence returns this for most files including images). Use `filename` parameter for specific files.
+platform_notes: |
+  Confluence API returns generic MIME types — use the `mediaTypeDescription` field for human-readable type info.

--- a/docs/_overrides/confluence_get_page.yaml
+++ b/docs/_overrides/confluence_get_page.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"page_id": "12345678", "include_metadata": true}
+tips: |
+  Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date.

--- a/docs/_overrides/confluence_get_page_views.yaml
+++ b/docs/_overrides/confluence_get_page_views.yaml
@@ -1,0 +1,6 @@
+example: |
+  {"page_id": "12345678", "period": "lastMonth"}
+tips: |
+  Useful for identifying popular or stale content. Available periods depend on your Confluence analytics configuration.
+platform_notes: |
+  Analytics features may require additional permissions on Server/DC.

--- a/docs/_overrides/confluence_search.yaml
+++ b/docs/_overrides/confluence_search.yaml
@@ -1,0 +1,6 @@
+example: |
+  {"query": "type=page AND space=DEV AND title~'Architecture'", "limit": 10}
+tips: |
+  Supports both CQL queries and simple text search. Simple text uses `siteSearch` by default with automatic fallback to `text` search.
+platform_notes: |
+  CQL syntax may differ slightly between Cloud and Server/DC. Personal spaces use `space="~username"` (quoted).

--- a/docs/_overrides/confluence_update_page.yaml
+++ b/docs/_overrides/confluence_update_page.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"page_id": "12345678", "title": "Updated Title", "content": "## Updated Content\n\nNew information...", "is_minor_edit": true}
+tips: |
+  Set `is_minor_edit: true` to skip notification emails. The page version is auto-incremented.

--- a/docs/_overrides/confluence_upload_attachment.yaml
+++ b/docs/_overrides/confluence_upload_attachment.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"page_id": "12345678", "file_path": "/path/to/diagram.png", "comment": "Updated architecture diagram"}
+tips: |
+  Supports any file type. If an attachment with the same name exists, it's updated (new version created).

--- a/docs/_overrides/jira_add_comment.yaml
+++ b/docs/_overrides/jira_add_comment.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"issue_key": "PROJ-123", "comment": "## Investigation\n\nFound the root cause in module X."}
+tips: |
+  Supports Markdown formatting. Use `visibility` parameter for restricted comments (e.g., service desk internal notes).

--- a/docs/_overrides/jira_batch_get_changelogs.yaml
+++ b/docs/_overrides/jira_batch_get_changelogs.yaml
@@ -1,0 +1,6 @@
+example: |
+  {"issue_keys": ["PROJ-1", "PROJ-2", "PROJ-3"]}
+tips: |
+  Efficient for tracking field changes across multiple issues at once. Returns change history for each issue.
+platform_notes: |
+  Only available on Jira Cloud.

--- a/docs/_overrides/jira_create_issue.yaml
+++ b/docs/_overrides/jira_create_issue.yaml
@@ -1,0 +1,6 @@
+example: |
+  {"project_key": "PROJ", "issue_type": "Task", "summary": "Implement new feature", "description": "## Requirements\n\n- Feature A\n- Feature B"}
+tips: |
+  Use Markdown in the description — it's automatically converted to ADF (Cloud) or wiki markup (Server/DC). For epics, provide `epic_name` parameter.
+platform_notes: |
+  Cloud uses ADF format internally (auto-converted from Markdown). Server/DC uses wiki markup.

--- a/docs/_overrides/jira_download_attachments.yaml
+++ b/docs/_overrides/jira_download_attachments.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"issue_key": "PROJ-123"}
+tips: |
+  Downloads all attachments from the issue. Files larger than 50MB are skipped. Returns base64-encoded content.

--- a/docs/_overrides/jira_get_agile_boards.yaml
+++ b/docs/_overrides/jira_get_agile_boards.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"board_name": "Sprint Board", "project_key": "PROJ", "board_type": "scrum"}
+tips: |
+  Supports fuzzy search by board name. Combine with `project_key` to narrow results.

--- a/docs/_overrides/jira_get_issue.yaml
+++ b/docs/_overrides/jira_get_issue.yaml
@@ -1,0 +1,6 @@
+example: |
+  {"issue_key": "PROJ-123", "fields": "summary,status,assignee", "comment_limit": 5}
+tips: |
+  Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
+platform_notes: |
+  Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.

--- a/docs/_overrides/jira_get_issue_sla.yaml
+++ b/docs/_overrides/jira_get_issue_sla.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"issue_key": "SD-456", "metrics": "cycle_time,time_in_status"}
+tips: |
+  Configure SLA calculation via `JIRA_SLA_*` environment variables. Set `JIRA_SLA_WORKING_HOURS_ONLY=true` for business hours only.

--- a/docs/_overrides/jira_get_sprint_issues.yaml
+++ b/docs/_overrides/jira_get_sprint_issues.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"sprint_id": "42", "fields": "summary,status,assignee,story_points"}
+tips: |
+  Get the sprint ID from `jira_get_sprints_from_board` first.

--- a/docs/_overrides/jira_search.yaml
+++ b/docs/_overrides/jira_search.yaml
@@ -1,0 +1,6 @@
+example: |
+  {"jql": "project = PROJ AND status = 'In Progress' ORDER BY updated DESC", "limit": 20}
+tips: |
+  Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
+platform_notes: |
+  Some JQL functions (e.g., `issueHistory()`) are Cloud-only.

--- a/docs/_overrides/jira_search_fields.yaml
+++ b/docs/_overrides/jira_search_fields.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"keyword": "story points", "issue_type": "Story", "project_key": "PROJ"}
+tips: |
+  Use this to discover custom field IDs before using them in `jira_create_issue` or `jira_update_issue`.

--- a/docs/_overrides/jira_transition_issue.yaml
+++ b/docs/_overrides/jira_transition_issue.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"issue_key": "PROJ-123", "transition_name": "Done", "comment": "Closing as completed"}
+tips: |
+  Use `jira_get_transitions` first to see available transitions for the current issue state.

--- a/docs/_overrides/jira_update_issue.yaml
+++ b/docs/_overrides/jira_update_issue.yaml
@@ -1,0 +1,4 @@
+example: |
+  {"issue_key": "PROJ-123", "summary": "Updated title", "description": "New description", "additional_fields": "{\"priority\": {\"name\": \"High\"}}"}
+tips: |
+  Use `additional_fields` as a JSON string for any field not covered by explicit parameters. Find field IDs with `jira_search_fields`.

--- a/docs/guides/common-workflows.mdx
+++ b/docs/guides/common-workflows.mdx
@@ -1,0 +1,135 @@
+---
+title: "Common Workflows"
+description: "Practical recipes for common Jira and Confluence tasks with MCP Atlassian"
+---
+
+This guide provides step-by-step workflows for common tasks using MCP Atlassian tools.
+
+## Jira Workflows
+
+### Triage New Issues
+
+1. **Find untriaged issues:**
+```json
+jira_search: {"jql": "project = PROJ AND status = 'Open' AND assignee IS EMPTY ORDER BY created DESC", "limit": 20}
+```
+
+2. **Review each issue** to understand the problem:
+```json
+jira_get_issue: {"issue_key": "PROJ-123", "comment_limit": 5}
+```
+
+3. **Assign and prioritize:**
+```json
+jira_update_issue: {"issue_key": "PROJ-123", "additional_fields": "{\"assignee\": {\"accountId\": \"user-id\"}, \"priority\": {\"name\": \"High\"}}"}
+```
+
+4. **Add a triage comment:**
+```json
+jira_add_comment: {"issue_key": "PROJ-123", "comment": "Triaged: High priority, assigned to backend team."}
+```
+
+### Sprint Planning
+
+1. **Get the board and active sprint:**
+```json
+jira_get_agile_boards: {"project_key": "PROJ", "board_type": "scrum"}
+```
+```json
+jira_get_sprints_from_board: {"board_id": "42", "state": "active,future"}
+```
+
+2. **Review current sprint progress:**
+```json
+jira_get_sprint_issues: {"sprint_id": "100", "fields": "summary,status,story_points,assignee"}
+```
+
+3. **Find backlog items for next sprint:**
+```json
+jira_search: {"jql": "project = PROJ AND sprint IS EMPTY AND status = 'Open' ORDER BY priority DESC, created ASC", "limit": 30}
+```
+
+### Bulk Issue Creation
+
+Create multiple related issues at once:
+```json
+jira_batch_create_issues: {
+  "project_key": "PROJ",
+  "issues": [
+    {"issue_type": "Task", "summary": "Set up CI pipeline", "description": "Configure GitHub Actions"},
+    {"issue_type": "Task", "summary": "Write unit tests", "description": "Add tests for core module"},
+    {"issue_type": "Task", "summary": "Update documentation", "description": "Document new API endpoints"}
+  ]
+}
+```
+
+### Track Issue Changes
+
+Monitor what changed across multiple issues:
+```json
+jira_batch_get_changelogs: {"issue_keys": ["PROJ-1", "PROJ-2", "PROJ-3"]}
+```
+
+<Note>Changelog tracking is only available on Jira Cloud.</Note>
+
+## Confluence Workflows
+
+### Create Documentation Structure
+
+1. **Create a parent page:**
+```json
+confluence_create_page: {"space_key": "DEV", "title": "Project Documentation", "content": "## Overview\n\nThis space contains all project docs."}
+```
+
+2. **Create child pages:**
+```json
+confluence_create_page: {"space_key": "DEV", "title": "API Reference", "content": "## API Endpoints\n\n...", "parent_id": "12345678"}
+```
+
+3. **Add labels for organization:**
+```json
+confluence_add_label: {"page_id": "12345678", "label": "api-docs"}
+```
+
+### Content Migration
+
+1. **Search for pages to migrate:**
+```json
+confluence_search: {"query": "space = OLD_SPACE AND label = 'migrate' ORDER BY title ASC"}
+```
+
+2. **Read each page's content:**
+```json
+confluence_get_page: {"page_id": "12345678", "include_metadata": true}
+```
+
+3. **Create in new space:**
+```json
+confluence_create_page: {"space_key": "NEW_SPACE", "title": "Migrated Page", "content": "...migrated content..."}
+```
+
+### Identify Stale Content
+
+Find pages that haven't been updated recently:
+```json
+confluence_search: {"query": "space = DEV AND type = page AND lastModified < '2024-01-01' ORDER BY lastModified ASC", "limit": 50}
+```
+
+Check page view analytics:
+```json
+confluence_get_page_views: {"page_id": "12345678"}
+```
+
+## Cross-Product Workflows
+
+### Link Jira Issues to Confluence Pages
+
+1. **Create a Confluence page with project context:**
+```json
+confluence_create_page: {"space_key": "DEV", "title": "Sprint 42 Retrospective", "content": "## Sprint 42\n\nSee PROJ-100 through PROJ-120 for completed work."}
+```
+
+2. **Add a remote link from Jira to Confluence:**
+```json
+jira_create_remote_issue_link: {"issue_key": "PROJ-100", "url": "https://your-instance.atlassian.net/wiki/spaces/DEV/pages/12345678", "title": "Sprint 42 Retro"}
+```

--- a/docs/guides/cql-guide.mdx
+++ b/docs/guides/cql-guide.mdx
@@ -1,0 +1,103 @@
+---
+title: "CQL Guide"
+description: "Master Confluence Query Language for searching content with MCP Atlassian"
+---
+
+CQL (Confluence Query Language) is used by `confluence_search` to find content. You can also use simple text queries that automatically use `siteSearch`.
+
+## Basic Syntax
+
+CQL queries follow the pattern: `field operator value`
+
+```
+type = page AND space = "DEV"
+```
+
+## Common Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `=` | Exact match | `type = "page"` |
+| `!=` | Not equal | `type != "comment"` |
+| `~` | Contains text | `title ~ "meeting notes"` |
+| `IN` | Match any in list | `space IN ("DEV", "TEAM")` |
+| `>`, `<`, `>=`, `<=` | Comparison | `created >= "2024-01-01"` |
+
+## Common Fields
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `type` | Content type | `type = "page"` or `type = "blogpost"` |
+| `space` | Space key | `space = "DEV"` |
+| `title` | Page title | `title ~ "architecture"` |
+| `text` | Full text search | `text ~ "API documentation"` |
+| `label` | Content label | `label = "approved"` |
+| `creator` | Created by | `creator = "john.doe"` |
+| `created` | Creation date | `created >= "2024-01-01"` |
+| `lastModified` | Last modified | `lastModified >= "2024-06-01"` |
+| `ancestor` | Parent page ID | `ancestor = "12345678"` |
+| `parent` | Direct parent ID | `parent = "12345678"` |
+
+## Search Types
+
+### CQL Query
+Pass a CQL string directly:
+```
+type=page AND space=DEV AND title~"Meeting Notes"
+```
+
+### Simple Text Search
+Pass plain text — `confluence_search` auto-detects and uses `siteSearch`:
+```
+project documentation architecture
+```
+
+## Practical Patterns
+
+### Pages in a Space
+```
+type = page AND space = "DEV" ORDER BY lastModified DESC
+```
+
+### Recently Modified Content
+```
+type = page AND lastModified >= "2024-06-01" ORDER BY lastModified DESC
+```
+
+### Content with Specific Label
+```
+type = page AND label = "architecture" ORDER BY title ASC
+```
+
+### Personal Space Search
+```
+space = "~username" AND type = page
+```
+
+<Warning>
+Personal space keys starting with `~` must be quoted in CQL: `space = "~username"`
+</Warning>
+
+### Pages Under a Parent
+```
+ancestor = "12345678" AND type = page ORDER BY title ASC
+```
+
+### Full Text Search in Space
+```
+space = "DEV" AND text ~ "database migration" ORDER BY lastModified DESC
+```
+
+## Tips
+
+<Tip>
+For simple searches, just pass plain text to `confluence_search` — it uses `siteSearch` by default, which mimics the Confluence web UI search.
+</Tip>
+
+<Tip>
+Use `siteSearch` for relevance-ranked results: `siteSearch ~ "important concept"`
+</Tip>
+
+<Warning>
+CQL syntax can differ slightly between Cloud and Server/DC. Test your queries if migrating between platforms.
+</Warning>

--- a/docs/guides/jql-guide.mdx
+++ b/docs/guides/jql-guide.mdx
@@ -1,0 +1,111 @@
+---
+title: "JQL Guide"
+description: "Master Jira Query Language for powerful issue searches with MCP Atlassian"
+---
+
+JQL (Jira Query Language) is the query language used by `jira_search` to find issues. This guide covers the most useful patterns.
+
+## Basic Syntax
+
+JQL queries follow the pattern: `field operator value`
+
+```
+project = "PROJ" AND status = "In Progress"
+```
+
+## Common Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `=` | Exact match | `status = "Done"` |
+| `!=` | Not equal | `status != "Closed"` |
+| `~` | Contains text | `summary ~ "bug fix"` |
+| `!~` | Does not contain | `summary !~ "test"` |
+| `IN` | Match any in list | `status IN ("Open", "In Progress")` |
+| `NOT IN` | Not in list | `priority NOT IN ("Low", "Lowest")` |
+| `IS` | Null check | `assignee IS EMPTY` |
+| `IS NOT` | Not null | `assignee IS NOT EMPTY` |
+| `>`, `<`, `>=`, `<=` | Comparison | `created >= "2024-01-01"` |
+
+## Common Fields
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `project` | Project key | `project = "PROJ"` |
+| `status` | Issue status | `status = "In Progress"` |
+| `assignee` | Assigned user | `assignee = currentUser()` |
+| `reporter` | Issue creator | `reporter = "john.doe"` |
+| `priority` | Priority level | `priority = "High"` |
+| `type` / `issuetype` | Issue type | `type = "Bug"` |
+| `labels` | Issue labels | `labels = "frontend"` |
+| `sprint` | Sprint name | `sprint = "Sprint 42"` |
+| `created` | Creation date | `created >= "-7d"` |
+| `updated` | Last updated | `updated >= "-24h"` |
+| `resolved` | Resolution date | `resolved >= startOfMonth()` |
+
+## Useful Functions
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `currentUser()` | Logged-in user | `assignee = currentUser()` |
+| `startOfDay()` | Start of today | `created >= startOfDay()` |
+| `startOfWeek()` | Start of this week | `updated >= startOfWeek()` |
+| `startOfMonth()` | Start of this month | `resolved >= startOfMonth()` |
+| `endOfDay()` | End of today | `due <= endOfDay()` |
+| `now()` | Current time | `updated >= now("-1h")` |
+
+## Practical Patterns
+
+### My Open Issues
+```
+assignee = currentUser() AND resolution = EMPTY ORDER BY priority DESC
+```
+
+### Sprint Burndown
+```
+sprint = "Sprint 42" AND status != "Done" ORDER BY rank ASC
+```
+
+### Recent Bugs
+```
+type = "Bug" AND created >= "-7d" ORDER BY created DESC
+```
+
+### Unassigned High Priority
+```
+assignee IS EMPTY AND priority IN ("High", "Highest") ORDER BY created ASC
+```
+
+### Issues Updated Today
+```
+updated >= startOfDay() AND project = "PROJ" ORDER BY updated DESC
+```
+
+### Overdue Issues
+```
+due < now() AND resolution = EMPTY ORDER BY due ASC
+```
+
+### Cross-Project Search
+```
+project IN ("PROJ", "DEVOPS", "INFRA") AND status = "In Progress"
+```
+
+### Text Search Across Fields
+```
+text ~ "database migration" ORDER BY relevance DESC
+```
+
+## Tips
+
+<Tip>
+Always include `ORDER BY` in your queries for deterministic, predictable results.
+</Tip>
+
+<Tip>
+Use relative dates (`"-7d"`, `"-1w"`, `"-1M"`) instead of absolute dates for reusable queries.
+</Tip>
+
+<Warning>
+Some JQL functions like `issueHistory()` are Cloud-only. Check your Jira version's documentation for supported functions.
+</Warning>

--- a/docs/tools/confluence-attachments.mdx
+++ b/docs/tools/confluence-attachments.mdx
@@ -17,6 +17,13 @@ Upload an attachment to Confluence content (page or blog post).
 | `file_path` | `string` | Yes | Full path to the file to upload. Can be absolute (e.g., '/home/user/document.pdf' or 'C:\Users\name\file.docx') or relative to the current working directory (e.g., './uploads/document.pdf'). If a file with the same name already exists, a new version will be created. |
 | `comment` | `string` | No | (Optional) A comment describing this attachment or version. Visible in the attachment history. Example: 'Updated Q4 2024 figures' |
 | `minor_edit` | `boolean` | No | (Optional) Whether this is a minor edit. If true, watchers are not notified. Default is false. |
+**Example:**
+
+```json
+{"page_id": "12345678", "file_path": "/path/to/diagram.png", "comment": "Updated architecture diagram"}
+```
+<Tip>Supports any file type. If an attachment with the same name exists, it's updated (new version created).
+</Tip>
 
 ---
 
@@ -50,6 +57,15 @@ List all attachments for a Confluence content item (page or blog post).
 | `limit` | `integer` | No | (Optional) Maximum number of attachments to return per request (1-100). Use pagination (start/limit) for large attachment lists. Default: 50 |
 | `filename` | `string` | No | (Optional) Filter results to only attachments matching this filename. Exact match only. Example: 'report.pdf' |
 | `media_type` | `string` | No | (Optional) Filter by MIME type. **Note**: Confluence API returns 'application/octet-stream' for most binary files (PNG, JPG, PDF) instead of specific MIME types like 'image/png'. For more reliable filtering, use the 'filename' parameter. Examples: 'application/octet-stream' (binary files), 'application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' (for .docx) |
+**Example:**
+
+```json
+{"content_id": "12345678", "media_type": "application/octet-stream"}
+```
+<Tip>Use `media_type="application/octet-stream"` for binary files (Confluence returns this for most files including images). Use `filename` parameter for specific files.
+</Tip>
+<Warning>Confluence API returns generic MIME types — use the `mediaTypeDescription` field for human-readable type info.
+</Warning>
 
 ---
 

--- a/docs/tools/confluence-comments.mdx
+++ b/docs/tools/confluence-comments.mdx
@@ -15,6 +15,13 @@ Add a comment to a Confluence page.
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | The ID of the page to add a comment to |
 | `content` | `string` | Yes | The comment content in Markdown format |
+**Example:**
+
+```json
+{"page_id": "12345678", "body": "Great documentation! Consider adding examples for the API section."}
+```
+<Tip>Supports Markdown formatting. Comments are added to the page's comment section.
+</Tip>
 
 ---
 
@@ -67,5 +74,14 @@ Get view statistics for a Confluence page.
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | Confluence page ID (numeric ID, can be found in the page URL). For example, in 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', the page ID is '123456789'. |
 | `include_title` | `boolean` | No | Whether to fetch and include the page title |
+**Example:**
+
+```json
+{"page_id": "12345678", "period": "lastMonth"}
+```
+<Tip>Useful for identifying popular or stale content. Available periods depend on your Confluence analytics configuration.
+</Tip>
+<Warning>Analytics features may require additional permissions on Server/DC.
+</Warning>
 
 ---

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -16,6 +16,13 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 | `space_key` | `string` | No | The key of the Confluence space where the page resides (e.g., 'DEV', 'TEAM'). Required if using 'title'. |
 | `include_metadata` | `boolean` | No | Whether to include page metadata such as creation date, last update, version, and labels. |
 | `convert_to_markdown` | `boolean` | No | Whether to convert page to markdown (true) or keep it in raw HTML format (false). Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: using HTML significantly increases token usage in AI responses. |
+**Example:**
+
+```json
+{"page_id": "12345678", "include_metadata": true}
+```
+<Tip>Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date.
+</Tip>
 
 ---
 
@@ -36,6 +43,13 @@ Create a new Confluence page.
 | `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
+**Example:**
+
+```json
+{"space_key": "DEV", "title": "Architecture Decision Record", "content": "## Context\n\nWe need to decide...", "parent_id": "98765432"}
+```
+<Tip>Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.
+</Tip>
 
 ---
 
@@ -58,6 +72,13 @@ Update an existing Confluence page.
 | `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
+**Example:**
+
+```json
+{"page_id": "12345678", "title": "Updated Title", "content": "## Updated Content\n\nNew information...", "is_minor_edit": true}
+```
+<Tip>Set `is_minor_edit: true` to skip notification emails. The page version is auto-incremented.
+</Tip>
 
 ---
 

--- a/docs/tools/confluence-search.mdx
+++ b/docs/tools/confluence-search.mdx
@@ -14,6 +14,15 @@ Search Confluence content using simple terms or CQL.
 | `query` | `string` | Yes | Search query - can be either a simple text (e.g. 'project documentation') or a CQL query string. Simple queries use 'siteSearch' by default, to mimic the WebUI search, with an automatic fallback to 'text' search if not supported. Examples of CQL: - Basic search: 'type=page AND space=DEV' - Personal space search: 'space="~username"' (note: personal space keys starting with ~ must be quoted) - Search by title: 'title~"Meeting Notes"' - Use siteSearch: 'siteSearch ~ "important concept"' - Use text search: 'text ~ "important concept"' - Recent content: 'created >= "2023-01-01"' - Content with specific label: 'label=documentation' - Recently modified content: 'lastModified > startOfMonth("-1M")' - Content modified this year: 'creator = currentUser() AND lastModified > startOfYear()' - Content you contributed to recently: 'contributor = currentUser() AND lastModified > startOfWeek()' - Content watched by user: 'watcher = "user@domain.com" AND type = page' - Exact phrase in content: 'text ~ "\"Urgent Review Required\"" AND label = "pending-approval"' - Title wildcards: 'title ~ "Minutes*" AND (space = "HR" OR space = "Marketing")' Note: Special identifiers need proper quoting in CQL: personal space keys (e.g., "~username"), reserved words, numeric IDs, and identifiers with special characters. |
 | `limit` | `integer` | No | Maximum number of results (1-50) |
 | `spaces_filter` | `string` | No | (Optional) Comma-separated list of space keys to filter results by. Overrides the environment variable CONFLUENCE_SPACES_FILTER if provided. Use empty string to disable filtering. |
+**Example:**
+
+```json
+{"query": "type=page AND space=DEV AND title~'Architecture'", "limit": 10}
+```
+<Tip>Supports both CQL queries and simple text search. Simple text uses `siteSearch` by default with automatic fallback to `text` search.
+</Tip>
+<Warning>CQL syntax may differ slightly between Cloud and Server/DC. Personal spaces use `space="~username"` (quoted).
+</Warning>
 
 ---
 

--- a/docs/tools/jira-agile.mdx
+++ b/docs/tools/jira-agile.mdx
@@ -16,6 +16,13 @@ Get jira agile boards by name, project key, or type.
 | `board_type` | `string` | No | (Optional) The type of jira board (e.g., 'scrum', 'kanban') |
 | `start_at` | `integer` | No | Starting index for pagination (0-based) |
 | `limit` | `integer` | No | Maximum number of results (1-50) |
+**Example:**
+
+```json
+{"board_name": "Sprint Board", "project_key": "PROJ", "board_type": "scrum"}
+```
+<Tip>Supports fuzzy search by board name. Combine with `project_key` to narrow results.
+</Tip>
 
 ---
 
@@ -63,6 +70,13 @@ Get jira issues from sprint.
 | `fields` | `string` | No | Comma-separated fields to return in the results. Use '*all' for all fields, or specify individual fields like 'summary,status,assignee,priority' |
 | `start_at` | `integer` | No | Starting index for pagination (0-based) |
 | `limit` | `integer` | No | Maximum number of results (1-50) |
+**Example:**
+
+```json
+{"sprint_id": "42", "fields": "summary,status,assignee,story_points"}
+```
+<Tip>Get the sprint ID from `jira_get_sprints_from_board` first.
+</Tip>
 
 ---
 

--- a/docs/tools/jira-attachments.mdx
+++ b/docs/tools/jira-attachments.mdx
@@ -12,6 +12,13 @@ Download attachments from a Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
+**Example:**
+
+```json
+{"issue_key": "PROJ-123"}
+```
+<Tip>Downloads all attachments from the issue. Files larger than 50MB are skipped. Returns base64-encoded content.
+</Tip>
 
 ---
 

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -16,6 +16,13 @@ Add a comment to a Jira issue.
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `comment` | `string` | Yes | Comment text in Markdown format |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '{"type":"group","value":"jira-users"}') |
+**Example:**
+
+```json
+{"issue_key": "PROJ-123", "comment": "## Investigation\n\nFound the root cause in module X."}
+```
+<Tip>Supports Markdown formatting. Use `visibility` parameter for restricted comments (e.g., service desk internal notes).
+</Tip>
 
 ---
 
@@ -78,6 +85,15 @@ Get changelogs for multiple Jira issues (Cloud only).
 | `issue_ids_or_keys` | `string` | Yes | Comma-separated list of Jira issue IDs or keys (e.g. 'PROJ-123,PROJ-124') |
 | `fields` | `string` | No | (Optional) Comma-separated list of fields to filter changelogs by (e.g. 'status,assignee'). Default to None for all fields. |
 | `limit` | `integer` | No | Maximum number of changelogs to return in result for each issue. Default to -1 for all changelogs. Notice that it only limits the results in the response, the function will still fetch all the data. |
+**Example:**
+
+```json
+{"issue_keys": ["PROJ-1", "PROJ-2", "PROJ-3"]}
+```
+<Tip>Efficient for tracking field changes across multiple issues at once. Returns change history for each issue.
+</Tip>
+<Warning>Only available on Jira Cloud.
+</Warning>
 
 ---
 

--- a/docs/tools/jira-forms-metrics.mdx
+++ b/docs/tools/jira-forms-metrics.mdx
@@ -70,6 +70,13 @@ Calculate SLA metrics for a Jira issue.
 | `metrics` | `string` | No | Comma-separated list of SLA metrics to calculate. Available: cycle_time, lead_time, time_in_status, due_date_compliance, resolution_time, first_response_time. Defaults to configured metrics or 'cycle_time,time_in_status'. |
 | `working_hours_only` | `boolean` | No | Calculate using working hours only (excludes weekends/non-business hours). Defaults to value from JIRA_SLA_WORKING_HOURS_ONLY environment variable. |
 | `include_raw_dates` | `boolean` | No | Include raw date values in the response |
+**Example:**
+
+```json
+{"issue_key": "SD-456", "metrics": "cycle_time,time_in_status"}
+```
+<Tip>Configure SLA calculation via `JIRA_SLA_*` environment variables. Set `JIRA_SLA_WORKING_HOURS_ONLY=true` for business hours only.
+</Tip>
 
 ---
 

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -17,6 +17,15 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
+**Example:**
+
+```json
+{"issue_key": "PROJ-123", "fields": "summary,status,assignee", "comment_limit": 5}
+```
+<Tip>Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
+</Tip>
+<Warning>Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
+</Warning>
 
 ---
 
@@ -37,6 +46,15 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 | `description` | `string` | No | Issue description in Markdown format |
 | `components` | `string` | No | (Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API') |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: {"priority": {"name": "High"}} - Add labels: {"labels": ["frontend", "urgent"]} - Link to parent (for any issue type): {"parent": "PROJ-123"} - Link to epic: {"epicKey": "EPIC-123"} or {"epic_link": "EPIC-123"} - Set Fix Version/s: {"fixVersions": [{"id": "10020"}]} - Custom fields: {"customfield_10010": "value"} |
+**Example:**
+
+```json
+{"project_key": "PROJ", "issue_type": "Task", "summary": "Implement new feature", "description": "## Requirements\n\n- Feature A\n- Feature B"}
+```
+<Tip>Use Markdown in the description — it's automatically converted to ADF (Cloud) or wiki markup (Server/DC). For epics, provide `epic_name` parameter.
+</Tip>
+<Warning>Cloud uses ADF format internally (auto-converted from Markdown). Server/DC uses wiki markup.
+</Warning>
 
 ---
 
@@ -55,6 +73,13 @@ Update an existing Jira issue including changing status, adding Epic links, upda
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: {"epicKey": "EPIC-123"} or {"epic_link": "EPIC-123"}. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names (e.g., 'Frontend,API') |
 | `attachments` | `string` | No | (Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt'] |
+**Example:**
+
+```json
+{"issue_key": "PROJ-123", "summary": "Updated title", "description": "New description", "additional_fields": "{\"priority\": {\"name\": \"High\"}}"}
+```
+<Tip>Use `additional_fields` as a JSON string for any field not covered by explicit parameters. Find field IDs with `jira_search_fields`.
+</Tip>
 
 ---
 
@@ -101,6 +126,13 @@ Transition a Jira issue to a new status.
 | `transition_id` | `string` | Yes | ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31' |
 | `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '{"resolution": {"name": "Fixed"}}' |
 | `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. |
+**Example:**
+
+```json
+{"issue_key": "PROJ-123", "transition_name": "Done", "comment": "Closing as completed"}
+```
+<Tip>Use `jira_get_transitions` first to see available transitions for the current issue state.
+</Tip>
 
 ---
 

--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -17,6 +17,15 @@ Search Jira issues using JQL (Jira Query Language).
 | `start_at` | `integer` | No | Starting index for pagination (0-based) |
 | `projects_filter` | `string` | No | (Optional) Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided. |
 | `expand` | `string` | No | (Optional) fields to expand. Examples: 'renderedFields', 'transitions', 'changelog' |
+**Example:**
+
+```json
+{"jql": "project = PROJ AND status = 'In Progress' ORDER BY updated DESC", "limit": 20}
+```
+<Tip>Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
+</Tip>
+<Warning>Some JQL functions (e.g., `issueHistory()`) are Cloud-only.
+</Warning>
 
 ---
 
@@ -31,6 +40,13 @@ Search Jira fields by keyword with fuzzy match.
 | `keyword` | `string` | No | Keyword for fuzzy search. If left empty, lists the first 'limit' available fields in their default order. |
 | `limit` | `integer` | No | Maximum number of results |
 | `refresh` | `boolean` | No | Whether to force refresh the field list |
+**Example:**
+
+```json
+{"keyword": "story points", "issue_type": "Story", "project_key": "PROJ"}
+```
+<Tip>Use this to discover custom field IDs before using them in `jira_create_issue` or `jira_update_issue`.
+</Tip>
 
 ---
 


### PR DESCRIPTION
## Summary

- Add 20 YAML sidecar overrides in `docs/_overrides/` with realistic examples, tips, and platform notes for the most-used Jira and Confluence tools
- Create 3 new guide pages in `docs/guides/`: JQL query patterns, CQL search patterns, and common cross-product workflows
- Regenerate all 12 tool reference pages to merge override content (examples, tips, platform warnings) into generated output

## Test plan

- [ ] Verify `ls docs/_overrides/*.yaml | wc -l` returns 20
- [ ] Verify `ls docs/guides/*.mdx | wc -l` returns 3
- [ ] Verify each override YAML has at least an `example` field
- [ ] Verify tool pages show merged examples after regeneration
- [ ] Verify no H1 headings in any new MDX file
- [ ] Verify `uv run python scripts/generate_tool_docs.py` runs cleanly