### PR TITLE
fix(docs): trigger Mintlify rebuild for jira-links-versions page

### DIFF
--- a/docs/tools/jira-links-versions.mdx
+++ b/docs/tools/jira-links-versions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jira Links & Versions"
-description: "Issue links, epic links, remote links, versions, and components"
+description: "Issue links, epic links, remote links, project versions, and components"
 ---
 
 ### Get Link Types


### PR DESCRIPTION
The brace escaping fix from #1023 was never deployed because the entire deployment was rolled back due to `<Tip>` parse errors in other files (fixed in #1024). This touches the file to trigger Mintlify's incremental rebuilder.