### PR TITLE
fix(jira): allow null values to clear fields in update_issue

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -986,6 +986,14 @@ class IssuesMixin(
                 logger.debug(f"Identified field '{key}' as standard system field ID.")
 
             if api_field_id:
+                # Allow None values to pass through for clearing fields
+                if value is None:
+                    fields[api_field_id] = None
+                    logger.debug(
+                        f"Setting field '{api_field_id}' to None from kwarg '{key}' (clearing field)."
+                    )
+                    continue
+
                 # Get the full field definition for formatting context if needed
                 field_definition = self.get_field_by_id(
                     api_field_id

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1058,6 +1058,7 @@ class IssuesMixin(
                 - assignee: New assignee for the issue
                 - parent: Parent issue key (str or {"key": "..."} dict)
                 - epicKey/epic_link/epicLink: Epic link alias
+                Pass None to clear a field (e.g., priority=None).
 
         Returns:
             JiraIssue model representing the updated issue

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -814,6 +814,44 @@ class TestIssuesMixin:
         assert "fixVersions" in fields
         assert fields["fixVersions"] == [{"name": "TestRelease"}]
 
+    def test_process_additional_fields_none_clears_field(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test _process_additional_fields passes None through to clear fields."""
+        fields = {}
+        kwargs = {"customfield_10013": None}  # Sprint field, set to null
+
+        issues_mixin._process_additional_fields(fields, kwargs)
+
+        # None must be preserved — it tells Jira API to clear the field
+        assert "customfield_10013" in fields
+        assert fields["customfield_10013"] is None
+
+    def test_process_additional_fields_none_clears_named_field(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test _process_additional_fields passes None through for named fields."""
+        fields = {}
+        kwargs = {"priority": None}
+
+        issues_mixin._process_additional_fields(fields, kwargs)
+
+        # priority=None should clear the priority field
+        assert "priority" in fields
+        assert fields["priority"] is None
+
+    def test_process_additional_fields_invalid_value_still_skipped(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test _process_additional_fields still skips fields with invalid format."""
+        fields = {}
+        kwargs = {"priority": 12345}  # Invalid: priority expects string or dict
+
+        issues_mixin._process_additional_fields(fields, kwargs)
+
+        # Invalid value should NOT be added to fields
+        assert "priority" not in fields
+
     def test_create_issue_with_parent_for_task(
         self, issues_mixin: IssuesMixin, make_issue_data
     ):

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -779,6 +779,29 @@ class TestIssuesMixin:
         )
         assert document.key == "TEST-123"
 
+    def test_update_issue_clears_field_with_none(self, issues_mixin: IssuesMixin):
+        """Test update_issue passes None through kwargs to clear a field."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        issues_mixin.update_issue(issue_key="TEST-123", priority=None)
+
+        issues_mixin.jira.update_issue.assert_called_once()
+        call_kwargs = issues_mixin.jira.update_issue.call_args
+        fields = call_kwargs[1]["update"]["fields"]
+        assert "priority" in fields
+        assert fields["priority"] is None
+
     def test_delete_issue(self, issues_mixin: IssuesMixin):
         """Test deleting an issue."""
         # Call the method


### PR DESCRIPTION
## Description

When calling `jira_update_issue` with `null` for a field (e.g., `customfield_10105: null` to clear Sprint), `_process_additional_fields` passes the value through `_format_field_value_for_write`, which returns `None` for both formatting errors **and** intentional `null` values. The subsequent `if formatted_value is not None` guard then silently drops the update.

This means there is currently no way to clear a custom or standard field via `jira_update_issue` — the `null` is indistinguishable from a formatting failure.

**Workaround before this fix:** Direct REST API call `PUT /rest/api/2/issue/{key}` with `{"fields": {"customfield_10105": null}}` works (HTTP 204), confirming this is a client-side filtering issue.

## Changes

- Add an early-return guard in `_process_additional_fields` that passes `None` directly to the fields dict, bypassing `_format_field_value_for_write` (`src/mcp_atlassian/jira/issues.py`)
- Document `None` clearing behavior in `update_issue` docstring
- Add 4 unit tests covering:
  - `None` for custom field IDs (e.g., `customfield_10013=None`)
  - `None` for named fields (e.g., `priority=None`)
  - Full `update_issue()` → API call path with `None` kwargs
  - Regression: invalid (non-None) values are still filtered out

This is consistent with the existing `assignee=None` pattern already in `update_issue` (line 1047–1048).

## Testing

- [x] Unit tests added/updated
- [x] All 46 tests pass (`uv run pytest tests/unit/jira/test_issues.py`)
- [x] Manual integration test: cleared Sprint (`customfield_10105`) on a real Jira Server issue via MCP tool call, confirmed field was set to `null`

### Test results

```
$ uv run pytest tests/unit/jira/test_issues.py -v
============================== 46 passed in 0.13s ==============================
```

```
$ uv run pre-commit run --files src/mcp_atlassian/jira/issues.py tests/unit/jira/test_issues.py
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
debug statements (python)................................................Passed
ruff-format..............................................................Passed
ruff.....................................................................Passed
mypy.....................................................................Passed
```

## Checklist

- [x] Code follows project style guidelines (linting passes)
- [x] Tests added/updated for changes
- [x] All tests pass locally
- [x] Documentation updated (docstring)