### PR TITLE
chore: add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: sooperset


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` to enable the GitHub Sponsors button on the repository