### PR TITLE
refactor: extract shared placeholder helpers for code block protection

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -273,6 +273,16 @@ class JiraPreprocessor(BasePreprocessor):
 
         # Protect code/noformat/inline-code blocks from downstream
         # transformations by replacing them with placeholders.
+        #
+        # Trade-off: when {quote} wraps a {code} block, the code
+        # content is extracted *before* the {quote} handler runs.
+        # The {quote} handler prefixes each remaining line with
+        # "> " but cannot reach inside the already-extracted block.
+        # After restoration the opening fence line may carry "> "
+        # while inner code lines do not, breaking blockquote
+        # continuity.  This is intentional: protecting code content
+        # from markup corruption is more important than preserving
+        # blockquote indentation around code fences.
         code_blocks: list[str] = []
         inline_codes: list[str] = []
 


### PR DESCRIPTION
## Summary
- Extract `_extract_blocks()` and `_restore_blocks()` as module-level helper functions in `preprocessing/jira.py` to eliminate duplicated placeholder logic
- Refactor `markdown_to_jira()` to use the shared helpers instead of inline closures (`save_code_block`, `save_inline_code`)
- Add placeholder extraction to `jira_to_markdown()` (previously missing), protecting `{code}`, `{noformat}`, and `{{inline}}` blocks from corruption by downstream regex transformations (`{quote}`, `{panel}`, `{color}`, bold/italic, etc.)

## Test plan
- [x] All 73 existing preprocessing tests pass (no regressions)
- [x] 8 new parametrized tests in `TestCodeBlockProtection` class verify:
  - `{quote}`, `{color}`, `{panel}` markup inside `{code}` blocks is preserved literally
  - `{noformat}` blocks also protect their content
  - Code blocks with language specifiers preserve content
  - Mixed content (markup outside + inside code blocks) is handled correctly
  - `{{inline}}` code inside code blocks is preserved
  - Jira->Markdown->Jira round-trip preserves code block content
- [x] Full unit test suite passes (2361 tests)
- [x] Pre-commit (ruff-format, ruff, mypy) passes clean