### PR TITLE
fix(auth): narrow exception catch and remove dead code in OAuth proxy

### DIFF
--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -33,7 +33,7 @@ def _resolve_oauth_access_token(fallback_token: str, service: str) -> str:
     """Resolve upstream OAuth token from FastMCP auth context with safe fallback."""
     try:
         access_token = get_access_token()
-    except Exception as e:
+    except (RuntimeError, LookupError) as e:
         logger.debug(
             "OAuth token resolution via FastMCP context failed for %s; "
             "using request token (%s)",

--- a/src/mcp_atlassian/servers/oauth_proxy.py
+++ b/src/mcp_atlassian/servers/oauth_proxy.py
@@ -66,9 +66,7 @@ class HardenedOAuthProxy(OAuthProxy):
                     forced_scope,
                 )
 
-        if updates:
-            client_info = client_info.model_copy(update=updates)
-
+        client_info = client_info.model_copy(update=updates)
         await super().register_client(client_info)
 
 


### PR DESCRIPTION
## Summary
- Narrow `_resolve_oauth_access_token` exception handler from bare `Exception` to `(RuntimeError, LookupError)` to surface unexpected errors instead of silently falling back
- Remove always-true `if updates:` guard in `HardenedOAuthProxy.register_client()`

Follow-up to #1054.

## Test plan
- [x] All 74 affected tests pass
- [x] Full unit suite (2345 tests) passes
- [x] Pre-commit (ruff + mypy) clean