### PR TITLE
docs: add SEO config to trigger full site revalidation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2,6 +2,9 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "MCP Atlassian",
+  "seo": {
+    "indexHiddenPages": false
+  },
   "favicon": "/docs/favicon.svg",
   "colors": {
     "primary": "#0052CC",


### PR DESCRIPTION
## Summary

- Add `seo.indexHiddenPages` config to docs.json
- Config change triggers full Mintlify site rebuild, flushing stale CDN cache

## Context

Mintlify's incremental deployments skip Vercel revalidation (`Skipping Vercel revalidation (subdomain not in revalidation list)`), causing the Cloudflare CDN to serve stale pages for 8+ hours. Previous content changes (Python 3.14 warning removal, link fixes) are deployed to Mintlify's origin but not propagated to the custom domain CDN.

A `docs.json` config change should trigger a different deployment path that forces full revalidation.