### PR TITLE
feat(jira): add include param to get_issue for inline enrichments (closes #857, #1101)

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -17,14 +17,15 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
+| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response. Supported values: `all`, `remote_links`, `transitions`, `watchers`, `changelog`, `comments`, `worklogs`. |
 **Example:**
 
 ```json
-{"issue_key": "PROJ-123", "fields": "summary,status,assignee", "comment_limit": 5}
+{"issue_key": "PROJ-123", "fields": "summary,status,assignee", "comment_limit": 5, "include": "remote_links,transitions"}
 ```
 
 <Tip>
-Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
+Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content. Use `include: "all"` to inline common enrichments that otherwise require separate tool calls.
 </Tip>
 
 

--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -185,6 +185,41 @@ class LinksMixin(JiraClient):
             raise Exception(f"Error creating remote issue link: {error_msg}") from e
 
     @handle_auth_errors("Jira API")
+    def get_remote_issue_links(self, issue_key: str) -> list[dict[str, Any]]:
+        """Get remote links (web links, Confluence links) for an issue.
+
+        Args:
+            issue_key: The issue key (e.g., 'PROJ-123')
+
+        Returns:
+            List of remote link data dictionaries
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails
+        """
+        try:
+            if self.config.is_cloud:
+                endpoint = f"rest/api/3/issue/{issue_key}/remotelink"
+            else:
+                endpoint = f"rest/api/2/issue/{issue_key}/remotelink"
+            result = self.jira.get(endpoint)
+            if isinstance(result, list):
+                return result
+            if isinstance(result, dict):
+                return result.get("remoteLinks", [result])
+            return []
+        except HTTPError:
+            raise  # let decorator handle auth errors
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(
+                f"Error getting remote links for {issue_key}: {error_msg}",
+                exc_info=True,
+            )
+            msg = f"Error getting remote links for {issue_key}: {error_msg}"
+            raise Exception(msg) from e
+
+    @handle_auth_errors("Jira API")
     def remove_issue_link(self, link_id: str) -> dict[str, Any]:
         """
         Remove a link between two issues.

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -344,33 +344,71 @@ async def get_issue(
     update_history: Annotated[
         bool,
         Field(
-            description="Whether to update the issue view history for the requesting user",
+            description=(
+                "Whether to update the issue view history for the requesting user"
+            ),
             default=True,
         ),
     ] = True,
+    include: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated sections to inline "
+                "in the response, avoiding extra tool calls. "
+                "Supported: remote_links, transitions, "
+                "watchers, changelog"
+            ),
+            default=None,
+        ),
+    ] = None,
 ) -> str:
-    """Get details of a specific Jira issue including its Epic links and relationship information.
+    """Get details of a specific Jira issue.
+
+    Includes Epic links and relationship information. Use the
+    ``include`` parameter to inline enrichments (remote_links,
+    transitions, watchers, changelog) so that separate tool calls
+    are not needed.
 
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
-        fields: Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'), a single field as a string (e.g., 'duedate'), '*all' for all fields, or omitted for essentials.
+        fields: Comma-separated fields to return.
         expand: Optional fields to expand.
         comment_limit: Maximum number of comments.
         properties: Issue properties to return.
         update_history: Whether to update issue view history.
+        include: Comma-separated enrichment sections to inline.
 
     Returns:
         JSON string representing the Jira issue object.
 
     Raises:
-        ValueError: If the Jira client is not configured or available.
+        ValueError: If the Jira client is not configured.
     """
     jira = await get_jira_fetcher(ctx)
     fields_list: str | list[str] | None = fields
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
 
+    # Parse include sections
+    include_sections: set[str] = set()
+    if include:
+        include_sections = {s.strip().lower() for s in include.split(",")}
+
+    # Some enrichments piggyback on Jira's expand mechanism
+    if include_sections & {"transitions", "changelog"}:
+        expand_additions = []
+        if "transitions" in include_sections:
+            expand_additions.append("transitions")
+        if "changelog" in include_sections:
+            expand_additions.append("changelog")
+        if expand:
+            expand = f"{expand},{','.join(expand_additions)}"
+        else:
+            expand = ",".join(expand_additions)
+
+    # Fetch the issue (with augmented expand)
     issue = jira.get_issue(
         issue_key=issue_key,
         fields=fields_list,
@@ -380,6 +418,20 @@ async def get_issue(
         update_history=update_history,
     )
     result = issue.to_simplified_dict()
+
+    # Enrichments that require separate API calls
+    if "remote_links" in include_sections:
+        try:
+            result["remote_links"] = jira.get_remote_issue_links(issue_key)
+        except Exception:  # noqa: BLE001
+            result["remote_links"] = []
+
+    if "watchers" in include_sections:
+        try:
+            result["watchers"] = jira.get_issue_watchers(issue_key)
+        except Exception:  # noqa: BLE001
+            result["watchers"] = {}
+
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -598,6 +598,11 @@ async def get_issue(
     )
     result = issue.to_simplified_dict()
 
+    if "comments" in include_sections:
+        result.setdefault("comments", [])
+    if "changelog" in include_sections:
+        result.setdefault("changelogs", [])
+
     # Enrichments that require separate API calls
     if "remote_links" in include_sections:
         try:

--- a/tests/e2e/cloud/test_jira_issue_include.py
+++ b/tests/e2e/cloud/test_jira_issue_include.py
@@ -1,0 +1,88 @@
+"""get_issue include param: inline enrichments in one call.
+
+Regression for https://github.com/sooperset/mcp-atlassian/issues/857
+and https://github.com/sooperset/mcp-atlassian/issues/1101
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestGetIssueIncludeEnrichments:
+    """get_issue include param inlines enrichments in one call.
+
+    Regression for github.com/sooperset/mcp-atlassian/issues/857
+    and github.com/sooperset/mcp-atlassian/issues/1101
+    """
+
+    def test_get_remote_issue_links(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Include test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        jira_fetcher.create_remote_issue_link(
+            issue.key,
+            {
+                "object": {
+                    "url": f"https://example.com/{uid}",
+                    "title": "Test Link",
+                }
+            },
+        )
+
+        links = jira_fetcher.get_remote_issue_links(issue.key)
+        assert isinstance(links, list)
+        assert len(links) >= 1
+
+    def test_get_transitions(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Transitions test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        transitions = jira_fetcher.get_transitions(issue.key)
+        assert isinstance(transitions, list)
+        assert len(transitions) > 0
+
+    def test_get_watchers(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Watchers test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        watchers = jira_fetcher.get_issue_watchers(issue.key)
+        assert isinstance(watchers, dict)

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -72,6 +72,28 @@ class TestMCPJiraTools:
         assert data["key"] == dc_instance.test_issue_key
 
     @pytest.mark.anyio
+    async def test_jira_get_issue_include_remote_links(
+        self,
+        mcp_client: Client,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        result = await call_tool(
+            mcp_client,
+            "jira_get_issue",
+            {
+                "issue_key": dc_instance.test_issue_key,
+                "fields": "summary,status",
+                "include": "remote_links",
+            },
+        )
+
+        assert not result.is_error
+        assert result.content and isinstance(result.content[0], TextContent)
+        data = json.loads(result.content[0].text)
+        assert data["key"] == dc_instance.test_issue_key
+        assert isinstance(data["remote_links"], list)
+
+    @pytest.mark.anyio
     async def test_jira_search(
         self,
         mcp_client: Client,

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -204,3 +204,93 @@ class TestLinksMixin:
 
         with pytest.raises(MCPAtlassianAuthenticationError):
             links_mixin.remove_issue_link(link_id)
+
+    @pytest.mark.parametrize(
+        "url, api_version",
+        [
+            pytest.param("https://test.atlassian.net", "3", id="cloud"),
+            pytest.param("https://jira.example.com", "2", id="server"),
+        ],
+    )
+    def test_get_remote_issue_links_success(
+        self,
+        jira_config_factory,
+        mock_atlassian_jira,
+        url: str,
+        api_version: str,
+    ):
+        """Test successful retrieval of remote issue links."""
+        config = jira_config_factory(url=url)
+        mixin = LinksMixin(config=config)
+        mixin.jira = mock_atlassian_jira
+        mock_links = [
+            {
+                "id": 1,
+                "object": {
+                    "url": "https://example.com",
+                    "title": "Link 1",
+                },
+            },
+            {
+                "id": 2,
+                "object": {
+                    "url": "https://example.org",
+                    "title": "Link 2",
+                },
+            },
+        ]
+        mixin.jira.get.return_value = mock_links
+
+        result = mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == mock_links
+        mixin.jira.get.assert_called_once_with(
+            f"rest/api/{api_version}/issue/PROJ-123/remotelink"
+        )
+
+    def test_get_remote_issue_links_dict_response(self, links_mixin):
+        """Test dict responses are unwrapped correctly."""
+        inner = [
+            {
+                "id": 1,
+                "object": {
+                    "url": "https://example.com",
+                    "title": "A",
+                },
+            }
+        ]
+        links_mixin.jira.get.return_value = {"remoteLinks": inner}
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == inner
+
+    def test_get_remote_issue_links_dict_without_key(self, links_mixin):
+        """Dict without remoteLinks wraps as single-element list."""
+        single = {
+            "id": 1,
+            "object": {
+                "url": "https://example.com",
+                "title": "A",
+            },
+        }
+        links_mixin.jira.get.return_value = single
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == [single]
+
+    def test_get_remote_issue_links_empty(self, links_mixin):
+        """Test empty list response."""
+        links_mixin.jira.get.return_value = []
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == []
+
+    def test_get_remote_issue_links_auth_error(self, links_mixin):
+        """Test authentication error is raised correctly."""
+        links_mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            links_mixin.get_remote_issue_links("PROJ-123")

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1042,8 +1042,8 @@ async def test_get_all_projects_tool(jira_client, mock_jira_fetcher):
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with default parameters (include_archived=False)
@@ -1091,8 +1091,8 @@ async def test_get_all_projects_tool_with_archived(jira_client, mock_jira_fetche
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with include_archived=True
@@ -1145,8 +1145,8 @@ async def test_get_all_projects_tool_with_projects_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up the projects filter in the config
@@ -1199,8 +1199,8 @@ async def test_get_all_projects_tool_no_projects_filter(jira_client, mock_jira_f
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Ensure no projects filter is set
@@ -1260,8 +1260,8 @@ async def test_get_all_projects_tool_case_insensitive_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up projects filter with mixed case and whitespace
@@ -2430,3 +2430,125 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
     # return_limit=1 caps to first match
     assert len(result) == 1
     assert result[0] == "High"
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_remote_links(jira_client, mock_jira_fetcher):
+    """get_issue with include=remote_links fetches remote links."""
+    mock_jira_fetcher.get_remote_issue_links.return_value = [
+        {
+            "id": 1,
+            "object": {
+                "url": "https://example.com",
+                "title": "Link",
+            },
+        }
+    ]
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "remote_links"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "remote_links" in content
+    assert len(content["remote_links"]) == 1
+    mock_jira_fetcher.get_remote_issue_links.assert_called_once_with("TEST-123")
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_watchers(jira_client, mock_jira_fetcher):
+    """get_issue with include=watchers fetches watchers."""
+    mock_jira_fetcher.get_issue_watchers.return_value = {
+        "watchCount": 1,
+        "watchers": [{"name": "user1"}],
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "watchers"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "watchers" in content
+    assert content["watchers"]["watchCount"] == 1
+    mock_jira_fetcher.get_issue_watchers.assert_called_once_with("TEST-123")
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_transitions_adds_expand(
+    jira_client, mock_jira_fetcher
+):
+    """get_issue with include=transitions adds to expand."""
+    await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "transitions"},
+    )
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "transitions" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_changelog_adds_expand(jira_client, mock_jira_fetcher):
+    """get_issue with include=changelog adds to expand."""
+    await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "changelog"},
+    )
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "changelog" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_multiple(jira_client, mock_jira_fetcher):
+    """get_issue with multiple include sections."""
+    mock_jira_fetcher.get_remote_issue_links.return_value = []
+    mock_jira_fetcher.get_issue_watchers.return_value = {
+        "watchCount": 0,
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {
+            "issue_key": "TEST-123",
+            "include": "remote_links,watchers,transitions,changelog",
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert "remote_links" in content
+    assert "watchers" in content
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "transitions" in expand_val
+    assert "changelog" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_preserves_existing_expand(
+    jira_client, mock_jira_fetcher
+):
+    """include merges with an existing expand parameter."""
+    await jira_client.call_tool(
+        "jira_get_issue",
+        {
+            "issue_key": "TEST-123",
+            "expand": "renderedFields",
+            "include": "transitions",
+        },
+    )
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "renderedFields" in expand_val
+    assert "transitions" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_none_no_enrichments(jira_client, mock_jira_fetcher):
+    """Omitting include produces no enrichment keys."""
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "remote_links" not in content
+    assert "watchers" not in content

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2714,10 +2714,12 @@ async def test_get_issue_include_transitions_fetches_transitions(
 @pytest.mark.anyio
 async def test_get_issue_include_changelog_adds_expand(jira_client, mock_jira_fetcher):
     """get_issue with include=changelog adds to expand."""
-    await jira_client.call_tool(
+    response = await jira_client.call_tool(
         "jira_get_issue",
         {"issue_key": "TEST-123", "include": "changelog"},
     )
+    content = json.loads(response.content[0].text)
+    assert content["changelogs"] == []
     call_args = mock_jira_fetcher.get_issue.call_args
     expand_val = call_args.kwargs.get("expand", "")
     assert "changelog" in expand_val
@@ -2728,7 +2730,7 @@ async def test_get_issue_include_comments_adds_comment_field(
     jira_client, mock_jira_fetcher
 ):
     """get_issue with include=comments requests the comment field."""
-    await jira_client.call_tool(
+    response = await jira_client.call_tool(
         "jira_get_issue",
         {
             "issue_key": "TEST-123",
@@ -2736,6 +2738,8 @@ async def test_get_issue_include_comments_adds_comment_field(
             "include": "comments",
         },
     )
+    content = json.loads(response.content[0].text)
+    assert content["comments"] == []
     call_args = mock_jira_fetcher.get_issue.call_args
     assert call_args.kwargs["fields"] == ["summary", "status", "comment"]
 
@@ -2806,6 +2810,8 @@ async def test_get_issue_include_all(jira_client, mock_jira_fetcher):
     assert content["transitions"] == [{"id": "11"}]
     assert content["watchers"] == {"watchCount": 1}
     assert content["worklogs"] == [{"id": "10001"}]
+    assert content["comments"] == []
+    assert content["changelogs"] == []
 
     call_args = mock_jira_fetcher.get_issue.call_args
     assert call_args.kwargs["fields"] == ["summary", "status", "comment"]


### PR DESCRIPTION
## Summary

Add an `include` parameter to the `get_issue` MCP tool so agents can inline related issue context in one call instead of chaining separate Jira tools.

**Supported sections:** `all`, `remote_links`, `transitions`, `watchers`, `changelog`, `comments`, `worklogs`

### How it works

- `all` expands to every supported include section.
- `changelog` is merged into Jira's native `expand` parameter and resolved by the existing issue model path.
- `comments` requests the Jira `comment` field and uses the existing `comment_limit` behavior.
- `remote_links`, `transitions`, `watchers`, and `worklogs` use existing Jira helper calls after the issue fetch. Failures return empty defaults so the main issue response is not lost.
- Unknown include sections are ignored with a warning. The existing `expand` parameter is preserved and merged when needed.

### Changes

| File | What |
|---|---|
| `src/mcp_atlassian/jira/links.py` | New `get_remote_issue_links()` method on `LinksMixin` |
| `src/mcp_atlassian/servers/jira.py` | New `include` param parsing and inline enrichment handling on `get_issue` |
| `tests/unit/jira/test_links.py` | Unit coverage for `get_remote_issue_links` on Cloud/Server, list/dict responses, empty results, and auth errors |
| `tests/unit/servers/test_jira_server.py` | Unit coverage for `include` parsing, `all`, comments, worklogs, transitions, fallbacks, and expand merging |
| `tests/e2e/cloud/test_jira_issue_include.py` | Cloud e2e coverage for remote links, transitions, watchers, and MCP `jira_get_issue include=all` |

### Usage example

```python
get_issue(issue_key="PROJ-123", include="all")
```

Returns the normal issue object with requested inline sections such as `remote_links`, `transitions`, `watchers`, `comments`, and `worklogs` included when available.

## Test plan

- [x] `uv run pytest tests/unit/servers/test_jira_server.py tests/unit/jira/test_links.py -xvs` — 131 passed
- [x] `uv run pytest tests/integration/ --integration -xvs` — 8 passed, 15 skipped
- [x] `uv run pytest tests/e2e/cloud --cloud-e2e -xvs` — 60 passed, 15 skipped
- [x] `uv run pytest tests/e2e/test_mcp_tools_dc.py::TestMCPJiraTools::test_jira_get_issue --dc-e2e -xvs` — 1 passed
- [x] `uv run pre-commit run --all-files`

DC note: `uv run pytest tests/e2e/test_jira_dc_operations.py tests/e2e/test_mcp_tools_dc.py --dc-e2e -xvs` reached the local DC instance, but the write suite is blocked by that Jira instance's expired license during issue creation.

Closes #857
Closes #1101
Closes #852
