### PR TITLE
feat: add intelligent error recovery with fuzzy matching and suggestions

### DIFF
--- a/src/mcp_atlassian/utils/suggestions.py
+++ b/src/mcp_atlassian/utils/suggestions.py
@@ -1,0 +1,116 @@
+"""Fuzzy matching and suggestion utilities for error recovery."""
+
+from __future__ import annotations
+
+import logging
+from difflib import get_close_matches
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp_atlassian.confluence import ConfluenceFetcher
+
+logger = logging.getLogger(__name__)
+
+
+def fuzzy_match(
+    user_input: str,
+    candidates: list[str],
+    max_results: int = 3,
+    cutoff: float = 0.5,
+) -> list[str]:
+    """Find candidates that fuzzy-match the user input.
+
+    Uses case-insensitive difflib matching plus substring matching.
+
+    Args:
+        user_input: The string the user provided.
+        candidates: Available valid strings to match against.
+        max_results: Maximum number of suggestions to return.
+        cutoff: Minimum similarity ratio (0.0-1.0) for difflib. Default 0.5.
+
+    Returns:
+        List of matching candidates (original case), best matches first.
+    """
+    if not user_input or not candidates:
+        return []
+
+    input_lower = user_input.lower()
+
+    # 1. Exact case-insensitive match (highest priority)
+    exact = [c for c in candidates if c.lower() == input_lower]
+    if exact:
+        return exact[:max_results]
+
+    # 2. difflib fuzzy matching (case-insensitive comparison)
+    lower_to_original: dict[str, str] = {}
+    for c in candidates:
+        lower_to_original.setdefault(c.lower(), c)
+
+    difflib_matches = get_close_matches(
+        input_lower,
+        list(lower_to_original.keys()),
+        n=max_results,
+        cutoff=cutoff,
+    )
+    results = [lower_to_original[m] for m in difflib_matches]
+
+    # 3. Substring matching (append any not already found)
+    if len(results) < max_results:
+        for c in candidates:
+            if input_lower in c.lower() and c not in results:
+                results.append(c)
+                if len(results) >= max_results:
+                    break
+
+    return results[:max_results]
+
+
+def format_suggestions(
+    error_msg: str,
+    suggestions: list[str],
+    hint: str | None = None,
+) -> dict[str, object]:
+    """Build a structured error response with suggestions.
+
+    Args:
+        error_msg: The primary error message.
+        suggestions: List of suggested corrections.
+        hint: Optional hint for the user.
+
+    Returns:
+        Dict with 'error', 'suggestions', and optionally 'hint'.
+    """
+    result: dict[str, object] = {
+        "error": error_msg,
+        "suggestions": suggestions,
+    }
+    if hint:
+        result["hint"] = hint
+    return result
+
+
+def suggest_spaces(
+    space_key_input: str,
+    fetcher: ConfluenceFetcher,
+) -> list[str]:
+    """Suggest similar space keys when the given key is invalid.
+
+    Fetches available spaces from Confluence and fuzzy-matches against them.
+    Designed to be lightweight -- single API call, no caching.
+
+    Args:
+        space_key_input: The invalid space key the user provided.
+        fetcher: A ConfluenceFetcher instance.
+
+    Returns:
+        List of similar space keys, best matches first.
+    """
+    try:
+        spaces_response = fetcher.get_spaces(limit=100)
+        results = spaces_response.get("results", [])
+        space_keys = [s["key"] for s in results if "key" in s]
+    except Exception:
+        logger.debug("Failed to fetch spaces for suggestions", exc_info=True)
+        return []
+
+    return fuzzy_match(space_key_input, space_keys)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -246,6 +246,26 @@ def should_include_tool_by_toolset(
     return toolset_name in enabled_toolsets
 
 
+def find_tool_toolset_from_registry(
+    tool_name: str,
+    all_tools: dict[str, object],
+) -> str | None:
+    """Find which toolset a tool belongs to by checking its tags.
+
+    Args:
+        tool_name: The tool name to look up.
+        all_tools: Dict of all registered tools (from get_tools()).
+
+    Returns:
+        Toolset name if found, None otherwise.
+    """
+    tool = all_tools.get(tool_name)
+    if tool is None:
+        return None
+    tags: set[str] = getattr(tool, "tags", set())
+    return get_toolset_tag(tags)
+
+
 def get_toolset_tag(tags: set[str]) -> str | None:
     """Extract the toolset name from a tool's tag set.
 

--- a/tests/unit/utils/test_suggestions.py
+++ b/tests/unit/utils/test_suggestions.py
@@ -1,0 +1,108 @@
+"""Tests for suggestion/fuzzy matching utilities."""
+
+from unittest.mock import MagicMock
+
+from mcp_atlassian.utils.suggestions import (
+    format_suggestions,
+    fuzzy_match,
+    suggest_spaces,
+)
+
+
+class TestFuzzyMatch:
+    """Tests for fuzzy_match()."""
+
+    def test_exact_case_insensitive_match(self):
+        """Exact match differing only in case returns single result."""
+        result = fuzzy_match("eruditis", ["ERUDITIS", "OTHER"])
+        assert result == ["ERUDITIS"]
+
+    def test_no_match_returns_empty(self):
+        """Completely unrelated input returns no suggestions."""
+        result = fuzzy_match("zzzzz", ["ALPHA", "BETA"])
+        assert result == []
+
+    def test_multiple_close_matches(self):
+        """Multiple similar candidates all returned."""
+        result = fuzzy_match("erud", ["ERUDITIS", "ERUDITISARCHIVE", "OTHER"])
+        assert "ERUDITIS" in result
+        assert "ERUDITISARCHIVE" in result
+        assert "OTHER" not in result
+
+    def test_empty_candidates(self):
+        """Empty candidate list returns empty."""
+        result = fuzzy_match("test", [])
+        assert result == []
+
+    def test_empty_input(self):
+        """Empty input returns empty."""
+        result = fuzzy_match("", ["ALPHA"])
+        assert result == []
+
+    def test_max_results_default(self):
+        """Returns at most 3 suggestions by default."""
+        candidates = [f"TEST{i}" for i in range(10)]
+        result = fuzzy_match("TEST", candidates)
+        assert len(result) <= 3
+
+    def test_substring_match(self):
+        """Substring of a candidate is found."""
+        result = fuzzy_match("pages", ["confluence_pages", "jira_issues"])
+        assert "confluence_pages" in result
+
+
+class TestFormatSuggestions:
+    """Tests for format_suggestions()."""
+
+    def test_with_suggestions_and_hint(self):
+        result = format_suggestions(
+            "Space 'erud' not found",
+            ["ERUDITIS", "ERUDITISARCHIVE"],
+            hint="Space keys are case-sensitive uppercase",
+        )
+        assert result["error"] == "Space 'erud' not found"
+        assert result["suggestions"] == ["ERUDITIS", "ERUDITISARCHIVE"]
+        assert result["hint"] == "Space keys are case-sensitive uppercase"
+
+    def test_without_hint(self):
+        result = format_suggestions("Not found", ["A", "B"])
+        assert "hint" not in result
+        assert result["suggestions"] == ["A", "B"]
+
+    def test_empty_suggestions(self):
+        result = format_suggestions("Not found", [])
+        assert result["suggestions"] == []
+        assert "hint" not in result
+
+
+class TestSuggestSpaces:
+    """Tests for suggest_spaces()."""
+
+    def _make_fetcher(self, space_keys: list[str]) -> MagicMock:
+        """Create a mock fetcher returning given space keys."""
+        fetcher = MagicMock()
+        results = [{"key": k, "name": f"Space {k}"} for k in space_keys]
+        fetcher.get_spaces.return_value = {"results": results}
+        return fetcher
+
+    def test_exact_case_insensitive(self):
+        fetcher = self._make_fetcher(["ERUDITIS", "OTHER"])
+        result = suggest_spaces("eruditis", fetcher)
+        assert result == ["ERUDITIS"]
+
+    def test_no_match(self):
+        fetcher = self._make_fetcher(["ALPHA", "BETA"])
+        result = suggest_spaces("zzzzz", fetcher)
+        assert result == []
+
+    def test_multiple_matches(self):
+        fetcher = self._make_fetcher(["ERUDITIS", "ERUDITISARCHIVE", "OTHER"])
+        result = suggest_spaces("erud", fetcher)
+        assert "ERUDITIS" in result
+        assert "ERUDITISARCHIVE" in result
+
+    def test_fetcher_error_returns_empty(self):
+        fetcher = MagicMock()
+        fetcher.get_spaces.side_effect = Exception("API error")
+        result = suggest_spaces("test", fetcher)
+        assert result == []

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -6,6 +6,7 @@ from mcp_atlassian.utils.toolsets import (
     ALL_TOOLSETS,
     DEFAULT_TOOLSETS,
     TOOLSET_TAG_PREFIX,
+    find_tool_toolset_from_registry,
     get_enabled_toolsets,
     get_toolset_tag,
     should_include_tool_by_toolset,
@@ -156,6 +157,35 @@ class TestShouldIncludeToolByToolset:
         tool_tags = {"jira", "read", "toolset:jira_worklog"}
         enabled = {"jira_issues", "jira_agile", "jira_fields"}
         assert should_include_tool_by_toolset(tool_tags, enabled) is False
+
+
+class TestFindToolToolsetFromRegistry:
+    """Tests for find_tool_toolset_from_registry() helper."""
+
+    def test_finds_toolset_for_known_tool(self):
+        """Return the toolset name when a tool has a toolset tag."""
+        from unittest.mock import MagicMock
+
+        tool = MagicMock()
+        tool.tags = {"jira", "read", "toolset:jira_agile"}
+        result = find_tool_toolset_from_registry(
+            "jira_get_board", {"jira_get_board": tool}
+        )
+        assert result == "jira_agile"
+
+    def test_returns_none_for_missing_tool(self):
+        """Return None when the tool is not in the registry."""
+        result = find_tool_toolset_from_registry("no_such", {})
+        assert result is None
+
+    def test_returns_none_when_no_toolset_tag(self):
+        """Return None when the tool exists but has no toolset tag."""
+        from unittest.mock import MagicMock
+
+        tool = MagicMock()
+        tool.tags = {"jira", "read"}
+        result = find_tool_toolset_from_registry("jira_foo", {"jira_foo": tool})
+        assert result is None
 
 
 class TestGetToolsetTag:


### PR DESCRIPTION
## Description

Builds on #486 (Informative Error Messages). When agents provide slightly wrong input, MCP tools should recover internally rather than failing and forcing retry loops. As [MCPs Are Not Like Other APIs](https://blog.fsck.com/2025/10/19/mcps-are-not-like-other-apis/) argues, tools should be designed "like scripts you're handing to an undertrained ops kid" — forgiving, recoverable, and helpful.

This PR adds three layers of error recovery:

**1. Space key recovery:** When an invalid `space_key` is provided, the tool fetches available spaces and fuzzy-matches. A single confident match (e.g., case mismatch `eruditis` → `ERUDITIS`) is auto-corrected with a note. Multiple matches return suggestions.

**2. Page title recovery:** When `get_page` can't find a title, it searches via CQL for similar titles and auto-corrects or suggests alternatives.

**3. Toolset-aware error messages:** When a filtered-out tool is called, the error explains *why* it's unavailable and *how* to enable it (e.g., "belongs to 'jira_agile' toolset — set TOOLSETS=default,jira_agile").

References #486

## Changes

- New `src/mcp_atlassian/utils/suggestions.py` module:
  - `fuzzy_match()` — case-insensitive `difflib.get_close_matches` + substring fallback
  - `format_suggestions()` — structured error response builder
  - `suggest_spaces()` — fetches spaces and fuzzy-matches
- `servers/confluence.py`:
  - `_try_correct_space_key()` / `_space_key_error_response()` shared helpers
  - Space key recovery in `get_page`, `create_page`, `search`
  - Title recovery in `get_page` via CQL search
- `servers/main.py`:
  - `_call_tool_mcp()` override with toolset-aware error messages
- `utils/toolsets.py`:
  - `find_tool_toolset_from_registry()` helper

## Testing

- [x] 14 tests for suggestion utilities (fuzzy match, format, suggest_spaces)
- [x] 12 Confluence server tests (space key auto-correction/suggestions/no-match, title auto-correction/suggestions/fallthrough, create_page recovery, search filter correction)
- [x] 6 toolset error message tests (unknown tool, write blocked, disabled toolset, config hints)
- [x] 3 toolset registry lookup tests
- [x] All 2556 tests pass
- [x] Pre-commit clean (ruff, mypy)

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).