### PR TITLE
fix(jira): fix "fixVersions" in get jira issue

### DIFF
--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -571,7 +571,7 @@ class JiraIssue(ApiModel, TimestampMixin):
         if self.components and should_include_field("components"):
             result["components"] = self.components
 
-        if self.fix_versions and should_include_field("fix_versions"):
+        if self.fix_versions and should_include_field("fixVersions"):
             result["fix_versions"] = self.fix_versions
 
         # Add epic fields if available and requested


### PR DESCRIPTION
The jira field key is 'fixVersions',  so it should use "fixVersions" instead of "fix_versions" when check "should include field".

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #896

## Changes

<!-- Briefly list the key changes made. -->

- use "fixVersions" instead of "fix_versions"

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `with fixVersions in "Get Issue" fields argument, it could return with "fix_versions"`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
