### PR TITLE
chore(ci): add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add Python 3.13 to the CI test matrix in GitHub Actions
- Python 3.14 is still in alpha and excluded for now

## Original PR
Reimplements #764 by @reneleonhardt. Thank you for the contribution!

## Test plan
- [x] CI workflow syntax validated
- [x] pre-commit clean