### PR TITLE
feat(confluence): add include_content option for create/update tool

### DIFF
--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -45,6 +45,7 @@ Create a new Confluence page.
 | `parent_id` | `string` | No | (Optional) parent page ID. If provided, this page will be created as a child of the specified page |
 | `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
+| `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at create time. |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
 **Example:**
 
@@ -77,6 +78,7 @@ Update an existing Confluence page.
 | `parent_id` | `string` | No | Optional the new parent page ID |
 | `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
+| `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at update time. |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
 **Example:**
 

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -505,6 +505,13 @@ async def create_page(
             default=False,
         ),
     ] = False,
+    include_content: Annotated[
+        bool,
+        Field(
+            description="(Optional) Whether to include page content in the response",
+            default=False,
+        ),
+    ] = False,
     emoji: Annotated[
         str | None,
         Field(
@@ -523,6 +530,7 @@ async def create_page(
         parent_id: Optional parent page ID.
         content_format: The format of the content ('markdown', 'wiki', or 'storage').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
+        include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
 
     Returns:
@@ -560,6 +568,8 @@ async def create_page(
         emoji=emoji,
     )
     result = page.to_simplified_dict()
+    if not include_content:
+        result.pop("content", None)
     return json.dumps(
         {"message": "Page created successfully", "page": result},
         indent=2,
@@ -607,6 +617,13 @@ async def update_page(
             default=False,
         ),
     ] = False,
+    include_content: Annotated[
+        bool,
+        Field(
+            description="(Optional) Whether to include page content in the response",
+            default=False,
+        ),
+    ] = False,
     emoji: Annotated[
         str | None,
         Field(
@@ -627,6 +644,7 @@ async def update_page(
         parent_id: Optional new parent page ID.
         content_format: The format of the content ('markdown', 'wiki', or 'storage').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
+        include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
 
     Returns:
@@ -666,6 +684,8 @@ async def update_page(
         emoji=emoji,
     )
     page_data = updated_page.to_simplified_dict()
+    if not include_content:
+        page_data.pop("content", None)
     return json.dumps(
         {"message": "Page updated successfully", "page": page_data},
         indent=2,

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -568,6 +568,26 @@ async def test_create_page_with_string_parent_id(client, mock_confluence_fetcher
     result_data = json.loads(response.content[0].text)
     assert result_data["message"] == "Page created successfully"
     assert result_data["page"]["title"] == "Test Page Mock Title"
+    assert "content" not in result_data["page"]
+
+
+@pytest.mark.anyio
+async def test_create_page_include_content(client, mock_confluence_fetcher):
+    """Test create_page can include content when requested."""
+    response = await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "Test Page",
+            "content": "Test content",
+            "include_content": True,
+        },
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["message"] == "Page created successfully"
+    assert result_data["page"]["title"] == "Test Page Mock Title"
+    assert "content" in result_data["page"]
 
 
 @pytest.mark.anyio
@@ -616,6 +636,26 @@ async def test_update_page_with_string_parent_id(client, mock_confluence_fetcher
     result_data = json.loads(response.content[0].text)
     assert result_data["message"] == "Page updated successfully"
     assert result_data["page"]["title"] == "Test Page Mock Title"
+    assert "content" not in result_data["page"]
+
+
+@pytest.mark.anyio
+async def test_update_page_include_content(client, mock_confluence_fetcher):
+    """Test update_page can include content when requested."""
+    response = await client.call_tool(
+        "confluence_update_page",
+        {
+            "page_id": "999999",
+            "title": "Updated Page",
+            "content": "Updated content",
+            "include_content": True,
+        },
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["message"] == "Page updated successfully"
+    assert result_data["page"]["title"] == "Test Page Mock Title"
+    assert "content" in result_data["page"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description
<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->
Add `include_content` (default: false) to Confluence create/update responses so callers can opt in to returning content. This reduces response payload/context usage by default.

Since callers already have the full content at create/update time, defaulting to `false` is reasonable.

## Changes
<!-- Briefly list the key changes made. -->
 - Add `include_content` parameter to `confluence_create_page` and `confluence_update_page`
 - Omit `content` from responses when `include_content=false`
 - Add/adjust unit tests for the new behavior
 - Document `include_content` in Confluence pages docs

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`

###  Test Result

#### Unit tests
```
  $ uv run pytest
  =========================================================================================== test session starts
  ===========================================================================================
  platform darwin -- Python 3.13.9, pytest-9.0.2, pluggy-1.6.0

  ... snip ...

  ============================================================================== 2549 passed, 161 skipped, 9 warnings in 9.17s
```

```
  $ uv run pre-commit run --all-files
  trim trailing whitespace.................................................Passed
  fix end of files.........................................................Passed
  check yaml...............................................................Passed
  check for added large files..............................................Passed
  check toml...............................................................Passed
  debug statements (python)................................................Passed
  ruff-format..............................................................Passed
  ruff.....................................................................Passed
  mypy.....................................................................Passed
```

#### Testing via Claude MCP
setup
```bash
  $ cat .mcp.json
  {
    "mcpServers": {
      "mcp-atlassian-test": {
        "command": "/path/to/sooperset/mcp-atlassian/.venv/bin/mcp-atlassian",
        "args": [],
        "env": {
          "CONFLUENCE_URL": "${CONFLUENCE_URL}",
          "CONFLUENCE_USERNAME": "${CONFLUENCE_USERNAME}",
          "CONFLUENCE_API_TOKEN": "${CONFLUENCE_PERSONAL_TOKEN}"
        }
      }
    }
  }
```

integration test
```bash
  $ CONFLUENCE_URL=xxx \
    CONFLUENCE_USERNAME=yyyy \
    CONFLUENCE_API_TOKEN=zzzz \
        claude

  ❯ confluence_create_page parentId=12345 space_key=user title="hello" content="hello world"

  # Default: content is omitted
  ⏺ mcp-atlassian-test - Create Page (MCP)(space_key: "~user", title: "hello", content: "hello world", parent_id: "12345")
    ⎿  {
         "result": "{\n  \"message\": \"Page created successfully\",\n  \"page\": {\n    \"id\": \"xxxx\",\n    \"title\": \"hello\",\n    \"type\": \"page\",\n    \"created\": \"\",\n
       \"updated\": \"\",\n    \"url\": \"https://path.to.wiki/pages/viewpage.action?pageId=xxxx\",\n    \"space\": {\n      \"key\": \"~user\",\n      \"name\": \"user\"\n    },\n
         \"version\": 1,\n    \"attachments\": []\n  }\n}"
       }

  ❯ confluence_create_page parentId=12345 space_key=user title="hello_2" content="hello world" include_content=true

  # include_content=true: content is returned
  ⏺ mcp-atlassian-test - Create Page (MCP)(space_key: "~user", title: "hello_2", content: "hello world", parent_id: "12345", include_content: true)
    ⎿  {
         "result": "{\n  \"message\": \"Page created successfully\",\n  \"page\": {\n    \"id\": \"xxxx\",\n    \"title\": \"hello_2\",\n    \"type\": \"page\",\n    \"created\": \"\",\n
       \"updated\": \"\",\n    \"url\": \"https://path.to.wiki/pages/viewpage.action?pageId=xxxx\",\n    \"space\": {\n      \"key\": \"~user\",\n      \"name\": \"user\"\n    },\n
         \"version\": 1,\n    \"attachments\": [],\n    \"content\": {\n      \"value\": \"hello world\",\n      \"format\": \"markdown\"\n    }\n  }\n}"
       }
```

## Checklist
- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).