### PR TITLE
docs: remove outdated Python 3.14 compatibility warning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # MCP Atlassian - Development Guide
 
-Model Context Protocol (MCP) server for Atlassian products (Jira & Confluence). Python ≥3.10, <3.14.
+Model Context Protocol (MCP) server for Atlassian products (Jira & Confluence). Python ≥3.10.
 
 ## Build, Test, and Lint
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,7 +37,3 @@ Ask your AI assistant to:
 | Confluence | Server/Data Center | Supported (v6.0+) |
 | Jira | Cloud | Fully supported |
 | Jira | Server/Data Center | Supported (v8.14+) |
-
-<Note>
-Python 3.14 is not yet supported due to upstream pydantic-core/PyO3 limitations. Use Python 3.10-3.13.
-</Note>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -13,7 +13,7 @@ The simplest way to run MCP Atlassian without permanent installation using [uvx]
 # Run directly (downloads on first use, cached for subsequent runs)
 uvx mcp-atlassian --help
 
-# Run with specific Python version (required for Python 3.14+)
+# Run with a specific Python version if needed
 uvx --python=3.12 mcp-atlassian --help
 ```
 
@@ -49,11 +49,6 @@ uvx --python=3.12 mcp-atlassian --help
     Open **Settings** → **MCP** → **+ Add new global MCP server**, then use the same JSON configuration.
   </Tab>
 </Tabs>
-
-<Note>
-Python 3.14 is not yet supported due to upstream pydantic-core/PyO3 limitations.
-Use `["--python=3.12", "mcp-atlassian"]` as args if needed.
-</Note>
 
 ## Docker
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -30,21 +30,6 @@ description: "Fix auth errors (401/403), field issues, rate limiting, SSL proble
     Ensure your Atlassian account has sufficient permissions to access the spaces/projects you're targeting.
   </Accordion>
 
-  <Accordion title="Python Version Issues">
-    Python 3.14 is not yet supported due to upstream pydantic-core/PyO3 limitations.
-
-    **Workaround with uvx:**
-    ```bash
-    uvx --python=3.12 mcp-atlassian
-    ```
-
-    **In IDE configuration:**
-    ```json
-    {
-      "args": ["--python=3.12", "mcp-atlassian"]
-    }
-    ```
-  </Accordion>
 </AccordionGroup>
 
 ## Debugging


### PR DESCRIPTION
## Summary

- Remove Python 3.14 incompatibility warnings from docs and copilot-instructions
- pydantic-core 2.42.0 and Pydantic v2.12 now fully support Python 3.14
- The warning was accurate in early 2025 but is no longer true

## Files changed

- `docs/index.mdx` — remove `<Note>` block
- `docs/installation.mdx` — remove `<Note>` block and update code comment
- `docs/troubleshooting.mdx` — remove "Python Version Issues" accordion
- `.github/copilot-instructions.md` — remove `<3.14` upper bound