### PR TITLE
feat(confluence): add get/add inline comment tools

### DIFF
--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -28,6 +28,23 @@ class CommentsMixin(ConfluenceClient):
             )
         return None
 
+    @property
+    def _inline_v2_adapter(self) -> ConfluenceV2Adapter | None:
+        """Get v2 API adapter for inline comment operations.
+
+        Inline comments require the v2 API on all Cloud instances because the
+        v1 ``POST /rest/api/content/`` endpoint does not support inline comment
+        creation on Confluence Cloud regardless of auth method.
+
+        Returns:
+            ConfluenceV2Adapter instance if this is a Cloud instance, None otherwise
+        """
+        if self.config.is_cloud:
+            return ConfluenceV2Adapter(
+                session=self.confluence._session, base_url=self.confluence.url
+            )
+        return None
+
     def get_page_comments(
         self, page_id: str, *, return_markdown: bool = True
     ) -> list[ConfluenceComment]:
@@ -65,6 +82,12 @@ class CommentsMixin(ConfluenceClient):
 
                 # Create a copy of the comment data to modify
                 modified_comment_data = comment_data.copy()
+                if "body" in modified_comment_data:
+                    modified_comment_data["body"] = modified_comment_data["body"].copy()
+                    if "view" in modified_comment_data["body"]:
+                        modified_comment_data["body"]["view"] = modified_comment_data[
+                            "body"
+                        ]["view"].copy()
 
                 # Modify the body value based on the return format
                 if "body" not in modified_comment_data:
@@ -206,6 +229,171 @@ class CommentsMixin(ConfluenceClient):
             logger.debug("Full exception details for comment reply:", exc_info=True)
             return None
 
+    def get_inline_comments(
+        self, page_id: str, *, return_markdown: bool = True
+    ) -> list[ConfluenceComment]:
+        """Get inline comments for a specific page.
+
+        Args:
+            page_id: The ID of the page to get inline comments from
+            return_markdown: When True, returns content in markdown format,
+                           otherwise returns raw HTML (keyword-only)
+
+        Returns:
+            List of ConfluenceComment models with location="inline"
+        """
+        try:
+            v2_adapter = self._inline_v2_adapter
+            if v2_adapter:
+                raw_comments = v2_adapter.get_inline_comments(page_id)
+                space_key = ""
+            else:
+                # v1: fetch all child comments then filter by location=inline
+                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
+                space_key = page.get("space", {}).get("key", "")
+                response = self.confluence.get_page_comments(
+                    content_id=page_id,
+                    expand="body.view.value,version,extensions.inlineProperties",
+                    depth="all",
+                )
+                raw_comments = [
+                    c
+                    for c in response.get("results", [])
+                    if c.get("extensions", {}).get("location") == "inline"
+                ]
+
+            comment_models = []
+            for comment_data in raw_comments:
+                body = comment_data.get("body", {}).get("view", {}).get("value", "")
+                processed_html, processed_markdown = (
+                    self.preprocessor.process_html_content(
+                        body, space_key=space_key, confluence_client=self.confluence
+                    )
+                )
+
+                modified_comment_data = comment_data.copy()
+                if "body" in modified_comment_data:
+                    modified_comment_data["body"] = modified_comment_data["body"].copy()
+                    if "view" in modified_comment_data["body"]:
+                        modified_comment_data["body"]["view"] = modified_comment_data[
+                            "body"
+                        ]["view"].copy()
+                if "body" not in modified_comment_data:
+                    modified_comment_data["body"] = {}
+                if "view" not in modified_comment_data["body"]:
+                    modified_comment_data["body"]["view"] = {}
+
+                modified_comment_data["body"]["view"]["value"] = (
+                    processed_markdown if return_markdown else processed_html
+                )
+
+                comment_models.append(
+                    ConfluenceComment.from_api_response(
+                        modified_comment_data, base_url=self.config.url
+                    )
+                )
+
+            return comment_models
+
+        except KeyError as e:
+            logger.error(f"Missing key in inline comment data: {str(e)}")
+            return []
+        except requests.RequestException as e:
+            logger.error(f"Network error when fetching inline comments: {str(e)}")
+            return []
+        except (ValueError, TypeError) as e:
+            logger.error(f"Error processing inline comment data: {str(e)}")
+            return []
+        except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging
+            logger.error(f"Unexpected error fetching inline comments: {str(e)}")
+            logger.debug("Full exception details for inline comments:", exc_info=True)
+            return []
+
+    def add_inline_comment(
+        self,
+        page_id: str,
+        content: str,
+        text_selection: str,
+        text_selection_match_count: int = 1,
+        text_selection_match_index: int = 0,
+    ) -> ConfluenceComment | None:
+        """Add an inline comment anchored to a text selection on a page.
+
+        For Cloud instances, uses the v2 API (POST /api/v2/inline-comments).
+        For Server/DC, uses the v1 API (POST /rest/api/content/).
+
+        Args:
+            page_id: The ID of the page to add the inline comment to
+            content: The comment content (Markdown or HTML/storage format)
+            text_selection: The text on the page to anchor the comment to
+            text_selection_match_count: How many times the text appears
+                on the page
+            text_selection_match_index: Zero-based index of which occurrence
+                to anchor to
+
+        Returns:
+            ConfluenceComment object if successful, None otherwise
+        """
+        try:
+            # Convert markdown to Confluence storage format if needed
+            if not content.strip().startswith("<"):
+                content = self.preprocessor.markdown_to_confluence_storage(content)
+
+            v2_adapter = self._inline_v2_adapter
+            if v2_adapter:
+                response = v2_adapter.create_inline_comment(
+                    page_id=page_id,
+                    body=content,
+                    text_selection=text_selection,
+                    text_selection_match_count=text_selection_match_count,
+                    text_selection_match_index=text_selection_match_index,
+                )
+                space_key = ""
+            else:
+                # v1 API: POST /rest/api/content/ with inline location
+                data: dict[str, Any] = {
+                    "type": "comment",
+                    "container": {
+                        "id": page_id,
+                        "type": "page",
+                    },
+                    "body": {
+                        "storage": {
+                            "value": content,
+                            "representation": "storage",
+                        },
+                    },
+                    "extensions": {
+                        "location": "inline",
+                        "inlineProperties": {
+                            "originalSelection": text_selection,
+                        },
+                    },
+                }
+                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
+                space_key = page.get("space", {}).get("key", "")
+                response = self.confluence.post("rest/api/content/", data=data)
+
+            if not response:
+                logger.error("Failed to add inline comment: empty response")
+                return None
+
+            return self._process_comment_response(response, space_key)
+
+        except requests.RequestException as e:
+            logger.error(f"Network error when adding inline comment: {str(e)}")
+            return None
+        except (ValueError, TypeError, KeyError) as e:
+            logger.error(f"Error processing inline comment data: {str(e)}")
+            return None
+        except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging
+            logger.error(f"Unexpected error adding inline comment: {str(e)}")
+            logger.debug(
+                "Full exception details for adding inline comment:",
+                exc_info=True,
+            )
+            return None
+
     def _process_comment_response(
         self, response: dict[str, Any], space_key: str
     ) -> ConfluenceComment:
@@ -225,6 +413,12 @@ class CommentsMixin(ConfluenceClient):
         )
 
         modified_response = response.copy()
+        if "body" in modified_response:
+            modified_response["body"] = modified_response["body"].copy()
+            if "view" in modified_response["body"]:
+                modified_response["body"]["view"] = modified_response["body"][
+                    "view"
+                ].copy()
         if "body" not in modified_response:
             modified_response["body"] = {}
         if "view" not in modified_response["body"]:

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -492,6 +492,148 @@ class ConfluenceV2Adapter:
             logger.error(f"Error creating footer comment: {e}")
             raise ValueError(f"Failed to create footer comment: {e}") from e
 
+    def get_inline_comments(
+        self,
+        page_id: str,
+        status: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get inline comments for a page using the v2 API.
+
+        Args:
+            page_id: The ID of the page to get inline comments from
+            status: Optional filter — "open" or "resolved"
+
+        Returns:
+            List of inline comments in v1-compatible format
+
+        Raises:
+            ValueError: If the API request fails
+        """
+        try:
+            url = f"{self.base_url}/api/v2/pages/{page_id}/inline-comments"
+            params: dict[str, Any] = {"body-format": "storage"}
+            if status:
+                params["status"] = status
+
+            response = self.session.get(url, params=params)
+            response.raise_for_status()
+
+            data = response.json()
+            results = data.get("results", [])
+            return [self._convert_v2_inline_comment_to_v1_format(r) for r in results]
+
+        except Exception as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                logger.error(
+                    f"HTTP error getting inline comments for page '{page_id}': {e}\n"
+                    f"Response: {e.response.text}"
+                )
+            else:
+                logger.error(f"Error getting inline comments for page '{page_id}': {e}")
+            raise ValueError(
+                f"Failed to get inline comments for page '{page_id}': {e}"
+            ) from e
+
+    def create_inline_comment(
+        self,
+        *,
+        page_id: str,
+        body: str,
+        text_selection: str,
+        text_selection_match_count: int = 1,
+        text_selection_match_index: int = 0,
+        representation: str = "storage",
+    ) -> dict[str, Any]:
+        """Create an inline comment anchored to a text selection using the v2 API.
+
+        Args:
+            page_id: The ID of the page to add the inline comment to
+            body: The comment content
+            text_selection: The text on the page to anchor the comment to
+            text_selection_match_count: Total number of times the text
+                appears on the page
+            text_selection_match_index: Zero-based index of which occurrence
+                to anchor to
+            representation: Content representation format (default: "storage")
+
+        Returns:
+            The created inline comment data in v1-compatible format
+
+        Raises:
+            ValueError: If creation fails
+        """
+        try:
+            data: dict[str, Any] = {
+                "pageId": page_id,
+                "body": {
+                    "representation": representation,
+                    "value": body,
+                },
+                "inlineCommentProperties": {
+                    "textSelection": text_selection,
+                    "textSelectionMatchCount": text_selection_match_count,
+                    "textSelectionMatchIndex": text_selection_match_index,
+                },
+            }
+
+            url = f"{self.base_url}/api/v2/inline-comments"
+            response = self.session.post(url, json=data)
+            response.raise_for_status()
+
+            result = response.json()
+            logger.debug("Successfully created inline comment with v2 API")
+
+            return self._convert_v2_inline_comment_to_v1_format(result)
+
+        except Exception as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                logger.error(
+                    f"HTTP error creating inline comment: {e}\n"
+                    f"Response: {e.response.text}"
+                )
+            else:
+                logger.error(f"Error creating inline comment: {e}")
+            raise ValueError(f"Failed to create inline comment: {e}") from e
+
+    def _convert_v2_inline_comment_to_v1_format(
+        self, v2_response: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Convert v2 inline comment response to v1-compatible format.
+
+        Args:
+            v2_response: The response from the v2 inline-comments API
+
+        Returns:
+            Response formatted like v1 API for compatibility
+        """
+        body_value = v2_response.get("body", {}).get("storage", {}).get("value", "")
+
+        v1_compatible: dict[str, Any] = {
+            "id": v2_response.get("id"),
+            "type": "comment",
+            "status": v2_response.get("status"),
+            "title": v2_response.get("title"),
+            "body": {
+                "view": {
+                    "value": body_value,
+                    "representation": "view",
+                },
+            },
+            "version": v2_response.get("version", {}),
+            "_links": v2_response.get("_links", {}),
+            "extensions": {"location": "inline"},
+            "created": v2_response.get("version", {}).get("createdAt", ""),
+            "updated": v2_response.get("version", {}).get("createdAt", ""),
+        }
+
+        if author := v2_response.get("author"):
+            v1_compatible["author"] = author
+
+        if inline_props := v2_response.get("inlineCommentProperties"):
+            v1_compatible["inlineCommentProperties"] = inline_props
+
+        return v1_compatible
+
     def _convert_v2_comment_to_v1_format(
         self, v2_response: dict[str, Any]
     ) -> dict[str, Any]:
@@ -521,6 +663,8 @@ class ConfluenceV2Adapter:
             },
             "version": v2_response.get("version", {}),
             "_links": v2_response.get("_links", {}),
+            "created": v2_response.get("version", {}).get("createdAt", ""),
+            "updated": v2_response.get("version", {}).get("createdAt", ""),
         }
 
         # Map v2 author to v1 format

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -974,6 +974,143 @@ async def reply_to_comment(
 
 
 @confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_comments"},
+    annotations={"title": "Get Inline Comments", "readOnlyHint": True},
+)
+async def get_inline_comments(
+    ctx: Context,
+    page_id: Annotated[
+        str, Field(description="The ID of the page to get inline comments from")
+    ],
+) -> str:
+    """Get all inline comments for a Confluence page.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to get inline comments from.
+
+    Returns:
+        JSON string with a list of inline comments.
+
+    Raises:
+        ValueError: If Confluence client is unavailable.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    try:
+        comments = confluence_fetcher.get_inline_comments(page_id)
+        response = {
+            "success": True,
+            "page_id": page_id,
+            "count": len(comments),
+            "comments": [c.to_simplified_dict() for c in comments],
+        }
+    except Exception as e:
+        logger.error(
+            f"Error getting inline comments for Confluence page {page_id}: {str(e)}"
+        )
+        response = {
+            "success": False,
+            "message": f"Error getting inline comments for page {page_id}",
+            "error": str(e),
+        }
+
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_comments"},
+    annotations={"title": "Add Inline Comment", "destructiveHint": True},
+)
+@check_write_access
+async def add_inline_comment(
+    ctx: Context,
+    page_id: Annotated[
+        str, Field(description="The ID of the page to add the inline comment to")
+    ],
+    body: Annotated[str, Field(description="The comment content in Markdown format")],
+    text_selection: Annotated[
+        str,
+        Field(
+            description=(
+                "The exact text on the page to anchor the inline comment to. "
+                "Must match text that exists in the page content."
+            )
+        ),
+    ],
+    text_selection_match_count: Annotated[
+        int,
+        Field(
+            description=(
+                "Total number of times the selected text appears on the page. "
+                "Defaults to 1."
+            ),
+            ge=1,
+        ),
+    ] = 1,
+    text_selection_match_index: Annotated[
+        int,
+        Field(
+            description=(
+                "Zero-based index of which occurrence of the text to anchor to. "
+                "Defaults to 0 (first occurrence)."
+            ),
+            ge=0,
+        ),
+    ] = 0,
+) -> str:
+    """Add an inline comment anchored to a specific text selection on a Confluence page.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to add the inline comment to.
+        body: The comment content in Markdown format.
+        text_selection: The exact text on the page to anchor the comment to.
+        text_selection_match_count: Total occurrences of the selected text on the page.
+        text_selection_match_index: Zero-based index of which occurrence to anchor to.
+
+    Returns:
+        JSON string representing the created inline comment.
+
+    Raises:
+        ValueError: If in read-only mode or Confluence client is unavailable.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    try:
+        comment = confluence_fetcher.add_inline_comment(
+            page_id=page_id,
+            content=body,
+            text_selection=text_selection,
+            text_selection_match_count=text_selection_match_count,
+            text_selection_match_index=text_selection_match_index,
+        )
+        if comment:
+            response = {
+                "success": True,
+                "message": "Inline comment added successfully",
+                "comment": comment.to_simplified_dict(),
+            }
+        else:
+            response = {
+                "success": False,
+                "message": (
+                    f"Unable to add inline comment to page {page_id}. "
+                    "API request completed but comment creation unsuccessful."
+                ),
+            }
+    except Exception as e:
+        logger.error(
+            f"Error adding inline comment to Confluence page {page_id}: {str(e)}"
+        )
+        response = {
+            "success": False,
+            "message": f"Error adding inline comment to page {page_id}",
+            "error": str(e),
+        }
+
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
     tags={"confluence", "read", "toolset:confluence_users"},
     annotations={"title": "Search User", "readOnlyHint": True},
 )

--- a/tests/fixtures/confluence_mocks.py
+++ b/tests/fixtures/confluence_mocks.py
@@ -598,3 +598,82 @@ MOCK_COMMENT_REPLY_V2_RESPONSE = {
         "webui": "/spaces/TEST/pages/12345?focusedCommentId=222333444",
     },
 }
+
+# ============================================================================
+# Inline Comment Mock Data
+# ============================================================================
+
+MOCK_INLINE_COMMENT_V1_RESPONSE = {
+    "id": "333444555",
+    "type": "comment",
+    "status": "current",
+    "title": "Inline Comment",
+    "container": {
+        "id": "12345",
+        "type": "page",
+        "status": "current",
+        "title": "Test Page",
+    },
+    "body": {
+        "view": {
+            "value": "<p>This is an inline comment</p>",
+            "representation": "view",
+        },
+    },
+    "version": {
+        "by": {
+            "type": "known",
+            "accountId": "user123",
+            "displayName": "Test User",
+        },
+        "when": "2024-01-03T10:00:00.000Z",
+        "number": 1,
+    },
+    "extensions": {
+        "location": "inline",
+        "inlineProperties": {
+            "originalSelection": "some text to anchor",
+        },
+    },
+    "_links": {
+        "webui": "/spaces/TEST/pages/12345?focusedCommentId=333444555",
+        "self": "https://example.atlassian.net/wiki/rest/api/content/333444555",
+    },
+}
+
+MOCK_INLINE_COMMENT_V2_RESPONSE = {
+    "id": "444555666",
+    "status": "open",
+    "pageId": "12345",
+    "inlineCommentProperties": {
+        "textSelection": "some text to anchor",
+        "textSelectionMatchCount": 1,
+        "textSelectionMatchIndex": 0,
+        "resolved": False,
+    },
+    "body": {
+        "storage": {
+            "value": "<p>This is a v2 inline comment</p>",
+            "representation": "storage",
+        },
+    },
+    "version": {
+        "number": 1,
+        "createdAt": "2024-01-03T10:00:00.000Z",
+    },
+    "author": {
+        "type": "known",
+        "accountId": "user123",
+        "displayName": "Test User",
+    },
+    "_links": {
+        "webui": "/spaces/TEST/pages/12345?focusedCommentId=444555666",
+    },
+}
+
+MOCK_INLINE_COMMENTS_V2_LIST_RESPONSE = {
+    "results": [MOCK_INLINE_COMMENT_V2_RESPONSE],
+    "_links": {
+        "self": "https://example.atlassian.net/wiki/api/v2/pages/12345/inline-comments",
+    },
+}

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -6,10 +6,13 @@ import pytest
 import requests
 
 from mcp_atlassian.confluence.comments import CommentsMixin
+from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.models.confluence import ConfluenceComment
 from tests.fixtures.confluence_mocks import (
     MOCK_COMMENT_REPLY_V1_RESPONSE,
     MOCK_COMMENT_REPLY_V2_RESPONSE,
+    MOCK_INLINE_COMMENT_V1_RESPONSE,
+    MOCK_INLINE_COMMENT_V2_RESPONSE,
 )
 
 
@@ -24,6 +27,37 @@ def comments_mixin(confluence_client):
         mixin.confluence = confluence_client.confluence
         mixin.config = confluence_client.config
         mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+@pytest.fixture
+def comments_mixin_dc():
+    """Create a CommentsMixin instance for Server/DC testing (is_cloud=False).
+
+    Inline comments on Server/DC use the v1 API path.
+    """
+    with patch(
+        "mcp_atlassian.confluence.comments.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = CommentsMixin()
+        mixin.config = ConfluenceConfig(
+            url="https://confluence.example.com",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+        )
+        mixin.confluence = MagicMock()
+        mixin.confluence._session = MagicMock()
+        mock_preprocessor = MagicMock()
+        mock_preprocessor.process_html_content.return_value = (
+            "<p>Processed HTML</p>",
+            "Processed Markdown",
+        )
+        mock_preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Processed</p>"
+        )
+        mixin.preprocessor = mock_preprocessor
         return mixin
 
 
@@ -513,3 +547,295 @@ class TestConfluenceCommentModel:
         comment = ConfluenceComment.from_api_response(data)
         result = comment.to_simplified_dict()
         assert "location" not in result
+
+
+class TestGetInlineComments:
+    """Tests for get_inline_comments method."""
+
+    def test_get_inline_comments_v1_success(self, comments_mixin_dc):
+        """get_inline_comments v1 (Server/DC) filters by location=inline."""
+        page_id = "12345"
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.get_page_comments.return_value = {
+            "results": [
+                MOCK_INLINE_COMMENT_V1_RESPONSE,
+                # footer comment that should be filtered out
+                {
+                    "id": "999",
+                    "body": {"view": {"value": "<p>footer</p>"}},
+                    "extensions": {"location": "footer"},
+                },
+            ]
+        }
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            "<p>This is an inline comment</p>",
+            "This is an inline comment",
+        )
+
+        result = comments_mixin_dc.get_inline_comments(page_id)
+
+        assert len(result) == 1
+        assert result[0].location == "inline"
+        assert result[0].id == "333444555"
+        # Verify expanded fields were requested
+        comments_mixin_dc.confluence.get_page_comments.assert_called_once_with(
+            content_id=page_id,
+            expand="body.view.value,version,extensions.inlineProperties",
+            depth="all",
+        )
+
+    def test_get_inline_comments_v2_cloud_success(self, comments_mixin):
+        """get_inline_comments uses v2 API on Cloud (any auth type)."""
+        mock_adapter = MagicMock()
+        mock_adapter.get_inline_comments.return_value = [
+            {
+                "id": "444555666",
+                "type": "comment",
+                "status": "open",
+                "body": {
+                    "view": {"value": "<p>v2 inline</p>", "representation": "view"}
+                },
+                "extensions": {"location": "inline"},
+                "version": {"number": 1},
+                "_links": {},
+            }
+        ]
+        comments_mixin.preprocessor.process_html_content.return_value = (
+            "<p>v2 inline</p>",
+            "v2 inline",
+        )
+
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=lambda: property(lambda self: mock_adapter),
+        ):
+            result = comments_mixin.get_inline_comments("12345")
+
+        assert len(result) == 1
+        mock_adapter.get_inline_comments.assert_called_once_with("12345")
+        # v1 API should not be called
+        comments_mixin.confluence.get_page_comments.assert_not_called()
+
+    def test_get_inline_comments_empty(self, comments_mixin_dc):
+        """get_inline_comments returns empty list if no inline comments (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.get_page_comments.return_value = {
+            "results": [
+                {
+                    "id": "999",
+                    "body": {"view": {"value": "<p>footer</p>"}},
+                    "extensions": {"location": "footer"},
+                }
+            ]
+        }
+
+        result = comments_mixin_dc.get_inline_comments("12345")
+
+        assert result == []
+
+    def test_get_inline_comments_network_error(self, comments_mixin_dc):
+        """get_inline_comments returns empty list on network error (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_comments.side_effect = (
+            requests.RequestException("Network error")
+        )
+
+        result = comments_mixin_dc.get_inline_comments("12345")
+
+        assert result == []
+
+    def test_get_inline_comments_html_format(self, comments_mixin_dc):
+        """get_inline_comments returns HTML body when return_markdown=False (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.get_page_comments.return_value = {
+            "results": [MOCK_INLINE_COMMENT_V1_RESPONSE]
+        }
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            "<p>HTML body</p>",
+            "Markdown body",
+        )
+
+        result = comments_mixin_dc.get_inline_comments("12345", return_markdown=False)
+
+        assert result[0].body == "<p>HTML body</p>"
+
+
+class TestAddInlineComment:
+    """Tests for add_inline_comment method."""
+
+    def test_add_inline_comment_v1_success(self, comments_mixin_dc):
+        """add_inline_comment v1 (Server/DC) posts with inline location."""
+        page_id = "12345"
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Inline comment</p>"
+        )
+        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            "<p>Inline comment</p>",
+            "Inline comment",
+        )
+
+        result = comments_mixin_dc.add_inline_comment(
+            page_id, "Inline comment", "some text to anchor"
+        )
+
+        assert result is not None
+        assert result.location == "inline"
+        call_args = comments_mixin_dc.confluence.post.call_args
+        assert call_args[0][0] == "rest/api/content/"
+        data = call_args[1]["data"]
+        assert data["extensions"]["location"] == "inline"
+        assert data["extensions"]["inlineProperties"]["originalSelection"] == (
+            "some text to anchor"
+        )
+
+    def test_add_inline_comment_v2_cloud_success(self, comments_mixin):
+        """add_inline_comment uses v2 API on Cloud (any auth type)."""
+
+        v2_converted = {
+            "id": "444555666",
+            "type": "comment",
+            "status": "open",
+            "body": {"view": {"value": "<p>v2 inline</p>", "representation": "view"}},
+            "extensions": {"location": "inline"},
+            "version": {"number": 1},
+            "_links": {},
+            "inlineCommentProperties": {
+                "textSelection": "some text to anchor",
+                "textSelectionMatchCount": 1,
+                "textSelectionMatchIndex": 0,
+            },
+        }
+
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.return_value = v2_converted
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>v2 inline</p>"
+        )
+        comments_mixin.preprocessor.process_html_content.return_value = (
+            "<p>v2 inline</p>",
+            "v2 inline",
+        )
+
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=lambda: property(lambda self: mock_adapter),
+        ):
+            result = comments_mixin.add_inline_comment(
+                "12345",
+                "v2 inline",
+                "some text to anchor",
+                text_selection_match_count=2,
+                text_selection_match_index=1,
+            )
+
+        assert result is not None
+        mock_adapter.create_inline_comment.assert_called_once_with(
+            page_id="12345",
+            body="<p>v2 inline</p>",
+            text_selection="some text to anchor",
+            text_selection_match_count=2,
+            text_selection_match_index=1,
+        )
+        # v1 API should not be called
+        comments_mixin.confluence.post.assert_not_called()
+
+    def test_add_inline_comment_with_html_content(self, comments_mixin_dc):
+        """add_inline_comment skips markdown conversion for HTML content (Server/DC)."""
+        html_content = "<p>Already <strong>HTML</strong></p>"
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            html_content,
+            "Already **HTML**",
+        )
+
+        result = comments_mixin_dc.add_inline_comment(
+            "12345", html_content, "some text"
+        )
+
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.assert_not_called()
+        assert result is not None
+
+    def test_add_inline_comment_empty_response(self, comments_mixin_dc):
+        """add_inline_comment returns None on empty API response (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Test</p>"
+        )
+        comments_mixin_dc.confluence.post.return_value = None
+
+        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+
+        assert result is None
+
+    def test_add_inline_comment_network_error(self, comments_mixin_dc):
+        """add_inline_comment returns None on network error (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Test</p>"
+        )
+        comments_mixin_dc.confluence.post.side_effect = requests.RequestException(
+            "Network error"
+        )
+
+        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+
+        assert result is None
+
+
+class TestInlineCommentModel:
+    """Tests for ConfluenceComment model with inline comment data."""
+
+    def test_inline_comment_from_v1_response(self):
+        """ConfluenceComment correctly parses v1 inline comment response."""
+        comment = ConfluenceComment.from_api_response(MOCK_INLINE_COMMENT_V1_RESPONSE)
+        assert comment.id == "333444555"
+        assert comment.location == "inline"
+        assert comment.body == "<p>This is an inline comment</p>"
+
+    def test_inline_comment_from_v2_response_converted(self):
+        """ConfluenceComment parses v2 inline comment after v1 conversion."""
+        # Simulate what _convert_v2_inline_comment_to_v1_format outputs
+        v1_converted = {
+            "id": "444555666",
+            "type": "comment",
+            "status": "open",
+            "body": {
+                "view": {
+                    "value": "<p>This is a v2 inline comment</p>",
+                    "representation": "view",
+                }
+            },
+            "version": MOCK_INLINE_COMMENT_V2_RESPONSE["version"],
+            "author": MOCK_INLINE_COMMENT_V2_RESPONSE["author"],
+            "_links": MOCK_INLINE_COMMENT_V2_RESPONSE["_links"],
+            "extensions": {"location": "inline"},
+            "inlineCommentProperties": {
+                "textSelection": "some text to anchor",
+                "textSelectionMatchCount": 1,
+                "textSelectionMatchIndex": 0,
+            },
+        }
+        comment = ConfluenceComment.from_api_response(v1_converted)
+        assert comment.id == "444555666"
+        assert comment.location == "inline"
+        assert comment.body == "<p>This is a v2 inline comment</p>"
+        assert comment.author is not None
+        assert comment.author.display_name == "Test User"

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 24, (
-            f"Expected 24 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 26, (
+            f"Expected 26 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
## Description

Adds two new MCP tools — `confluence_get_inline_comments` and `confluence_add_inline_comment` — and the backing `CommentsMixin` methods to fetch and create inline comments anchored to a text selection on a Confluence page.

The existing `confluence_add_comment` tool only supports footer (page-level) comments. There was no way to create inline comments through the MCP server. This is a commonly requested capability since inline comments are widely used for contextual feedback in Confluence.

The root cause is that `POST /rest/api/content/` (v1) does not support inline comment creation on Confluence Cloud regardless of auth method — the v2 API is required. A dedicated `_inline_v2_adapter` property activates the v2 path based on `is_cloud` (not `auth_type`), so basic auth and OAuth users on Cloud both benefit.

Fixes: #715 

## Changes

- `confluence/comments.py` — `_inline_v2_adapter` property; `get_inline_comments()` and `add_inline_comment()` methods with Cloud (v2) and Server/DC (v1) paths
- `confluence/v2_adapter.py` — `get_inline_comments()`, `create_inline_comment()`, `_convert_v2_inline_comment_to_v1_format()`; timestamp fields (`created`/`updated`) mapped from `version.createdAt` in both v2 comment converters
- `servers/confluence.py` — `confluence_get_inline_comments` and `confluence_add_inline_comment` tools registered with `toolset:confluence_comments` tags
- `tests/fixtures/confluence_mocks.py` — `MOCK_INLINE_COMMENT_V1_RESPONSE`, `MOCK_INLINE_COMMENT_V2_RESPONSE`, `MOCK_INLINE_COMMENTS_V2_LIST_RESPONSE`
- `tests/unit/confluence/test_comments.py` — `comments_mixin_dc` fixture; 10 new tests covering v1/v2 routing, empty response, network error, HTML format, model parsing
- `tests/unit/utils/test_toolsets.py` — updated Confluence tool count (24 → 26)

## Testing

- [x] Unit tests added/updated (10 new tests: v1/v2 routing, empty response, network error, HTML format, model parsing)
- [ ] Integration tests passed
- [x] Manual checks performed: tested `confluence_add_inline_comment` and `confluence_get_inline_comments` end-to-end against a live Confluence Cloud instance using basic auth (API token). Inline comment created successfully; response returned correct `id`, `body`, `created`, and `updated` fields.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).