### PR TITLE
feat(server): add ALLOW_DELETE_TOOLS safety filter for destructive operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,12 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # Disables all write operations (create, update, delete). Default is false.
 #READ_ONLY_MODE=false
 
+# --- Delete Tools Safety Filter ---
+# Controls whether destructive delete tools (delete issue, delete page, etc.)
+# are exposed. When false (default), delete tools are hidden from the tool listing.
+# Set to true to allow delete operations.
+#ALLOW_DELETE_TOOLS=false
+
 # --- Ignore Proxy Auth Headers ---
 # Set to 'true' to ignore Authorization headers from reverse proxies
 # (e.g., GCP Cloud Run, AWS ALB). When enabled, the server uses only

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -674,7 +674,7 @@ async def update_page(
 
 
 @confluence_mcp.tool(
-    tags={"confluence", "write", "toolset:confluence_pages"},
+    tags={"confluence", "write", "delete", "toolset:confluence_pages"},
     annotations={"title": "Delete Page", "destructiveHint": True},
 )
 @check_write_access
@@ -1793,7 +1793,13 @@ async def download_content_attachments(
 
 
 @confluence_mcp.tool(
-    tags={"confluence", "write", "attachments", "toolset:confluence_attachments"},
+    tags={
+        "confluence",
+        "write",
+        "delete",
+        "attachments",
+        "toolset:confluence_attachments",
+    },
     annotations={"title": "Delete Attachment", "destructiveHint": True},
 )
 @check_write_access

--- a/src/mcp_atlassian/servers/context.py
+++ b/src/mcp_atlassian/servers/context.py
@@ -19,5 +19,6 @@ class MainAppContext:
     full_jira_config: JiraConfig | None = None
     full_confluence_config: ConfluenceConfig | None = None
     read_only: bool = False
+    allow_delete: bool = False
     enabled_tools: list[str] | None = None
     enabled_toolsets: set[str] | None = None

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1691,7 +1691,7 @@ async def update_issue(
 
 
 @jira_mcp.tool(
-    tags={"jira", "write", "toolset:jira_issues"},
+    tags={"jira", "write", "delete", "toolset:jira_issues"},
     annotations={"title": "Delete Issue", "destructiveHint": True},
 )
 @check_write_access

--- a/src/mcp_atlassian/utils/io.py
+++ b/src/mcp_atlassian/utils/io.py
@@ -6,6 +6,21 @@ from pathlib import Path
 from mcp_atlassian.utils.env import is_env_extended_truthy
 
 
+def is_delete_tools_allowed() -> bool:
+    """Check if delete tools are allowed.
+
+    When disabled (the default), tools tagged with ``"delete"`` are hidden
+    from the tool listing, preventing destructive operations such as
+    deleting issues or pages.  Set the ``ALLOW_DELETE_TOOLS`` environment
+    variable to a truthy value (``true``, ``1``, ``yes``, ``y``, ``on``)
+    to expose these tools.
+
+    Returns:
+        True if ALLOW_DELETE_TOOLS env var is set to a truthy value.
+    """
+    return is_env_extended_truthy("ALLOW_DELETE_TOOLS", "false")
+
+
 def is_read_only_mode() -> bool:
     """Check if the server is running in read-only mode.
 

--- a/tests/unit/utils/test_io.py
+++ b/tests/unit/utils/test_io.py
@@ -6,7 +6,11 @@ from unittest.mock import patch
 
 import pytest
 
-from mcp_atlassian.utils.io import is_read_only_mode, validate_safe_path
+from mcp_atlassian.utils.io import (
+    is_delete_tools_allowed,
+    is_read_only_mode,
+    validate_safe_path,
+)
 
 
 def test_is_read_only_mode_default():
@@ -84,6 +88,36 @@ def test_is_read_only_mode_false():
 
         # Assert
         assert result is False
+
+
+# --- is_delete_tools_allowed tests ---
+
+
+class TestIsDeleteToolsAllowed:
+    """Tests for is_delete_tools_allowed()."""
+
+    def test_default_is_false(self):
+        """Delete tools are blocked by default when env var is unset."""
+        with patch.dict(os.environ, clear=True):
+            assert is_delete_tools_allowed() is False
+
+    @pytest.mark.parametrize(
+        "value",
+        ["true", "True", "TRUE", "1", "yes", "YES", "y", "on"],
+    )
+    def test_truthy_values(self, value: str):
+        """Delete tools are allowed for standard truthy values."""
+        with patch.dict(os.environ, {"ALLOW_DELETE_TOOLS": value}):
+            assert is_delete_tools_allowed() is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["false", "False", "0", "no", "off", "", "random"],
+    )
+    def test_falsy_values(self, value: str):
+        """Delete tools are blocked for non-truthy values."""
+        with patch.dict(os.environ, {"ALLOW_DELETE_TOOLS": value}):
+            assert is_delete_tools_allowed() is False
 
 
 # --- validate_safe_path tests ---

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -247,6 +247,17 @@ class TestToolsetTagCompleteness:
                     f"'{toolset_name}' (not in ALL_TOOLSETS)"
                 )
 
+    def test_delete_tools_have_delete_tag(self, jira_tools, confluence_tools):
+        """Every tool whose function name contains 'delete' must have the 'delete' tag."""
+        all_tools = {**jira_tools, **confluence_tools}
+        for name, tool in all_tools.items():
+            if "delete" in name.lower():
+                tags = tool.tags if hasattr(tool, "tags") else set()
+                assert "delete" in tags, (
+                    f"Tool '{name}' looks like a delete tool but is missing "
+                    f"the 'delete' tag (tags: {tags})"
+                )
+
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
         assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"


### PR DESCRIPTION
## Description

Adds a safety layer for destructive delete operations, complementary to `READ_ONLY_MODE` and the `DISABLED_TOOLS` feature from #1008.

While `DISABLED_TOOLS` lets users disable any specific tool, `ALLOW_DELETE_TOOLS` provides a simpler UX for the common safety case: allow all writes (create, update) but gate deletes behind an explicit opt-in. This is useful for teams that want agents to create and modify content but not permanently destroy it.

**New env var:** `ALLOW_DELETE_TOOLS` (default: `false`)

When `false`, the following tools are excluded from the tool list:
- `jira_delete_issue`
- `confluence_delete_page`
- `confluence_delete_attachment`

This is independent from `READ_ONLY_MODE` — you can have writes enabled but deletes blocked.

## Changes

- Add `ALLOW_DELETE_TOOLS` env var parsing in `utils/io.py` (uses existing `is_env_extended_truthy` helper)
- Add `allow_delete` field to `MainAppContext`
- Tag delete tools with `"delete"` in server tool definitions (`jira.py`, `confluence.py`)
- Filter delete-tagged tools in `_list_tools_mcp()` when `allow_delete=False`
- Log delete tool status at server startup
- Update `.env.example` with documented variable

## Testing

- [x] Parametrized tests for env var parsing (truthy/falsy values)
- [x] Tag validation test ensuring all delete tools have the `"delete"` tag
- [x] All existing tests pass (2538 passed)
- [x] Pre-commit clean (ruff, mypy)

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).