### PR TITLE
docs(readme): simplify Key Tools table

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,8 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_create_issue` - Create issues | `confluence_create_page` - Create pages |
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
-| `jira_get_queue_issues` - Read JSM queue items | |
-| `jira_get_issue_sla` - Calculate SLA metrics | `confluence_get_page_history` - Get historical page versions |
-| `jira_get_issue_development_info` - Get linked PRs, branches, commits | `confluence_get_page_views` - Get page view stats (Cloud only) |
-| `jira_get_issue_proforma_forms` - Get ProForma forms | |
-| `jira_get_proforma_form_details` - Get form details | |
-| `jira_update_proforma_form_answers` - Update form answers | |
 
-See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**65 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Simplify Key Tools table to 5 core tools per product (search, get, create, update, transition/comment)
- Remove specialized tools (SLA, ProForma, dev info, page history, page views, queue issues) from README — discoverable via full Tools Reference
- Add "65 tools total" callout linking to the complete reference

Keeps the README scannable without overwhelming new users with niche tools.