### PR TITLE
fix(docs): reformat MDX components to block-level syntax

### DIFF
--- a/docs/tools/confluence-attachments.mdx
+++ b/docs/tools/confluence-attachments.mdx
@@ -22,8 +22,11 @@ Upload an attachment to Confluence content (page or blog post).
 ```json
 {"page_id": "12345678", "file_path": "/path/to/diagram.png", "comment": "Updated architecture diagram"}
 ```
-<Tip>Supports any file type. If an attachment with the same name exists, it's updated (new version created).
+
+<Tip>
+Supports any file type. If an attachment with the same name exists, it's updated (new version created).
 </Tip>
+
 
 ---
 
@@ -62,10 +65,16 @@ List all attachments for a Confluence content item (page or blog post).
 ```json
 {"content_id": "12345678", "media_type": "application/octet-stream"}
 ```
-<Tip>Use `media_type="application/octet-stream"` for binary files (Confluence returns this for most files including images). Use `filename` parameter for specific files.
+
+<Tip>
+Use `media_type="application/octet-stream"` for binary files (Confluence returns this for most files including images). Use `filename` parameter for specific files.
 </Tip>
-<Warning>Confluence API returns generic MIME types — use the `mediaTypeDescription` field for human-readable type info.
+
+
+<Warning>
+Confluence API returns generic MIME types — use the `mediaTypeDescription` field for human-readable type info.
 </Warning>
+
 
 ---
 

--- a/docs/tools/confluence-comments.mdx
+++ b/docs/tools/confluence-comments.mdx
@@ -20,8 +20,11 @@ Add a comment to a Confluence page.
 ```json
 {"page_id": "12345678", "body": "Great documentation! Consider adding examples for the API section."}
 ```
-<Tip>Supports Markdown formatting. Comments are added to the page's comment section.
+
+<Tip>
+Supports Markdown formatting. Comments are added to the page's comment section.
 </Tip>
+
 
 ---
 
@@ -79,9 +82,15 @@ Get view statistics for a Confluence page.
 ```json
 {"page_id": "12345678", "period": "lastMonth"}
 ```
-<Tip>Useful for identifying popular or stale content. Available periods depend on your Confluence analytics configuration.
+
+<Tip>
+Useful for identifying popular or stale content. Available periods depend on your Confluence analytics configuration.
 </Tip>
-<Warning>Analytics features may require additional permissions on Server/DC.
+
+
+<Warning>
+Analytics features may require additional permissions on Server/DC.
 </Warning>
+
 
 ---

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -21,8 +21,11 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 ```json
 {"page_id": "12345678", "include_metadata": true}
 ```
-<Tip>Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date.
+
+<Tip>
+Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date.
 </Tip>
+
 
 ---
 
@@ -48,8 +51,11 @@ Create a new Confluence page.
 ```json
 {"space_key": "DEV", "title": "Architecture Decision Record", "content": "## Context\n\nWe need to decide...", "parent_id": "98765432"}
 ```
-<Tip>Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.
+
+<Tip>
+Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.
 </Tip>
+
 
 ---
 
@@ -77,8 +83,11 @@ Update an existing Confluence page.
 ```json
 {"page_id": "12345678", "title": "Updated Title", "content": "## Updated Content\n\nNew information...", "is_minor_edit": true}
 ```
-<Tip>Set `is_minor_edit: true` to skip notification emails. The page version is auto-incremented.
+
+<Tip>
+Set `is_minor_edit: true` to skip notification emails. The page version is auto-incremented.
 </Tip>
+
 
 ---
 

--- a/docs/tools/confluence-search.mdx
+++ b/docs/tools/confluence-search.mdx
@@ -19,10 +19,16 @@ Search Confluence content using simple terms or CQL.
 ```json
 {"query": "type=page AND space=DEV AND title~'Architecture'", "limit": 10}
 ```
-<Tip>Supports both CQL queries and simple text search. Simple text uses `siteSearch` by default with automatic fallback to `text` search.
+
+<Tip>
+Supports both CQL queries and simple text search. Simple text uses `siteSearch` by default with automatic fallback to `text` search.
 </Tip>
-<Warning>CQL syntax may differ slightly between Cloud and Server/DC. Personal spaces use `space="~username"` (quoted).
+
+
+<Warning>
+CQL syntax may differ slightly between Cloud and Server/DC. Personal spaces use `space="~username"` (quoted).
 </Warning>
+
 
 ---
 

--- a/docs/tools/jira-agile.mdx
+++ b/docs/tools/jira-agile.mdx
@@ -21,8 +21,11 @@ Get jira agile boards by name, project key, or type.
 ```json
 {"board_name": "Sprint Board", "project_key": "PROJ", "board_type": "scrum"}
 ```
-<Tip>Supports fuzzy search by board name. Combine with `project_key` to narrow results.
+
+<Tip>
+Supports fuzzy search by board name. Combine with `project_key` to narrow results.
 </Tip>
+
 
 ---
 
@@ -75,8 +78,11 @@ Get jira issues from sprint.
 ```json
 {"sprint_id": "42", "fields": "summary,status,assignee,story_points"}
 ```
-<Tip>Get the sprint ID from `jira_get_sprints_from_board` first.
+
+<Tip>
+Get the sprint ID from `jira_get_sprints_from_board` first.
 </Tip>
+
 
 ---
 

--- a/docs/tools/jira-attachments.mdx
+++ b/docs/tools/jira-attachments.mdx
@@ -17,8 +17,11 @@ Download attachments from a Jira issue.
 ```json
 {"issue_key": "PROJ-123"}
 ```
-<Tip>Downloads all attachments from the issue. Files larger than 50MB are skipped. Returns base64-encoded content.
+
+<Tip>
+Downloads all attachments from the issue. Files larger than 50MB are skipped. Returns base64-encoded content.
 </Tip>
+
 
 ---
 

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -21,8 +21,11 @@ Add a comment to a Jira issue.
 ```json
 {"issue_key": "PROJ-123", "comment": "## Investigation\n\nFound the root cause in module X."}
 ```
-<Tip>Supports Markdown formatting. Use `visibility` parameter for restricted comments (e.g., service desk internal notes).
+
+<Tip>
+Supports Markdown formatting. Use `visibility` parameter for restricted comments (e.g., service desk internal notes).
 </Tip>
+
 
 ---
 
@@ -90,10 +93,16 @@ Get changelogs for multiple Jira issues (Cloud only).
 ```json
 {"issue_keys": ["PROJ-1", "PROJ-2", "PROJ-3"]}
 ```
-<Tip>Efficient for tracking field changes across multiple issues at once. Returns change history for each issue.
+
+<Tip>
+Efficient for tracking field changes across multiple issues at once. Returns change history for each issue.
 </Tip>
-<Warning>Only available on Jira Cloud.
+
+
+<Warning>
+Only available on Jira Cloud.
 </Warning>
+
 
 ---
 

--- a/docs/tools/jira-forms-metrics.mdx
+++ b/docs/tools/jira-forms-metrics.mdx
@@ -75,8 +75,11 @@ Calculate SLA metrics for a Jira issue.
 ```json
 {"issue_key": "SD-456", "metrics": "cycle_time,time_in_status"}
 ```
-<Tip>Configure SLA calculation via `JIRA_SLA_*` environment variables. Set `JIRA_SLA_WORKING_HOURS_ONLY=true` for business hours only.
+
+<Tip>
+Configure SLA calculation via `JIRA_SLA_*` environment variables. Set `JIRA_SLA_WORKING_HOURS_ONLY=true` for business hours only.
 </Tip>
+
 
 ---
 

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -22,10 +22,16 @@ Get details of a specific Jira issue including its Epic links and relationship i
 ```json
 {"issue_key": "PROJ-123", "fields": "summary,status,assignee", "comment_limit": 5}
 ```
-<Tip>Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
+
+<Tip>
+Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
 </Tip>
-<Warning>Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
+
+
+<Warning>
+Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
 </Warning>
+
 
 ---
 
@@ -51,10 +57,16 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 ```json
 {"project_key": "PROJ", "issue_type": "Task", "summary": "Implement new feature", "description": "## Requirements\n\n- Feature A\n- Feature B"}
 ```
-<Tip>Use Markdown in the description — it's automatically converted to ADF (Cloud) or wiki markup (Server/DC). For epics, provide `epic_name` parameter.
+
+<Tip>
+Use Markdown in the description — it's automatically converted to ADF (Cloud) or wiki markup (Server/DC). For epics, provide `epic_name` parameter.
 </Tip>
-<Warning>Cloud uses ADF format internally (auto-converted from Markdown). Server/DC uses wiki markup.
+
+
+<Warning>
+Cloud uses ADF format internally (auto-converted from Markdown). Server/DC uses wiki markup.
 </Warning>
+
 
 ---
 
@@ -78,8 +90,11 @@ Update an existing Jira issue including changing status, adding Epic links, upda
 ```json
 {"issue_key": "PROJ-123", "summary": "Updated title", "description": "New description", "additional_fields": "{\"priority\": {\"name\": \"High\"}}"}
 ```
-<Tip>Use `additional_fields` as a JSON string for any field not covered by explicit parameters. Find field IDs with `jira_search_fields`.
+
+<Tip>
+Use `additional_fields` as a JSON string for any field not covered by explicit parameters. Find field IDs with `jira_search_fields`.
 </Tip>
+
 
 ---
 
@@ -131,8 +146,11 @@ Transition a Jira issue to a new status.
 ```json
 {"issue_key": "PROJ-123", "transition_name": "Done", "comment": "Closing as completed"}
 ```
-<Tip>Use `jira_get_transitions` first to see available transitions for the current issue state.
+
+<Tip>
+Use `jira_get_transitions` first to see available transitions for the current issue state.
 </Tip>
+
 
 ---
 

--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -22,10 +22,16 @@ Search Jira issues using JQL (Jira Query Language).
 ```json
 {"jql": "project = PROJ AND status = 'In Progress' ORDER BY updated DESC", "limit": 20}
 ```
-<Tip>Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
+
+<Tip>
+Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
 </Tip>
-<Warning>Some JQL functions (e.g., `issueHistory()`) are Cloud-only.
+
+
+<Warning>
+Some JQL functions (e.g., `issueHistory()`) are Cloud-only.
 </Warning>
+
 
 ---
 
@@ -45,8 +51,11 @@ Search Jira fields by keyword with fuzzy match.
 ```json
 {"keyword": "story points", "issue_type": "Story", "project_key": "PROJ"}
 ```
-<Tip>Use this to discover custom field IDs before using them in `jira_create_issue` or `jira_update_issue`.
+
+<Tip>
+Use this to discover custom field IDs before using them in `jira_create_issue` or `jira_update_issue`.
 </Tip>
+
 
 ---
 

--- a/scripts/templates/tool_category.mdx.j2
+++ b/scripts/templates/tool_category.mdx.j2
@@ -26,10 +26,16 @@ description: "{{ category.description }}"
 {{ tool.override.example }}```
 {% endif %}
 {% if tool.override and tool.override.tips %}
-<Tip>{{ tool.override.tips }}</Tip>
+
+<Tip>
+{{ tool.override.tips | trim }}
+</Tip>
 {% endif %}
 {% if tool.override and tool.override.platform_notes %}
-<Warning>{{ tool.override.platform_notes }}</Warning>
+
+<Warning>
+{{ tool.override.platform_notes | trim }}
+</Warning>
 {% endif %}
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to #1023. Mintlify's MDX parser requires `<Tip>` and `<Warning>` components to have content on a **separate line** (block-level), not inline with the opening tag. The inline format (`<Tip>content</Tip>`) causes a parsing error:

```
Expected a closing tag for `<Tip>` before the end of `paragraph`
```

This prevented `jira-issues` and `jira-comments-worklogs` pages from deploying (returning 404).

### Changes
- Reformat all `<Tip>` and `<Warning>` components across 10 tool pages to block-level syntax
- Update Jinja2 template to generate proper block-level format for future regenerations

### Before
```mdx
<Tip>Content on same line as tag.
</Tip>
```

### After
```mdx
<Tip>
Content on its own line.
</Tip>
```

## Test plan

- [ ] Mintlify deployment succeeds (no parse errors)
- [ ] `/docs/tools/jira-issues` loads (was 404)
- [ ] `/docs/tools/jira-comments-worklogs` loads (was 404)