### PR TITLE
refactor: extract handle_auth_errors decorator for consistent 401/403 handling

### DIFF
--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from requests.exceptions import HTTPError
 
-from ..exceptions import MCPAtlassianAuthenticationError
 from ..models.jira import JiraIssueLinkType
+from ..utils.decorators import handle_auth_errors
 from .client import JiraClient
 
 logger = logging.getLogger("mcp-jira")
@@ -15,6 +15,7 @@ logger = logging.getLogger("mcp-jira")
 class LinksMixin(JiraClient):
     """Mixin for Jira issue link operations."""
 
+    @handle_auth_errors("Jira API")
     def get_issue_link_types(self) -> list[JiraIssueLinkType]:
         """
         Get all available issue link types.
@@ -23,61 +24,51 @@ class LinksMixin(JiraClient):
             List of JiraIssueLinkType objects
 
         Raises:
-            MCPAtlassianAuthenticationError: If authentication fails with the Jira API
-                (401/403)
+            MCPAtlassianAuthenticationError: If authentication fails
+                with the Jira API (401/403)
             Exception: If there is an error retrieving issue link types
         """
         try:
             link_types_response = self.jira.get("rest/api/2/issueLinkType")
             if not isinstance(link_types_response, dict):
-                msg = f"Unexpected return value type from `jira.get`: {type(link_types_response)}"
+                msg = (
+                    "Unexpected return value type from "
+                    f"`jira.get`: {type(link_types_response)}"
+                )
                 logger.error(msg)
                 raise TypeError(msg)
 
             link_types_data = link_types_response.get("issueLinkTypes", [])
 
-            link_types = [
+            return [
                 JiraIssueLinkType.from_api_response(link_type)
                 for link_type in link_types_data
             ]
-
-            return link_types
-
-        except HTTPError as http_err:
-            if http_err.response is not None and http_err.response.status_code in [
-                401,
-                403,
-            ]:
-                error_msg = (
-                    f"Authentication failed for Jira API "
-                    f"({http_err.response.status_code}). "
-                    "Token may be expired or invalid. Please verify credentials."
-                )
-                logger.error(error_msg)
-                raise MCPAtlassianAuthenticationError(error_msg) from http_err
-            else:
-                logger.error(f"HTTP error during API call: {http_err}", exc_info=True)
-                raise Exception(
-                    f"Error getting issue link types: {http_err}"
-                ) from http_err
+        except HTTPError:
+            raise  # let decorator handle auth errors
         except Exception as e:
             error_msg = str(e)
-            logger.error(f"Error getting issue link types: {error_msg}", exc_info=True)
+            logger.error(
+                f"Error getting issue link types: {error_msg}",
+                exc_info=True,
+            )
             raise Exception(f"Error getting issue link types: {error_msg}") from e
 
+    @handle_auth_errors("Jira API")
     def create_issue_link(self, data: dict[str, Any]) -> dict[str, Any]:
         """
         Create a link between two issues.
 
         Args:
-            data: A dictionary containing the link data with the following structure:
+            data: A dictionary containing the link data with the
+                following structure:
                 {
-                    "type": {"name": "Duplicate" },  # Link type name (e.g., "Duplicate", "Blocks", "Relates to")
-                    "inwardIssue": { "key": "ISSUE-1"},  # The issue that is the source of the link
-                    "outwardIssue": {"key": "ISSUE-2"},  # The issue that is the target of the link
-                    "comment": {  # Optional comment to add to the link
+                    "type": {"name": "Duplicate" },
+                    "inwardIssue": { "key": "ISSUE-1"},
+                    "outwardIssue": {"key": "ISSUE-2"},
+                    "comment": {
                         "body": "Linked related issue!",
-                        "visibility": {  # Optional visibility settings
+                        "visibility": {
                             "type": "group",
                             "value": "jira-software-users"
                         }
@@ -89,7 +80,8 @@ class LinksMixin(JiraClient):
 
         Raises:
             ValueError: If required fields are missing
-            MCPAtlassianAuthenticationError: If authentication fails with the Jira API (401/403)
+            MCPAtlassianAuthenticationError: If authentication fails
+                with the Jira API (401/403)
             Exception: If there is an error creating the issue link
         """
         # Validate required fields
@@ -105,56 +97,46 @@ class LinksMixin(JiraClient):
             self.jira.create_issue_link(data)
 
             # Return a response with the link information
-            response = {
+            inward = data["inwardIssue"]["key"]
+            outward = data["outwardIssue"]["key"]
+            return {
                 "success": True,
-                "message": f"Link created between {data['inwardIssue']['key']} and {data['outwardIssue']['key']}",
+                "message": (f"Link created between {inward} and {outward}"),
                 "link_type": data["type"]["name"],
-                "inward_issue": data["inwardIssue"]["key"],
-                "outward_issue": data["outwardIssue"]["key"],
+                "inward_issue": inward,
+                "outward_issue": outward,
             }
-
-            return response
-
-        except HTTPError as http_err:
-            if http_err.response is not None and http_err.response.status_code in [
-                401,
-                403,
-            ]:
-                error_msg = (
-                    f"Authentication failed for Jira API "
-                    f"({http_err.response.status_code}). "
-                    "Token may be expired or invalid. Please verify credentials."
-                )
-                logger.error(error_msg)
-                raise MCPAtlassianAuthenticationError(error_msg) from http_err
-            else:
-                logger.error(f"HTTP error during API call: {http_err}", exc_info=True)
-                raise Exception(f"Error creating issue link: {http_err}") from http_err
+        except HTTPError:
+            raise  # let decorator handle auth errors
         except Exception as e:
             error_msg = str(e)
-            logger.error(f"Error creating issue link: {error_msg}", exc_info=True)
+            logger.error(
+                f"Error creating issue link: {error_msg}",
+                exc_info=True,
+            )
             raise Exception(f"Error creating issue link: {error_msg}") from e
 
+    @handle_auth_errors("Jira API")
     def create_remote_issue_link(
         self, issue_key: str, link_data: dict[str, Any]
     ) -> dict[str, Any]:
         """
-        Create a remote issue link (web link or Confluence link) for an issue.
+        Create a remote issue link (web link or Confluence link).
 
         Args:
-            issue_key: The key of the issue to add the link to (e.g., 'PROJ-123')
-            link_data: A dictionary containing the remote link data with the following structure:
+            issue_key: The key of the issue (e.g., 'PROJ-123')
+            link_data: Remote link data dict with structure:
                 {
                     "object": {
-                        "url": "https://example.com/page",  # The URL to link to
-                        "title": "Example Page",  # The title/name of the link
-                        "summary": "Optional description of the link",  # Optional description
-                        "icon": {  # Optional icon configuration
+                        "url": "https://example.com/page",
+                        "title": "Example Page",
+                        "summary": "Optional description",
+                        "icon": {
                             "url16x16": "https://example.com/icon16.png",
                             "title": "Icon Title"
                         }
                     },
-                    "relationship": "causes"  # Optional relationship description
+                    "relationship": "causes"
                 }
 
         Returns:
@@ -162,8 +144,9 @@ class LinksMixin(JiraClient):
 
         Raises:
             ValueError: If required fields are missing
-            MCPAtlassianAuthenticationError: If authentication fails with the Jira API (401/403)
-            Exception: If there is an error creating the remote issue link
+            MCPAtlassianAuthenticationError: If authentication fails
+                with the Jira API (401/403)
+            Exception: If there is an error creating the link
         """
         # Validate required fields
         if not issue_key:
@@ -176,50 +159,32 @@ class LinksMixin(JiraClient):
             raise ValueError("Title is required in link object")
 
         try:
-            # Create the remote issue link using the Jira API
-            # Cloud uses v3 API, Server/Data Center uses v2 API
+            # Cloud uses v3 API, Server/DC uses v2 API
             if self.config.is_cloud:
                 endpoint = f"rest/api/3/issue/{issue_key}/remotelink"
             else:
                 endpoint = f"rest/api/2/issue/{issue_key}/remotelink"
-            response = self.jira.post(endpoint, json=link_data)
+            self.jira.post(endpoint, json=link_data)
 
-            # Return a response with the link information
-            result = {
+            return {
                 "success": True,
-                "message": f"Remote link created for issue {issue_key}",
+                "message": (f"Remote link created for issue {issue_key}"),
                 "issue_key": issue_key,
                 "link_title": link_data["object"]["title"],
                 "link_url": link_data["object"]["url"],
                 "relationship": link_data.get("relationship", ""),
             }
-
-            return result
-
-        except HTTPError as http_err:
-            if http_err.response is not None and http_err.response.status_code in [
-                401,
-                403,
-            ]:
-                error_msg = (
-                    f"Authentication failed for Jira API "
-                    f"({http_err.response.status_code}). "
-                    "Token may be expired or invalid. Please verify credentials."
-                )
-                logger.error(error_msg)
-                raise MCPAtlassianAuthenticationError(error_msg) from http_err
-            else:
-                logger.error(f"HTTP error during API call: {http_err}", exc_info=True)
-                raise Exception(
-                    f"Error creating remote issue link: {http_err}"
-                ) from http_err
+        except HTTPError:
+            raise  # let decorator handle auth errors
         except Exception as e:
             error_msg = str(e)
             logger.error(
-                f"Error creating remote issue link: {error_msg}", exc_info=True
+                f"Error creating remote issue link: {error_msg}",
+                exc_info=True,
             )
             raise Exception(f"Error creating remote issue link: {error_msg}") from e
 
+    @handle_auth_errors("Jira API")
     def remove_issue_link(self, link_id: str) -> dict[str, Any]:
         """
         Remove a link between two issues.
@@ -232,7 +197,8 @@ class LinksMixin(JiraClient):
 
         Raises:
             ValueError: If link_id is empty
-            MCPAtlassianAuthenticationError: If authentication fails with the Jira API (401/403)
+            MCPAtlassianAuthenticationError: If authentication fails
+                with the Jira API (401/403)
             Exception: If there is an error removing the issue link
         """
         # Validate input
@@ -240,34 +206,19 @@ class LinksMixin(JiraClient):
             raise ValueError("Link ID is required")
 
         try:
-            # Remove the issue link
             self.jira.remove_issue_link(link_id)
 
-            # Return a response indicating success
-            response = {
+            return {
                 "success": True,
-                "message": f"Link with ID {link_id} has been removed",
+                "message": (f"Link with ID {link_id} has been removed"),
                 "link_id": link_id,
             }
-
-            return response
-
-        except HTTPError as http_err:
-            if http_err.response is not None and http_err.response.status_code in [
-                401,
-                403,
-            ]:
-                error_msg = (
-                    f"Authentication failed for Jira API "
-                    f"({http_err.response.status_code}). "
-                    "Token may be expired or invalid. Please verify credentials."
-                )
-                logger.error(error_msg)
-                raise MCPAtlassianAuthenticationError(error_msg) from http_err
-            else:
-                logger.error(f"HTTP error during API call: {http_err}", exc_info=True)
-                raise Exception(f"Error removing issue link: {http_err}") from http_err
+        except HTTPError:
+            raise  # let decorator handle auth errors
         except Exception as e:
             error_msg = str(e)
-            logger.error(f"Error removing issue link: {error_msg}", exc_info=True)
+            logger.error(
+                f"Error removing issue link: {error_msg}",
+                exc_info=True,
+            )
             raise Exception(f"Error removing issue link: {error_msg}") from e

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -752,7 +752,7 @@ class TestUsersMixin:
 
         with pytest.raises(
             MCPAtlassianAuthenticationError,
-            match="Permission denied accessing user 'restricted_user'.",
+            match="Authentication failed for Jira API",
         ):
             users_mixin.get_user_profile_by_identifier("restricted_user")
 


### PR DESCRIPTION
## Summary

- Add a narrow `handle_auth_errors` decorator to `utils/decorators.py` that catches only 401/403 HTTPError and raises `MCPAtlassianAuthenticationError` with a standardized message
- Apply the decorator to 11 methods across 5 files, replacing hand-written auth-check blocks
- Preserve nuanced error handling (404 in users.py, non-auth HTTPError propagation) by keeping targeted `except HTTPError: raise` guards in methods with broad `except Exception` handlers
- Not applied to methods with complex error handling: `get_issue` (404/429), comments (string matching), `get_current_user_account_id` (different pattern)

### Files changed
| File | Methods | Notes |
|------|---------|-------|
| `utils/decorators.py` | new `handle_auth_errors` | Narrow scope: only 401/403 |
| `jira/links.py` | 4 methods | All link CRUD operations |
| `jira/transitions.py` | 2 methods | `get_available_transitions`, `transition_issue` |
| `jira/search.py` | 1 method | `search_issues` |
| `confluence/pages.py` | 3 methods | `get_page_content`, `get_page_ancestors`, `get_page_history` |
| `jira/users.py` | 1 method | `get_user_profile_by_identifier` (preserves 404 handling) |

## Test plan
- [x] New decorator tests: 401, 403, 404 passthrough, non-HTTP passthrough, no-response passthrough
- [x] All 2359 unit tests pass
- [x] pre-commit (ruff-format, ruff, mypy) clean