### PR TITLE
fix(jira):fix allow underscores in issue and project key patterns

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -27,8 +27,9 @@ _ATTACHMENT_MAX_BYTES = 50 * 1024 * 1024
 # Regex patterns for Jira key validation.
 # Per Atlassian docs, Cloud project keys are 2-10 chars. Server/Data Center
 # allows longer keys (configurable). We accept any length to support both.
-ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9]+-\d+$"
-PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9]+$"
+# Underscores are also allowed to support non-standard project key formats
+ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+$"
+PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+$"
 
 jira_mcp = FastMCP(
     name="Jira MCP Service",

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1485,6 +1485,8 @@ def test_issue_key_pattern_validation():
     assert re.match(ISSUE_KEY_PATTERN, "CMSV2-1")
     assert re.match(ISSUE_KEY_PATTERN, "AB-1")
     assert re.match(ISSUE_KEY_PATTERN, "ABCDEFGHIJ-99")
+    assert re.match(ISSUE_KEY_PATTERN, "D_DEV-123")
+    assert re.match(ISSUE_KEY_PATTERN, "MY_PROJECT-1")
     # Invalid issue keys
     assert not re.match(ISSUE_KEY_PATTERN, "a-1")
     assert not re.match(ISSUE_KEY_PATTERN, "PROJ")
@@ -1497,6 +1499,8 @@ def test_issue_key_pattern_validation():
     assert re.match(PROJECT_KEY_PATTERN, "CMSV2")
     assert re.match(PROJECT_KEY_PATTERN, "AB")
     assert re.match(PROJECT_KEY_PATTERN, "ABCDEFGHIJ")
+    assert re.match(PROJECT_KEY_PATTERN, "D_DEV")
+    assert re.match(PROJECT_KEY_PATTERN, "MY_PROJECT")
     # Invalid project keys
     assert not re.match(PROJECT_KEY_PATTERN, "a")
     assert not re.match(PROJECT_KEY_PATTERN, "2ABC")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Some Jira Server/Data Center instances use non-standard project key formats that include underscores (e.g., D_DEV-123). The previous patterns only allowed uppercase letters and digits, causing all MCP tools that accept an issue_key parameter (jira_get_issue, jira_update_issue, jira_transition_issue, etc.) to reject these keys at validation time — before any API call was even made.

## Changes

<!-- Briefly list the key changes made. -->

- Allow Underscores in Jira Issue and Project Key Patterns

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [X] Unit tests added/updated
- [X] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [X] Code follows project style guidelines (linting passes).
- [X] Tests added/updated for changes.
- [X] All tests pass locally.
- [ ] Documentation updated (if needed).
