### PR TITLE
fix(jira): allow underscores in preprocessing issue key patterns

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -168,7 +168,7 @@ class JiraPreprocessor(BasePreprocessor):
             link_url = match.group(2)
 
             # Extract issue key if it's a Jira issue link
-            issue_key_match = re.search(r"browse/([A-Z]+-\d+)", link_url)
+            issue_key_match = re.search(r"browse/([A-Z][A-Z0-9_]+-\d+)", link_url)
             # Check if it's a Confluence wiki link
             confluence_match = re.search(
                 r"wiki/spaces/.+?/pages/\d+/(.+?)(?:\?|$)", link_url
@@ -181,7 +181,7 @@ class JiraPreprocessor(BasePreprocessor):
             elif confluence_match:
                 url_title = confluence_match.group(1)
                 readable_title = url_title.replace("+", " ")
-                readable_title = re.sub(r"^[A-Z]+-\d+\s+", "", readable_title)
+                readable_title = re.sub(r"^[A-Z][A-Z0-9_]+-\d+\s+", "", readable_title)
                 text = text.replace(full_match, f"[{readable_title}]({link_url})")
             else:
                 clean_url = link_url.split("?")[0]


### PR DESCRIPTION
## Summary

- Update two regex patterns in `preprocessing/jira.py` to allow underscores in Jira project keys (e.g., `D_DEV-123`)
- Follow-up to #1030 which fixed the same patterns in `servers/jira.py`

## Test plan

- [ ] Verify existing preprocessing tests still pass
- [ ] Confirm browse URL pattern matches `D_DEV-123` format
- [ ] Confirm issue key prefix stripping works with underscore keys