### PR TITLE
chore(docs): optimize descriptions, add navigation for guides and advanced pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -16,6 +16,10 @@
     {
       "name": "PyPI",
       "url": "https://pypi.org/project/mcp-atlassian/"
+    },
+    {
+      "name": "Releases",
+      "url": "https://github.com/sooperset/mcp-atlassian/releases"
     }
   ],
   "anchors": [
@@ -47,9 +51,15 @@
             "group": "Usage",
             "pages": [
               "docs/configuration",
-              "docs/tools-reference",
-              "docs/http-transport",
-              "docs/compatibility"
+              "docs/tools-reference"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "docs/guides/jql-guide",
+              "docs/guides/cql-guide",
+              "docs/guides/common-workflows"
             ]
           },
           {
@@ -72,6 +82,15 @@
               "docs/tools/confluence-search",
               "docs/tools/confluence-attachments",
               "docs/tools/confluence-comments"
+            ]
+          },
+          {
+            "group": "Advanced",
+            "pages": [
+              "docs/http-transport",
+              "docs/compatibility",
+              "docs/advanced/sla-metrics",
+              "docs/advanced/docker-production"
             ]
           },
           {

--- a/docs/compatibility.mdx
+++ b/docs/compatibility.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI Platform Compatibility"
-description: "Compatibility status across AI platforms, clients, and gateways"
+description: "Platform compatibility matrix — Claude Desktop, Cursor, Cline, and Cloud vs Server/DC feature comparison"
 ---
 
 MCP Atlassian works with any MCP-compatible client. This page documents platform-specific notes and known issues.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-description: "IDE integration, environment variables, and advanced configuration options"
+description: "Configure MCP Atlassian for Claude Desktop, Cursor, Windsurf, and VS Code with environment variables"
 ---
 
 This guide covers IDE integration, environment variables, and advanced configuration options.

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -1,6 +1,6 @@
 ---
 title: "HTTP Transport"
-description: "Run MCP Atlassian as an HTTP service for multi-user scenarios"
+description: "Deploy MCP Atlassian as an HTTP service with SSE or streamable-http for multi-user and remote scenarios"
 ---
 
 Instead of using `stdio`, you can run the server as a persistent HTTP service. This enables multi-user scenarios and remote deployment.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MCP Atlassian"
-description: "Model Context Protocol server for Jira and Confluence"
+description: "MCP server connecting AI assistants to Jira and Confluence — search, create, update issues and pages"
 ---
 
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.

--- a/docs/sigpipe-analysis.mdx
+++ b/docs/sigpipe-analysis.mdx
@@ -4,7 +4,6 @@ description: "Critical SIGPIPE signal handling requirement for MCP servers on Un
 ---
 
 **Date**: 2026-01-31
-**Discovery Phase**: Phase 4.6 - Technical Debt Removal
 **Impact**: CRITICAL for Unix/Linux MCP server stability
 
 ---

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tools Reference"
-description: "All available MCP Atlassian tools for Jira and Confluence"
+description: "Overview of all 65 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
 MCP Atlassian provides **65 tools** for interacting with Jira and Confluence. Tools are organized by category below.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting"
-description: "Common issues and debugging tips for MCP Atlassian"
+description: "Fix auth errors (401/403), field issues, rate limiting, SSL problems, and debug MCP Atlassian connections"
 ---
 
 ## Common Issues

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -7,6 +7,9 @@ tool metadata, then renders per-category MDX pages via a Jinja2 template.
 Usage:
     python scripts/generate_tool_docs.py           # generate docs/tools/*.mdx
     python scripts/generate_tool_docs.py --check   # verify all tools are mapped
+
+CI usage:
+    python scripts/generate_tool_docs.py --check   # exits 1 if any tool is undocumented
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Update `docs.json` navigation to include all new pages from PRs 1-4: Guides group (JQL, CQL, common workflows), Advanced group (HTTP transport, compatibility, SLA metrics, Docker production), reorganized Usage and Help groups
- Add "Releases" link to topbar navigation
- Optimize frontmatter `description` fields across 6 MDX pages for better `llms.txt` quality and SEO (keyword-rich, under 160 characters)
- Remove internal project language ("Discovery Phase: Phase 4.6") from `sigpipe-analysis.mdx`
- Document CI usage of `scripts/generate_tool_docs.py --check` in its docstring

## Test plan

- [ ] Verify `docs.json` has all 7 navigation groups: Getting Started, Usage, Guides, Jira Tools, Confluence Tools, Advanced, Help
- [ ] Verify topbar has both PyPI and Releases links
- [ ] Confirm all frontmatter descriptions are keyword-rich and under 160 characters
- [ ] Confirm `sigpipe-analysis.mdx` has no "Phase" internal language
- [ ] Run `mintlify dev` or equivalent to verify navigation renders correctly