### PR TITLE
fix(jira): use correct case-sensitive applicationType values for dev-status API

### DIFF
--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -26,7 +26,9 @@ class DevelopmentMixin(JiraClient):
         Args:
             issue_key: The issue key (e.g., PROJECT-123)
             application_type: Filter by application type
-                (e.g., 'stash', 'github', 'bitbucket').
+                (e.g., 'stash', 'GitHub', 'bitbucket').
+                Values are case-sensitive (the dev-status API
+                returns empty results or 500 errors on mismatch).
                 If None, tries common application types.
             data_type: Filter by data type
                 (e.g., 'pullrequest', 'branch', 'repository').
@@ -65,8 +67,9 @@ class DevelopmentMixin(JiraClient):
                 )
 
             # Otherwise, try common application types and merge results
-            # Common types: stash (Bitbucket Server), bitbucket, github, gitlab
-            app_types = ["stash", "bitbucket", "github", "gitlab"]
+            # Values are case-sensitive — the dev-status API requires the
+            # exact casing registered by each DVCS connector plugin.
+            app_types = ["stash", "bitbucket", "GitHub", "GitLab"]
             # Data types to try for each app type
             data_types = ["pullrequest", "branch", "repository"]
             merged_result: dict[str, Any] = {
@@ -132,7 +135,7 @@ class DevelopmentMixin(JiraClient):
         Args:
             issue_key: The issue key
             issue_id: The numeric issue ID
-            application_type: The application type (stash, github, etc.)
+            application_type: The application type (stash, GitHub, etc.) — case-sensitive
             data_type: Optional data type filter
 
         Returns:

--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -67,7 +67,7 @@ class DevelopmentMixin(JiraClient):
                 )
 
             # Otherwise, try common application types and merge results
-            # Values are case-sensitive — the dev-status API requires the
+            # Values are case-sensitive; the dev-status API requires the
             # exact casing registered by each DVCS connector plugin.
             app_types = ["stash", "bitbucket", "GitHub", "GitLab"]
             # Data types to try for each app type
@@ -135,7 +135,8 @@ class DevelopmentMixin(JiraClient):
         Args:
             issue_key: The issue key
             issue_id: The numeric issue ID
-            application_type: The application type (stash, GitHub, etc.) — case-sensitive
+            application_type: The case-sensitive application type
+                (stash, GitHub, etc.)
             data_type: Optional data type filter
 
         Returns:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3164,8 +3164,8 @@ async def get_issue_development_info(
         str | None,
         Field(
             description=(
-                "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "(Optional) Filter by application type (case-sensitive). "
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'GitLab'"
             )
         ),
     ] = None,
@@ -3229,8 +3229,8 @@ async def get_issues_development_info(
         str | None,
         Field(
             description=(
-                "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "(Optional) Filter by application type (case-sensitive). "
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'GitLab'"
             )
         ),
     ] = None,

--- a/tests/unit/jira/test_development.py
+++ b/tests/unit/jira/test_development.py
@@ -209,6 +209,42 @@ class TestDevelopmentMixin:
         assert development_mixin.jira._session.get.call_count > 1
         assert result["issue_key"] == "TEST-123"
 
+    def test_get_issue_development_info_auto_discovery_uses_app_type_casing(
+        self, development_mixin
+    ):
+        """Test auto-discovery uses case-sensitive dev-status app types."""
+        development_mixin.jira.get_issue.return_value = {
+            "id": "12345",
+            "key": "TEST-123",
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"detail": []}
+        mock_response.raise_for_status = MagicMock()
+        development_mixin.jira._session.get.return_value = mock_response
+
+        development_mixin.get_issue_development_info("TEST-123")
+
+        application_types = [
+            call.kwargs["params"]["applicationType"]
+            for call in development_mixin.jira._session.get.call_args_list
+        ]
+
+        assert application_types == [
+            "stash",
+            "stash",
+            "stash",
+            "bitbucket",
+            "bitbucket",
+            "bitbucket",
+            "GitHub",
+            "GitHub",
+            "GitHub",
+            "GitLab",
+            "GitLab",
+            "GitLab",
+        ]
+
     def test_get_issues_development_info_success(
         self, development_mixin, mock_dev_status_response
     ):


### PR DESCRIPTION
## Summary

The Atlassian dev-status API (`/rest/dev-status/1.0/issue/detail`) requires the `applicationType` query parameter to use the **exact casing** registered by each DVCS connector plugin. For GitHub integrations the correct value is `GitHub` (capital G), not `github`.

**Current behaviour:**
- Passing `applicationType=github` (lowercase) returns a **500 Internal Server Error** on Atlassian Cloud.
- When no `application_type` is specified, the fallback loop in `DevelopmentMixin` tries lowercase `"github"`, catches the resulting exception, and returns **empty results** — silently hiding all linked PRs/branches/commits.

**After this fix:**
- The fallback list uses the correct casing: `["stash", "bitbucket", "GitHub", "GitLab"]`
- Docstrings and MCP tool `Field` descriptions now show `'GitHub'` (not `'github'`) and note that values are case-sensitive, so LLMs and users pass the right value on the first attempt.

## Changes

- `src/mcp_atlassian/jira/development.py` — fix fallback `app_types` list + update docstrings
- `src/mcp_atlassian/servers/jira.py` — update `Field(description=...)` for `application_type` in both `get_issue_development_info` and `get_issues_development_info`

## How I found this

While building a support agent that calls `jira_get_issue_development_info` via MCP, the tool consistently returned empty results. Tracing the HTTP calls revealed the 500 from the dev-status endpoint when `applicationType=github` was sent. Changing to `applicationType=GitHub` immediately returned the expected PR/branch data.

## Test plan

- [x] Verified `applicationType=GitHub` returns linked PRs on Atlassian Cloud (tested against a real Jira issue)
- [x] Confirmed `applicationType=github` (lowercase) returns 500
- [x] Confirmed omitting `applicationType` now falls back to the correct casing and returns results

Made with [Cursor](https://cursor.com)