### PR TITLE
feat(jira): add watcher tools for issues

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -29,6 +29,7 @@ from .search import SearchMixin
 from .sprints import SprintsMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
+from .watchers import WatchersMixin
 from .worklog import WorklogMixin
 
 
@@ -45,6 +46,7 @@ class JiraFetcher(
     SearchMixin,
     IssuesMixin,
     UsersMixin,
+    WatchersMixin,
     BoardsMixin,
     SprintsMixin,
     QueuesMixin,
@@ -68,6 +70,7 @@ class JiraFetcher(
     - SearchMixin: Search operations
     - IssuesMixin: Issue operations
     - UsersMixin: User operations
+    - WatchersMixin: Watcher operations
     - BoardsMixin: Board operations
     - SprintsMixin: Sprint operations
     - AttachmentsMixin: Attachment download operations

--- a/src/mcp_atlassian/jira/watchers.py
+++ b/src/mcp_atlassian/jira/watchers.py
@@ -1,0 +1,98 @@
+"""Module for Jira watcher operations."""
+
+import logging
+from typing import Any
+
+from ..models.jira.common import JiraUser
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class WatchersMixin(JiraClient):
+    """Mixin for Jira issue watcher operations."""
+
+    def get_issue_watchers(self, issue_key: str) -> dict[str, Any]:
+        """Get watchers for a specific issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+
+        Returns:
+            Dictionary with watcher count, is_watching flag,
+            and list of watchers.
+        """
+        result = self.jira.issue_get_watchers(issue_key)
+
+        if not isinstance(result, dict):
+            logger.error(
+                "Unexpected response type from issue_get_watchers: %s",
+                type(result),
+            )
+            return {
+                "issue_key": issue_key,
+                "watcher_count": 0,
+                "is_watching": False,
+                "watchers": [],
+            }
+
+        watchers = []
+        for watcher_data in result.get("watchers", []):
+            user = JiraUser.from_api_response(watcher_data)
+            watchers.append(user.to_simplified_dict())
+
+        return {
+            "issue_key": issue_key,
+            "watcher_count": result.get("watchCount", len(watchers)),
+            "is_watching": result.get("isWatching", False),
+            "watchers": watchers,
+        }
+
+    def add_watcher(self, issue_key: str, user_identifier: str) -> dict[str, Any]:
+        """Add a user as a watcher to an issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            user_identifier: Account ID (Cloud) or username (Server/DC).
+
+        Returns:
+            Success confirmation dictionary.
+        """
+        self.jira.issue_add_watcher(issue_key, user_identifier)
+        return {
+            "success": True,
+            "message": (f"User '{user_identifier}' added as watcher to {issue_key}"),
+            "issue_key": issue_key,
+            "user": user_identifier,
+        }
+
+    def remove_watcher(
+        self,
+        issue_key: str,
+        username: str | None = None,
+        account_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Remove a user from watching an issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            username: Username to remove (Server/DC).
+            account_id: Account ID to remove (Cloud).
+
+        Returns:
+            Success confirmation dictionary.
+
+        Raises:
+            ValueError: If neither username nor account_id is provided.
+        """
+        if not username and not account_id:
+            raise ValueError("Either username or account_id must be provided")
+
+        user_display = account_id or username
+        self.jira.issue_delete_watcher(issue_key, user=username, account_id=account_id)
+        return {
+            "success": True,
+            "message": (f"User '{user_display}' removed from watching {issue_key}"),
+            "issue_key": issue_key,
+            "user": user_display,
+        }

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -164,6 +164,133 @@ async def get_user_profile(
 
 @jira_mcp.tool(
     tags={"jira", "read"},
+    annotations={"title": "Get Issue Watchers", "readOnlyHint": True},
+)
+async def get_issue_watchers(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+) -> str:
+    """Get the list of watchers for a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+
+    Returns:
+        JSON string with watcher count and list of watchers.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_issue_watchers(issue_key)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write"},
+    annotations={
+        "title": "Add Issue Watcher",
+        "readOnlyHint": False,
+    },
+)
+@check_write_access
+async def add_watcher(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    user_identifier: Annotated[
+        str,
+        Field(
+            description=(
+                "User to add as watcher. For Jira Cloud, use the"
+                " account ID. For Jira Server/DC, use the username."
+            ),
+        ),
+    ],
+) -> str:
+    """Add a user as a watcher to a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        user_identifier: Account ID (Cloud) or username (Server/DC).
+
+    Returns:
+        JSON string with success confirmation.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.add_watcher(issue_key, user_identifier)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write"},
+    annotations={
+        "title": "Remove Issue Watcher",
+        "readOnlyHint": False,
+    },
+)
+@check_write_access
+async def remove_watcher(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    username: Annotated[
+        str | None,
+        Field(
+            description=("Username to remove (for Jira Server/DC)."),
+            default=None,
+        ),
+    ] = None,
+    account_id: Annotated[
+        str | None,
+        Field(
+            description=("Account ID to remove (for Jira Cloud)."),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Remove a user from watching a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        username: Username to remove (Server/DC).
+        account_id: Account ID to remove (Cloud).
+
+    Returns:
+        JSON string with success confirmation.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.remove_watcher(issue_key, username=username, account_id=account_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read"},
     annotations={"title": "Get Issue", "readOnlyHint": True},
 )
 async def get_issue(

--- a/tests/unit/jira/test_watchers.py
+++ b/tests/unit/jira/test_watchers.py
@@ -1,0 +1,201 @@
+"""Tests for Jira watcher operations."""
+
+import pytest
+
+from mcp_atlassian.jira.watchers import WatchersMixin
+
+
+class TestGetIssueWatchers:
+    """Tests for get_issue_watchers method."""
+
+    @pytest.fixture
+    def watchers_mixin(self, jira_client):
+        """Create a WatchersMixin instance with mocked dependencies."""
+        mixin = WatchersMixin(config=jira_client.config)
+        mixin.jira = jira_client.jira
+        return mixin
+
+    def test_get_watchers_returns_watcher_list(self, watchers_mixin):
+        """Test getting watchers for an issue."""
+        mock_result = {
+            "watchCount": 2,
+            "isWatching": True,
+            "watchers": [
+                {
+                    "accountId": "abc123",
+                    "displayName": "Alice",
+                    "emailAddress": "alice@example.com",
+                    "avatarUrls": {"48x48": "https://avatar/alice"},
+                },
+                {
+                    "accountId": "def456",
+                    "displayName": "Bob",
+                    "emailAddress": "bob@example.com",
+                    "avatarUrls": {"48x48": "https://avatar/bob"},
+                },
+            ],
+        }
+        watchers_mixin.jira.issue_get_watchers.return_value = mock_result
+
+        result = watchers_mixin.get_issue_watchers("TEST-123")
+
+        watchers_mixin.jira.issue_get_watchers.assert_called_once_with("TEST-123")
+        assert result["issue_key"] == "TEST-123"
+        assert result["watcher_count"] == 2
+        assert result["is_watching"] is True
+        assert len(result["watchers"]) == 2
+        assert result["watchers"][0]["display_name"] == "Alice"
+        assert result["watchers"][1]["display_name"] == "Bob"
+
+    def test_get_watchers_uses_jira_user_model(self, watchers_mixin):
+        """Test that watchers are processed through JiraUser model."""
+        mock_result = {
+            "watchCount": 1,
+            "isWatching": False,
+            "watchers": [
+                {
+                    "accountId": "abc123",
+                    "name": "alice",
+                    "displayName": "Alice Smith",
+                    "emailAddress": "alice@example.com",
+                    "avatarUrls": {"48x48": "https://avatar/alice"},
+                },
+            ],
+        }
+        watchers_mixin.jira.issue_get_watchers.return_value = mock_result
+
+        result = watchers_mixin.get_issue_watchers("TEST-123")
+
+        watcher = result["watchers"][0]
+        assert watcher["display_name"] == "Alice Smith"
+        assert watcher["name"] == "alice"
+        assert watcher["email"] == "alice@example.com"
+        assert watcher["avatar_url"] == "https://avatar/alice"
+
+    def test_get_watchers_empty_list(self, watchers_mixin):
+        """Test getting watchers when no one is watching."""
+        mock_result = {
+            "watchCount": 0,
+            "isWatching": False,
+            "watchers": [],
+        }
+        watchers_mixin.jira.issue_get_watchers.return_value = mock_result
+
+        result = watchers_mixin.get_issue_watchers("TEST-123")
+
+        assert result["issue_key"] == "TEST-123"
+        assert result["watcher_count"] == 0
+        assert result["is_watching"] is False
+        assert result["watchers"] == []
+
+    def test_get_watchers_invalid_response(self, watchers_mixin):
+        """Test graceful handling of unexpected response type."""
+        watchers_mixin.jira.issue_get_watchers.return_value = "unexpected string"
+
+        result = watchers_mixin.get_issue_watchers("TEST-123")
+
+        assert result["issue_key"] == "TEST-123"
+        assert result["watcher_count"] == 0
+        assert result["is_watching"] is False
+        assert result["watchers"] == []
+
+    def test_get_watchers_count_fallback(self, watchers_mixin):
+        """Test that watcher count falls back to len(watchers)."""
+        mock_result = {
+            "isWatching": False,
+            "watchers": [
+                {"displayName": "Alice"},
+                {"displayName": "Bob"},
+            ],
+        }
+        watchers_mixin.jira.issue_get_watchers.return_value = mock_result
+
+        result = watchers_mixin.get_issue_watchers("TEST-123")
+
+        assert result["watcher_count"] == 2
+
+
+class TestAddWatcher:
+    """Tests for add_watcher method."""
+
+    @pytest.fixture
+    def watchers_mixin(self, jira_client):
+        """Create a WatchersMixin instance with mocked dependencies."""
+        mixin = WatchersMixin(config=jira_client.config)
+        mixin.jira = jira_client.jira
+        return mixin
+
+    def test_add_watcher_success(self, watchers_mixin):
+        """Test adding a watcher to an issue."""
+        watchers_mixin.jira.issue_add_watcher.return_value = None
+
+        result = watchers_mixin.add_watcher("TEST-123", "abc123")
+
+        assert result["success"] is True
+        assert result["issue_key"] == "TEST-123"
+        assert result["user"] == "abc123"
+        assert "abc123" in result["message"]
+
+    def test_add_watcher_calls_correct_api(self, watchers_mixin):
+        """Test that issue_add_watcher is called with correct args."""
+        watchers_mixin.jira.issue_add_watcher.return_value = None
+
+        watchers_mixin.add_watcher("PROJ-456", "user-id-789")
+
+        watchers_mixin.jira.issue_add_watcher.assert_called_once_with(
+            "PROJ-456", "user-id-789"
+        )
+
+
+class TestRemoveWatcher:
+    """Tests for remove_watcher method."""
+
+    @pytest.fixture
+    def watchers_mixin(self, jira_client):
+        """Create a WatchersMixin instance with mocked dependencies."""
+        mixin = WatchersMixin(config=jira_client.config)
+        mixin.jira = jira_client.jira
+        return mixin
+
+    def test_remove_watcher_with_account_id(self, watchers_mixin):
+        """Test removing a watcher using account ID (Cloud)."""
+        watchers_mixin.jira.issue_delete_watcher.return_value = None
+
+        result = watchers_mixin.remove_watcher("TEST-123", account_id="abc123")
+
+        assert result["success"] is True
+        assert result["issue_key"] == "TEST-123"
+        assert result["user"] == "abc123"
+        watchers_mixin.jira.issue_delete_watcher.assert_called_once_with(
+            "TEST-123", user=None, account_id="abc123"
+        )
+
+    def test_remove_watcher_with_username(self, watchers_mixin):
+        """Test removing a watcher using username (Server/DC)."""
+        watchers_mixin.jira.issue_delete_watcher.return_value = None
+
+        result = watchers_mixin.remove_watcher("TEST-123", username="jdoe")
+
+        assert result["success"] is True
+        assert result["issue_key"] == "TEST-123"
+        assert result["user"] == "jdoe"
+        watchers_mixin.jira.issue_delete_watcher.assert_called_once_with(
+            "TEST-123", user="jdoe", account_id=None
+        )
+
+    def test_remove_watcher_no_identifier_raises_error(self, watchers_mixin):
+        """Test that ValueError is raised when no identifier provided."""
+        with pytest.raises(
+            ValueError, match="Either username or account_id must be provided"
+        ):
+            watchers_mixin.remove_watcher("TEST-123")
+
+    def test_remove_watcher_prefers_account_id_display(self, watchers_mixin):
+        """Test that account_id is used for display when both provided."""
+        watchers_mixin.jira.issue_delete_watcher.return_value = None
+
+        result = watchers_mixin.remove_watcher(
+            "TEST-123", username="jdoe", account_id="abc123"
+        )
+
+        assert result["user"] == "abc123"


### PR DESCRIPTION
## Summary

- Adds three new tools for managing Jira issue watchers:
  - `jira_get_issue_watchers` — list watchers and watcher count for an issue
  - `jira_add_watcher` — add a user as a watcher (account ID for Cloud, username for Server/DC)
  - `jira_remove_watcher` — remove a user from watching (supports both Cloud and Server/DC)
- Implements `WatchersMixin` with `JiraUser.from_api_response()` for consistent model handling
- Write tools respect `READ_ONLY_MODE` via `@check_write_access` decorator

Reimplements #1032 by @fatherlinux with unit tests, lint compliance, and improved error handling.

## Test plan

- [x] `get_issue_watchers`: returns watcher count and list with JiraUser model
- [x] `get_issue_watchers`: handles empty watcher list
- [x] `get_issue_watchers`: handles unexpected response type gracefully
- [x] `get_issue_watchers`: falls back to len(watchers) when watchCount missing
- [x] `add_watcher`: calls correct API with user identifier
- [x] `remove_watcher`: works with account_id (Cloud)
- [x] `remove_watcher`: works with username (Server/DC)
- [x] `remove_watcher`: raises ValueError when no identifier provided
- [x] All existing tests still pass (2270 passed)
- [x] pre-commit clean (ruff + mypy)

Closes #1032