### PR TITLE
feat(docs): add SLA metrics, Docker deployment, and expanded troubleshooting guides

### DIFF
--- a/docs/advanced/docker-production.mdx
+++ b/docs/advanced/docker-production.mdx
@@ -52,7 +52,7 @@ services:
       - PORT=8000
       - HOST=0.0.0.0
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -151,13 +151,13 @@ spec:
             name: atlassian-credentials
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8000
           initialDelaySeconds: 10
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/docs/advanced/sla-metrics.mdx
+++ b/docs/advanced/sla-metrics.mdx
@@ -103,7 +103,7 @@ Get development info for multiple issues:
 
 ```json
 jira_get_issues_development_info: {
-  "issue_keys": ["PROJ-1", "PROJ-2", "PROJ-3"]
+  "issue_keys": "PROJ-1,PROJ-2,PROJ-3"
 }
 ```
 

--- a/docs/compatibility.mdx
+++ b/docs/compatibility.mdx
@@ -119,9 +119,9 @@ MCP Atlassian supports both Atlassian Cloud and Server/Data Center deployments, 
 | Tool | Cloud | Server/DC | Notes |
 |------|-------|-----------|-------|
 | `jira_batch_get_changelogs` | Yes | No | Cloud-only changelog API |
-| `jira_get_issue_proforma_forms` | Yes | Yes | Requires ProForma app |
-| `jira_get_service_desk_queues` | Yes | Yes | Requires JSM |
-| `confluence_get_page_views` | Yes | Limited | Analytics may require additional Server/DC plugins |
+| `jira_get_issue_proforma_forms` | Yes | No | Cloud-only (requires cloud_id for Forms API) |
+| `jira_get_service_desk_queues` | Yes | Yes | Requires Jira Service Management |
+| `confluence_get_page_views` | Yes | No | Cloud-only analytics API |
 
 ### Content Format Differences
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -189,7 +189,7 @@ Header values containing sensitive information are automatically masked in logs.
     3. Custom field IDs differ between Cloud and Server/DC instances
 
     ```json
-    jira_search_fields: {"keyword": "story points", "project_key": "PROJ"}
+    jira_search_fields: {"keyword": "story points"}
     ```
   </Accordion>
 


### PR DESCRIPTION
## Summary

- Add `docs/advanced/sla-metrics.mdx` covering all SLA-related environment variables (`JIRA_SLA_METRICS`, working hours, timezone), available metrics, tool usage examples, and a production configuration example
- Add `docs/advanced/docker-production.mdx` with Docker quick start, Compose setups (basic, health check, multi-service), environment file patterns, read-only mode, and Kubernetes deployment manifests
- Expand `docs/troubleshooting.mdx` with detailed accordion sections for authentication errors (401/403/OAuth), field and data errors, rate limiting (429), and connection issues (SSL, timeout, proxy)
- Expand `docs/compatibility.mdx` with a Cloud vs Server/Data Center feature matrix covering authentication methods, tool availability, content format differences, and API differences

## Test plan

- [ ] Verify `docs/advanced/sla-metrics.mdx` renders correctly in Mintlify
- [ ] Verify `docs/advanced/docker-production.mdx` renders correctly in Mintlify
- [ ] Verify new troubleshooting accordion sections expand/collapse properly
- [ ] Verify compatibility feature matrix tables render properly
- [ ] Confirm no existing content was removed from troubleshooting or compatibility pages
- [ ] Confirm `docs.json` was not modified (navigation changes deferred to PR 5)