### PR TITLE
refactor: fix type annotations and remove dead code

### DIFF
--- a/src/mcp_atlassian/confluence/users.py
+++ b/src/mcp_atlassian/confluence/users.py
@@ -15,7 +15,7 @@ class UsersMixin(ConfluenceClient):
     """Mixin for Confluence user operations."""
 
     def get_user_details_by_accountid(
-        self, account_id: str, expand: str = None
+        self, account_id: str, expand: str | None = None
     ) -> dict[str, Any]:
         """Get user details by account ID.
 
@@ -32,7 +32,7 @@ class UsersMixin(ConfluenceClient):
         return self.confluence.get_user_details_by_accountid(account_id, expand)
 
     def get_user_details_by_username(
-        self, username: str, expand: str = None
+        self, username: str, expand: str | None = None
     ) -> dict[str, Any]:
         """Get user details by username.
 

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -357,9 +357,9 @@ class JiraClient:
         self,
         project: str,
         name: str,
-        start_date: str = None,
-        release_date: str = None,
-        description: str = None,
+        start_date: str | None = None,
+        release_date: str | None = None,
+        description: str | None = None,
     ) -> dict[str, Any]:
         """
         Create a new version in a Jira project.

--- a/src/mcp_atlassian/jira/epics.py
+++ b/src/mcp_atlassian/jira/epics.py
@@ -115,7 +115,7 @@ class EpicsMixin(
         fields: dict[str, Any],
         summary: str,
         kwargs: dict[str, Any],
-        project_key: str = None,
+        project_key: str | None = None,
     ) -> None:
         """
         Prepare epic-specific fields for issue creation.

--- a/src/mcp_atlassian/jira/fields.py
+++ b/src/mcp_atlassian/jira/fields.py
@@ -587,7 +587,7 @@ class FieldsMixin(JiraClient, EpicOperationsProto, UsersOperationsProto):
                         return {"accountId": identifier}
                     else:
                         return {"name": identifier}
-                except (ValueError, Exception) as e:
+                except Exception as e:
                     logger.warning(f"Could not resolve user for field {field_id}: {e}")
                     return None
             return value

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1085,10 +1085,7 @@ class IssuesMixin(
 
                 elif key == "attachments":
                     # Handle attachments separately - they're not part of fields update
-                    if value and isinstance(value, list | tuple):
-                        # We'll process attachments after updating fields
-                        pass
-                    else:
+                    if not value or not isinstance(value, list | tuple):
                         logger.warning(f"Invalid attachments value: {value}")
 
                 elif key == "assignee":

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -439,9 +439,9 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
         self,
         project_key: str,
         name: str,
-        start_date: str = None,
-        release_date: str = None,
-        description: str = None,
+        start_date: str | None = None,
+        release_date: str | None = None,
+        description: str | None = None,
     ) -> dict[str, Any]:
         """
         Create a new version in the specified Jira project.

--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -127,7 +127,7 @@ class EpicOperationsProto(Protocol):
         fields: dict[str, Any],
         summary: str,
         kwargs: dict[str, Any],
-        project_key: str = None,
+        project_key: str | None = None,
     ) -> None:
         """
         Prepare epic-specific fields for issue creation.

--- a/src/mcp_atlassian/utils/oauth_setup.py
+++ b/src/mcp_atlassian/utils/oauth_setup.py
@@ -371,7 +371,9 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
         return False
 
 
-def _prompt_for_input(prompt: str, env_var: str = None, is_secret: bool = False) -> str:
+def _prompt_for_input(
+    prompt: str, env_var: str | None = None, is_secret: bool = False
+) -> str:
     """Prompt the user for input with sanitization for Windows line endings and whitespace."""
     value = os.getenv(env_var, "") if env_var else ""
     if value:


### PR DESCRIPTION
## Summary
- Fix `str = None` → `str | None = None` in 6 files where None default lacked Optional type
- Simplify `except (ValueError, Exception)` → `except Exception` (ValueError is subclass)
- Remove dead `pass` block in issue attachments handling

## Test plan
- [ ] Pre-commit passes (Ruff + mypy)
- [ ] All unit tests pass
- [ ] No behavior change — type hint and dead code cleanup only