### PR TITLE
fix(confluence): add ancestors to expand params in get_page_content (closes #1131)

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -63,7 +63,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = v2_adapter.get_page(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,ancestors",
                 )
             else:
                 logger.debug(
@@ -72,7 +72,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = self.confluence.get_page_by_id(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,ancestors",
                 )
 
             # Check if API returned an error string
@@ -1031,7 +1031,7 @@ class PagesMixin(ConfluenceClient):
                 page = v2_adapter.get_page_by_version(
                     page_id=page_id,
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,ancestors",
                 )
             else:
                 logger.debug(
@@ -1043,7 +1043,7 @@ class PagesMixin(ConfluenceClient):
                     page_id=page_id,
                     status="historical",
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,ancestors",
                 )
 
             if isinstance(page, str):

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -137,3 +137,44 @@ class TestConfluenceCloudComments:
 
         comments = confluence_fetcher.get_page_comments(page.id)
         assert len(comments) > 0
+
+
+class TestConfluencePageAncestors:
+    """get_page_content should populate the ancestors field.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/1131
+    Root cause: 'ancestors' not included in expand params in get_page_content().
+    """
+
+    def test_child_page_has_ancestors(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        parent = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Ancestor Parent {uid}",
+            body="<p>Parent page.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(parent.id)
+
+        child = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Ancestor Child {uid}",
+            body="<p>Child page.</p>",
+            is_markdown=False,
+            parent_id=parent.id,
+        )
+        resource_tracker.add_confluence_page(child.id)
+
+        fetched = confluence_fetcher.get_page_content(child.id)
+        assert len(fetched.ancestors) > 0, (
+            "ancestors is empty — 'ancestors' missing from expand params"
+        )
+        parent_ids = [a.get("id") for a in fetched.ancestors]
+        assert parent.id in parent_ids, (
+            f"parent {parent.id} not in ancestors: {parent_ids}"
+        )

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -178,3 +178,17 @@ class TestConfluencePageAncestors:
         assert parent.id in parent_ids, (
             f"parent {parent.id} not in ancestors: {parent_ids}"
         )
+
+        # Verify to_simplified_dict() — this is what the MCP tool returns
+        simplified = fetched.to_simplified_dict()
+        assert "ancestors" in simplified, (
+            "ancestors missing from to_simplified_dict() output"
+        )
+        simplified_parent_ids = [a["id"] for a in simplified["ancestors"]]
+        assert parent.id in simplified_parent_ids, (
+            f"parent {parent.id} not in simplified ancestors: {simplified['ancestors']}"
+        )
+        # Each ancestor should have id and title
+        for ancestor in simplified["ancestors"]:
+            assert "id" in ancestor, f"ancestor missing 'id': {ancestor}"
+            assert "title" in ancestor, f"ancestor missing 'title': {ancestor}"

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -128,6 +128,14 @@ class TestConfluenceDCPageHierarchy:
         resource_tracker.add_confluence_page(child.id)
         assert child.id is not None
 
+        fetched = confluence_fetcher.get_page_content(child.id)
+        assert fetched.ancestors
+        assert parent.id in [ancestor.get("id") for ancestor in fetched.ancestors]
+
+        simplified = fetched.to_simplified_dict()
+        assert "ancestors" in simplified
+        assert parent.id in [ancestor["id"] for ancestor in simplified["ancestors"]]
+
 
 class TestConfluenceDCLabels:
     """Label operations."""

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -68,6 +68,42 @@ class TestPagesMixin:
         assert result.attachments[0].id is not None
         assert result.attachments[1].id is not None
 
+    def test_get_page_content_includes_ancestors_in_response(self, pages_mixin):
+        """Ancestors in API response flow through to ConfluencePage model.
+
+        Regression for https://github.com/sooperset/mcp-atlassian/issues/1131
+        Verifies the full path: API response → model → to_simplified_dict().
+        """
+        # Arrange — build a page response with ancestors included
+        import copy
+
+        from tests.fixtures.confluence_mocks import MOCK_PAGE_RESPONSE
+
+        page_with_ancestors = copy.deepcopy(MOCK_PAGE_RESPONSE)
+        page_with_ancestors["ancestors"] = [
+            {"id": "111", "title": "Grandparent Page", "type": "page"},
+            {"id": "222", "title": "Parent Page", "type": "page"},
+        ]
+        pages_mixin.confluence.get_page_by_id.return_value = page_with_ancestors
+        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+
+        # Act
+        result = pages_mixin.get_page_content("987654321", convert_to_markdown=True)
+
+        # Assert — ancestors populated on model
+        assert len(result.ancestors) == 2
+        assert result.ancestors[0]["id"] == "111"
+        assert result.ancestors[0]["title"] == "Grandparent Page"
+        assert result.ancestors[1]["id"] == "222"
+        assert result.ancestors[1]["title"] == "Parent Page"
+
+        # Assert — ancestors included in simplified dict (MCP tool output)
+        simplified = result.to_simplified_dict()
+        assert "ancestors" in simplified
+        assert len(simplified["ancestors"]) == 2
+        assert simplified["ancestors"][0] == {"id": "111", "title": "Grandparent Page"}
+        assert simplified["ancestors"][1] == {"id": "222", "title": "Parent Page"}
+
     def test_get_page_ancestors(self, pages_mixin):
         """Test getting page ancestors (parent pages)."""
         # Arrange

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -38,7 +38,8 @@ class TestPagesMixin:
 
         # Assert
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,ancestors",
         )
 
         # Verify result structure
@@ -698,7 +699,8 @@ class TestPagesMixin:
 
         # Verify the API call
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,ancestors",
         )
 
         # Verify the result
@@ -1029,7 +1031,7 @@ class TestPagesMixin:
             page_id=page_id,
             status="historical",
             version=version,
-            expand="body.storage,version,space,children.attachment",
+            expand="body.storage,version,space,children.attachment,ancestors",
         )
 
         # Verify result is a ConfluencePage
@@ -1453,7 +1455,8 @@ class TestPagesOAuthMixin:
 
             # Assert that v2 API was used instead of v1
             mock_v2_adapter.get_page.assert_called_once_with(
-                page_id=page_id, expand="body.storage,version,space,children.attachment"
+                page_id=page_id,
+                expand="body.storage,version,space,children.attachment,ancestors",
             )
 
             # Verify v1 API was NOT called
@@ -1544,7 +1547,7 @@ class TestPagesOAuthMixin:
             mock_v2_adapter.get_page_by_version.assert_called_once_with(
                 page_id=page_id,
                 version=version,
-                expand="body.storage,version,space,children.attachment",
+                expand="body.storage,version,space,children.attachment,ancestors",
             )
 
             # Verify v1 API was NOT called


### PR DESCRIPTION
## Summary

- Add `ancestors` to the expand parameter in `get_page_content()` so `confluence_get_page` responses include the ancestor chain (parent, grandparent, etc.)
- Same fix applied to the version-history code path (`get_page_by_version`)
- The `ConfluencePage` model already has an `ancestors` field and `to_simplified_dict()` already formats it — only the expand param was missing

## Test plan

- [x] Unit tests updated to assert new expand string
- [x] E2E test added: creates parent→child hierarchy, fetches child, verifies ancestors populated with parent ID
- [ ] Verify on Cloud instance
- [ ] Verify on Server/DC instance

Closes #1131

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)