### PR TITLE
feat(auth): add opt-in OAuth proxy + DCR/discovery endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,11 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #ATLASSIAN_OAUTH_CLIENT_SECRET=your_oauth_client_secret
 #ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback # Must match your app's redirect URI
 #ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:jira-user read:confluence-space.summary read:confluence-content.summary read:confluence-content.all write:confluence-content search:confluence read:page:confluence offline_access # IMPORTANT: 'offline_access' is crucial for refresh tokens
+#ATLASSIAN_OAUTH_PROXY_ENABLE=true # Enables MCP OAuth proxy + DCR + /.well-known routes (default: false)
+#PUBLIC_BASE_URL=https://mcp.example.com/mcp-atlassian # Public URL where clients reach this server
+#ATLASSIAN_OAUTH_ALLOWED_CLIENT_REDIRECT_URIS=http://localhost:*,http://127.0.0.1:*,https://chatgpt.com/connector_platform_oauth_redirect
+#ATLASSIAN_OAUTH_ALLOWED_GRANT_TYPES=authorization_code,refresh_token
+#ATLASSIAN_OAUTH_REQUIRE_CONSENT=true
 
 # Required for the server AFTER running --oauth-setup (this ID is printed by the setup wizard):
 #ATLASSIAN_OAUTH_CLOUD_ID=your_atlassian_cloud_id_from_oauth_setup

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -110,6 +110,25 @@ ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-content.all
 Include `offline_access` in your scope to allow automatic token refresh.
 </Warning>
 
+### MCP OAuth Proxy (DCR + Discovery)
+
+Enable this when running a remote MCP endpoint that should onboard MCP clients
+through the standard OAuth discovery/DCR flow (`401` challenge, `/.well-known/*`,
+`/register`, `/authorize`, `/token`, callback).
+
+```bash
+ATLASSIAN_OAUTH_PROXY_ENABLE=true
+PUBLIC_BASE_URL=https://mcp.example.com/mcp-atlassian
+ATLASSIAN_OAUTH_ALLOWED_CLIENT_REDIRECT_URIS=http://localhost:*,http://127.0.0.1:*,https://chatgpt.com/connector_platform_oauth_redirect
+ATLASSIAN_OAUTH_ALLOWED_GRANT_TYPES=authorization_code,refresh_token
+ATLASSIAN_OAUTH_REQUIRE_CONSENT=true
+```
+
+<Note>
+This mode is opt-in. Existing API token, PAT, and header-based OAuth flows continue
+to work without enabling the proxy.
+</Note>
+
 ### Bring Your Own Token (BYOT)
 
 If you manage OAuth tokens externally (e.g., through a central identity provider):

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -150,6 +150,11 @@ This guide covers IDE integration, environment variables, and advanced configura
 | `MCP_VERBOSE` | Enable verbose logging (`true`/`false`) |
 | `MCP_VERY_VERBOSE` | Enable debug logging (`true`/`false`) |
 | `MCP_LOGGING_STDOUT` | Log to stdout instead of stderr (`true`/`false`) |
+| `ATLASSIAN_OAUTH_PROXY_ENABLE` | Enable OAuth proxy + DCR + `/.well-known/*` routes (`true`/`false`) |
+| `PUBLIC_BASE_URL` | Public base URL for OAuth discovery metadata |
+| `ATLASSIAN_OAUTH_ALLOWED_CLIENT_REDIRECT_URIS` | Comma-separated allowed redirect URI patterns for DCR clients |
+| `ATLASSIAN_OAUTH_ALLOWED_GRANT_TYPES` | Comma-separated grant types allowed during DCR |
+| `ATLASSIAN_OAUTH_REQUIRE_CONSENT` | Require local consent page before upstream redirect (`true`/`false`) |
 
 See [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) for all available options.
 

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -158,9 +158,26 @@ Both transport types support per-request authentication where each user provides
     ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback
     ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:confluence-content.all write:confluence-content offline_access
     ATLASSIAN_OAUTH_CLOUD_ID=your_cloud_id_from_setup_wizard
+    # Optional: enable MCP OAuth proxy + DCR/discovery endpoints
+    ATLASSIAN_OAUTH_PROXY_ENABLE=true
+    PUBLIC_BASE_URL=https://mcp.example.com/mcp-atlassian
     ```
   </Step>
 </Steps>
+
+### OAuth Discovery + DCR for MCP Clients
+
+When `ATLASSIAN_OAUTH_PROXY_ENABLE=true`, the HTTP service exposes OAuth discovery
+and DCR endpoints so MCP clients can onboard users through spec-aligned OAuth:
+
+- `/.well-known/oauth-protected-resource`
+- `/.well-known/oauth-authorization-server`
+- `POST /register`
+- `GET /authorize`
+- `POST /token`
+- callback route derived from `ATLASSIAN_OAUTH_REDIRECT_URI`
+
+Use this for remote clients like ChatGPT/Codex that expect discovery + DCR.
 
 ### Multi-Cloud Support
 

--- a/src/mcp_atlassian/servers/oauth_proxy.py
+++ b/src/mcp_atlassian/servers/oauth_proxy.py
@@ -1,0 +1,75 @@
+"""OAuth proxy extensions and configuration helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from mcp.server.auth.provider import OAuthClientInformationFull
+
+logger = logging.getLogger("mcp-atlassian.server.oauth_proxy")
+
+
+def _normalize_list(values: Iterable[str] | None) -> list[str] | None:
+    if values is None:
+        return None
+    return [value.strip() for value in values if value and value.strip()]
+
+
+def parse_env_list(raw: str | None) -> list[str] | None:
+    if raw is None:
+        return None
+    if not raw.strip():
+        return []
+    normalized = raw.replace(",", " ")
+    return [item.strip() for item in normalized.split() if item.strip()]
+
+
+class HardenedOAuthProxy(OAuthProxy):
+    """OAuthProxy with stricter DCR controls for grants and scopes."""
+
+    def __init__(
+        self,
+        *,
+        allowed_grant_types: list[str] | None = None,
+        forced_scopes: list[str] | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._allowed_grant_types = _normalize_list(allowed_grant_types)
+        self._forced_scopes = _normalize_list(forced_scopes)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        updates: dict[str, object] = {"response_types": ["code"]}
+
+        if self._allowed_grant_types is not None:
+            requested = list(client_info.grant_types or [])
+            filtered = [gt for gt in requested if gt in self._allowed_grant_types]
+            if requested and set(requested) - set(filtered):
+                logger.warning(
+                    "DCR requested unsupported grant types %s; enforcing %s",
+                    sorted(set(requested) - set(filtered)),
+                    self._allowed_grant_types,
+                )
+            if not filtered:
+                filtered = list(self._allowed_grant_types)
+            updates["grant_types"] = filtered
+
+        if self._forced_scopes is not None:
+            forced_scope = " ".join(self._forced_scopes).strip()
+            updates["scope"] = forced_scope or None
+            if client_info.scope and client_info.scope != forced_scope:
+                logger.warning(
+                    "DCR requested scope '%s'; enforcing '%s'",
+                    client_info.scope,
+                    forced_scope,
+                )
+
+        if updates:
+            client_info = client_info.model_copy(update=updates)
+
+        await super().register_client(client_info)
+
+
+__all__ = ["HardenedOAuthProxy", "parse_env_list"]

--- a/src/mcp_atlassian/utils/token_verifier.py
+++ b/src/mcp_atlassian/utils/token_verifier.py
@@ -1,0 +1,29 @@
+"""Token verifier for Atlassian opaque OAuth tokens.
+
+FastMCP's OAuthProxy requires a TokenVerifier for loaded upstream access tokens.
+Atlassian OAuth tokens are opaque in many environments and there is no stable
+JWKS endpoint for verification, so we accept non-empty tokens and attach the
+required scopes.
+"""
+
+from __future__ import annotations
+
+import time
+
+from fastmcp.server.auth.auth import AccessToken, TokenVerifier
+
+
+class AtlassianOpaqueTokenVerifier(TokenVerifier):
+    """Accept opaque Atlassian tokens and wrap them in AccessToken."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:  # noqa: D401
+        if not token:
+            return None
+
+        scopes = self.required_scopes or []
+        return AccessToken(
+            token=token,
+            client_id="atlassian",
+            scopes=scopes,
+            expires_at=int(time.time()) + 86400 * 30,
+        )

--- a/tests/unit/servers/test_oauth_proxy_build.py
+++ b/tests/unit/servers/test_oauth_proxy_build.py
@@ -1,0 +1,243 @@
+"""Unit tests for OAuth proxy provider construction and hardening."""
+
+from __future__ import annotations
+
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+
+from mcp_atlassian.servers.main import _build_auth_provider
+from mcp_atlassian.utils.oauth import CLOUD_AUTHORIZE_URL, CLOUD_TOKEN_URL
+
+
+def _set_required_oauth_env(monkeypatch, *, redirect_uri: str) -> None:
+    monkeypatch.setenv("ATLASSIAN_OAUTH_PROXY_ENABLE", "true")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_REDIRECT_URI", redirect_uri)
+
+
+def test_build_auth_provider_disabled_by_default(monkeypatch):
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_REDIRECT_URI", "http://localhost:3000/callback")
+    monkeypatch.delenv("ATLASSIAN_OAUTH_PROXY_ENABLE", raising=False)
+
+    provider = _build_auth_provider()
+
+    assert provider is None
+
+
+def test_build_auth_provider_disabled_when_flag_false(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_OAUTH_PROXY_ENABLE", "false")
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_REDIRECT_URI", "http://localhost:3000/callback")
+
+    provider = _build_auth_provider()
+
+    assert provider is None
+
+
+def test_build_auth_provider_falls_back_to_jira_url(monkeypatch):
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.delenv("CONFLUENCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(
+        monkeypatch, redirect_uri="https://mcp.example.com/mcp-atlassian/callback"
+    )
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+
+
+def test_build_auth_provider_supports_service_specific_credentials(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_OAUTH_PROXY_ENABLE", "true")
+    monkeypatch.delenv("ATLASSIAN_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ATLASSIAN_OAUTH_CLIENT_SECRET", raising=False)
+    monkeypatch.setenv("JIRA_OAUTH_CLIENT_ID", "jira-client-id")
+    monkeypatch.setenv("JIRA_OAUTH_CLIENT_SECRET", "jira-client-secret")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_REDIRECT_URI", "http://localhost:3000/callback")
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert provider._upstream_client_id == "jira-client-id"
+    assert provider._upstream_client_secret.get_secret_value() == "jira-client-secret"
+
+
+def test_build_auth_provider_uses_cloud_endpoints_for_atlassian_cloud(monkeypatch):
+    monkeypatch.setenv("JIRA_URL", "https://acme.atlassian.net")
+    _set_required_oauth_env(monkeypatch, redirect_uri="http://localhost:3000/callback")
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert provider._upstream_authorization_endpoint == CLOUD_AUTHORIZE_URL
+    assert provider._upstream_token_endpoint == CLOUD_TOKEN_URL
+    assert provider._extra_authorize_params == {
+        "audience": "api.atlassian.com",
+        "prompt": "consent",
+    }
+
+
+def test_build_auth_provider_uses_dc_endpoints_for_datacenter_url(monkeypatch):
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(monkeypatch, redirect_uri="http://localhost:3000/callback")
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert (
+        provider._upstream_authorization_endpoint
+        == "https://jira.example.com/rest/oauth2/latest/authorize"
+    )
+    assert (
+        provider._upstream_token_endpoint
+        == "https://jira.example.com/rest/oauth2/latest/token"
+    )
+
+
+def test_build_auth_provider_infers_base_url_from_redirect_uri(monkeypatch):
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(
+        monkeypatch, redirect_uri="https://mcp.example.com/mcp-atlassian/callback"
+    )
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert str(provider.base_url) == "https://mcp.example.com/mcp-atlassian"
+    assert provider._redirect_path == "/callback"
+
+
+def test_build_auth_provider_prefers_public_base_url(monkeypatch):
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://mcp.example.com/mcp-atlassian")
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(
+        monkeypatch, redirect_uri="https://mcp.example.com/mcp-atlassian/callback"
+    )
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert str(provider.base_url) == "https://mcp.example.com/mcp-atlassian"
+    assert provider._redirect_path == "/callback"
+
+
+def test_build_auth_provider_supports_root_redirect_uri(monkeypatch):
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(monkeypatch, redirect_uri="http://localhost:3000/callback")
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert str(provider.base_url).rstrip("/") == "http://localhost:3000"
+    assert provider._redirect_path == "/callback"
+
+
+def test_build_auth_provider_allows_chatgpt_oauth_redirect(monkeypatch):
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(
+        monkeypatch, redirect_uri="https://mcp.example.com/mcp-atlassian/callback"
+    )
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert (
+        "https://chatgpt.com/connector_platform_oauth_redirect"
+        in provider._allowed_client_redirect_uris
+    )
+
+
+def test_build_auth_provider_uses_env_redirect_uris(monkeypatch):
+    monkeypatch.setenv(
+        "ATLASSIAN_OAUTH_ALLOWED_CLIENT_REDIRECT_URIS", "https://example.com/callback"
+    )
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(
+        monkeypatch, redirect_uri="https://mcp.example.com/mcp-atlassian/callback"
+    )
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert provider._allowed_client_redirect_uris == ["https://example.com/callback"]
+
+
+def test_build_auth_provider_can_disable_consent(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_OAUTH_REQUIRE_CONSENT", "false")
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(
+        monkeypatch, redirect_uri="https://mcp.example.com/mcp-atlassian/callback"
+    )
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    assert provider._require_authorization_consent is False
+
+
+def test_build_auth_provider_exposes_discovery_and_dcr_routes(monkeypatch):
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(monkeypatch, redirect_uri="http://localhost:3000/callback")
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    route_paths = {route.path for route in provider.get_routes("/mcp")}
+    assert "/authorize" in route_paths
+    assert "/token" in route_paths
+    assert "/register" in route_paths
+    assert "/.well-known/oauth-authorization-server" in route_paths
+    assert "/.well-known/oauth-protected-resource/mcp" in route_paths
+    assert "/callback" in route_paths
+
+
+@pytest.mark.anyio
+async def test_register_client_hardens_grant_types_and_scopes(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_OAUTH_SCOPE", "read:jira-work")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_ALLOWED_GRANT_TYPES", "authorization_code")
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ATLASSIAN_OAUTH_INSTANCE_URL", raising=False)
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    _set_required_oauth_env(
+        monkeypatch, redirect_uri="https://mcp.example.com/mcp-atlassian/callback"
+    )
+
+    provider = _build_auth_provider()
+
+    assert provider is not None
+    client = OAuthClientInformationFull(
+        client_id="client-123",
+        client_secret="secret",
+        redirect_uris=["http://localhost:1234/callback"],
+        grant_types=[
+            "refresh_token",
+            "authorization_code",
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        ],
+        scope="read:jira-work write:jira-work",
+    )
+
+    await provider.register_client(client)
+    stored = await provider._client_store.get(key="client-123")
+
+    assert stored is not None
+    assert stored.grant_types == ["authorization_code"]
+    assert stored.scope == "read:jira-work"

--- a/tests/unit/utils/test_token_verifier.py
+++ b/tests/unit/utils/test_token_verifier.py
@@ -1,0 +1,29 @@
+"""Unit tests for Atlassian opaque token verifier."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.server.auth.auth import AccessToken
+
+from mcp_atlassian.utils.token_verifier import AtlassianOpaqueTokenVerifier
+
+
+@pytest.mark.anyio
+async def test_verify_token_returns_fastmcp_access_token() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert isinstance(token, AccessToken)
+    assert token is not None
+    assert token.token == "opaque-token"
+    assert token.scopes == ["read:jira-work"]
+
+
+@pytest.mark.anyio
+async def test_verify_token_returns_none_for_empty_token() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(required_scopes=[])
+
+    token = await verifier.verify_token("")
+
+    assert token is None


### PR DESCRIPTION
## Summary
This adds an **opt-in** OAuth proxy mode for remote MCP deployments that need spec-aligned OAuth onboarding (discovery + DCR + auth code flow), without changing existing default auth behavior.

When `ATLASSIAN_OAUTH_PROXY_ENABLE=true`, the server now exposes:
- `/.well-known/oauth-protected-resource`
- `/.well-known/oauth-authorization-server`
- `POST /register`
- `GET /authorize`
- `POST /token`
- callback route derived from `ATLASSIAN_OAUTH_REDIRECT_URI`

## What is included
- New `HardenedOAuthProxy` wrapper with DCR hardening for allowed grant types/scopes.
- Opt-in wiring in main server bootstrap (`auth=_build_auth_provider()` only when enabled).
- Cloud/DC upstream endpoint resolution:
  - Cloud -> `auth.atlassian.com` endpoints (+ `audience`/`prompt` authorize params)
  - Data Center -> `<instance>/rest/oauth2/latest/{authorize,token}`
- FastMCP auth-context token resolution in dependencies (`get_access_token()`), so OAuth tool calls use the upstream token when available.
- Env/docs updates for proxy mode and DCR controls.
- Unit coverage for provider construction/hardening and token resolution behavior.

## Backward compatibility
- Proxy mode is disabled by default.
- Existing API token, PAT, and header-based OAuth flows continue to work unchanged unless enabled.

## Validation
- `uv run pre-commit run --all-files`
- `uv run pytest -q`

Closes #610
Refs #527
