### PR TITLE
fix(jira): use API field names in should_include_field checks

### DIFF
--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -517,7 +517,7 @@ class JiraIssue(ApiModel, TimestampMixin):
             result["status"] = self.status.to_simplified_dict()
 
         # Add issue type if available and requested
-        if self.issue_type and should_include_field("issue_type"):
+        if self.issue_type and should_include_field("issuetype"):
             result["issue_type"] = self.issue_type.to_simplified_dict()
 
         # Add priority if available and requested
@@ -571,7 +571,7 @@ class JiraIssue(ApiModel, TimestampMixin):
         if self.components and should_include_field("components"):
             result["components"] = self.components
 
-        if self.fix_versions and should_include_field("fix_versions"):
+        if self.fix_versions and should_include_field("fixVersions"):
             result["fix_versions"] = self.fix_versions
 
         # Add epic fields if available and requested

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -16,6 +16,7 @@ from mcp_atlassian.models.constants import (
 from mcp_atlassian.models.jira import (
     JiraIssue,
     JiraIssueLink,
+    JiraIssueType,
     JiraProject,
     JiraResolution,
     JiraTimetracking,
@@ -649,6 +650,28 @@ class TestJiraIssue:
         simplified = issue.to_simplified_dict()
         assert "timetracking" in simplified
         assert simplified["timetracking"]["original_estimate"] == "1d"
+
+    @pytest.mark.parametrize(
+        ("requested_field", "expected_key"),
+        [
+            ("fixVersions", "fix_versions"),
+            ("issuetype", "issue_type"),
+        ],
+    )
+    def test_to_simplified_dict_with_api_field_names(
+        self, requested_field, expected_key
+    ):
+        """Regression: should_include_field must match Jira API field names."""
+        issue = JiraIssue(
+            id="1",
+            key="TEST-1",
+            summary="Test",
+            issue_type=JiraIssueType(id="1", name="Task"),
+            fix_versions=["1.0"],
+            requested_fields=[requested_field],
+        )
+        result = issue.to_simplified_dict()
+        assert expected_key in result
 
 
 class TestProcessCustomFieldValue:


### PR DESCRIPTION
## Summary
- Fix `to_simplified_dict()` to use Jira API field names (`fixVersions`, `issuetype`) instead of Python attribute names (`fix_versions`, `issue_type`) when checking `should_include_field()`
- This bug caused these fields to be excluded from results when users specified them in `requested_fields`

Closes #896

## Original PR
Reimplements #1027 by @yliu. Thank you for the contribution!

## Test plan
- [x] Regression tests for fixVersions and issuetype field matching
- [x] pre-commit clean
- [x] Full unit test suite passes