### PR TITLE
test: add regression test for Jira REST API v3 (closes #338)

### DIFF
--- a/tests/unit/jira/test_api_version.py
+++ b/tests/unit/jira/test_api_version.py
@@ -1,0 +1,63 @@
+"""Tests confirming Jira REST API v3 support is implemented.
+
+Regression tests for https://github.com/sooperset/mcp-atlassian/issues/338
+Feature was requested: support Jira REST API v3 for Cloud.
+Already implemented — _post_api3 and _put_api3 helpers in client.py,
+and Cloud search uses rest/api/3/search/jql endpoint.
+"""
+
+import inspect
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.search import SearchMixin
+
+
+class TestJiraRestApiV3:
+    """Jira REST API v3 is used on Cloud for ADF payloads.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/338
+    Feature was requested: support Jira REST API v3.
+    Already implemented — _post_api3 and _put_api3 helpers in client.py,
+    and Cloud search uses rest/api/3/search/jql endpoint.
+    """
+
+    def test_client_has_v3_post_method(self, jira_fetcher: JiraFetcher) -> None:
+        """JiraClient exposes a v3 POST helper for ADF payloads."""
+        assert hasattr(jira_fetcher, "_post_api3"), (
+            "_post_api3 method missing from JiraClient"
+        )
+
+    def test_client_has_v3_put_method(self, jira_fetcher: JiraFetcher) -> None:
+        """JiraClient exposes a v3 PUT helper for ADF payloads."""
+        assert hasattr(jira_fetcher, "_put_api3"), (
+            "_put_api3 method missing from JiraClient"
+        )
+
+    def test_v3_post_method_is_callable(self, jira_fetcher: JiraFetcher) -> None:
+        """_post_api3 is a callable method, not a plain attribute."""
+        assert callable(jira_fetcher._post_api3), "_post_api3 is not callable"
+
+    def test_v3_put_method_is_callable(self, jira_fetcher: JiraFetcher) -> None:
+        """_put_api3 is a callable method, not a plain attribute."""
+        assert callable(jira_fetcher._put_api3), "_put_api3 is not callable"
+
+    def test_cloud_uses_v3_search_endpoint(self) -> None:
+        """Cloud JQL search is routed through the v3 API endpoint."""
+        source = inspect.getsource(SearchMixin.search_issues)
+        assert "rest/api/3/search" in source, (
+            "Cloud v3 search endpoint not found in search_issues source"
+        )
+
+    def test_v3_post_uses_api_version_3(self, jira_fetcher: JiraFetcher) -> None:
+        """_post_api3 implementation explicitly requests api_version='3'."""
+        source = inspect.getsource(jira_fetcher._post_api3)
+        assert 'api_version="3"' in source or "api_version='3'" in source, (
+            "_post_api3 does not request API version 3 from resource_url"
+        )
+
+    def test_v3_put_uses_api_version_3(self, jira_fetcher: JiraFetcher) -> None:
+        """_put_api3 implementation explicitly requests api_version='3'."""
+        source = inspect.getsource(jira_fetcher._put_api3)
+        assert 'api_version="3"' in source or "api_version='3'" in source, (
+            "_put_api3 does not request API version 3 from resource_url"
+        )

--- a/tests/unit/jira/test_api_version.py
+++ b/tests/unit/jira/test_api_version.py
@@ -1,63 +1,66 @@
-"""Tests confirming Jira REST API v3 support is implemented.
+"""Regression tests for Jira REST API v3 support.
 
-Regression tests for https://github.com/sooperset/mcp-atlassian/issues/338
-Feature was requested: support Jira REST API v3 for Cloud.
-Already implemented — _post_api3 and _put_api3 helpers in client.py,
-and Cloud search uses rest/api/3/search/jql endpoint.
+The v3 helpers are required for Jira Cloud payloads that contain Atlassian
+Document Format (ADF) objects. Regression coverage for issue #338.
 """
 
-import inspect
+from typing import Any
 
 from mcp_atlassian.jira import JiraFetcher
-from mcp_atlassian.jira.search import SearchMixin
 
 
 class TestJiraRestApiV3:
-    """Jira REST API v3 is used on Cloud for ADF payloads.
+    """Jira Cloud ADF writes use the REST API v3 endpoint."""
 
-    Regression for https://github.com/sooperset/mcp-atlassian/issues/338
-    Feature was requested: support Jira REST API v3.
-    Already implemented — _post_api3 and _put_api3 helpers in client.py,
-    and Cloud search uses rest/api/3/search/jql endpoint.
-    """
+    def test_post_api3_uses_v3_endpoint_and_forwards_params(
+        self, jira_fetcher: JiraFetcher
+    ) -> None:
+        """The v3 POST helper builds a v3 URL and forwards its request."""
+        payload: dict[str, Any] = {
+            "fields": {
+                "description": {
+                    "version": 1,
+                    "type": "doc",
+                    "content": [],
+                }
+            }
+        }
+        params = {"notifyUsers": "false"}
+        expected_response = {"id": "10000"}
+        expected_url = "https://jira.example.com/rest/api/3/issue"
+        jira_fetcher.jira.resource_url.return_value = expected_url
+        jira_fetcher.jira.post.return_value = expected_response
 
-    def test_client_has_v3_post_method(self, jira_fetcher: JiraFetcher) -> None:
-        """JiraClient exposes a v3 POST helper for ADF payloads."""
-        assert hasattr(jira_fetcher, "_post_api3"), (
-            "_post_api3 method missing from JiraClient"
+        result = jira_fetcher._post_api3("issue", data=payload, params=params)
+
+        assert result == expected_response
+        jira_fetcher.jira.resource_url.assert_called_once_with("issue", api_version="3")
+        jira_fetcher.jira.post.assert_called_once_with(
+            expected_url, data=payload, params=params
         )
 
-    def test_client_has_v3_put_method(self, jira_fetcher: JiraFetcher) -> None:
-        """JiraClient exposes a v3 PUT helper for ADF payloads."""
-        assert hasattr(jira_fetcher, "_put_api3"), (
-            "_put_api3 method missing from JiraClient"
+    def test_put_api3_uses_v3_endpoint_and_forwards_payload(
+        self, jira_fetcher: JiraFetcher
+    ) -> None:
+        """The v3 PUT helper builds a v3 URL and forwards the payload."""
+        payload: dict[str, Any] = {
+            "fields": {
+                "description": {
+                    "version": 1,
+                    "type": "doc",
+                    "content": [],
+                }
+            }
+        }
+        expected_response = {"key": "TEST-123"}
+        expected_url = "https://jira.example.com/rest/api/3/issue/TEST-123"
+        jira_fetcher.jira.resource_url.return_value = expected_url
+        jira_fetcher.jira.put.return_value = expected_response
+
+        result = jira_fetcher._put_api3("issue/TEST-123", data=payload)
+
+        assert result == expected_response
+        jira_fetcher.jira.resource_url.assert_called_once_with(
+            "issue/TEST-123", api_version="3"
         )
-
-    def test_v3_post_method_is_callable(self, jira_fetcher: JiraFetcher) -> None:
-        """_post_api3 is a callable method, not a plain attribute."""
-        assert callable(jira_fetcher._post_api3), "_post_api3 is not callable"
-
-    def test_v3_put_method_is_callable(self, jira_fetcher: JiraFetcher) -> None:
-        """_put_api3 is a callable method, not a plain attribute."""
-        assert callable(jira_fetcher._put_api3), "_put_api3 is not callable"
-
-    def test_cloud_uses_v3_search_endpoint(self) -> None:
-        """Cloud JQL search is routed through the v3 API endpoint."""
-        source = inspect.getsource(SearchMixin.search_issues)
-        assert "rest/api/3/search" in source, (
-            "Cloud v3 search endpoint not found in search_issues source"
-        )
-
-    def test_v3_post_uses_api_version_3(self, jira_fetcher: JiraFetcher) -> None:
-        """_post_api3 implementation explicitly requests api_version='3'."""
-        source = inspect.getsource(jira_fetcher._post_api3)
-        assert 'api_version="3"' in source or "api_version='3'" in source, (
-            "_post_api3 does not request API version 3 from resource_url"
-        )
-
-    def test_v3_put_uses_api_version_3(self, jira_fetcher: JiraFetcher) -> None:
-        """_put_api3 implementation explicitly requests api_version='3'."""
-        source = inspect.getsource(jira_fetcher._put_api3)
-        assert 'api_version="3"' in source or "api_version='3'" in source, (
-            "_put_api3 does not request API version 3 from resource_url"
-        )
+        jira_fetcher.jira.put.assert_called_once_with(expected_url, data=payload)


### PR DESCRIPTION
Adds regression coverage for Jira REST API v3 support from #338.

## What This Does

- Verifies `_post_api3` requests a v3 resource URL and forwards ADF data and query parameters.
- Verifies `_put_api3` requests a v3 resource URL and forwards ADF data.
- Keeps the existing behavioral Cloud search coverage in `tests/unit/jira/test_search.py`.

## Test Evidence

```
tests/unit/jira/test_api_version.py             2 passed
tests/unit/jira/test_search.py                 47 passed
```

The full Jira unit suite passes locally: 926 passed.