### PR TITLE
docs: align parameter names with #1044 renames

### DIFF
--- a/docs/_overrides/jira_add_comment.yaml
+++ b/docs/_overrides/jira_add_comment.yaml
@@ -1,4 +1,4 @@
 example: |
-  {"issue_key": "PROJ-123", "comment": "## Investigation\n\nFound the root cause in module X."}
+  {"issue_key": "PROJ-123", "body": "## Investigation\n\nFound the root cause in module X."}
 tips: |
   Supports Markdown formatting. Use `visibility` parameter for restricted comments (e.g., service desk internal notes).

--- a/docs/guides/common-workflows.mdx
+++ b/docs/guides/common-workflows.mdx
@@ -26,7 +26,7 @@ jira_update_issue: {"issue_key": "PROJ-123", "additional_fields": "{\"assignee\"
 
 4. **Add a triage comment:**
 ```json
-jira_add_comment: {"issue_key": "PROJ-123", "comment": "Triaged: High priority, assigned to backend team."}
+jira_add_comment: {"issue_key": "PROJ-123", "body": "Triaged: High priority, assigned to backend team."}
 ```
 
 ### Sprint Planning

--- a/docs/tools/confluence-comments.mdx
+++ b/docs/tools/confluence-comments.mdx
@@ -14,7 +14,7 @@ Add a comment to a Confluence page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | The ID of the page to add a comment to |
-| `content` | `string` | Yes | The comment content in Markdown format |
+| `body` | `string` | Yes | The comment content in Markdown format |
 **Example:**
 
 ```json

--- a/docs/tools/jira-agile.mdx
+++ b/docs/tools/jira-agile.mdx
@@ -97,7 +97,7 @@ Create Jira sprint for a board.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `board_id` | `string` | Yes | The id of board (e.g., '1000') |
-| `sprint_name` | `string` | Yes | Name of the sprint (e.g., 'Sprint 1') |
+| `name` | `string` | Yes | Name of the sprint (e.g., 'Sprint 1') |
 | `start_date` | `string` | Yes | Start time for sprint (ISO 8601 format) |
 | `end_date` | `string` | Yes | End time for sprint (ISO 8601 format) |
 | `goal` | `string` | No | (Optional) Goal of the sprint |
@@ -115,7 +115,7 @@ Update jira sprint.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `sprint_id` | `string` | Yes | The id of sprint (e.g., '10001') |
-| `sprint_name` | `string` | No | (Optional) New name for the sprint |
+| `name` | `string` | No | (Optional) New name for the sprint |
 | `state` | `string` | No | (Optional) New state for the sprint (future\|active\|closed) |
 | `start_date` | `string` | No | (Optional) New start date for the sprint |
 | `end_date` | `string` | No | (Optional) New end date for the sprint |

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -14,12 +14,12 @@ Add a comment to a Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `comment` | `string` | Yes | Comment text in Markdown format |
+| `body` | `string` | Yes | Comment text in Markdown format |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
 **Example:**
 
 ```json
-{"issue_key": "PROJ-123", "comment": "## Investigation\n\nFound the root cause in module X."}
+{"issue_key": "PROJ-123", "body": "## Investigation\n\nFound the root cause in module X."}
 ```
 
 <Tip>
@@ -41,7 +41,7 @@ Edit an existing comment on a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `comment_id` | `string` | Yes | The ID of the comment to edit |
-| `comment` | `string` | Yes | Updated comment text in Markdown format |
+| `body` | `string` | Yes | Updated comment text in Markdown format |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
 
 ---


### PR DESCRIPTION
## Summary
- Update docs to reflect MCP tool parameter renames from #1044
- `comment` → `body` in Jira `add_comment` / `edit_comment` docs
- `sprint_name` → `name` in `create_sprint` / `update_sprint` docs
- `content` → `body` in Confluence `add_comment` docs

## Test plan
- [x] Verified all parameter references match current tool signatures

Reported-by:@hteichmann-strato