### PR TITLE
fix(docs): trigger Mintlify rebuild for pages with broken internal links

### DIFF
--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Authentication"
-description: "Configure authentication for MCP Atlassian - API tokens, PATs, and OAuth 2.0"
+description: "Configure authentication for MCP Atlassian — API tokens, PATs, and OAuth 2.0"
 ---
 
 MCP Atlassian supports three authentication methods depending on your Atlassian deployment type.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MCP Atlassian"
-description: "MCP server connecting AI assistants to Jira and Confluence — search, create, update issues and pages"
+description: "Connect AI assistants to Jira and Confluence — search, create, update issues and pages via MCP"
 ---
 
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install MCP Atlassian using uvx, Docker, pip, or from source"
+description: "Install and configure MCP Atlassian using uvx, Docker, pip, or from source"
 ---
 
 MCP Atlassian can be installed using several methods. Choose the one that best fits your workflow.


### PR DESCRIPTION
## Summary

- Trigger Mintlify deployment rebuild for 3 pages whose link fixes (from PR #1023) were never deployed due to a rollback
- Pages affected: `index.mdx`, `installation.mdx`, `authentication.mdx`
- 6 broken internal links total (4 Card hrefs on index + 2 Markdown links)

## Context

PR #1023 fixed broken Card `href` values and internal links, but its Mintlify deployment was fully rolled back due to MDX `<Tip>` parse errors in other files (fixed in PR #1024). The link fixes were committed to git but never deployed to the live site.

## Verification

After merge and Mintlify deployment, verify these links resolve correctly:
- `https://mcp-atlassian.soomiles.com/docs` → 4 Card links should navigate to `/docs/installation`, `/docs/authentication`, `/docs/tools-reference`, `/docs/configuration`
- `https://mcp-atlassian.soomiles.com/docs/installation` → "Configuration" link should go to `/docs/configuration`
- `https://mcp-atlassian.soomiles.com/docs/authentication` → "HTTP Transport" link should go to `/docs/http-transport`