### PR TITLE
fix(jira): preserve username and key fields in JiraUser model

### DIFF
--- a/src/mcp_atlassian/models/jira/common.py
+++ b/src/mcp_atlassian/models/jira/common.py
@@ -31,6 +31,8 @@ class JiraUser(ApiModel):
     """
 
     account_id: str | None = None
+    username: str | None = None
+    user_key: str | None = None
     display_name: str = UNASSIGNED
     email: str | None = None
     active: bool = True
@@ -66,6 +68,8 @@ class JiraUser(ApiModel):
 
         return cls(
             account_id=data.get("accountId"),
+            username=data.get("name"),
+            user_key=data.get("key"),
             display_name=str(data.get("displayName", UNASSIGNED)),
             email=data.get("emailAddress"),
             active=bool(data.get("active", True)),
@@ -75,12 +79,15 @@ class JiraUser(ApiModel):
 
     def to_simplified_dict(self) -> dict[str, Any]:
         """Convert to simplified dictionary for API response."""
-        return {
+        result: dict[str, Any] = {
             "display_name": self.display_name,
-            "name": self.display_name,  # Add name for backward compatibility
+            "name": self.username or self.display_name,
             "email": self.email,
             "avatar_url": self.avatar_url,
         }
+        if self.user_key:
+            result["key"] = self.user_key
+        return result
 
 
 class JiraStatusCategory(ApiModel):


### PR DESCRIPTION
## Summary

- `JiraUser.from_api_response()` was discarding the `name` (login username) and `key` fields from Jira Server/DC API responses, mapping `displayName` to both `display_name` and `name`
- This made `[~username]` mentions impossible on Server/DC where login username differs from display name
- Adds `username` and `user_key` fields, returns login username in `to_simplified_dict()` with Cloud fallback

Reimplements #1031 by @fatherlinux with added regression tests and lint compliance.

## Test plan

- [x] Server/DC with name+key: captures both fields correctly
- [x] Cloud without name/key: falls back to display_name
- [x] Server/DC name only (no key): captures name, key is None
- [x] to_simplified_dict uses login username on Server/DC
- [x] to_simplified_dict falls back to display_name on Cloud
- [x] All existing JiraUser tests still pass
- [x] pre-commit clean, full unit test suite passing

Closes #1031