### PR TITLE
fix(jira): preserve username and key fields in JiraUser model

### DIFF
--- a/src/mcp_atlassian/models/jira/common.py
+++ b/src/mcp_atlassian/models/jira/common.py
@@ -31,6 +31,8 @@ class JiraUser(ApiModel):
     """
 
     account_id: str | None = None
+    username: str | None = None  # Jira API "name" field - login username for [~username] mentions
+    user_key: str | None = None  # Jira API "key" field - internal user key
     display_name: str = UNASSIGNED
     email: str | None = None
     active: bool = True
@@ -66,6 +68,8 @@ class JiraUser(ApiModel):
 
         return cls(
             account_id=data.get("accountId"),
+            username=data.get("name"),  # Jira API "name" field (login username)
+            user_key=data.get("key"),  # Jira API "key" field (internal user key)
             display_name=str(data.get("displayName", UNASSIGNED)),
             email=data.get("emailAddress"),
             active=bool(data.get("active", True)),
@@ -75,12 +79,15 @@ class JiraUser(ApiModel):
 
     def to_simplified_dict(self) -> dict[str, Any]:
         """Convert to simplified dictionary for API response."""
-        return {
+        result = {
             "display_name": self.display_name,
-            "name": self.display_name,  # Add name for backward compatibility
+            "name": self.username or self.display_name,  # Jira login username for [~name] mentions
             "email": self.email,
             "avatar_url": self.avatar_url,
         }
+        if self.user_key:
+            result["key"] = self.user_key
+        return result
 
 
 class JiraStatusCategory(ApiModel):


### PR DESCRIPTION
## Summary

- **JiraUser model** was discarding the `name` and `key` fields from the Jira REST API, mapping `displayName` into both `display_name` and `name` in `to_simplified_dict()`. This made it impossible for MCP clients to construct valid `[~username]` mentions on Jira Server/Data Center, where the login username (e.g., `rh-ee-jdoe`) differs from the display name (e.g., `John Doe`).
- Adds `username` and `user_key` fields to the model, captures them from the API response, and returns the actual login username in the `name` field of the simplified dict output.
- Falls back to `display_name` when `username` is not available, preserving Cloud compatibility.

## Test plan

- [ ] Verify `JiraUser.from_api_response()` captures `name` and `key` from Jira Server/DC API responses
- [ ] Verify `to_simplified_dict()` returns login username in `name` field (not display name)
- [ ] Verify Cloud responses still work (falls back to `display_name` when `name` is absent)
- [ ] Verify `[~username]` mentions resolve correctly when using the `name` field from the simplified dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)