### PR TITLE
fix(docs): escape MDX braces in tool pages and fix broken internal links

### DIFF
--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -141,4 +141,4 @@ For multi-tenant applications where users provide their own OAuth tokens:
    - `Authorization: Bearer <user_oauth_token>`
    - `X-Atlassian-Cloud-Id: <user_cloud_id>`
 
-See [HTTP Transport](/http-transport) for more details on multi-user authentication.
+See [HTTP Transport](/docs/http-transport) for more details on multi-user authentication.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,16 +6,16 @@ description: "MCP server connecting AI assistants to Jira and Confluence — sea
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.
 
 <CardGroup cols={2}>
-  <Card title="Quick Start" icon="rocket" href="/installation">
+  <Card title="Quick Start" icon="rocket" href="/docs/installation">
     Get started in 5 minutes with uvx
   </Card>
-  <Card title="Authentication" icon="key" href="/authentication">
+  <Card title="Authentication" icon="key" href="/docs/authentication">
     Set up API tokens, PATs, or OAuth 2.0
   </Card>
-  <Card title="Tools Reference" icon="wrench" href="/tools-reference">
+  <Card title="Tools Reference" icon="wrench" href="/docs/tools-reference">
     Browse all available Jira and Confluence tools
   </Card>
-  <Card title="Configuration" icon="gear" href="/configuration">
+  <Card title="Configuration" icon="gear" href="/docs/configuration">
     IDE setup and environment variables
   </Card>
 </CardGroup>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -101,7 +101,7 @@ docker run --rm -i \
 }
 ```
 
-See [Configuration](/configuration) for more Docker options including environment files.
+See [Configuration](/docs/configuration) for more Docker options including environment files.
 
 ## pip
 

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -15,7 +15,7 @@ Add a comment to a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `comment` | `string` | Yes | Comment text in Markdown format |
-| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '{"type":"group","value":"jira-users"}') |
+| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
 **Example:**
 
 ```json
@@ -39,7 +39,7 @@ Edit an existing comment on a Jira issue.
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `comment_id` | `string` | Yes | The ID of the comment to edit |
 | `comment` | `string` | Yes | Updated comment text in Markdown format |
-| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '{"type":"group","value":"jira-users"}') |
+| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
 
 ---
 

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -45,7 +45,7 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 | `assignee` | `string` | No | (Optional) Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...') |
 | `description` | `string` | No | Issue description in Markdown format |
 | `components` | `string` | No | (Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API') |
-| `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: {"priority": {"name": "High"}} - Add labels: {"labels": ["frontend", "urgent"]} - Link to parent (for any issue type): {"parent": "PROJ-123"} - Link to epic: {"epicKey": "EPIC-123"} or {"epic_link": "EPIC-123"} - Set Fix Version/s: {"fixVersions": [{"id": "10020"}]} - Custom fields: {"customfield_10010": "value"} |
+| `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: `{"priority": {"name": "High"}}` - Add labels: `{"labels": ["frontend", "urgent"]}` - Link to parent (for any issue type): `{"parent": "PROJ-123"}` - Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}` - Set Fix Version/s: `{"fixVersions": [{"id": "10020"}]}` - Custom fields: `{"customfield_10010": "value"}` |
 **Example:**
 
 ```json
@@ -69,8 +69,8 @@ Update an existing Jira issue including changing status, adding Epic links, upda
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format. Example: '{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}' |
-| `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: {"epicKey": "EPIC-123"} or {"epic_link": "EPIC-123"}. |
+| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format. Example: `'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}'` |
+| `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}`. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names (e.g., 'Frontend,API') |
 | `attachments` | `string` | No | (Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt'] |
 **Example:**
@@ -107,7 +107,7 @@ Create multiple Jira issues in a batch.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: [ {"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}, {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]} ] |
+| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: `[{"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}, {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}]` |
 | `validate_only` | `boolean` | No | If true, only validates the issues without creating them |
 
 ---
@@ -124,7 +124,7 @@ Transition a Jira issue to a new status.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `transition_id` | `string` | Yes | ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31' |
-| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '{"resolution": {"name": "Fixed"}}' |
+| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: `'{"resolution": {"name": "Fixed"}}'` |
 | `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. |
 **Example:**
 

--- a/docs/tools/jira-links-versions.mdx
+++ b/docs/tools/jira-links-versions.mdx
@@ -29,7 +29,7 @@ Create a link between two Jira issues.
 | `inward_issue_key` | `string` | Yes | The key of the inward issue (e.g., 'PROJ-123', 'ACV2-642') |
 | `outward_issue_key` | `string` | Yes | The key of the outward issue (e.g., 'PROJ-456') |
 | `comment` | `string` | No | (Optional) Comment to add to the link |
-| `comment_visibility` | `string` | No | (Optional) Visibility settings for the comment as JSON string (e.g. '{"type":"group","value":"jira-users"}') |
+| `comment_visibility` | `string` | No | (Optional) Visibility settings for the comment as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
 
 ---
 
@@ -134,6 +134,6 @@ Batch create multiple versions in a Jira project.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `project_key` | `string` | Yes | Jira project key (e.g., 'PROJ', 'ACV2') |
-| `versions` | `string` | Yes | JSON array of version objects. Each object should contain: - name (required): Name of the version - startDate (optional): Start date (YYYY-MM-DD) - releaseDate (optional): Release date (YYYY-MM-DD) - description (optional): Description of the version Example: [ {"name": "v1.0", "startDate": "2025-01-01", "releaseDate": "2025-02-01", "description": "First release"}, {"name": "v2.0"} ] |
+| `versions` | `string` | Yes | JSON array of version objects. Each object should contain: - name (required): Name of the version - startDate (optional): Start date (YYYY-MM-DD) - releaseDate (optional): Release date (YYYY-MM-DD) - description (optional): Description of the version Example: `[{"name": "v1.0", "startDate": "2025-01-01", "releaseDate": "2025-02-01", "description": "First release"}, {"name": "v2.0"}]` |
 
 ---

--- a/scripts/templates/tool_category.mdx.j2
+++ b/scripts/templates/tool_category.mdx.j2
@@ -17,7 +17,7 @@ description: "{{ category.description }}"
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 {% for param in tool.parameters -%}
-| `{{ param.name }}` | `{{ param.type }}` | {{ "Yes" if param.required else "No" }} | {{ param.description | escape_pipe }} |
+| `{{ param.name }}` | `{{ param.type }}` | {{ "Yes" if param.required else "No" }} | {{ param.description | escape_pipe | escape_mdx }} |
 {% endfor %}
 {% if tool.override and tool.override.example %}
 **Example:**


### PR DESCRIPTION
## Summary

- **3 tool pages returning 404**: `jira-issues`, `jira-comments-worklogs`, and `jira-links-versions` had unescaped curly braces `{}` in Markdown table cells. MDX parses these as JSX expressions, causing Mintlify to silently fail building those pages. Fixed by wrapping JSON examples in backticks.
- **6 broken internal links**: Card `href` values in `index.mdx` and Markdown links in `authentication.mdx` and `installation.mdx` were missing the `/docs/` prefix, resulting in 404s.
- **Generator template hardened**: Added `escape_mdx` Jinja2 filter to `tool_category.mdx.j2` that auto-wraps brace-containing text in backticks, preventing future regressions when tool docs are regenerated.

Supersedes #1022.

## Test plan

- [ ] Verify all 17 new pages load: `docs/tools/*`, `docs/guides/*`, `docs/advanced/*`
- [ ] Verify index.mdx card links navigate correctly
- [ ] Verify authentication.mdx and installation.mdx internal links work