### PR TITLE
feat(jira): add tool to move issues to a sprint

### DIFF
--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -130,6 +130,25 @@ class SprintsMixin(JiraClient):
             logger.error(f"Error updating sprint: {str(e)}")
             return None
 
+    def add_issues_to_sprint(self, sprint_id: str, issue_keys: list[str]) -> bool:
+        """Add issues to a sprint.
+
+        Args:
+            sprint_id: The sprint ID to add issues to.
+            issue_keys: List of issue keys to add (e.g., ["PROJ-1", "PROJ-2"]).
+
+        Returns:
+            True if successful.
+
+        Raises:
+            requests.HTTPError: If the API call fails.
+        """
+        self.jira.post(
+            f"rest/agile/1.0/sprint/{sprint_id}/issue",
+            data={"issues": issue_keys},
+        )
+        return True
+
     def create_sprint(
         self,
         board_id: str,

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2325,6 +2325,43 @@ async def update_sprint(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_agile"},
+    annotations={"title": "Add Issues to Sprint", "readOnlyHint": False},
+)
+@check_write_access
+async def add_issues_to_sprint(
+    ctx: Context,
+    sprint_id: Annotated[str, Field(description="Sprint ID to add issues to")],
+    issue_keys: Annotated[
+        str,
+        Field(description="Comma-separated issue keys (e.g., 'PROJ-1,PROJ-2')"),
+    ],
+) -> str:
+    """Add issues to a Jira sprint.
+
+    Args:
+        ctx: The FastMCP context.
+        sprint_id: The ID of the sprint.
+        issue_keys: Comma-separated issue keys.
+
+    Returns:
+        JSON string with success message.
+
+    Raises:
+        ValueError: If in read-only mode or Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    keys_list = [k.strip() for k in issue_keys.split(",") if k.strip()]
+    jira.add_issues_to_sprint(sprint_id, keys_list)
+    result = {
+        "message": f"Successfully added {len(keys_list)} issue(s) to sprint",
+        "sprint_id": sprint_id,
+        "issue_keys": keys_list,
+    }
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_projects"},
     annotations={"title": "Get Project Versions", "readOnlyHint": True},
 )

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 48, f"Expected 48 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary
- Add `jira_add_issues_to_sprint` tool to move issues into a sprint
- Uses Jira Agile REST API: `POST /rest/agile/1.0/sprint/{id}/issue`
- Accepts comma-separated issue keys
- Write-protected via `@check_write_access`

## Original PR
Reimplements #566 by @freudenfranz. Thank you for the contribution!

## Test plan
- [x] Mixin unit tests (single key, multiple keys, API error)
- [x] Server tool unit tests
- [x] pre-commit clean
- [x] Full unit test suite passes