### PR TITLE
feat(server): change TOOLSETS default from 6 core to all toolsets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,12 +156,13 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # --- Toolset Filtering ---
 # Group-level tool filtering. Toolsets group related tools together.
 # Keywords: "all" (all toolsets), "default" (core toolsets only)
-# Default toolsets: jira_issues, jira_fields, jira_comments, jira_transitions,
+# Core toolsets: jira_issues, jira_fields, jira_comments, jira_transitions,
 #   confluence_pages, confluence_comments
 # Example: TOOLSETS=default                      # Only core tools (~23 tools)
 # Example: TOOLSETS=default,jira_agile           # Core + agile tools
 # Example: TOOLSETS=all                          # All 21 toolsets (68 tools)
-# If unset, default toolsets are enabled (~23 tools). Use TOOLSETS=all for all tools.
+# If unset, all toolsets are enabled (68 tools). Set TOOLSETS=all explicitly to
+# preserve this behavior — in v0.22.0, the default will change to core toolsets only.
 # Unknown names are silently ignored; if ALL names are unknown, no tools are enabled (fail-closed).
 #TOOLSETS=
 

--- a/docs/advanced/docker-production.mdx
+++ b/docs/advanced/docker-production.mdx
@@ -113,7 +113,7 @@ For production environments where write operations should be disabled:
 ```yaml
 environment:
   - READ_ONLY_MODE=true
-  - TOOLSETS=default  # Optional: also limit to core toolsets
+  - TOOLSETS=default  # Optional: restrict to core toolsets only
 ```
 
 This disables all create, update, and delete tools at the server level.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -211,13 +211,13 @@ Toolsets provide group-level tool control. Instead of listing individual tool na
 enable entire groups of related tools at once using the `TOOLSETS` environment variable.
 
 ```bash
-# Only core tools (~23 tools across 6 default toolsets)
+# Restrict to core tools only (~23 tools across 6 core toolsets)
 TOOLSETS=default
 
 # Core tools plus agile boards/sprints
 TOOLSETS=default,jira_agile
 
-# All toolsets (override default)
+# All toolsets (same as current default when TOOLSETS is unset)
 TOOLSETS=all
 ```
 
@@ -226,12 +226,16 @@ Command-line alternative:
 uvx mcp-atlassian --toolsets "default,jira_agile"
 ```
 
-**Default toolsets** (included with `TOOLSETS=default`):
+**Core toolsets** (included with `TOOLSETS=default`):
 `jira_issues`, `jira_fields`, `jira_comments`, `jira_transitions`, `confluence_pages`, `confluence_comments`
 
 When both `TOOLSETS` and `ENABLED_TOOLS` are set, they intersect — a tool must pass
-both filters. If `TOOLSETS` is not set, default toolsets are enabled. Use `TOOLSETS=all`
-to enable all toolsets.
+both filters. If `TOOLSETS` is not set, all toolsets are currently enabled.
+
+<Warning>
+In v0.22.0, the default will change from all toolsets to 6 core toolsets only.
+Set `TOOLSETS=all` explicitly to preserve current behavior.
+</Warning>
 
 <Note>
 Unknown toolset names are silently ignored. If **all** names are unknown, no tools are

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -89,8 +89,8 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `confluence_attachments` | No | `confluence_upload_attachment`, `confluence_upload_attachments`, `confluence_get_attachments`, `confluence_download_attachment`, `confluence_download_content_attachments`, `confluence_delete_attachment`, `confluence_get_page_images` |
 
 ```bash
-# Default toolsets are enabled when TOOLSETS is not set.
-# To explicitly add more toolsets on top of defaults:
+# All toolsets are enabled when TOOLSETS is not set.
+# To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
 # Enable all toolsets (68 tools)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -155,17 +155,18 @@ def get_enabled_toolsets() -> set[str]:
     Supports keywords 'all' (all 21 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
-    When TOOLSETS is unset or empty, returns DEFAULT_TOOLSETS (6 core toolsets).
-    Use ``TOOLSETS=all`` to explicitly enable all toolsets.
+    When TOOLSETS is unset or empty, returns all toolsets with a deprecation
+    warning. In v0.22.0 the default will change to DEFAULT_TOOLSETS (6 core).
+    Set ``TOOLSETS=all`` explicitly to preserve current behavior.
 
     Returns:
-        A set of valid toolset names. Defaults to DEFAULT_TOOLSETS when unset.
+        A set of valid toolset names. Defaults to all toolsets when unset.
         Unknown names are silently dropped with a warning. If only unknown
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> DEFAULT_TOOLSETS (6 defaults)
-        TOOLSETS="" -> DEFAULT_TOOLSETS (6 defaults)
+        TOOLSETS unset -> all 21 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 21 toolsets (with deprecation warning)
         TOOLSETS="all" -> all 21 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
@@ -173,16 +174,26 @@ def get_enabled_toolsets() -> set[str]:
     """
     toolsets_str = os.getenv("TOOLSETS")
     if not toolsets_str:
-        logger.info("TOOLSETS not set — using default toolsets.")
-        return set(DEFAULT_TOOLSETS)
+        logger.info("TOOLSETS not set — all toolsets enabled.")
+        logger.warning(
+            "TOOLSETS is not set — currently defaults to all toolsets. "
+            "In v0.22.0, the default will change to 6 core toolsets only. "
+            "Set TOOLSETS=all explicitly to preserve current behavior."
+        )
+        return set(ALL_TOOLSETS.keys())
 
     # Split by comma and strip whitespace, filter empty tokens
     tokens = [t.strip() for t in toolsets_str.split(",")]
     tokens = [t for t in tokens if t]
 
     if not tokens:
-        logger.info("TOOLSETS empty — using default toolsets.")
-        return set(DEFAULT_TOOLSETS)
+        logger.info("TOOLSETS empty — all toolsets enabled.")
+        logger.warning(
+            "TOOLSETS is not set — currently defaults to all toolsets. "
+            "In v0.22.0, the default will change to 6 core toolsets only. "
+            "Set TOOLSETS=all explicitly to preserve current behavior."
+        )
+        return set(ALL_TOOLSETS.keys())
 
     result: set[str] = set()
 

--- a/tests/unit/servers/test_mcp_protocol.py
+++ b/tests/unit/servers/test_mcp_protocol.py
@@ -1174,9 +1174,9 @@ class TestMCPProtocolIntegration:
             assert "confluence_get_page" in tool_names
             assert len(tools) == 2
 
-    async def test_lifespan_toolsets_unset_uses_defaults(self):
-        """Test lifespan uses default toolsets when TOOLSETS env var is absent."""
-        from mcp_atlassian.utils.toolsets import DEFAULT_TOOLSETS
+    async def test_lifespan_toolsets_unset_uses_all(self):
+        """Test lifespan uses all toolsets when TOOLSETS env var is absent."""
+        from mcp_atlassian.utils.toolsets import ALL_TOOLSETS
 
         with MockEnvironment.basic_auth_env():
             with patch.dict(os.environ, {}, clear=False):
@@ -1192,7 +1192,7 @@ class TestMCPProtocolIntegration:
                     app = MagicMock()
                     async with main_lifespan(app) as context:
                         app_context = context["app_lifespan_context"]
-                        assert app_context.enabled_toolsets == DEFAULT_TOOLSETS
+                        assert app_context.enabled_toolsets == set(ALL_TOOLSETS.keys())
 
     async def test_lifespan_with_toolsets(self):
         """Test lifespan parses TOOLSETS env var into MainAppContext.enabled_toolsets."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -18,9 +18,9 @@ class TestGetEnabledToolsets:
     @pytest.mark.parametrize(
         "env_value, expected",
         [
-            pytest.param(None, DEFAULT_TOOLSETS, id="unset_uses_defaults"),
-            pytest.param("", DEFAULT_TOOLSETS, id="empty_uses_defaults"),
-            pytest.param(" , , ", DEFAULT_TOOLSETS, id="whitespace_uses_defaults"),
+            pytest.param(None, set(ALL_TOOLSETS.keys()), id="unset_uses_all"),
+            pytest.param("", set(ALL_TOOLSETS.keys()), id="empty_uses_all"),
+            pytest.param(" , , ", set(ALL_TOOLSETS.keys()), id="whitespace_uses_all"),
             pytest.param("jira_agile", {"jira_agile"}, id="single_toolset"),
             pytest.param("typo_name", set(), id="unknown_name_fail_closed"),
         ],


### PR DESCRIPTION
## Summary

- Change `TOOLSETS` default (when unset) from 6 core toolsets (~23 tools) to all 21 toolsets (68 tools), preventing a breaking change for existing users upgrading
- Log a deprecation warning when `TOOLSETS` is unset, advising users to set `TOOLSETS=all` explicitly before v0.22.0
- Update docs and `.env.example` to reflect the new default behavior and migration timeline

## Test plan

- [x] Pre-commit passes (ruff, mypy)
- [x] Unit tests updated and passing (31 tests)
- [x] Smoke test: unset `TOOLSETS` returns all 21 toolsets with deprecation warning