### PR TITLE
feat(jira): add dedicated assign_issue tool

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1163,6 +1163,48 @@ class IssuesMixin(
             logger.error(f"Error updating issue {issue_key}: {error_msg}")
             raise ValueError(f"Failed to update issue {issue_key}: {error_msg}") from e
 
+    def assign_issue(
+        self,
+        issue_key: str,
+        assignee: str | None,
+    ) -> JiraIssue:
+        """
+        Assign a Jira issue to a user using the dedicated assignment endpoint.
+
+        Unlike update_issue (which sets assignee via the fields update and is
+        silently ignored by some Jira configurations), this method calls
+        PUT /rest/api/3/issue/{key}/assignee directly.
+
+        Pass None or empty string to unassign.
+
+        Args:
+            issue_key: The key of the issue to assign (e.g., 'PROJ-123')
+            assignee: User identifier (email, display name, or account ID).
+                      Pass None or "" to unassign.
+
+        Returns:
+            JiraIssue model representing the updated issue
+
+        Raises:
+            ValueError: If the user cannot be resolved or assignment fails
+        """
+        try:
+            if assignee is None or assignee == "":
+                # Unassign: the atlassian-python-api accepts None for unassignment
+                self.jira.assign_issue(issue_key, None)
+            else:
+                account_id = self._get_account_id(assignee)
+                self.jira.assign_issue(issue_key, account_id)
+
+            # Return the updated issue
+            return self.get_issue(issue_key)
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error assigning issue {issue_key}: {error_msg}")
+            raise ValueError(
+                f"Failed to assign issue {issue_key}: {error_msg}"
+            ) from e
+
     def _update_issue_with_status(
         self, issue_key: str, fields: dict[str, Any]
     ) -> JiraIssue:

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1201,9 +1201,7 @@ class IssuesMixin(
         except Exception as e:
             error_msg = str(e)
             logger.error(f"Error assigning issue {issue_key}: {error_msg}")
-            raise ValueError(
-                f"Failed to assign issue {issue_key}: {error_msg}"
-            ) from e
+            raise ValueError(f"Failed to assign issue {issue_key}: {error_msg}") from e
 
     def _update_issue_with_status(
         self, issue_key: str, fields: dict[str, Any]

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1191,7 +1191,7 @@ class IssuesMixin(
     def assign_issue(
         self,
         issue_key: str,
-        assignee: str | None,
+        assignee: str | dict[str, Any] | None,
     ) -> JiraIssue:
         """
         Assign a Jira issue to a user using the dedicated assignment endpoint.
@@ -1204,8 +1204,10 @@ class IssuesMixin(
 
         Args:
             issue_key: The key of the issue to assign (e.g., 'PROJ-123')
-            assignee: User identifier (email, display name, or account ID).
-                      Pass None or "" to unassign.
+            assignee: User identifier (email, display name, or account ID), or a
+                resolved user dict containing ``accountId``/``account_id`` for
+                Cloud or ``name``/``username``/``key`` for Server/DC. Pass None
+                or "" to unassign.
 
         Returns:
             JiraIssue model representing the updated issue
@@ -1217,6 +1219,29 @@ class IssuesMixin(
             if assignee is None or assignee == "":
                 # Unassign: the atlassian-python-api accepts None for unassignment
                 self.jira.assign_issue(issue_key, None)
+            elif isinstance(assignee, dict):
+                if self.config.is_cloud:
+                    assignee_identifier = assignee.get("accountId") or assignee.get(
+                        "account_id"
+                    )
+                    if not assignee_identifier:
+                        raise ValueError(
+                            "Cloud assignee dict must include accountId or account_id"
+                        )
+                else:
+                    assignee_identifier = (
+                        assignee.get("name")
+                        or assignee.get("username")
+                        or assignee.get("key")
+                        or assignee.get("accountId")
+                        or assignee.get("account_id")
+                    )
+                    if not assignee_identifier:
+                        raise ValueError(
+                            "Server/DC assignee dict must include name, username, "
+                            "key, accountId, or account_id"
+                        )
+                self.jira.assign_issue(issue_key, str(assignee_identifier))
             else:
                 account_id = self._get_account_id(assignee)
                 self.jira.assign_issue(issue_key, account_id)

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1188,6 +1188,46 @@ class IssuesMixin(
             logger.error(f"Error updating issue {issue_key}: {error_msg}")
             raise ValueError(f"Failed to update issue {issue_key}: {error_msg}") from e
 
+    def assign_issue(
+        self,
+        issue_key: str,
+        assignee: str | None,
+    ) -> JiraIssue:
+        """
+        Assign a Jira issue to a user using the dedicated assignment endpoint.
+
+        Unlike update_issue (which sets assignee via the fields update and is
+        silently ignored by some Jira configurations), this method calls
+        PUT /rest/api/3/issue/{key}/assignee directly.
+
+        Pass None or empty string to unassign.
+
+        Args:
+            issue_key: The key of the issue to assign (e.g., 'PROJ-123')
+            assignee: User identifier (email, display name, or account ID).
+                      Pass None or "" to unassign.
+
+        Returns:
+            JiraIssue model representing the updated issue
+
+        Raises:
+            ValueError: If the user cannot be resolved or assignment fails
+        """
+        try:
+            if assignee is None or assignee == "":
+                # Unassign: the atlassian-python-api accepts None for unassignment
+                self.jira.assign_issue(issue_key, None)
+            else:
+                account_id = self._get_account_id(assignee)
+                self.jira.assign_issue(issue_key, account_id)
+
+            # Return the updated issue
+            return self.get_issue(issue_key)
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error assigning issue {issue_key}: {error_msg}")
+            raise ValueError(f"Failed to assign issue {issue_key}: {error_msg}") from e
+
     def _update_issue_with_status(
         self, issue_key: str, fields: dict[str, Any]
     ) -> JiraIssue:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1692,6 +1692,62 @@ async def update_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_issues"},
+    annotations={"title": "Assign Issue", "readOnlyHint": False},
+)
+@check_write_access
+async def assign_issue(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    assignee: Annotated[
+        str | None,
+        Field(
+            description=(
+                "User identifier to assign (email, display name, or account ID). "
+                "Pass null or empty string to unassign the issue."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Assign a Jira issue to a user using the dedicated assignment endpoint.
+
+    This is more reliable than setting assignee via update_issue, which is
+    silently ignored by some Jira configurations. Uses PUT /issue/{key}/assignee.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        assignee: User identifier (email, display name, or account ID).
+                  Pass None or empty string to unassign.
+
+    Returns:
+        JSON string representing the updated issue object.
+
+    Raises:
+        ValueError: If in read-only mode, Jira client unavailable, or user not found.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        issue = jira.assign_issue(issue_key=issue_key, assignee=assignee)
+        result = issue.to_simplified_dict()
+        return json.dumps(
+            {"message": f"Issue {issue_key} assigned successfully", "issue": result},
+            indent=2,
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error(f"Error assigning issue {issue_key}: {str(e)}", exc_info=True)
+        raise ValueError(f"Failed to assign issue {issue_key}: {str(e)}")
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_issues"},
     annotations={"title": "Delete Issue", "destructiveHint": True},
 )
 @check_write_access

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1828,7 +1828,8 @@ async def assign_issue(
         str | None,
         Field(
             description=(
-                "User identifier to assign (email, display name, or account ID). "
+                "User identifier to assign (email, display name, or account ID), "
+                "or a JSON object string from jira_search_assignable_users. "
                 "Pass null or empty string to unassign the issue."
             ),
             default=None,
@@ -1843,8 +1844,9 @@ async def assign_issue(
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
-        assignee: User identifier (email, display name, or account ID).
-                  Pass None or empty string to unassign.
+        assignee: User identifier (email, display name, or account ID), or a
+            JSON object string from jira_search_assignable_users. Pass None or
+            empty string to unassign.
 
     Returns:
         JSON string representing the updated issue object.
@@ -1854,7 +1856,16 @@ async def assign_issue(
     """
     jira = await get_jira_fetcher(ctx)
     try:
-        issue = jira.assign_issue(issue_key=issue_key, assignee=assignee)
+        parsed_assignee: str | dict[str, Any] | None = assignee
+        if assignee and assignee.strip().startswith("{"):
+            try:
+                parsed_assignee = json.loads(assignee)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"assignee is not valid JSON: {e}") from e
+            if not isinstance(parsed_assignee, dict):
+                raise ValueError("assignee JSON must be an object.")
+
+        issue = jira.assign_issue(issue_key=issue_key, assignee=parsed_assignee)
         result = issue.to_simplified_dict()
         return json.dumps(
             {"message": f"Issue {issue_key} assigned successfully", "issue": result},

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1812,6 +1812,62 @@ async def update_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_issues"},
+    annotations={"title": "Assign Issue", "readOnlyHint": False},
+)
+@check_write_access
+async def assign_issue(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    assignee: Annotated[
+        str | None,
+        Field(
+            description=(
+                "User identifier to assign (email, display name, or account ID). "
+                "Pass null or empty string to unassign the issue."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Assign a Jira issue to a user using the dedicated assignment endpoint.
+
+    This is more reliable than setting assignee via update_issue, which is
+    silently ignored by some Jira configurations. Uses PUT /issue/{key}/assignee.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        assignee: User identifier (email, display name, or account ID).
+                  Pass None or empty string to unassign.
+
+    Returns:
+        JSON string representing the updated issue object.
+
+    Raises:
+        ValueError: If in read-only mode, Jira client unavailable, or user not found.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        issue = jira.assign_issue(issue_key=issue_key, assignee=assignee)
+        result = issue.to_simplified_dict()
+        return json.dumps(
+            {"message": f"Issue {issue_key} assigned successfully", "issue": result},
+            indent=2,
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error(f"Error assigning issue {issue_key}: {str(e)}", exc_info=True)
+        raise ValueError(f"Failed to assign issue {issue_key}: {str(e)}")
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_issues"},
     annotations={"title": "Delete Issue", "destructiveHint": True},
 )
 @check_write_access

--- a/tests/e2e/cloud/test_mcp_tools_cloud.py
+++ b/tests/e2e/cloud/test_mcp_tools_cloud.py
@@ -13,6 +13,7 @@ from fastmcp import Client
 from fastmcp.client import FastMCPTransport
 from mcp.types import CallToolResult, TextContent
 
+from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.servers import main_mcp
 
 from .conftest import CloudInstanceInfo
@@ -120,6 +121,49 @@ class TestMCPJiraTools:
             "jira_delete_issue",
             {"issue_key": issue_key},
         )
+
+    @pytest.mark.anyio
+    async def test_jira_assign_issue(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+        jira_fetcher: JiraFetcher,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        result = await call_tool(
+            mcp_client,
+            "jira_create_issue",
+            {
+                "project_key": cloud_instance.project_key,
+                "summary": f"Cloud MCP Assign Test {uid}",
+                "description": "Created for MCP assign_issue test.",
+                "issue_type": "Task",
+            },
+        )
+        assert not result.is_error
+        assert result.content and isinstance(result.content[0], TextContent)
+        data = json.loads(result.content[0].text)
+        issue_key = data["issue"]["key"]
+
+        try:
+            account_id = jira_fetcher.get_current_user_account_id()
+            assign_result = await call_tool(
+                mcp_client,
+                "jira_assign_issue",
+                {"issue_key": issue_key, "assignee": account_id},
+            )
+            assert not assign_result.is_error
+            assert assign_result.content
+            assign_data = json.loads(assign_result.content[0].text)
+            assignee = assign_data["issue"].get("assignee")
+            assert isinstance(assignee, dict)
+            assert assignee.get("account_id") == account_id
+        finally:
+            await call_tool(
+                mcp_client,
+                "jira_delete_issue",
+                {"issue_key": issue_key},
+            )
 
 
 class TestMCPConfluenceTools:

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -121,6 +121,27 @@ class TestMCPJiraTools:
             {"issue_key": issue_key},
         )
 
+    @pytest.mark.anyio
+    async def test_jira_assign_issue(
+        self,
+        mcp_client: Client,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        assign_result = await call_tool(
+            mcp_client,
+            "jira_assign_issue",
+            {
+                "issue_key": dc_instance.test_issue_key,
+                "assignee": dc_instance.admin_username,
+            },
+        )
+        assert not assign_result.is_error
+        assert assign_result.content
+        assign_data = json.loads(assign_result.content[0].text)
+        assignee = assign_data["issue"].get("assignee")
+        assert isinstance(assignee, dict)
+        assert assignee.get("name") or assignee.get("display_name")
+
 
 class TestMCPConfluenceTools:
     """MCP Confluence tool tests against DC."""

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -738,9 +738,7 @@ class TestIssuesMixin:
         issues_mixin._get_account_id = MagicMock(return_value="account-123")
 
         with pytest.raises(ValueError, match="Failed to assign issue TEST-123"):
-            issues_mixin.assign_issue(
-                issue_key="TEST-123", assignee="user@example.com"
-            )
+            issues_mixin.assign_issue(issue_key="TEST-123", assignee="user@example.com")
 
     def test_update_issue_components(self, issues_mixin: IssuesMixin):
         """Test updating an issue's components field."""

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -684,6 +684,64 @@ class TestIssuesMixin:
         assert not issues_mixin._get_account_id.called
         assert document.key == "TEST-123"
 
+    def test_assign_issue(self, issues_mixin: IssuesMixin, make_issue_data):
+        """Test assigning an issue to a user via dedicated endpoint."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock(return_value="account-123")
+
+        document = issues_mixin.assign_issue(
+            issue_key="TEST-123", assignee="user@example.com"
+        )
+
+        issues_mixin._get_account_id.assert_called_once_with("user@example.com")
+        issues_mixin.jira.assign_issue.assert_called_once_with(
+            "TEST-123", "account-123"
+        )
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_unassign(self, issues_mixin: IssuesMixin, make_issue_data):
+        """Test unassigning an issue (passing None)."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(issue_key="TEST-123", assignee=None)
+
+        issues_mixin.jira.assign_issue.assert_called_once_with("TEST-123", None)
+        assert not issues_mixin._get_account_id.called
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_empty_string(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Test unassigning an issue (passing empty string)."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(issue_key="TEST-123", assignee="")
+
+        issues_mixin.jira.assign_issue.assert_called_once_with("TEST-123", None)
+        assert not issues_mixin._get_account_id.called
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_error(self, issues_mixin: IssuesMixin):
+        """Test error handling when assignment fails."""
+        issues_mixin.jira.assign_issue.side_effect = Exception("Permission denied")
+        issues_mixin._get_account_id = MagicMock(return_value="account-123")
+
+        with pytest.raises(ValueError, match="Failed to assign issue TEST-123"):
+            issues_mixin.assign_issue(
+                issue_key="TEST-123", assignee="user@example.com"
+            )
+
     def test_update_issue_components(self, issues_mixin: IssuesMixin):
         """Test updating an issue's components field."""
         issue_data = {

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -758,6 +758,62 @@ class TestIssuesMixin:
 
         issues_mixin.jira.update_issue.assert_not_called()
 
+    def test_assign_issue(self, issues_mixin: IssuesMixin, make_issue_data):
+        """Test assigning an issue to a user via dedicated endpoint."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock(return_value="account-123")
+
+        document = issues_mixin.assign_issue(
+            issue_key="TEST-123", assignee="user@example.com"
+        )
+
+        issues_mixin._get_account_id.assert_called_once_with("user@example.com")
+        issues_mixin.jira.assign_issue.assert_called_once_with(
+            "TEST-123", "account-123"
+        )
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_unassign(self, issues_mixin: IssuesMixin, make_issue_data):
+        """Test unassigning an issue (passing None)."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(issue_key="TEST-123", assignee=None)
+
+        issues_mixin.jira.assign_issue.assert_called_once_with("TEST-123", None)
+        assert not issues_mixin._get_account_id.called
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_empty_string(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Test unassigning an issue (passing empty string)."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(issue_key="TEST-123", assignee="")
+
+        issues_mixin.jira.assign_issue.assert_called_once_with("TEST-123", None)
+        assert not issues_mixin._get_account_id.called
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_error(self, issues_mixin: IssuesMixin):
+        """Test error handling when assignment fails."""
+        issues_mixin.jira.assign_issue.side_effect = Exception("Permission denied")
+        issues_mixin._get_account_id = MagicMock(return_value="account-123")
+
+        with pytest.raises(ValueError, match="Failed to assign issue TEST-123"):
+            issues_mixin.assign_issue(issue_key="TEST-123", assignee="user@example.com")
+
     def test_update_issue_components(self, issues_mixin: IssuesMixin):
         """Test updating an issue's components field."""
         issue_data = {

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -806,6 +806,47 @@ class TestIssuesMixin:
         assert not issues_mixin._get_account_id.called
         assert document.key == "TEST-123"
 
+    def test_assign_issue_assignee_dict_passthrough_account_id(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Cloud-shaped assignee dict is unwrapped without user lookup."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(
+            issue_key="TEST-123",
+            assignee={"account_id": "5b10ac8d82e05b22cc7d4ef5"},
+        )
+
+        issues_mixin._get_account_id.assert_not_called()
+        issues_mixin.jira.assign_issue.assert_called_once_with(
+            "TEST-123", "5b10ac8d82e05b22cc7d4ef5"
+        )
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_assignee_dict_passthrough_name(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Server/DC-shaped assignee dict is unwrapped without user lookup."""
+        issues_mixin.config.url = "https://jira.example.com"
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(
+            issue_key="TEST-123",
+            assignee={"name": "jdoe"},
+        )
+
+        issues_mixin._get_account_id.assert_not_called()
+        issues_mixin.jira.assign_issue.assert_called_once_with("TEST-123", "jdoe")
+        assert document.key == "TEST-123"
+
     def test_assign_issue_error(self, issues_mixin: IssuesMixin):
         """Test error handling when assignment fails."""
         issues_mixin.jira.assign_issue.side_effect = Exception("Permission denied")

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -146,6 +146,23 @@ def mock_jira_fetcher():
 
     mock_fetcher.update_issue.side_effect = mock_update_issue
 
+    # Configure assign_issue
+    def mock_assign_issue(issue_key, assignee=None):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test Issue",
+            "status": {"name": "Open"},
+            "assignee": (
+                {"displayName": "Test User", "accountId": "test-account-id"}
+                if assignee
+                else None
+            ),
+        }
+        return mock_issue
+
+    mock_fetcher.assign_issue.side_effect = mock_assign_issue
+
     # Configure batch_create_issues
     def mock_batch_create_issues(issues, validate_only=False):
         if not isinstance(issues, list):
@@ -383,6 +400,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         add_comment,
         add_issues_to_sprint,
         add_worklog,
+        assign_issue,
         batch_create_issues,
         batch_create_versions,
         batch_get_changelogs,
@@ -445,6 +463,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(batch_create_issues)
     jira_sub_mcp.add_tool(batch_get_changelogs)
     jira_sub_mcp.add_tool(update_issue)
+    jira_sub_mcp.add_tool(assign_issue)
     jira_sub_mcp.add_tool(delete_issue)
     jira_sub_mcp.add_tool(add_comment)
     jira_sub_mcp.add_tool(edit_comment)
@@ -2430,3 +2449,58 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
     # return_limit=1 caps to first match
     assert len(result) == 1
     assert result[0] == "High"
+
+
+# =============================================================================
+# assign_issue tests
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_assign_issue(jira_client, mock_jira_fetcher):
+    """Test assigning an issue to a user."""
+    response = await jira_client.call_tool(
+        "jira_assign_issue",
+        {
+            "issue_key": "TEST-123",
+            "assignee": "user@example.com",
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue TEST-123 assigned successfully"
+    assert "issue" in content
+    mock_jira_fetcher.assign_issue.assert_called_once_with(
+        issue_key="TEST-123", assignee="user@example.com"
+    )
+
+
+@pytest.mark.anyio
+async def test_assign_issue_unassign(jira_client, mock_jira_fetcher):
+    """Test unassigning an issue (passing None)."""
+    response = await jira_client.call_tool(
+        "jira_assign_issue",
+        {
+            "issue_key": "TEST-123",
+            "assignee": None,
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue TEST-123 assigned successfully"
+    mock_jira_fetcher.assign_issue.assert_called_once_with(
+        issue_key="TEST-123", assignee=None
+    )
+
+
+@pytest.mark.anyio
+async def test_assign_issue_error(jira_client, mock_jira_fetcher):
+    """Test assign_issue error handling."""
+    mock_jira_fetcher.assign_issue.side_effect = ValueError("User not found")
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_assign_issue",
+            {
+                "issue_key": "TEST-123",
+                "assignee": "nonexistent@example.com",
+            },
+        )
+    assert "User not found" in str(excinfo.value)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -146,6 +146,23 @@ def mock_jira_fetcher():
 
     mock_fetcher.update_issue.side_effect = mock_update_issue
 
+    # Configure assign_issue
+    def mock_assign_issue(issue_key: str, assignee: str | None = None) -> MagicMock:
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test Issue",
+            "status": {"name": "Open"},
+            "assignee": (
+                {"displayName": "Test User", "accountId": "test-account-id"}
+                if assignee
+                else None
+            ),
+        }
+        return mock_issue
+
+    mock_fetcher.assign_issue.side_effect = mock_assign_issue
+
     # Configure batch_create_issues
     def mock_batch_create_issues(issues, validate_only=False):
         if not isinstance(issues, list):
@@ -383,6 +400,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         add_comment,
         add_issues_to_sprint,
         add_worklog,
+        assign_issue,
         batch_create_issues,
         batch_create_versions,
         batch_get_changelogs,
@@ -449,6 +467,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(batch_create_issues)
     jira_sub_mcp.add_tool(batch_get_changelogs)
     jira_sub_mcp.add_tool(update_issue)
+    jira_sub_mcp.add_tool(assign_issue)
     jira_sub_mcp.add_tool(delete_issue)
     jira_sub_mcp.add_tool(add_comment)
     jira_sub_mcp.add_tool(edit_comment)
@@ -2551,3 +2570,58 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
     # return_limit=1 caps to first match
     assert len(result) == 1
     assert result[0] == "High"
+
+
+# =============================================================================
+# assign_issue tests
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_assign_issue(jira_client, mock_jira_fetcher):
+    """Test assigning an issue to a user."""
+    response = await jira_client.call_tool(
+        "jira_assign_issue",
+        {
+            "issue_key": "TEST-123",
+            "assignee": "user@example.com",
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue TEST-123 assigned successfully"
+    assert "issue" in content
+    mock_jira_fetcher.assign_issue.assert_called_once_with(
+        issue_key="TEST-123", assignee="user@example.com"
+    )
+
+
+@pytest.mark.anyio
+async def test_assign_issue_unassign(jira_client, mock_jira_fetcher):
+    """Test unassigning an issue (passing None)."""
+    response = await jira_client.call_tool(
+        "jira_assign_issue",
+        {
+            "issue_key": "TEST-123",
+            "assignee": None,
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue TEST-123 assigned successfully"
+    mock_jira_fetcher.assign_issue.assert_called_once_with(
+        issue_key="TEST-123", assignee=None
+    )
+
+
+@pytest.mark.anyio
+async def test_assign_issue_error(jira_client, mock_jira_fetcher):
+    """Test assign_issue error handling."""
+    mock_jira_fetcher.assign_issue.side_effect = ValueError("User not found")
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_assign_issue",
+            {
+                "issue_key": "TEST-123",
+                "assignee": "nonexistent@example.com",
+            },
+        )
+    assert "User not found" in str(excinfo.value)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -4,6 +4,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -147,7 +148,9 @@ def mock_jira_fetcher():
     mock_fetcher.update_issue.side_effect = mock_update_issue
 
     # Configure assign_issue
-    def mock_assign_issue(issue_key: str, assignee: str | None = None) -> MagicMock:
+    def mock_assign_issue(
+        issue_key: str, assignee: str | dict[str, Any] | None = None
+    ) -> MagicMock:
         mock_issue = MagicMock()
         mock_issue.to_simplified_dict.return_value = {
             "key": issue_key,
@@ -2609,6 +2612,28 @@ async def test_assign_issue_unassign(jira_client, mock_jira_fetcher):
     assert content["message"] == "Issue TEST-123 assigned successfully"
     mock_jira_fetcher.assign_issue.assert_called_once_with(
         issue_key="TEST-123", assignee=None
+    )
+
+
+@pytest.mark.anyio
+async def test_assign_issue_with_resolved_user_dict(jira_client, mock_jira_fetcher):
+    """Test assigning an issue with a resolved user object JSON string."""
+    assignee = {
+        "account_id": "5b10ac8d82e05b22cc7d4ef5",
+        "display_name": "Test User",
+    }
+
+    response = await jira_client.call_tool(
+        "jira_assign_issue",
+        {
+            "issue_key": "TEST-123",
+            "assignee": json.dumps(assignee),
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue TEST-123 assigned successfully"
+    mock_jira_fetcher.assign_issue.assert_called_once_with(
+        issue_key="TEST-123", assignee=assignee
     )
 
 

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 50, f"Expected 50 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 51, f"Expected 51 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 52, f"Expected 52 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

Add a new `jira_assign_issue` MCP tool that uses the dedicated Jira assignment endpoint (`PUT /rest/api/3/issue/{key}/assignee`) instead of relying on the fields update in `update_issue`.

### Motivation

On some Jira Cloud configurations, setting the assignee field via `update_issue` (which uses the generic fields update endpoint) is **silently ignored** — the API returns 204 but the assignee doesn't change. The dedicated assignment endpoint works reliably in all configurations.

### Changes

- **`src/mcp_atlassian/jira/issues.py`**: Add `assign_issue()` method to `IssuesMixin`
- **`src/mcp_atlassian/servers/jira.py`**: Add `jira_assign_issue` tool with `@check_write_access` decorator
- **`tests/unit/jira/test_issues.py`**: Unit tests for mixin (assign, unassign via None, unassign via empty string, error handling)
- **`tests/unit/servers/test_jira_server.py`**: Server-layer tests (assign, unassign, error propagation)

### Features

- Accepts email, display name, or account ID as user identifier
- Supports unassignment (pass `null` or empty string)
- Resolves user identifiers via `_get_account_id` (Cloud/Server compatible)
- Returns the updated issue after assignment
- Tagged with `jira`, `write`, `toolset:jira_issues`
- Respects `READ_ONLY_MODE` via `@check_write_access`