### PR TITLE
fix(jira): route worklog ADF comments through v3 API on Cloud

### DIFF
--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -274,7 +274,12 @@ class JiraClient:
             logger.warning(f"Error converting markdown to Jira format: {str(e)}")
             return markdown_text
 
-    def _post_api3(self, resource: str, data: dict[str, Any]) -> Any:
+    def _post_api3(
+        self,
+        resource: str,
+        data: dict[str, Any],
+        params: dict[str, str] | None = None,
+    ) -> Any:
         """POST to Jira REST API v3 (required for ADF payloads on Cloud).
 
         The atlassian-python-api library defaults to /rest/api/2/ which
@@ -282,7 +287,7 @@ class JiraClient:
         Callers are responsible for choosing v2 vs v3 based on payload type.
         """
         url = self.jira.resource_url(resource, api_version="3")
-        return self.jira.post(url, data=data)
+        return self.jira.post(url, data=data, params=params)
 
     def _put_api3(self, resource: str, data: dict[str, Any]) -> Any:
         """PUT to Jira REST API v3 (required for ADF payloads on Cloud)."""

--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -127,10 +127,16 @@ class WorklogMixin(JiraClient):
                 remaining_estimate_updated = True
 
             # Step 4: Add the worklog with remaining estimate adjustment
-            base_url = self.jira.resource_url("issue")
-            url = f"{base_url}/{issue_key}/worklog"
-
-            result = self.jira.post(url, data=worklog_data, params=params)
+            if isinstance(worklog_data.get("comment"), dict) and self.config.is_cloud:
+                result = self._post_api3(
+                    f"issue/{issue_key}/worklog",
+                    data=worklog_data,
+                    params=params or None,
+                )
+            else:
+                base_url = self.jira.resource_url("issue")
+                url = f"{base_url}/{issue_key}/worklog"
+                result = self.jira.post(url, data=worklog_data, params=params)
             if not isinstance(result, dict):
                 msg = f"Unexpected return value type from `jira.post`: {type(result)}"
                 logger.error(msg)


### PR DESCRIPTION
## Summary
- On Cloud, `_markdown_to_jira()` returns ADF dicts for worklog comments. The v2 API silently drops these, losing the comments entirely.
- Routes worklog ADF comments through `_post_api3()` on Cloud, matching the pattern already used in `comments.py`.
- Adds `params` kwarg to `_post_api3()` so remaining estimate adjustments work correctly with the v3 API path.

Fixes #1045

## Test plan
- [x] Unit test: Cloud + ADF dict comment → `_post_api3` called, `jira.post` NOT called
- [x] Unit test: Cloud + ADF + remaining_estimate → `_post_api3` with params
- [x] Unit test: Server/DC + wiki string → `jira.post` called (v2 path unchanged)
- [x] Pre-commit (ruff + mypy) clean
- [x] All 23 worklog tests pass