### PR TITLE
fix(confluence): improve include_content test coverage and descriptions

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -560,7 +560,7 @@ async def create_page(
     include_content: Annotated[
         bool,
         Field(
-            description="(Optional) Whether to include page content in the response",
+            description="(Optional) Whether to include page content in the response. Defaults to false since callers already have the content at create time",
             default=False,
         ),
     ] = False,
@@ -672,7 +672,7 @@ async def update_page(
     include_content: Annotated[
         bool,
         Field(
-            description="(Optional) Whether to include page content in the response",
+            description="(Optional) Whether to include page content in the response. Defaults to false since callers already have the content at update time",
             default=False,
         ),
     ] = False,

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -612,6 +612,7 @@ async def test_create_page_with_numeric_parent_id(client, mock_confluence_fetche
     result_data = json.loads(response.content[0].text)
     assert result_data["message"] == "Page created successfully"
     assert result_data["page"]["title"] == "Test Page Mock Title"
+    assert "content" not in result_data["page"]
 
 
 @pytest.mark.anyio
@@ -680,6 +681,7 @@ async def test_update_page_with_numeric_parent_id(client, mock_confluence_fetche
     result_data = json.loads(response.content[0].text)
     assert result_data["message"] == "Page updated successfully"
     assert result_data["page"]["title"] == "Test Page Mock Title"
+    assert "content" not in result_data["page"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Add missing `"content" not in` assertions to numeric `parent_id` tests for consistency with string `parent_id` tests
- Add "Defaults to false" context to `include_content` Field descriptions for self-documenting tool schemas

Follow-up to #1098.

## Test plan
- [x] All 6 affected tests pass (`pytest -k "parent_id or include_content"`)
- [x] Pre-commit (ruff + mypy) clean