### PR TITLE
test(jira): cover JSM queue request contracts

### DIFF
--- a/tests/unit/jira/test_queues.py
+++ b/tests/unit/jira/test_queues.py
@@ -175,3 +175,100 @@ def test_queue_methods_reject_cloud(
     """All queue methods should raise NotImplementedError on Cloud."""
     with pytest.raises(NotImplementedError, match="Server/Data Center"):
         getattr(cloud_queues_fetcher, method)(*args)
+
+
+class TestJiraServiceManagementTools:
+    """JSM tools exist and return structured data when mocked.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/447
+    """
+
+    def test_get_service_desk_for_project_exists(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_service_desk_for_project is implemented on JiraFetcher."""
+        assert hasattr(queues_fetcher, "get_service_desk_for_project")
+        assert callable(queues_fetcher.get_service_desk_for_project)
+
+    def test_get_service_desk_queues_exists(self, queues_fetcher: JiraFetcher) -> None:
+        """get_service_desk_queues is implemented on JiraFetcher."""
+        assert hasattr(queues_fetcher, "get_service_desk_queues")
+        assert callable(queues_fetcher.get_service_desk_queues)
+
+    def test_get_queue_issues_exists(self, queues_fetcher: JiraFetcher) -> None:
+        """get_queue_issues is implemented on JiraFetcher."""
+        assert hasattr(queues_fetcher, "get_queue_issues")
+        assert callable(queues_fetcher.get_queue_issues)
+
+    def test_get_service_desk_for_project_returns_model(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_service_desk_for_project returns a JiraServiceDesk model when found."""
+        from mcp_atlassian.models.jira import JiraServiceDesk
+
+        queues_fetcher.jira.get = MagicMock(
+            return_value={
+                "start": 0,
+                "limit": 50,
+                "isLastPage": True,
+                "values": [
+                    {
+                        "id": "1",
+                        "projectKey": "HELP",
+                        "projectId": "10001",
+                        "projectName": "Help Desk",
+                    }
+                ],
+            }
+        )
+        result = queues_fetcher.get_service_desk_for_project("HELP")
+        assert isinstance(result, JiraServiceDesk)
+        assert result.project_key == "HELP"
+
+    def test_get_service_desk_queues_returns_structured_result(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_service_desk_queues returns JiraServiceDeskQueuesResult."""
+        queues_fetcher.jira.get = MagicMock(
+            return_value={
+                "start": 0,
+                "limit": 50,
+                "size": 1,
+                "isLastPage": True,
+                "values": [{"id": "10", "name": "Open Issues", "issueCount": 5}],
+            }
+        )
+        result = queues_fetcher.get_service_desk_queues("1")
+        assert isinstance(result, JiraServiceDeskQueuesResult)
+        assert result.service_desk_id == "1"
+        assert len(result.queues) == 1
+        assert result.queues[0].name == "Open Issues"
+
+    def test_get_queue_issues_returns_structured_result(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_queue_issues returns JiraQueueIssuesResult with issues list."""
+        queues_fetcher.jira.get = MagicMock(
+            side_effect=[
+                {"id": "10", "name": "Open Issues", "issueCount": 1},
+                {
+                    "start": 0,
+                    "limit": 50,
+                    "size": 1,
+                    "isLastPage": True,
+                    "values": [
+                        {
+                            "id": "100",
+                            "key": "HELP-1",
+                            "fields": {"summary": "Need help"},
+                        }
+                    ],
+                },
+            ]
+        )
+        result = queues_fetcher.get_queue_issues("1", "10")
+        assert isinstance(result, JiraQueueIssuesResult)
+        assert result.service_desk_id == "1"
+        assert result.queue_id == "10"
+        assert len(result.issues) == 1
+        assert result.issues[0]["key"] == "HELP-1"

--- a/tests/unit/jira/test_queues.py
+++ b/tests/unit/jira/test_queues.py
@@ -1,6 +1,6 @@
 """Tests for Jira Service Management queue read operations."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -57,7 +57,16 @@ def test_get_service_desk_for_project_found_on_second_page(queues_fetcher: JiraF
     assert result.id == "4"
     assert result.project_key == "SUP"
     assert result.project_name == "support"
-    assert queues_fetcher.jira.get.call_count == 2
+    assert queues_fetcher.jira.get.call_args_list == [
+        call(
+            "rest/servicedeskapi/servicedesk",
+            params={"start": 0, "limit": 50},
+        ),
+        call(
+            "rest/servicedeskapi/servicedesk",
+            params={"start": 1, "limit": 50},
+        ),
+    ]
 
 
 def test_get_service_desk_for_project_not_found(queues_fetcher: JiraFetcher):
@@ -95,6 +104,10 @@ def test_get_service_desk_queues_success(queues_fetcher: JiraFetcher):
     assert len(result.queues) == 2
     assert result.queues[0].id == "47"
     assert result.queues[0].issue_count == 11
+    queues_fetcher.jira.get.assert_called_once_with(
+        "rest/servicedeskapi/servicedesk/4/queue",
+        params={"start": 0, "limit": 50, "includeCount": "true"},
+    )
 
 
 def test_get_queue_issues_success(queues_fetcher: JiraFetcher):
@@ -130,6 +143,16 @@ def test_get_queue_issues_success(queues_fetcher: JiraFetcher):
     assert result.size == 2
     assert len(result.issues) == 2
     assert result.issues[0]["key"] == "SUP-1"
+    assert queues_fetcher.jira.get.call_args_list == [
+        call(
+            "rest/servicedeskapi/servicedesk/4/queue/47",
+            params={"includeCount": "true"},
+        ),
+        call(
+            "rest/servicedeskapi/servicedesk/4/queue/47/issue",
+            params={"start": 0, "limit": 2},
+        ),
+    ]
 
 
 def test_get_queue_issues_invalid_payload_returns_safe_default(
@@ -175,3 +198,27 @@ def test_queue_methods_reject_cloud(
     """All queue methods should raise NotImplementedError on Cloud."""
     with pytest.raises(NotImplementedError, match="Server/Data Center"):
         getattr(cloud_queues_fetcher, method)(*args)
+
+
+@pytest.mark.parametrize(
+    "method,args,error",
+    [
+        ("get_service_desk_for_project", ("",), "Project key is required"),
+        ("get_service_desk_queues", ("",), "Service desk ID is required"),
+        ("get_service_desk_queues", ("4", -1), "start_at must be >= 0"),
+        ("get_service_desk_queues", ("4", 0, 0), "limit must be >= 1"),
+        ("get_queue_issues", ("", "47"), "Service desk ID is required"),
+        ("get_queue_issues", ("4", ""), "Queue ID is required"),
+        ("get_queue_issues", ("4", "47", -1), "start_at must be >= 0"),
+        ("get_queue_issues", ("4", "47", 0, 0), "limit must be >= 1"),
+    ],
+)
+def test_queue_methods_validate_input(
+    queues_fetcher: JiraFetcher,
+    method: str,
+    args: tuple[object, ...],
+    error: str,
+) -> None:
+    """Queue methods should reject invalid identifiers and pagination values."""
+    with pytest.raises(ValueError, match=error):
+        getattr(queues_fetcher, method)(*args)


### PR DESCRIPTION
## Summary

The Jira Service Management queue tools are already implemented for Server/Data Center. This PR strengthens their regression coverage by testing the request contract that existing model-parsing tests did not cover.

- Assert the exact Service Desk and queue REST paths
- Assert pagination and `includeCount` request parameters
- Cover invalid project keys, service desk IDs, queue IDs, offsets, and limits

This is test-only follow-up coverage for #447 and the queue tools merged in #979 and #982.

## Verification

- `uv run pytest tests/unit/jira/test_queues.py -xvs` (16 passed)
- `uv run pytest tests/unit/` (3222 passed, 5 skipped)
- `env -u NO_PROXY -u no_proxy uv run pytest tests/integration/ --integration` (8 passed, 15 skipped)
- `uv run pytest tests/e2e/ --dc-e2e` (98 passed, 103 Cloud tests skipped)
- `pre-commit run --all-files` (all hooks passed, including Ruff and mypy)
