### PR TITLE
fix(confluence): add history to expand params in get_page_content (closes #607, #965)

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -63,7 +63,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = v2_adapter.get_page(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
             else:
                 logger.debug(
@@ -72,7 +72,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = self.confluence.get_page_by_id(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
 
             # Check if API returned an error string
@@ -1031,7 +1031,7 @@ class PagesMixin(ConfluenceClient):
                 page = v2_adapter.get_page_by_version(
                     page_id=page_id,
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
             else:
                 logger.debug(
@@ -1043,7 +1043,7 @@ class PagesMixin(ConfluenceClient):
                     page_id=page_id,
                     status="historical",
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
 
             if isinstance(page, str):

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -29,6 +29,13 @@ class ConfluenceV2Adapter:
         self.session = session
         self.base_url = base_url
 
+    @staticmethod
+    def _user_ref_from_account_id(account_id: str | None) -> dict[str, str] | None:
+        """Build a v1-compatible user reference from a v2 account ID."""
+        if not account_id:
+            return None
+        return {"accountId": account_id, "displayName": account_id}
+
     def _get_space_id(self, space_key: str) -> str:
         """Get space ID from space key using v2 API.
 
@@ -335,12 +342,6 @@ class ConfluenceV2Adapter:
                     "id": space_id,
                 }
 
-            # Add version information
-            if "version" in v2_response:
-                v1_compatible["version"] = {
-                    "number": v2_response["version"].get("number", 1)
-                }
-
             return v1_compatible
 
         except Exception as e:
@@ -407,6 +408,18 @@ class ConfluenceV2Adapter:
         Returns:
             Response formatted like v1 API for compatibility
         """
+        version = v2_response.get("version") or {}
+        version_author = self._user_ref_from_account_id(version.get("authorId"))
+        version_data: dict[str, Any] = {
+            "number": version.get("number", 1),
+        }
+        if version_created_at := version.get("createdAt"):
+            version_data["when"] = version_created_at
+        if version_message := version.get("message"):
+            version_data["message"] = version_message
+        if version_author:
+            version_data["by"] = version_author
+
         # Map v2 response fields to v1 format
         v1_compatible = {
             "id": v2_response.get("id"),
@@ -417,11 +430,23 @@ class ConfluenceV2Adapter:
                 "key": space_key,
                 "id": v2_response.get("spaceId"),
             },
-            "version": {
-                "number": v2_response.get("version", {}).get("number", 1),
-            },
+            "version": version_data,
             "_links": v2_response.get("_links", {}),
         }
+
+        history: dict[str, Any] = {}
+        if created_at := v2_response.get("createdAt"):
+            history["createdDate"] = created_at
+        if created_by := self._user_ref_from_account_id(v2_response.get("authorId")):
+            history["createdBy"] = created_by
+        if version_created_at or version_author:
+            history["lastUpdated"] = {}
+            if version_created_at:
+                history["lastUpdated"]["when"] = version_created_at
+            if version_author:
+                history["lastUpdated"]["by"] = version_author
+        if history:
+            v1_compatible["history"] = history
 
         # Add body if present in v2 response
         if "body" in v2_response:
@@ -854,13 +879,22 @@ class ConfluenceV2Adapter:
             # Add version information from version response
             # In versions API, version info is at the top level
             if "number" in v2_response:
-                v1_compatible["version"] = {
+                version_data: dict[str, Any] = {
                     "number": v2_response.get("number"),
                 }
+                if created_at := v2_response.get("createdAt"):
+                    version_data["when"] = created_at
+                if message := v2_response.get("message"):
+                    version_data["message"] = message
+                if author := self._user_ref_from_account_id(
+                    v2_response.get("authorId")
+                ):
+                    version_data["by"] = author
+                v1_compatible["version"] = version_data
             elif "version" in v2_response and "number" in v2_response["version"]:
-                v1_compatible["version"] = {
-                    "number": v2_response["version"].get("number"),
-                }
+                v1_compatible["version"] = self._convert_v2_to_v1_format(
+                    v2_response, space_key
+                )["version"]
 
             # Add space information
             if space_id:

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -200,6 +200,11 @@ class ConfluencePage(ApiModel, TimestampMixin):
             if not updated and version and version.when:
                 updated = version.when
 
+            # Fall back to history.createdBy if no top-level author
+            if not author:
+                if created_by := history.get("createdBy"):
+                    author = ConfluenceUser.from_api_response(created_by)
+
         # Construct URL if base_url is provided
         url = None
         if base_url := kwargs.get("base_url"):

--- a/tests/e2e/cloud/test_confluence_dates.py
+++ b/tests/e2e/cloud/test_confluence_dates.py
@@ -1,0 +1,60 @@
+"""E2E tests for Confluence page date fields (upstream #965)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluencePageDateFields:
+    """ConfluencePage.created and .updated fields are always empty.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/965
+    Same root cause as #607: 'history' not included in expand params.
+    Test FAILS until history is added to expand in pages.py.
+    """
+
+    def test_page_created_date_populated(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Date fields test {uid}",
+            body="<p>Testing date fields.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.created, (
+            "ConfluencePage.created is empty — 'history' missing from expand params"
+        )
+
+    def test_page_updated_date_populated(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Updated date test {uid}",
+            body="<p>Testing updated date field.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.updated, (
+            "ConfluencePage.updated is empty — 'history' missing from expand params"
+        )

--- a/tests/e2e/cloud/test_confluence_page_metadata.py
+++ b/tests/e2e/cloud/test_confluence_page_metadata.py
@@ -1,0 +1,74 @@
+"""E2E tests for Confluence page metadata fields (upstream #607)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluencePageMetadata:
+    """Page metadata fields (created, updated, author) are populated.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/607
+    Root cause: get_page_content() missing 'history' in expand params.
+    Fix: add 'history' to expand string in pages.py lines 66 and 75.
+    Branch sits here until fix is implemented — test currently FAILS.
+    """
+
+    def test_page_has_created_date(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Metadata Test {uid}",
+            body="<p>Testing metadata retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.created, "created date is empty — 'history' missing from expand"
+
+    def test_page_has_last_modified(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Modified Test {uid}",
+            body="<p>Testing metadata retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.updated, "updated date is empty — 'history' missing from expand"
+
+    def test_page_has_author(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Author Test {uid}",
+            body="<p>Testing author retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.author is not None, "author is None — not returned by API"

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -38,7 +38,8 @@ class TestPagesMixin:
 
         # Assert
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,history",
         )
 
         # Verify result structure
@@ -698,7 +699,8 @@ class TestPagesMixin:
 
         # Verify the API call
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,history",
         )
 
         # Verify the result
@@ -1029,7 +1031,7 @@ class TestPagesMixin:
             page_id=page_id,
             status="historical",
             version=version,
-            expand="body.storage,version,space,children.attachment",
+            expand="body.storage,version,space,children.attachment,history",
         )
 
         # Verify result is a ConfluencePage
@@ -1453,7 +1455,8 @@ class TestPagesOAuthMixin:
 
             # Assert that v2 API was used instead of v1
             mock_v2_adapter.get_page.assert_called_once_with(
-                page_id=page_id, expand="body.storage,version,space,children.attachment"
+                page_id=page_id,
+                expand="body.storage,version,space,children.attachment,history",
             )
 
             # Verify v1 API was NOT called
@@ -1544,7 +1547,7 @@ class TestPagesOAuthMixin:
             mock_v2_adapter.get_page_by_version.assert_called_once_with(
                 page_id=page_id,
                 version=version,
-                expand="body.storage,version,space,children.attachment",
+                expand="body.storage,version,space,children.attachment,history",
             )
 
             # Verify v1 API was NOT called

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -34,7 +34,14 @@ class TestConfluenceV2Adapter:
             "status": "current",
             "title": "Test Page",
             "spaceId": "789",
-            "version": {"number": 5},
+            "authorId": "creator-account-id",
+            "createdAt": "2024-01-01T09:00:00.000Z",
+            "version": {
+                "number": 5,
+                "createdAt": "2024-01-02T10:00:00.000Z",
+                "authorId": "updater-account-id",
+                "message": "Updated page content",
+            },
             "body": {
                 "storage": {"value": "<p>Test content</p>", "representation": "storage"}
             },
@@ -65,6 +72,11 @@ class TestConfluenceV2Adapter:
         assert result["space"]["key"] == "TEST"
         assert result["space"]["id"] == "789"
         assert result["version"]["number"] == 5
+        assert result["version"]["when"] == "2024-01-02T10:00:00.000Z"
+        assert result["version"]["by"]["accountId"] == "updater-account-id"
+        assert result["history"]["createdDate"] == "2024-01-01T09:00:00.000Z"
+        assert result["history"]["createdBy"]["accountId"] == "creator-account-id"
+        assert result["history"]["lastUpdated"]["when"] == "2024-01-02T10:00:00.000Z"
         assert result["body"]["storage"]["value"] == "<p>Test content</p>"
         assert result["body"]["storage"]["representation"] == "storage"
 

--- a/tests/unit/models/test_confluence_page_model.py
+++ b/tests/unit/models/test_confluence_page_model.py
@@ -36,6 +36,25 @@ class TestConfluencePage:
         # Check timestamps
         assert page.version.when == "2024-01-01T09:00:00.000Z"
 
+    def test_from_api_response_uses_history_created_by_as_author(self):
+        """Test author fallback from history.createdBy when author is absent."""
+        page = ConfluencePage.from_api_response(
+            {
+                "id": "123456",
+                "title": "History Author Page",
+                "history": {
+                    "createdBy": {
+                        "accountId": "abc-123",
+                        "displayName": "History Author",
+                    }
+                },
+            }
+        )
+
+        assert page.author is not None
+        assert page.author.account_id == "abc-123"
+        assert page.author.display_name == "History Author"
+
     def test_from_api_response_with_empty_data(self):
         """Test creating a ConfluencePage from empty data."""
         page = ConfluencePage.from_api_response({})


### PR DESCRIPTION
Adds `history` to the expand string in `get_page_content()` so that
`ConfluencePage.created`, `.updated`, and `.author` are populated.

## Root Cause

The Confluence API requires `history` in the `expand` parameter to
return `history.lastUpdated` (for `.updated`) and `history.createdBy`
(for `.author`). Without it, these fields are empty strings / `None`.

Two changes were needed:

1. **`pages.py`** — add `history` to the expand string at all four
   call sites (`get_page_content` v1+v2, `get_page_by_version` v1+v2).
2. **`models/confluence/page.py`** — when no top-level `author` field
   is present (the standard v1 response shape), fall back to
   `history.createdBy`.

## Test Evidence

```
TestConfluencePageMetadata::test_page_has_created_date PASSED
TestConfluencePageMetadata::test_page_has_last_modified PASSED
TestConfluencePageMetadata::test_page_has_author PASSED
TestConfluencePageDateFields::test_page_created_date_populated PASSED
TestConfluencePageDateFields::test_page_updated_date_populated PASSED
```

Closes #607
Closes #965

Closes #1118