### PR TITLE
feat(confluence): add confluence_update_page_section tool for lossless partial page updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**72 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**77 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 72 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 73 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **72 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **73 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -81,7 +81,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
-| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_diff` |
+| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_diff` |
 | `confluence_comments` | Yes | `confluence_get_comments`, `confluence_add_comment`, `confluence_reply_to_comment` |
 | `confluence_labels` | No | `confluence_get_labels`, `confluence_add_label` |
 | `confluence_users` | No | `confluence_search_user` |
@@ -93,7 +93,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (72 tools)
+# Enable all toolsets (73 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 73 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 77 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **73 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **77 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -81,7 +81,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
-| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_diff` |
+| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_space_page_tree`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_diff` |
 | `confluence_comments` | Yes | `confluence_get_comments`, `confluence_add_comment`, `confluence_reply_to_comment` |
 | `confluence_labels` | No | `confluence_get_labels`, `confluence_add_label` |
 | `confluence_users` | No | `confluence_search_user` |
@@ -93,7 +93,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (73 tools)
+# Enable all toolsets (77 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -93,6 +93,40 @@ Set `is_minor_edit: true` to skip notification emails. The page version is auto-
 
 ---
 
+### Update Page Section
+
+Update a single section of a Confluence page without affecting the rest.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | `string` | Yes | The ID of the page to update |
+| `heading_text` | `string` | Yes | Exact text of the heading that starts the section to replace. Matching is case-sensitive. Use `confluence_get_page` with `convert_to_markdown=false` to inspect exact heading text when unsure. |
+| `new_content` | `string` | Yes | Replacement content for the section body. Do not include the heading itself — only the body beneath it. Format is controlled by `content_format`. |
+| `content_format` | `string` | No | Format of `new_content`. Options: `'markdown'` (default) or `'storage'` (raw Confluence storage XML). Use `'storage'` to insert macros or elements that markdown cannot express. |
+| `is_minor_edit` | `boolean` | No | Whether this is a minor edit |
+| `version_comment` | `string` | No | Optional comment for this version |
+
+**Example:**
+
+```json
+{"page_id": "12345678", "heading_text": "Weekly Update", "new_content": "- Shipped v2.1\n- Started v2.2 planning", "version_comment": "Weekly sync"}
+```
+
+<Tip>
+Use this instead of `confluence_update_page` when the page contains macros, layouts, task lists, or other Confluence-specific elements you don't want to lose. The tool fetches the page as raw storage XML, surgically replaces only the target section, and writes the full XML back — so everything outside the section is preserved exactly.
+</Tip>
+
+<Warning>
+`heading_text` must match the heading exactly as it appears in Confluence (case-sensitive, no surrounding emoji — emoji in headings are stripped automatically). If the heading is not found, a `ValueError` is raised.
+</Warning>
+
+
+---
+
 ### Delete Page
 
 Delete an existing Confluence page.

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import requests
+from bs4 import BeautifulSoup, Tag
 from requests.exceptions import HTTPError
 
 from ..models.confluence import ConfluencePage
@@ -716,6 +717,121 @@ class PagesMixin(ConfluenceClient):
         except Exception as e:
             logger.error(f"Error updating page {page_id}: {str(e)}")
             raise Exception(f"Failed to update page {page_id}: {str(e)}") from e
+
+    def update_page_section(
+        self,
+        page_id: str,
+        heading_text: str,
+        new_content: str,
+        *,
+        content_format: str = "markdown",
+        is_minor_edit: bool = False,
+        version_comment: str = "",
+    ) -> ConfluencePage:
+        """Update a single section of a Confluence page without affecting the rest.
+
+        Fetches the page in raw storage format, locates the section identified by
+        its heading text, replaces only the content between that heading and the
+        next heading of the same or higher level, and writes the modified storage
+        XML back. This is lossless: macros, layouts, mentions, and all other
+        Confluence-specific elements outside the target section are preserved.
+
+        Args:
+            page_id: The ID of the page to update.
+            heading_text: Exact text of the heading that starts the section to
+                replace. Matching is case-sensitive and whitespace-normalised.
+            new_content: Replacement content for the section body (excluding the
+                heading itself).
+            content_format: Format of new_content — ``'markdown'`` (default) or
+                ``'storage'``. When ``'markdown'``, the content is
+                converted to Confluence storage format before insertion.
+                (keyword-only)
+            is_minor_edit: Whether to flag the page version as a minor edit.
+                (keyword-only)
+            version_comment: Optional version comment. (keyword-only)
+
+        Returns:
+            Updated ``ConfluencePage`` with the section replaced.
+
+        Raises:
+            ValueError: If ``heading_text`` is not found on the page, or if
+                ``content_format`` is not one of the accepted values.
+            Exception: If retrieving or updating the page fails.
+        """
+        if content_format not in ("markdown", "storage"):
+            raise ValueError(
+                f"Invalid content_format '{content_format}'. "
+                "Must be 'markdown' or 'storage'."
+            )
+
+        # 1. Fetch raw storage XML — no markdown conversion so nothing is lost.
+        page = self.get_page_content(page_id, convert_to_markdown=False)
+        raw_storage = page.content or ""
+
+        # 2. Convert new_content to storage format when necessary.
+        if content_format == "markdown":
+            new_storage_fragment = self.preprocessor.markdown_to_confluence_storage(
+                new_content
+            )
+        else:
+            new_storage_fragment = new_content
+
+        # 3. Parse the full storage XML with BeautifulSoup.
+        soup = BeautifulSoup(raw_storage, "html.parser")
+
+        heading_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
+        target_heading: Tag | None = None
+        for tag in soup.find_all(heading_tags):
+            if isinstance(tag, Tag) and tag.get_text(strip=True) == heading_text.strip():
+                target_heading = tag
+                break
+
+        if target_heading is None:
+            raise ValueError(
+                f"Heading '{heading_text}' not found in page {page_id}. "
+                "Heading text must match exactly (case-sensitive)."
+            )
+
+        heading_level = int(target_heading.name[1])  # e.g. "h2" → 2
+
+        # 4. Collect all sibling nodes that belong to this section (between
+        #    this heading and the next heading of the same or higher level).
+        siblings_to_remove: list[Tag] = []
+        current = target_heading.next_sibling
+        while current is not None:
+            if isinstance(current, Tag) and current.name in heading_tags:
+                if int(current.name[1]) <= heading_level:
+                    break
+            siblings_to_remove.append(current)  # type: ignore[arg-type]
+            current = current.next_sibling
+
+        # 5. Remove old section body nodes.
+        for node in siblings_to_remove:
+            node.extract()
+
+        # 6. Parse and insert the new section body after the heading.
+        new_fragment_soup = BeautifulSoup(new_storage_fragment, "html.parser")
+        insert_after = target_heading
+        for child in list(new_fragment_soup.contents):
+            child_copy = child.__copy__()
+            insert_after.insert_after(child_copy)
+            insert_after = child_copy
+
+        # 7. Write the full modified storage XML back — no format conversion,
+        #    so every macro and element outside the section is untouched.
+        logger.debug(
+            f"Updating section '{heading_text}' on page {page_id} "
+            "using lossless storage-format write-back."
+        )
+        return self.update_page(
+            page_id=page_id,
+            title=page.title or "",
+            body=str(soup),
+            is_markdown=False,
+            content_representation="storage",
+            is_minor_edit=is_minor_edit,
+            version_comment=version_comment,
+        )
 
     def get_page_children(
         self,

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -791,7 +791,7 @@ class PagesMixin(ConfluenceClient):
 
         if target_heading is None:
             raise ValueError(
-                f"Heading '{heading_text}' not found in page {page_id}. "
+                f"Heading '{heading_text.strip()}' not found in page {page_id}. "
                 "Heading text must match exactly (case-sensitive)."
             )
 
@@ -799,31 +799,32 @@ class PagesMixin(ConfluenceClient):
 
         # 4. Collect all sibling nodes that belong to this section (between
         #    this heading and the next heading of the same or higher level).
-        siblings_to_remove: list[Tag] = []
+        #    NavigableString nodes (whitespace, text) are included alongside
+        #    Tag nodes, so we type the list broadly.
+        siblings_to_remove: list = []
         current = target_heading.next_sibling
         while current is not None:
             if isinstance(current, Tag) and current.name in heading_tags:
                 if int(current.name[1]) <= heading_level:
                     break
-            siblings_to_remove.append(current)  # type: ignore[arg-type]
+            siblings_to_remove.append(current)
             current = current.next_sibling
 
-        # 5. (old nodes removed in step 6 below)
-
-        # 6. Remove old nodes then do string-based insertion so we avoid
-        # moving nodes between BS4 trees (which causes type and mutation issues).
-        # Capture the heading HTML string before extracting siblings.
+        # 5. Capture heading HTML, remove old section nodes, then splice in the
+        #    new fragment via string operations — avoids moving nodes between
+        #    BS4 trees which causes type and mutation issues.
         heading_html = str(target_heading)
         for node in siblings_to_remove:
             node.extract()
 
-        # Rebuild: find the heading in the now-pruned HTML and splice in the
-        # new fragment immediately after it.
         pruned_html = str(soup)
         heading_pos = pruned_html.find(heading_html)
         if heading_pos == -1:
+            # Should not happen: heading was found by BS4 and serialised above.
+            # Guard against unexpected BS4 serialisation edge cases.
             raise ValueError(
-                f"Could not relocate heading '{heading_text}' after pruning page HTML."
+                f"Internal error: could not locate heading '{heading_text.strip()}' "
+                "in serialised page HTML. Please report this as a bug."
             )
         insert_at = heading_pos + len(heading_html)
         final_html = (

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -782,7 +782,10 @@ class PagesMixin(ConfluenceClient):
         heading_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
         target_heading: Tag | None = None
         for tag in soup.find_all(heading_tags):
-            if isinstance(tag, Tag) and tag.get_text(strip=True) == heading_text.strip():
+            if (
+                isinstance(tag, Tag)
+                and tag.get_text(strip=True) == heading_text.strip()
+            ):
                 target_heading = tag
                 break
 
@@ -805,17 +808,27 @@ class PagesMixin(ConfluenceClient):
             siblings_to_remove.append(current)  # type: ignore[arg-type]
             current = current.next_sibling
 
-        # 5. Remove old section body nodes.
+        # 5. (old nodes removed in step 6 below)
+
+        # 6. Remove old nodes then do string-based insertion so we avoid
+        # moving nodes between BS4 trees (which causes type and mutation issues).
+        # Capture the heading HTML string before extracting siblings.
+        heading_html = str(target_heading)
         for node in siblings_to_remove:
             node.extract()
 
-        # 6. Parse and insert the new section body after the heading.
-        new_fragment_soup = BeautifulSoup(new_storage_fragment, "html.parser")
-        insert_after = target_heading
-        for child in list(new_fragment_soup.contents):
-            child_copy = child.__copy__()
-            insert_after.insert_after(child_copy)
-            insert_after = child_copy
+        # Rebuild: find the heading in the now-pruned HTML and splice in the
+        # new fragment immediately after it.
+        pruned_html = str(soup)
+        heading_pos = pruned_html.find(heading_html)
+        if heading_pos == -1:
+            raise ValueError(
+                f"Could not relocate heading '{heading_text}' after pruning page HTML."
+            )
+        insert_at = heading_pos + len(heading_html)
+        final_html = (
+            pruned_html[:insert_at] + new_storage_fragment + pruned_html[insert_at:]
+        )
 
         # 7. Write the full modified storage XML back — no format conversion,
         #    so every macro and element outside the section is untouched.
@@ -826,7 +839,7 @@ class PagesMixin(ConfluenceClient):
         return self.update_page(
             page_id=page_id,
             title=page.title or "",
-            body=str(soup),
+            body=final_html,
             is_markdown=False,
             content_representation="storage",
             is_minor_edit=is_minor_edit,

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -759,10 +759,11 @@ class PagesMixin(ConfluenceClient):
             Exception: If retrieving or updating the page fails.
         """
         if content_format not in ("markdown", "storage"):
-            raise ValueError(
-                f"Invalid content_format '{content_format}'. "
-                "Must be 'markdown' or 'storage'."
+            error_msg = (
+                f"Invalid content_format '{content_format}'. Must be "
+                "'markdown' or 'storage'."
             )
+            raise ValueError(error_msg)
 
         # 1. Fetch raw storage XML — no markdown conversion so nothing is lost.
         page = self.get_page_content(page_id, convert_to_markdown=False)
@@ -790,10 +791,11 @@ class PagesMixin(ConfluenceClient):
                 break
 
         if target_heading is None:
-            raise ValueError(
+            error_msg = (
                 f"Heading '{heading_text.strip()}' not found in page {page_id}. "
                 "Heading text must match exactly (case-sensitive)."
             )
+            raise ValueError(error_msg)
 
         heading_level = int(target_heading.name[1])  # e.g. "h2" → 2
 
@@ -801,7 +803,7 @@ class PagesMixin(ConfluenceClient):
         #    this heading and the next heading of the same or higher level).
         #    NavigableString nodes (whitespace, text) are included alongside
         #    Tag nodes, so we type the list broadly.
-        siblings_to_remove: list = []
+        siblings_to_remove: list[Any] = []
         current = target_heading.next_sibling
         while current is not None:
             if isinstance(current, Tag) and current.name in heading_tags:
@@ -822,10 +824,11 @@ class PagesMixin(ConfluenceClient):
         if heading_pos == -1:
             # Should not happen: heading was found by BS4 and serialised above.
             # Guard against unexpected BS4 serialisation edge cases.
-            raise ValueError(
+            error_msg = (
                 f"Internal error: could not locate heading '{heading_text.strip()}' "
                 "in serialised page HTML. Please report this as a bug."
             )
+            raise ValueError(error_msg)
         insert_at = heading_pos + len(heading_html)
         final_html = (
             pruned_html[:insert_at] + new_storage_fragment + pruned_html[insert_at:]

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -745,6 +745,104 @@ async def update_page(
     )
 
 
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Update Page Section", "destructiveHint": True},
+)
+@check_write_access
+async def update_page_section(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page to update")],
+    heading_text: Annotated[
+        str,
+        Field(
+            description=(
+                "Exact text of the heading that starts the section to replace. "
+                "Matching is case-sensitive. Use confluence_get_page with "
+                "convert_to_markdown=false to inspect exact heading text when unsure."
+            )
+        ),
+    ],
+    new_content: Annotated[
+        str,
+        Field(
+            description=(
+                "Replacement content for the section body. "
+                "Do NOT include the heading itself — only the body beneath it. "
+                "Format is controlled by content_format."
+            )
+        ),
+    ],
+    content_format: Annotated[
+        str,
+        Field(
+            description=(
+                "(Optional) Format of new_content. "
+                "Options: 'markdown' (default) or 'storage' (raw Confluence storage XML). "
+                "Use 'storage' to insert macros or elements that markdown cannot express."
+            ),
+            default="markdown",
+        ),
+    ] = "markdown",
+    is_minor_edit: Annotated[
+        bool, Field(description="Whether this is a minor edit", default=False)
+    ] = False,
+    version_comment: Annotated[
+        str | None,
+        Field(description="Optional comment for this version", default=None),
+    ] = None,
+) -> str:
+    """Update a single section of a Confluence page without affecting the rest.
+
+    Replaces only the content beneath a named heading, leaving all other
+    sections, macros, layouts, and Confluence-specific elements completely
+    intact. This avoids the data loss that occurs when a full page is
+    downloaded as Markdown, edited, and re-uploaded.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to update.
+        heading_text: Exact heading text identifying the section to replace.
+        new_content: New body content for the section (heading not included).
+        content_format: Format of new_content ('markdown' or 'storage').
+        is_minor_edit: Whether to flag this as a minor edit.
+        version_comment: Optional version comment.
+
+    Returns:
+        JSON string representing the updated page metadata.
+
+    Raises:
+        ValueError: If Confluence client is not configured, heading is not
+            found, or content_format is invalid.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    if content_format not in ("markdown", "storage"):
+        raise ValueError(
+            f"Invalid content_format '{content_format}'. Must be 'markdown' or 'storage'."
+        )
+
+    updated_page = confluence_fetcher.update_page_section(
+        page_id=page_id,
+        heading_text=heading_text,
+        new_content=new_content,
+        content_format=content_format,
+        is_minor_edit=is_minor_edit,
+        version_comment=version_comment or "",
+    )
+
+    page_data = updated_page.to_simplified_dict()
+    page_data.pop("content", None)
+    return json.dumps(
+        {
+            "message": f"Section '{heading_text}' updated successfully",
+            "page": page_data,
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_pages"},
     annotations={"title": "Delete Page", "destructiveHint": True},

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -745,7 +745,6 @@ async def update_page(
     )
 
 
-
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_pages"},
     annotations={"title": "Update Page Section", "destructiveHint": True},
@@ -842,6 +841,7 @@ async def update_page_section(
         indent=2,
         ensure_ascii=False,
     )
+
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_pages"},

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -772,13 +772,15 @@ async def update_page_section(
             )
         ),
     ],
+    *,
     content_format: Annotated[
         str,
         Field(
             description=(
                 "(Optional) Format of new_content. "
-                "Options: 'markdown' (default) or 'storage' (raw Confluence storage XML). "
-                "Use 'storage' to insert macros or elements that markdown cannot express."
+                "Options: 'markdown' (default) or 'storage' "
+                "(raw Confluence storage XML). Use 'storage' to insert "
+                "macros or elements that markdown cannot express."
             ),
             default="markdown",
         ),
@@ -817,9 +819,11 @@ async def update_page_section(
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
     if content_format not in ("markdown", "storage"):
-        raise ValueError(
-            f"Invalid content_format '{content_format}'. Must be 'markdown' or 'storage'."
+        error_msg = (
+            f"Invalid content_format '{content_format}'. Must be "
+            "'markdown' or 'storage'."
         )
+        raise ValueError(error_msg)
 
     updated_page = confluence_fetcher.update_page_section(
         page_id=page_id,

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 77 tools into 21 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 

--- a/tests/e2e/cloud/test_confluence_auth_matrix.py
+++ b/tests/e2e/cloud/test_confluence_auth_matrix.py
@@ -110,6 +110,39 @@ class TestConfluenceWriteOperations:
         )
         assert updated is not None
 
+    def test_update_page_section(
+        self,
+        authed_confluence: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = authed_confluence.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Section Update Test {uid}",
+            body=(
+                "# Summary\n\nKeep summary.\n\n"
+                "## Target Section\n\nOld target body.\n\n"
+                "## Next Section\n\nKeep next."
+            ),
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        updated = authed_confluence.update_page_section(
+            page_id=page.id,
+            heading_text="Target Section",
+            new_content="New target body.",
+            is_minor_edit=True,
+            version_comment="Cloud e2e section update",
+        )
+        assert updated is not None
+
+        retrieved = authed_confluence.get_page_content(page.id)
+        assert "New target body" in (retrieved.content or "")
+        assert "Old target body" not in (retrieved.content or "")
+        assert "Keep summary" in (retrieved.content or "")
+        assert "Keep next" in (retrieved.content or "")
+
     def test_add_comment(
         self,
         authed_confluence: ConfluenceFetcher,

--- a/tests/e2e/cloud/test_mcp_tools_cloud.py
+++ b/tests/e2e/cloud/test_mcp_tools_cloud.py
@@ -225,3 +225,64 @@ class TestMCPConfluenceTools:
             "confluence_delete_page",
             {"page_id": page_id},
         )
+
+    @pytest.mark.anyio
+    async def test_confluence_update_page_section(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page_id = None
+        create_result = await call_tool(
+            mcp_client,
+            "confluence_create_page",
+            {
+                "space_key": cloud_instance.space_key,
+                "title": f"Cloud MCP Section Update Test {uid}",
+                "content": (
+                    "# Summary\n\nKeep summary.\n\n"
+                    "## Target Section\n\nOld target body.\n\n"
+                    "## Next Section\n\nKeep next."
+                ),
+            },
+        )
+        assert not create_result.is_error
+        assert create_result.content and isinstance(
+            create_result.content[0], TextContent
+        )
+        page_id = json.loads(create_result.content[0].text)["page"]["id"]
+
+        try:
+            update_result = await call_tool(
+                mcp_client,
+                "confluence_update_page_section",
+                {
+                    "page_id": page_id,
+                    "heading_text": "Target Section",
+                    "new_content": "New target body.",
+                    "is_minor_edit": True,
+                    "version_comment": "Cloud MCP e2e section update",
+                },
+            )
+            assert not update_result.is_error
+
+            get_result = await call_tool(
+                mcp_client,
+                "confluence_get_page",
+                {"page_id": page_id, "include_metadata": False},
+            )
+            assert not get_result.is_error
+            assert get_result.content and isinstance(get_result.content[0], TextContent)
+            content = json.loads(get_result.content[0].text)["content"]["value"]
+            assert "New target body" in content
+            assert "Old target body" not in content
+            assert "Keep summary" in content
+            assert "Keep next" in content
+        finally:
+            if page_id:
+                await call_tool(
+                    mcp_client,
+                    "confluence_delete_page",
+                    {"page_id": page_id},
+                )

--- a/tests/e2e/test_confluence_auth_matrix.py
+++ b/tests/e2e/test_confluence_auth_matrix.py
@@ -110,6 +110,39 @@ class TestConfluenceWriteOperations:
         )
         assert updated is not None
 
+    def test_update_page_section(
+        self,
+        authed_confluence: ConfluenceFetcher,
+        dc_instance: DCInstanceInfo,
+        resource_tracker: DCResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = authed_confluence.create_page(
+            space_key=dc_instance.space_key,
+            title=f"E2E Section Update Test {uid}",
+            body=(
+                "# Summary\n\nKeep summary.\n\n"
+                "## Target Section\n\nOld target body.\n\n"
+                "## Next Section\n\nKeep next."
+            ),
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        updated = authed_confluence.update_page_section(
+            page_id=page.id,
+            heading_text="Target Section",
+            new_content="New target body.",
+            is_minor_edit=True,
+            version_comment="DC e2e section update",
+        )
+        assert updated is not None
+
+        retrieved = authed_confluence.get_page_content(page.id)
+        assert "New target body" in (retrieved.content or "")
+        assert "Old target body" not in (retrieved.content or "")
+        assert "Keep summary" in (retrieved.content or "")
+        assert "Keep next" in (retrieved.content or "")
+
     def test_add_comment(
         self,
         authed_confluence: ConfluenceFetcher,

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -202,3 +202,64 @@ class TestMCPConfluenceTools:
             "confluence_delete_page",
             {"page_id": page_id},
         )
+
+    @pytest.mark.anyio
+    async def test_confluence_update_page_section(
+        self,
+        mcp_client: Client,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page_id = None
+        create_result = await call_tool(
+            mcp_client,
+            "confluence_create_page",
+            {
+                "space_key": dc_instance.space_key,
+                "title": f"MCP Section Update Test {uid}",
+                "content": (
+                    "# Summary\n\nKeep summary.\n\n"
+                    "## Target Section\n\nOld target body.\n\n"
+                    "## Next Section\n\nKeep next."
+                ),
+            },
+        )
+        assert not create_result.is_error
+        assert create_result.content and isinstance(
+            create_result.content[0], TextContent
+        )
+        page_id = json.loads(create_result.content[0].text)["page"]["id"]
+
+        try:
+            update_result = await call_tool(
+                mcp_client,
+                "confluence_update_page_section",
+                {
+                    "page_id": page_id,
+                    "heading_text": "Target Section",
+                    "new_content": "New target body.",
+                    "is_minor_edit": True,
+                    "version_comment": "DC MCP e2e section update",
+                },
+            )
+            assert not update_result.is_error
+
+            get_result = await call_tool(
+                mcp_client,
+                "confluence_get_page",
+                {"page_id": page_id, "include_metadata": False},
+            )
+            assert not get_result.is_error
+            assert get_result.content and isinstance(get_result.content[0], TextContent)
+            content = json.loads(get_result.content[0].text)["content"]["value"]
+            assert "New target body" in content
+            assert "Old target body" not in content
+            assert "Keep summary" in content
+            assert "Keep next" in content
+        finally:
+            if page_id:
+                await call_tool(
+                    mcp_client,
+                    "confluence_delete_page",
+                    {"page_id": page_id},
+                )

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -2987,7 +2987,9 @@ class TestUpdatePageSection:
 
         with (
             patch.object(pages_mixin, "get_page_content", return_value=raw_page),
-            patch.object(pages_mixin, "update_page", return_value=updated_page) as mock_update,
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
         ):
             result = pages_mixin.update_page_section(
                 page_id="123",
@@ -3026,7 +3028,9 @@ class TestUpdatePageSection:
 
         with (
             patch.object(pages_mixin, "get_page_content", return_value=raw_page),
-            patch.object(pages_mixin, "update_page", return_value=updated_page) as mock_update,
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
         ):
             pages_mixin.update_page_section("1", "Section B", "new b")
 
@@ -3062,11 +3066,7 @@ class TestUpdatePageSection:
             '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
             "</ac:structured-macro>"
         )
-        storage = (
-            f"{macro}"
-            "<h2>Section</h2><p>old</p>"
-            "<h2>Other</h2><p>other</p>"
-        )
+        storage = f"{macro}<h2>Section</h2><p>old</p><h2>Other</h2><p>other</p>"
         raw_page = self._make_page("1", "P", storage)
         updated_page = self._make_page("1", "P", "")
 
@@ -3076,7 +3076,9 @@ class TestUpdatePageSection:
 
         with (
             patch.object(pages_mixin, "get_page_content", return_value=raw_page),
-            patch.object(pages_mixin, "update_page", return_value=updated_page) as mock_update,
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
         ):
             pages_mixin.update_page_section("1", "Section", "new")
 
@@ -3085,9 +3087,7 @@ class TestUpdatePageSection:
 
     def test_storage_format_content_not_converted(self, pages_mixin):
         """When content_format='storage', markdown_to_confluence_storage is not called."""
-        raw_page = self._make_page(
-            "1", "P", "<h2>Section</h2><p>old</p>"
-        )
+        raw_page = self._make_page("1", "P", "<h2>Section</h2><p>old</p>")
         updated_page = self._make_page("1", "P", "")
 
         with (

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -2944,3 +2944,161 @@ class TestPageHierarchy:
 
         assert result["total_pages"] == 1
         assert result["has_more"] is False
+
+
+class TestUpdatePageSection:
+    """Tests for PagesMixin.update_page_section."""
+
+    @pytest.fixture
+    def pages_mixin(self, confluence_client):
+        """Create a PagesMixin instance for testing."""
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceClient.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            mixin = PagesMixin()
+            mixin.confluence = confluence_client.confluence
+            mixin.config = confluence_client.config
+            mixin.preprocessor = confluence_client.preprocessor
+            return mixin
+
+    def _make_page(self, page_id: str, title: str, storage_html: str) -> ConfluencePage:
+        return ConfluencePage(
+            id=page_id,
+            title=title,
+            content=storage_html,
+            space={"key": "PROJ", "name": "Project"},
+            version={"number": 1},
+        )
+
+    def test_replaces_section_content(self, pages_mixin):
+        """Section body is replaced; heading and surrounding content are kept."""
+        storage = (
+            "<h1>Intro</h1><p>intro text</p>"
+            "<h2>Target Section</h2><p>old content</p>"
+            "<h2>Another Section</h2><p>other content</p>"
+        )
+        raw_page = self._make_page("123", "My Page", storage)
+        updated_page = self._make_page("123", "My Page", "updated")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new content</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(pages_mixin, "update_page", return_value=updated_page) as mock_update,
+        ):
+            result = pages_mixin.update_page_section(
+                page_id="123",
+                heading_text="Target Section",
+                new_content="new content",
+            )
+
+        assert result is updated_page
+        call_body: str = mock_update.call_args.kwargs["body"]
+        # Heading preserved
+        assert "<h2>Target Section</h2>" in call_body
+        # New content inserted
+        assert "<p>new content</p>" in call_body
+        # Old content removed
+        assert "old content" not in call_body
+        # Sibling section untouched
+        assert "<h2>Another Section</h2>" in call_body
+        assert "<p>other content</p>" in call_body
+        # Written back as storage format
+        assert mock_update.call_args.kwargs["is_markdown"] is False
+        assert mock_update.call_args.kwargs["content_representation"] == "storage"
+
+    def test_stops_at_same_level_heading(self, pages_mixin):
+        """Content replacement stops at the next heading of the same level."""
+        storage = (
+            "<h2>Section A</h2><p>a content</p>"
+            "<h2>Section B</h2><p>b content</p><h3>Sub</h3><p>sub</p>"
+            "<h2>Section C</h2><p>c content</p>"
+        )
+        raw_page = self._make_page("1", "P", storage)
+        updated_page = self._make_page("1", "P", "")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new b</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(pages_mixin, "update_page", return_value=updated_page) as mock_update,
+        ):
+            pages_mixin.update_page_section("1", "Section B", "new b")
+
+        body: str = mock_update.call_args.kwargs["body"]
+        assert "b content" not in body
+        assert "<p>new b</p>" in body
+        # Section C must be intact
+        assert "<h2>Section C</h2>" in body
+        assert "<p>c content</p>" in body
+        # Section A must be intact
+        assert "<h2>Section A</h2>" in body
+        assert "<p>a content</p>" in body
+
+    def test_heading_not_found_raises(self, pages_mixin):
+        """ValueError is raised when heading text does not exist on the page."""
+        raw_page = self._make_page("1", "P", "<h2>Existing</h2><p>content</p>")
+
+        with patch.object(pages_mixin, "get_page_content", return_value=raw_page):
+            with pytest.raises(ValueError, match="not found in page"):
+                pages_mixin.update_page_section("1", "Nonexistent Heading", "data")
+
+    def test_invalid_content_format_raises(self, pages_mixin):
+        """ValueError is raised for unsupported content_format values."""
+        with pytest.raises(ValueError, match="Invalid content_format"):
+            pages_mixin.update_page_section(
+                "1", "Heading", "content", content_format="wiki"
+            )
+
+    def test_macros_outside_section_preserved(self, pages_mixin):
+        """Confluence macros outside the target section survive the update."""
+        macro = (
+            '<ac:structured-macro ac:name="toc">'
+            '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        storage = (
+            f"{macro}"
+            "<h2>Section</h2><p>old</p>"
+            "<h2>Other</h2><p>other</p>"
+        )
+        raw_page = self._make_page("1", "P", storage)
+        updated_page = self._make_page("1", "P", "")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(pages_mixin, "update_page", return_value=updated_page) as mock_update,
+        ):
+            pages_mixin.update_page_section("1", "Section", "new")
+
+        body: str = mock_update.call_args.kwargs["body"]
+        assert 'ac:name="toc"' in body
+
+    def test_storage_format_content_not_converted(self, pages_mixin):
+        """When content_format='storage', markdown_to_confluence_storage is not called."""
+        raw_page = self._make_page(
+            "1", "P", "<h2>Section</h2><p>old</p>"
+        )
+        updated_page = self._make_page("1", "P", "")
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(pages_mixin, "update_page", return_value=updated_page),
+        ):
+            pages_mixin.update_page_section(
+                "1",
+                "Section",
+                "<p>raw storage</p>",
+                content_format="storage",
+            )
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -3137,7 +3137,7 @@ class TestUpdatePageSection:
         assert 'ac:name="toc"' in body
 
     def test_storage_format_content_not_converted(self, pages_mixin):
-        """When content_format='storage', markdown_to_confluence_storage is not called."""
+        """Storage content is inserted without markdown conversion."""
         raw_page = self._make_page("1", "P", "<h2>Section</h2><p>old</p>")
         updated_page = self._make_page("1", "P", "")
 

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -59,6 +59,7 @@ def mock_confluence_fetcher():
     }
     mock_fetcher.create_page.return_value = mock_page
     mock_fetcher.update_page.return_value = mock_page
+    mock_fetcher.update_page_section.return_value = mock_page
     mock_fetcher.delete_page.return_value = True
 
     # Mock comment
@@ -204,6 +205,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
         search,
         search_user,
         update_page,
+        update_page_section,
         upload_attachment,
         upload_attachments,
     )
@@ -235,6 +237,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
     confluence_sub_mcp.add_tool(add_label)
     confluence_sub_mcp.add_tool(create_page)
     confluence_sub_mcp.add_tool(update_page)
+    confluence_sub_mcp.add_tool(update_page_section)
     confluence_sub_mcp.add_tool(delete_page)
     confluence_sub_mcp.add_tool(search_user)
     confluence_sub_mcp.add_tool(upload_attachment)
@@ -273,6 +276,7 @@ def no_fetcher_test_confluence_mcp(mock_base_confluence_config):
         search,
         search_user,
         update_page,
+        update_page_section,
         upload_attachment,
         upload_attachments,
     )
@@ -306,6 +310,7 @@ def no_fetcher_test_confluence_mcp(mock_base_confluence_config):
     confluence_sub_mcp.add_tool(add_label)
     confluence_sub_mcp.add_tool(create_page)
     confluence_sub_mcp.add_tool(update_page)
+    confluence_sub_mcp.add_tool(update_page_section)
     confluence_sub_mcp.add_tool(delete_page)
     confluence_sub_mcp.add_tool(search_user)
     confluence_sub_mcp.add_tool(upload_attachment)
@@ -726,6 +731,56 @@ async def test_update_page_include_content(client, mock_confluence_fetcher):
     assert result_data["message"] == "Page updated successfully"
     assert result_data["page"]["title"] == "Test Page Mock Title"
     assert "content" in result_data["page"]
+
+
+@pytest.mark.anyio
+async def test_update_page_section(client, mock_confluence_fetcher):
+    """Test update_page_section passes section update parameters."""
+    response = await client.call_tool(
+        "confluence_update_page_section",
+        {
+            "page_id": "999999",
+            "heading_text": "Weekly Update",
+            "new_content": "- Shipped v2.1",
+            "content_format": "markdown",
+            "is_minor_edit": True,
+            "version_comment": "Weekly sync",
+        },
+    )
+
+    mock_confluence_fetcher.update_page_section.assert_called_once_with(
+        page_id="999999",
+        heading_text="Weekly Update",
+        new_content="- Shipped v2.1",
+        content_format="markdown",
+        is_minor_edit=True,
+        version_comment="Weekly sync",
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["message"] == "Section 'Weekly Update' updated successfully"
+    assert result_data["page"]["title"] == "Test Page Mock Title"
+    assert "content" not in result_data["page"]
+
+
+@pytest.mark.anyio
+async def test_update_page_section_default_version_comment(
+    client, mock_confluence_fetcher
+):
+    """Test update_page_section sends an empty version comment by default."""
+    await client.call_tool(
+        "confluence_update_page_section",
+        {
+            "page_id": "999999",
+            "heading_text": "Weekly Update",
+            "new_content": "- Shipped v2.1",
+        },
+    )
+
+    call_kwargs = mock_confluence_fetcher.update_page_section.call_args.kwargs
+    assert call_kwargs["content_format"] == "markdown"
+    assert call_kwargs["is_minor_edit"] is False
+    assert call_kwargs["version_comment"] == ""
 
 
 @pytest.mark.anyio

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 24, (
-            f"Expected 24 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 25, (
+            f"Expected 25 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
## Description

Adds a new `confluence_update_page_section` MCP tool and backing `PagesMixin.update_page_section()` method that replaces the content of a single named section without touching the rest of the page.

The existing `confluence_update_page` flow converts the full page to Markdown and back, which destroys macros (TOC, Page Properties, Status, task lists, decision lists, etc.), multi-column layouts, and user mentions. This is a well-known pain point reported in #842 and the [Atlassian community](https://community.atlassian.com/forums/Confluence-questions/Confluence-MCP-amp-page-macros/qaq-p/3073340).

**How it works (lossless):**
1. Fetch raw Confluence storage XML — no Markdown conversion, macros untouched
2. Locate the target section by heading text using BeautifulSoup
3. Replace only the nodes between that heading and the next same-or-higher-level heading
4. Write the full modified storage XML back with `content_representation=storage`

Everything outside the target section — macros, layouts, mentions, task lists, decision lists — is preserved exactly as-is.

Fixes: #842 (partial)

## Changes

- `confluence/pages.py` — `PagesMixin.update_page_section()` method
- `servers/confluence.py` — `confluence_update_page_section` MCP tool registered with `destructiveHint: True`
- `tests/unit/confluence/test_pages.py` — 6 unit tests
- `tests/unit/utils/test_toolsets.py` — updated Confluence tool count (24 → 25)
- `docs/tools/confluence-pages.mdx` — new Update Page Section entry
- `docs/tools-reference.mdx` — tool added to toolset list, count 72 → 73

## Testing

- [x] Unit tests added/updated (6 new tests: section replacement, boundary detection, macro preservation, error cases, format handling)
- [ ] Integration tests passed (no integration test env available)
- [x] Manual checks performed: tested end-to-end against a real Confluence Cloud instance with a meeting notes page containing TOC macro, emoji headings, discussion table, task list, and decision list — all preserved after section update

**Manual test result:** Updated the "Goals" section on a live Confluence page. All 7 checks passed:
- ✓ TOC macro preserved
- ✓ Discussion table preserved
- ✓ Action items task list preserved
- ✓ Decision list preserved
- ✓ All 8 headings intact
- ✓ New content inserted correctly
- ✓ Old placeholder removed

## Checklist

- [x] Code follows project style guidelines (linting passes)
- [x] Tests added/updated for changes
- [x] All tests pass locally (Python 3.10–3.13)
- [x] Documentation updated (confluence-pages.mdx, tools-reference.mdx)