### PR TITLE
fix: mask potential token-in-logs (closes #1134)

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -667,7 +667,11 @@ class UserTokenMiddleware:
         elif auth_header.strip():
             # Non-empty but unsupported auth type
             auth_value = auth_header.strip()
-            auth_type = auth_value.split(" ", 1)[0] if " " in auth_value else auth_value
+            auth_type = (
+                auth_value.split(" ", 1)[0]
+                if " " in auth_value
+                else f"(masked) {mask_sensitive(auth_value)}"
+            )
             logger.warning(f"Unsupported Authorization type: {auth_type}")
             scope["state"]["auth_validation_error"] = (
                 "Unauthorized: Only 'Bearer <OAuthToken>', "


### PR DESCRIPTION

## Description

When the user omits Auth-Type from their config, i.e. they pass:

`Authorization: <My Token Here>
instead of e.g.
`Authorization: Bearer <My Token Here>`

We currently print the full token to the logs.
In case there is only 1 word (e.g. the `split(" ") fails) - use `mask_sensitive` to log the error.

Fixes: #1134 

## Changes

- Use mask_sensitive for logging

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ no ] Unit tests added/updated
- [ yes ] Integration tests passed
- [ no ] Manual checks performed: `[briefly describe]`

## Checklist

- [ yes ] Code follows project style guidelines (linting passes).
- [ n/a ] Tests added/updated for changes.
- [ yes ] All tests pass locally.
- [ n/a ] Documentation updated (if needed).
