### PR TITLE
feat(auth): add SSO cookie support for Jira and Confluence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,3 +239,10 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 
 # Confluence-specific custom headers.
 #CONFLUENCE_CUSTOM_HEADERS=X-Confluence-Service=mcp-integration,X-Custom-Auth=confluence-token,X-ALB-Token=secret-token
+
+# --- Cookie Configuration (Advanced) ---
+# Raw cookie string attached to every Jira/Confluence request.
+# Useful behind SSO / reverse proxies that require session cookies.
+# Format: name=value pairs separated by "; " (exactly as a Cookie header).
+#JIRA_COOKIE=JSESSIONID=abc123; other_cookie=xyz
+#CONFLUENCE_COOKIE=JSESSIONID=abc123; other_cookie=xyz

--- a/.env.example
+++ b/.env.example
@@ -268,6 +268,7 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # --- Cookie Configuration (Advanced) ---
 # Raw cookie string attached to every Jira/Confluence request.
 # Useful behind SSO / reverse proxies that require session cookies.
+# Treat these values as secrets.
 # Format: name=value pairs separated by "; " (exactly as a Cookie header).
 #JIRA_COOKIE=JSESSIONID=abc123; other_cookie=xyz
 #CONFLUENCE_COOKIE=JSESSIONID=abc123; other_cookie=xyz

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -208,8 +208,28 @@ CONFLUENCE_CUSTOM_HEADERS=X-Service=mcp-integration,X-ALB-Token=secret
 ```
 
 <Note>
-Header values are masked in debug logs for security.
+Sensitive header values are masked in debug logs for security.
 </Note>
+
+### SSO Cookies
+
+For SSO gateways or reverse proxies that require session cookies, configure a raw
+`Cookie` header independently for Jira and Confluence:
+
+```bash
+JIRA_COOKIE="JSESSIONID=abc123; other_cookie=xyz"
+CONFLUENCE_COOKIE="JSESSIONID=abc123; other_cookie=xyz"
+```
+
+| Variable | Description |
+|----------|-------------|
+| `JIRA_COOKIE` | Raw cookie string attached to every Jira request |
+| `CONFLUENCE_COOKIE` | Raw cookie string attached to every Confluence request |
+
+<Warning>
+Cookie values are authentication secrets. Keep them out of source control and
+rotate them if they are exposed.
+</Warning>
 
 ## Tool Filtering
 

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -145,6 +145,11 @@ class ConfluenceClient:
         if self.config.custom_headers:
             self._apply_custom_headers()
 
+        # Apply cookie if configured
+        if self.config.cookie:
+            self.confluence._session.headers["Cookie"] = self.config.cookie
+            logger.debug("Applied configured cookie to Confluence session")
+
         # Import here to avoid circular imports
         from ..preprocessing.confluence import ConfluencePreprocessor
 

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -40,6 +40,7 @@ class ConfluenceConfig:
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
     timeout: int = 75  # Connection timeout in seconds
+    cookie: str | None = None  # Raw cookie string to attach to all requests
 
     @property
     def is_cloud(self) -> bool:
@@ -187,6 +188,9 @@ class ConfluenceConfig:
         ):
             timeout = int(os.getenv("CONFLUENCE_TIMEOUT", "75"))
 
+        # Cookie configuration
+        cookie = os.getenv("CONFLUENCE_COOKIE")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -205,6 +209,7 @@ class ConfluenceConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cookie=cookie,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -158,6 +158,11 @@ class JiraClient:
         if self.config.custom_headers:
             self._apply_custom_headers()
 
+        # Apply cookie if configured
+        if self.config.cookie:
+            self.jira._session.headers["Cookie"] = self.config.cookie
+            logger.debug("Applied configured cookie to Jira session")
+
         # Initialize the text preprocessor for text processing capabilities
         self.preprocessor = JiraPreprocessor(
             base_url=self.config.url,

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -116,6 +116,7 @@ class JiraConfig:
     client_key_password: str | None = None  # Password for encrypted private key
     sla_config: SLAConfig | None = None  # Optional SLA configuration
     timeout: int = 75  # Connection timeout in seconds
+    cookie: str | None = None  # Raw cookie string to attach to all requests
 
     @property
     def is_cloud(self) -> bool:
@@ -262,6 +263,9 @@ class JiraConfig:
         if os.getenv("JIRA_TIMEOUT") and os.getenv("JIRA_TIMEOUT", "").isdigit():
             timeout = int(os.getenv("JIRA_TIMEOUT", "75"))
 
+        # Cookie configuration
+        cookie = os.getenv("JIRA_COOKIE")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -281,6 +285,7 @@ class JiraConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cookie=cookie,
         )
 
     def is_auth_configured(self) -> bool:

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -501,3 +501,24 @@ def test_confluence_client_custom_user_agent_overrides_default():
         ConfluenceClient(config=config)
 
         assert headers["User-Agent"] == "my-app/1.0"
+
+
+def test_confluence_client_applies_configured_cookie() -> None:
+    """The configured raw cookie is attached to the Confluence session."""
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        headers: dict[str, str] = {}
+        mock_confluence.return_value._session.headers = headers
+
+        config = ConfluenceConfig(
+            url="https://confluence.example.com",
+            auth_type="pat",
+            personal_token="pat",
+            cookie="JSESSIONID=abc123; sso_token=xyz",
+        )
+        ConfluenceClient(config=config)
+
+        assert headers["Cookie"] == "JSESSIONID=abc123; sso_token=xyz"

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -329,3 +329,32 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://confluence.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+def test_from_env_with_cookie():
+    """Test that from_env reads CONFLUENCE_COOKIE and stores it in config."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+            "CONFLUENCE_COOKIE": "JSESSIONID=abc123; other=xyz",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cookie == "JSESSIONID=abc123; other=xyz"
+
+
+def test_from_env_without_cookie():
+    """Test that cookie defaults to None when CONFLUENCE_COOKIE is not set."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cookie is None

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -362,7 +362,7 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.is_cloud is False
 
 
-def test_from_env_with_cookie():
+def test_from_env_with_cookie() -> None:
     """Test that from_env reads CONFLUENCE_COOKIE and stores it in config."""
     with patch.dict(
         os.environ,
@@ -377,7 +377,7 @@ def test_from_env_with_cookie():
         assert config.cookie == "JSESSIONID=abc123; other=xyz"
 
 
-def test_from_env_without_cookie():
+def test_from_env_without_cookie() -> None:
     """Test that cookie defaults to None when CONFLUENCE_COOKIE is not set."""
     with patch.dict(
         os.environ,

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -524,6 +524,26 @@ def test_jira_client_custom_user_agent_overrides_default() -> None:
         assert headers["User-Agent"] == "my-app/1.0"
 
 
+def test_jira_client_applies_configured_cookie() -> None:
+    """The configured raw cookie is attached to the Jira session."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        headers: dict[str, str] = {}
+        mock_jira.return_value._session.headers = headers
+
+        config = JiraConfig(
+            url="https://jira.example.com",
+            auth_type="pat",
+            personal_token="pat",
+            cookie="JSESSIONID=abc123; sso_token=xyz",
+        )
+        JiraClient(config=config)
+
+        assert headers["Cookie"] == "JSESSIONID=abc123; sso_token=xyz"
+
+
 @pytest.mark.parametrize(
     "url",
     [

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -401,3 +401,32 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://jira.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+def test_from_env_with_cookie():
+    """Test that from_env reads JIRA_COOKIE and stores it in config."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+            "JIRA_COOKIE": "JSESSIONID=abc123; other=xyz",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cookie == "JSESSIONID=abc123; other=xyz"
+
+
+def test_from_env_without_cookie():
+    """Test that cookie defaults to None when JIRA_COOKIE is not set."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cookie is None

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -403,7 +403,7 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.is_cloud is False
 
 
-def test_from_env_with_cookie():
+def test_from_env_with_cookie() -> None:
     """Test that from_env reads JIRA_COOKIE and stores it in config."""
     with patch.dict(
         os.environ,
@@ -418,7 +418,7 @@ def test_from_env_with_cookie():
         assert config.cookie == "JSESSIONID=abc123; other=xyz"
 
 
-def test_from_env_without_cookie():
+def test_from_env_without_cookie() -> None:
     """Test that cookie defaults to None when JIRA_COOKIE is not set."""
     with patch.dict(
         os.environ,


### PR DESCRIPTION
## Summary

- Add `JIRA_COOKIE` and `CONFLUENCE_COOKIE` environment settings.
- Attach the configured raw cookie to the corresponding HTTP session for all auth modes.
- Document the cookie format and secret-handling requirements.
- Cover both environment parsing and session application for Jira and Confluence.
- Synchronize the contributor branch with current `main`.

## Motivation

Some SSO gateways and reverse proxies require a session cookie in addition to the normal Jira or Confluence credentials. Dedicated cookie settings make that deployment pattern available without embedding the value in general custom-header configuration.

## Verification

- Focused Jira and Confluence config/client tests: 81 passed
- Full unit suite: 3,067 passed, 5 skipped
- Integration suite: 8 passed, 15 service-specific cases skipped
- Pre-commit: Ruff formatting, Ruff lint, and strict mypy passed
- Cloud e2e: 82 passed, 15 optional OAuth cases skipped
- Data Center e2e: 94 passed, 1 skipped