### PR TITLE
fix(jira): handle 403 Forbidden for non-JSM ServiceDesk comments

### DIFF
--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -186,6 +186,12 @@ class CommentsMixin(JiraClient):
             }
         except Exception as e:
             error_msg = str(e)
+            if "403" in error_msg or "forbidden" in error_msg.lower():
+                raise Exception(
+                    f"Issue {issue_key} is not a JSM service "
+                    f"desk issue or you lack permission: "
+                    f"{error_msg}"
+                ) from e
             if "404" in error_msg or "not found" in error_msg.lower():
                 raise Exception(
                     f"Issue {issue_key} is not a JSM service "

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -510,8 +510,15 @@ class TestCommentsMixin:
         comments_mixin.jira.post.assert_called_once()
         comments_mixin._post_api3.assert_not_called()
 
+    def test_add_comment_servicedesk_403(self, comments_mixin):
+        """public=True on non-JSM project gives clear 403 error."""
+        comments_mixin.jira.post.side_effect = Exception("403 Client Error: Forbidden")
+
+        with pytest.raises(Exception, match="not a JSM service desk issue"):
+            comments_mixin.add_comment("TEST-123", "Test", public=True)
+
     def test_add_comment_servicedesk_404(self, comments_mixin):
-        """public=True on non-JSM issue gives clear 404 error."""
+        """public=True on non-existent issue gives clear 404 error."""
         comments_mixin.jira.post.side_effect = Exception("404 Client Error: Not Found")
 
         with pytest.raises(Exception, match="not a JSM service desk issue"):


### PR DESCRIPTION
## Summary
- Non-JSM projects return 403 Forbidden (not 404) from the ServiceDesk API when using `public` parameter
- Add 403 detection with clear error message: "not a JSM service desk issue or you lack permission"
- Found during E2E smoke testing of v0.20.0

## Test plan
- [x] Unit test: 403 → clear error message
- [x] Live Cloud smoke test: non-JSM project correctly returns descriptive 403 error
- [x] 2324 unit tests pass, pre-commit clean