### PR TITLE
fix(docs): add /docs/ prefix to index page card links

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,16 +6,16 @@ description: "MCP server connecting AI assistants to Jira and Confluence — sea
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.
 
 <CardGroup cols={2}>
-  <Card title="Quick Start" icon="rocket" href="/installation">
+  <Card title="Quick Start" icon="rocket" href="/docs/installation">
     Get started in 5 minutes with uvx
   </Card>
-  <Card title="Authentication" icon="key" href="/authentication">
+  <Card title="Authentication" icon="key" href="/docs/authentication">
     Set up API tokens, PATs, or OAuth 2.0
   </Card>
-  <Card title="Tools Reference" icon="wrench" href="/tools-reference">
+  <Card title="Tools Reference" icon="wrench" href="/docs/tools-reference">
     Browse all available Jira and Confluence tools
   </Card>
-  <Card title="Configuration" icon="gear" href="/configuration">
+  <Card title="Configuration" icon="gear" href="/docs/configuration">
     IDE setup and environment variables
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- The 4 CardGroup cards on the docs index page link to `/installation` etc. instead of `/docs/installation`. This causes 404 errors.

## Changes
- `href="/installation"` -> `href="/docs/installation"`
- `href="/authentication"` -> `href="/docs/authentication"`
- `href="/tools-reference"` -> `href="/docs/tools-reference"`
- `href="/configuration"` -> `href="/docs/configuration"`