### PR TITLE
fix(test): add TOOLSETS=all to E2E MCP tool test fixtures

### DIFF
--- a/tests/e2e/cloud/test_adf_write.py
+++ b/tests/e2e/cloud/test_adf_write.py
@@ -42,6 +42,7 @@ def cloud_env(cloud_instance: CloudInstanceInfo) -> dict[str, str]:
         "CONFLUENCE_USERNAME": cloud_instance.username,
         "CONFLUENCE_API_TOKEN": cloud_instance.api_token,
         "READ_ONLY_MODE": "false",
+        "TOOLSETS": "all",
     }
 
 

--- a/tests/e2e/cloud/test_images_cloud.py
+++ b/tests/e2e/cloud/test_images_cloud.py
@@ -41,6 +41,7 @@ def cloud_env(cloud_instance: CloudInstanceInfo) -> dict[str, str]:
         "CONFLUENCE_USERNAME": cloud_instance.username,
         "CONFLUENCE_API_TOKEN": cloud_instance.api_token,
         "READ_ONLY_MODE": "false",
+        "TOOLSETS": "all",
     }
 
 

--- a/tests/e2e/cloud/test_mcp_tools_cloud.py
+++ b/tests/e2e/cloud/test_mcp_tools_cloud.py
@@ -38,6 +38,7 @@ def cloud_env(cloud_instance: CloudInstanceInfo) -> dict[str, str]:
         "CONFLUENCE_USERNAME": cloud_instance.username,
         "CONFLUENCE_API_TOKEN": cloud_instance.api_token,
         "READ_ONLY_MODE": "false",
+        "TOOLSETS": "all",
     }
 
 

--- a/tests/e2e/test_images_dc.py
+++ b/tests/e2e/test_images_dc.py
@@ -41,6 +41,7 @@ def dc_env(dc_instance: DCInstanceInfo) -> dict[str, str]:
         "CONFLUENCE_USERNAME": dc_instance.admin_username,
         "CONFLUENCE_API_TOKEN": dc_instance.admin_password,
         "READ_ONLY_MODE": "false",
+        "TOOLSETS": "all",
     }
 
 

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -38,6 +38,7 @@ def dc_env(dc_instance: DCInstanceInfo) -> dict[str, str]:
         "CONFLUENCE_USERNAME": dc_instance.admin_username,
         "CONFLUENCE_API_TOKEN": dc_instance.admin_password,
         "READ_ONLY_MODE": "false",
+        "TOOLSETS": "all",
     }
 
 

--- a/tests/e2e/test_user_lookup_dc.py
+++ b/tests/e2e/test_user_lookup_dc.py
@@ -43,6 +43,7 @@ def dc_env(dc_instance: DCInstanceInfo) -> dict[str, str]:
         "CONFLUENCE_USERNAME": dc_instance.admin_username,
         "CONFLUENCE_API_TOKEN": dc_instance.admin_password,
         "READ_ONLY_MODE": "false",
+        "TOOLSETS": "all",
     }
 
 


### PR DESCRIPTION
## Summary
- Add `"TOOLSETS": "all"` to `dc_env`/`cloud_env` fixtures in all 6 E2E MCP tool test files
- After #1041 introduced toolset filtering (default ~23 tools), E2E tests exercising image/attachment tools would fail since those tools aren't in the default toolsets
- Validated with full DC (72 passed) and Cloud (47 passed) E2E runs

## Test plan
- [x] Full DC E2E suite: `uv run pytest tests/e2e/ --dc-e2e` — 72 passed
- [x] Full Cloud E2E suite: `uv run pytest tests/e2e/cloud/ --cloud-e2e` — 47 passed
- [x] Toolset filtering validation (default=23, all=68, read-only=41, bogus=fail-closed)
- [x] Watcher CRUD on DC and Cloud
- [x] SSE and streamable-HTTP transports
- [x] Regression checks (Zephyr removal, timestamp overflow, underscore keys)