### PR TITLE
fix(confluence): preserve date lozenges in page content

### DIFF
--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -122,6 +122,10 @@ class BasePreprocessor:
             self._process_user_mentions_in_soup(soup, confluence_client)
             self._process_user_profile_macros_in_soup(soup, confluence_client)
 
+            # Preserve Confluence date lozenges, whose value is stored only in
+            # the datetime attribute and would otherwise be dropped by markdownify.
+            self._process_date_elements_in_soup(soup)
+
             # Process Confluence image tags
             self._process_images_in_soup(soup, content_id, attachments)
 
@@ -134,6 +138,18 @@ class BasePreprocessor:
         except Exception as e:
             logger.error(f"Error in process_html_content: {str(e)}")
             raise
+
+    @staticmethod
+    def _process_date_elements_in_soup(soup: BeautifulSoup) -> None:
+        """Expose Confluence date-lozenge values as element text."""
+        for date_element in soup.find_all("time"):
+            datetime_value = date_element.get("datetime")
+            if (
+                isinstance(datetime_value, str)
+                and datetime_value
+                and not date_element.get_text(strip=True)
+            ):
+                date_element.string = datetime_value
 
     def _process_user_mentions_in_soup(
         self, soup: BeautifulSoup, confluence_client: ConfluenceClient | None = None

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -137,3 +137,38 @@ class TestConfluenceCloudComments:
 
         comments = confluence_fetcher.get_page_comments(page.id)
         assert len(comments) > 0
+
+
+class TestConfluenceDateMacro:
+    """Date macros in storage format are preserved in page content.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/897
+    """
+
+    def test_date_macro_preserved_in_page_content(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        storage_body = (
+            "<p>Meeting date: "
+            '<ac:structured-macro ac:name="date">'
+            '<ac:parameter ac:name="date">2026-02-04</ac:parameter>'
+            "</ac:structured-macro>"
+            "</p>"
+        )
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Date Macro Test {uid}",
+            body=storage_body,
+            is_markdown=False,
+            content_representation="storage",
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        content = fetched.content or ""
+        assert "2026-02-04" in content or "Feb" in content or "February" in content, (
+            f"Date macro value missing from content. Got: {content[:500]}"
+        )

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -456,6 +456,7 @@ class TestConfluenceCloudComments:
             content_representation="storage",
         )
         resource_tracker.add_confluence_page(page.id)
+
         comment = confluence_fetcher.add_inline_comment(
             page_id=page.id,
             content=f"Cloud E2E inline test comment {uid}",
@@ -468,29 +469,23 @@ class TestConfluenceCloudComments:
         assert any(inline_comment.id == comment.id for inline_comment in comments)
 
 
-class TestConfluenceDateMacro:
-    """Date macros in storage format are preserved in page content.
+class TestConfluenceDateLozenge:
+    """Date lozenges in storage format are preserved in page content.
 
     Regression for https://github.com/sooperset/mcp-atlassian/issues/897
     """
 
-    def test_date_macro_preserved_in_page_content(
+    def test_date_lozenge_preserved_in_page_content(
         self,
         confluence_fetcher: ConfluenceFetcher,
         cloud_instance: CloudInstanceInfo,
         resource_tracker: CloudResourceTracker,
     ) -> None:
         uid = uuid.uuid4().hex[:8]
-        storage_body = (
-            "<p>Meeting date: "
-            '<ac:structured-macro ac:name="date">'
-            '<ac:parameter ac:name="date">2026-02-04</ac:parameter>'
-            "</ac:structured-macro>"
-            "</p>"
-        )
+        storage_body = '<p>Meeting date: <time datetime="2026-02-04" /></p>'
         page = confluence_fetcher.create_page(
             space_key=cloud_instance.space_key,
-            title=f"Cloud E2E Date Macro Test {uid}",
+            title=f"Cloud E2E Date Lozenge Test {uid}",
             body=storage_body,
             is_markdown=False,
             content_representation="storage",
@@ -498,6 +493,6 @@ class TestConfluenceDateMacro:
         resource_tracker.add_confluence_page(page.id)
         fetched = confluence_fetcher.get_page_content(page.id)
         content = fetched.content or ""
-        assert "2026-02-04" in content or "Feb" in content or "February" in content, (
-            f"Date macro value missing from content. Got: {content[:500]}"
+        assert "2026-02-04" in content, (
+            f"Date lozenge value missing from content. Got: {content[:500]}"
         )

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -456,7 +456,6 @@ class TestConfluenceCloudComments:
             content_representation="storage",
         )
         resource_tracker.add_confluence_page(page.id)
-
         comment = confluence_fetcher.add_inline_comment(
             page_id=page.id,
             content=f"Cloud E2E inline test comment {uid}",
@@ -467,3 +466,38 @@ class TestConfluenceCloudComments:
 
         comments = confluence_fetcher.get_inline_comments(page.id)
         assert any(inline_comment.id == comment.id for inline_comment in comments)
+
+
+class TestConfluenceDateMacro:
+    """Date macros in storage format are preserved in page content.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/897
+    """
+
+    def test_date_macro_preserved_in_page_content(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        storage_body = (
+            "<p>Meeting date: "
+            '<ac:structured-macro ac:name="date">'
+            '<ac:parameter ac:name="date">2026-02-04</ac:parameter>'
+            "</ac:structured-macro>"
+            "</p>"
+        )
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Date Macro Test {uid}",
+            body=storage_body,
+            is_markdown=False,
+            content_representation="storage",
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        content = fetched.content or ""
+        assert "2026-02-04" in content or "Feb" in content or "February" in content, (
+            f"Date macro value missing from content. Got: {content[:500]}"
+        )

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -89,6 +89,20 @@ def test_process_html_content_basic(preprocessor_with_confluence):
     assert processed_markdown.strip() == "Simple text"
 
 
+def test_process_html_content_preserves_confluence_date_lozenge(
+    preprocessor_with_confluence,
+):
+    """Date lozenges retain values stored only in datetime attributes."""
+    html = '<p>Meeting date: <time datetime="2026-02-04" /></p>'
+
+    processed_html, processed_markdown = (
+        preprocessor_with_confluence.process_html_content(html)
+    )
+
+    assert '<time datetime="2026-02-04">2026-02-04</time>' in processed_html
+    assert processed_markdown.strip() == "Meeting date: 2026-02-04"
+
+
 def test_process_html_content_with_user_mentions(preprocessor_with_confluence):
     """Test HTML content processing with user mentions."""
     html = """


### PR DESCRIPTION
Fixes #897.

## Summary

- Preserve Confluence date-lozenge values stored in `<time datetime="...">` elements when page storage content is converted to Markdown.
- Exercise the actual date-lozenge storage representation in the Cloud regression test.
- Add unit coverage for the preprocessing behavior.

## Verification

- `uv run pytest tests/unit/preprocessing/ tests/unit/confluence/test_pages.py tests/integration/ -xvs` — 285 passed, 23 skipped (credential-gated integration tests).
- `uv run pytest tests/e2e/cloud --cloud-e2e -xvs` — 88 passed, 15 skipped (OAuth variants unavailable in the worker environment).
- `uv run pre-commit run --all-files` — passed, including Ruff formatting/lint and strict mypy.
