### PR TITLE
fix(jira): preserve complex custom field objects in _process_custom_field_value

### DIFF
--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -695,7 +695,13 @@ class JiraIssue(ApiModel, TimestampMixin):
             if "value" in field_value:
                 return field_value["value"]
             elif "name" in field_value:
-                return field_value["name"]
+                # Standard Jira reference objects (priority, user, group) have a
+                # "self" URL key — simplify those to just the name. Plugin data
+                # objects (e.g. Okapya checklist items) don't have "self" and
+                # should be preserved in full to retain metadata like "checked".
+                if "self" in field_value:
+                    return field_value["name"]
+                return field_value
             return field_value
 
         if isinstance(field_value, list):


### PR DESCRIPTION
## Summary
- Fixes `_process_custom_field_value()` stripping metadata from plugin data objects (e.g., Okapya Checklist items) by only simplifying dicts with a `"self"` URL key (standard Jira reference objects like priority/user/group)
- Plugin data objects without `"self"` are now preserved in full, retaining fields like `checked`, `isHeader`, `rank`, etc.
- Adds comprehensive test suite for `_process_custom_field_value` with 12 tests including an end-to-end test

Closes #1053

## Test plan
- [x] Unit tests for all `_process_custom_field_value` code paths (primitives, select options, Jira references, plugin data, lists, end-to-end)
- [x] Full unit test suite passes (2336 passed)
- [x] Pre-commit checks pass (ruff-format, ruff, mypy)