### PR TITLE
feat(jira): add human-readable custom field keys

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -17,6 +17,7 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -25,6 +26,10 @@ Get details of a specific Jira issue including its Epic links and relationship i
 
 <Tip>
 Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
 </Tip>
 
 

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -18,6 +18,7 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
 | `include` | `string` | No | (Optional) Comma-separated sections to inline in the response. Supported values: `all`, `remote_links`, `transitions`, `watchers`, `changelog`, `comments`, `worklogs`. |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -26,6 +27,11 @@ Get details of a specific Jira issue including its Epic links and relationship i
 
 <Tip>
 Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content. Use `include: "all"` to inline common enrichments that otherwise require separate tool calls.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
+If a display name conflicts with another output key, that custom field keeps its raw ID so no value is lost.
 </Tip>
 
 

--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -18,6 +18,7 @@ Search Jira issues using JQL (Jira Query Language).
 | `projects_filter` | `string` | No | (Optional) Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided. |
 | `expand` | `string` | No | (Optional) fields to expand. Examples: 'renderedFields', 'transitions', 'changelog' |
 | `page_token` | `string` | No | Pagination token from a previous search result. Cloud only — Server/DC uses `start_at` for pagination. |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -26,6 +27,10 @@ Search Jira issues using JQL (Jira Query Language).
 
 <Tip>
 Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
 </Tip>
 
 

--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -18,6 +18,7 @@ Search Jira issues using JQL (Jira Query Language).
 | `projects_filter` | `string` | No | (Optional) Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided. |
 | `expand` | `string` | No | (Optional) fields to expand. Examples: 'renderedFields', 'transitions', 'changelog' |
 | `page_token` | `string` | No | Pagination token from a previous search result. Cloud only — Server/DC uses `start_at` for pagination. |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -26,6 +27,11 @@ Search Jira issues using JQL (Jira Query Language).
 
 <Tip>
 Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
+If a display name conflicts with another output key, that custom field keeps its raw ID so no value is lost.
 </Tip>
 
 

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -133,13 +133,9 @@ class IssuesMixin(
             fields_set = (
                 set(fields_param.split(",")) if fields_param != "*all" else None
             )
-            if fields_param == "*all" or fields_set == DEFAULT_READ_JIRA_FIELDS:
+            if fields_set == DEFAULT_READ_JIRA_FIELDS:
                 # Default fields are being used - preserve the order
-                default_fields_list = (
-                    fields_param.split(",")
-                    if fields_param != "*all"
-                    else list(DEFAULT_READ_JIRA_FIELDS)
-                )
+                default_fields_list = fields_param.split(",")
                 additional_fields = []
 
                 # Add appropriate fields based on expand parameter

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -142,6 +142,7 @@ class SearchMixin(JiraClient, IssueOperationsProto):
 
                 # Fetch issues using v3 API with nextPageToken pagination
                 all_issues: list[dict[str, Any]] = []
+                field_names: dict[str, Any] = {}
                 next_page_token: str | None = page_token
 
                 while len(all_issues) < limit:
@@ -166,6 +167,10 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                     issues = response.get("issues", [])
                     all_issues.extend(issues)
 
+                    names = response.get("names")
+                    if isinstance(names, dict):
+                        field_names.update(names)
+
                     # Check for more pages
                     next_page_token = response.get("nextPageToken")
                     if not next_page_token:
@@ -181,6 +186,8 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                 }
                 if next_page_token:
                     response_dict["nextPageToken"] = next_page_token
+                if field_names:
+                    response_dict["names"] = field_names
 
                 search_result = JiraSearchResult.from_api_response(
                     response_dict,

--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -761,6 +761,95 @@ class JiraIssue(ApiModel, TimestampMixin):
 
         return None, None
 
+    def get_custom_field_by_name(
+        self, display_name: str, *, case_sensitive: bool = False
+    ) -> Any:
+        """Look up a custom field value by its human-readable display name.
+
+        This is a convenience wrapper over the internal ``custom_fields`` dict
+        (which is keyed by ``customfield_XXXXX``).  It searches the ``name``
+        entry stored inside each value object, so the underlying data structure
+        is completely untouched.
+
+        Args:
+            display_name: The human-readable name of the field
+                (e.g. ``"Story Points"``, ``"Severity"``).
+            case_sensitive: If *False* (default) the comparison is
+                case-insensitive.
+
+        Returns:
+            The processed field value if found, or *None*.
+        """
+        target = display_name if case_sensitive else display_name.lower()
+        for field_data in self.custom_fields.values():
+            if not isinstance(field_data, dict):
+                continue
+            stored_name = field_data.get("name")
+            if stored_name is None:
+                continue
+            candidate = stored_name if case_sensitive else stored_name.lower()
+            if candidate == target:
+                return self._process_custom_field_value(field_data.get("value"))
+        return None
+
+    @property
+    def custom_fields_by_display_name(self) -> dict[str, Any]:
+        """Return ``custom_fields`` re-keyed by display name.
+
+        Fields that do not carry a ``name`` entry keep their original
+        ``customfield_XXXXX`` key so nothing is silently dropped.
+
+        Each value retains the upstream structure
+        (``{"value": …, "name": …}``) with an additional ``"field_id"`` key
+        for reverse-lookup convenience.
+
+        Returns:
+            A **new** dict — the original ``custom_fields`` is never mutated.
+        """
+        result: dict[str, Any] = {}
+        for field_id, field_data in self.custom_fields.items():
+            if not isinstance(field_data, dict):
+                result[field_id] = field_data
+                continue
+            display_key = field_data.get("name", field_id)
+            entry = {**field_data, "field_id": field_id}
+            result[display_key] = entry
+        return result
+
+    def to_display_name_dict(self) -> dict[str, Any]:
+        """Like ``to_simplified_dict`` but with custom fields keyed by display name.
+
+        Standard fields (summary, status, etc.) are identical to
+        ``to_simplified_dict()``.  Only the custom-field section changes:
+        each ``customfield_XXXXX`` key is replaced by its human-readable
+        name when one is available.
+
+        Returns:
+            A simplified dict suitable for tool / API output where custom
+            fields use human-friendly keys.
+        """
+        base = self.to_simplified_dict()
+
+        rekeyed_customs: dict[str, Any] = {}
+        removed_keys: list[str] = []
+
+        for key, value in base.items():
+            if not key.startswith("customfield_"):
+                continue
+            removed_keys.append(key)
+            if isinstance(value, dict) and "name" in value:
+                display_key = value["name"]
+                entry = {**value, "field_id": key}
+                rekeyed_customs[display_key] = entry
+            else:
+                rekeyed_customs[key] = value
+
+        for k in removed_keys:
+            del base[k]
+
+        base.update(rekeyed_customs)
+        return base
+
     def _get_epic_name(self) -> str | None:
         """Get the epic name from custom fields if available."""
         # Try each pattern in order

--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -778,6 +778,141 @@ class JiraIssue(ApiModel, TimestampMixin):
 
         return None, None
 
+    def get_custom_field_by_name(
+        self, display_name: str, *, case_sensitive: bool = False
+    ) -> Any:
+        """Look up a custom field value by its human-readable display name.
+
+        This is a convenience wrapper over the internal ``custom_fields`` dict
+        (which is keyed by ``customfield_XXXXX``).  It searches the ``name``
+        entry stored inside each value object, so the underlying data structure
+        is completely untouched.
+
+        Args:
+            display_name: The human-readable name of the field
+                (e.g. ``"Story Points"``, ``"Severity"``).
+            case_sensitive: If *False* (default) the comparison is
+                case-insensitive.
+
+        Returns:
+            The processed field value if found, or *None*.
+        """
+        target = display_name if case_sensitive else display_name.lower()
+        for field_data in self.custom_fields.values():
+            if not isinstance(field_data, dict):
+                continue
+            stored_name = field_data.get("name")
+            if stored_name is None:
+                continue
+            candidate = stored_name if case_sensitive else stored_name.lower()
+            if candidate == target:
+                return self._process_custom_field_value(field_data.get("value"))
+        return None
+
+    @staticmethod
+    def _get_display_key(
+        field_id: str,
+        field_data: Any,
+        *,
+        reserved_keys: set[str],
+        used_keys: set[str],
+    ) -> str:
+        """Choose a display key without overwriting another field."""
+        if not isinstance(field_data, dict):
+            return field_id
+
+        display_name = field_data.get("name")
+        if (
+            not isinstance(display_name, str)
+            or not display_name
+            or display_name in reserved_keys
+            or display_name in used_keys
+        ):
+            return field_id
+        return display_name
+
+    @property
+    def custom_fields_by_display_name(self) -> dict[str, Any]:
+        """Return ``custom_fields`` re-keyed by display name.
+
+        Fields that do not carry a ``name`` entry keep their original
+        ``customfield_XXXXX`` key so nothing is silently dropped.
+
+        Each value retains the upstream structure
+        (``{"value": …}``) with an additional ``"field_id"`` key
+        for reverse-lookup convenience.  The redundant ``"name"`` entry is
+        stripped since the display name is already used as the dict key.
+
+        Returns:
+            A **new** dict — the original ``custom_fields`` is never mutated.
+        """
+        result: dict[str, Any] = {}
+        reserved_keys = set(self.custom_fields)
+        for field_id, field_data in self.custom_fields.items():
+            if not isinstance(field_data, dict):
+                result[field_id] = field_data
+                continue
+            display_key = self._get_display_key(
+                field_id,
+                field_data,
+                reserved_keys=reserved_keys,
+                used_keys=set(result),
+            )
+            entry = {**field_data, "field_id": field_id}
+            entry.pop("name", None)
+            result[display_key] = entry
+        return result
+
+    def to_display_name_dict(
+        self, extra_reserved_keys: set[str] | None = None
+    ) -> dict[str, Any]:
+        """Like ``to_simplified_dict`` but with custom fields keyed by display name.
+
+        Standard fields (summary, status, etc.) are identical to
+        ``to_simplified_dict()``.  Only the custom-field section changes:
+        each ``customfield_XXXXX`` key is replaced by its human-readable
+        name when one is available.
+
+        Args:
+            extra_reserved_keys: Additional keys that must not be claimed by
+                custom fields (e.g. enrichment section output keys like
+                ``"comments"``, ``"watchers"``).
+
+        Returns:
+            A simplified dict suitable for tool / API output where custom
+            fields use human-friendly keys.
+        """
+        base = self.to_simplified_dict()
+
+        custom_items = [
+            (key, value)
+            for key, value in base.items()
+            if key.startswith("customfield_")
+        ]
+        custom_field_ids = {key for key, _ in custom_items}
+        reserved_keys = set(base).difference(custom_field_ids) | custom_field_ids
+        if extra_reserved_keys:
+            reserved_keys |= extra_reserved_keys
+        rekeyed_customs: dict[str, Any] = {}
+
+        for key, value in custom_items:
+            display_key = self._get_display_key(
+                key,
+                value,
+                reserved_keys=reserved_keys,
+                used_keys=set(rekeyed_customs),
+            )
+            if isinstance(value, dict):
+                value = {**value, "field_id": key}
+                value.pop("name", None)
+            rekeyed_customs[display_key] = value
+
+        for key in custom_field_ids:
+            del base[key]
+
+        base.update(rekeyed_customs)
+        return base
+
     def _get_epic_name(self) -> str | None:
         """Get the epic name from custom fields if available."""
         # Try each pattern in order

--- a/src/mcp_atlassian/models/jira/search.py
+++ b/src/mcp_atlassian/models/jira/search.py
@@ -49,9 +49,15 @@ class JiraSearchResult(ApiModel):
 
         issues = []
         issues_data = data.get("issues", [])
+        # The 'names' map (field ID → display name) lives at the top level
+        # of search responses.  Propagate it into each issue dict so that
+        # JiraIssue.from_api_response can populate display names.
+        top_level_names = data.get("names")
         if isinstance(issues_data, list):
             for issue_data in issues_data:
                 if issue_data:
+                    if top_level_names and isinstance(issue_data, dict):
+                        issue_data = {**issue_data, "names": top_level_names}
                     requested_fields = kwargs.get("requested_fields")
                     issues.append(
                         JiraIssue.from_api_response(
@@ -108,6 +114,18 @@ class JiraSearchResult(ApiModel):
             "start_at": self.start_at,
             "max_results": self.max_results,
             "issues": [issue.to_simplified_dict() for issue in self.issues],
+        }
+        if self.next_page_token is not None:
+            result["next_page_token"] = self.next_page_token
+        return result
+
+    def to_display_name_dict(self) -> dict[str, Any]:
+        """Like ``to_simplified_dict`` but with display-name keys on each issue."""
+        result: dict[str, Any] = {
+            "total": self.total,
+            "start_at": self.start_at,
+            "max_results": self.max_results,
+            "issues": [issue.to_display_name_dict() for issue in self.issues],
         }
         if self.next_page_token is not None:
             result["next_page_token"] = self.next_page_token

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -348,6 +348,18 @@ async def get_issue(
             default=True,
         ),
     ] = True,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Get details of a specific Jira issue including its Epic links and relationship information.
 
@@ -359,6 +371,7 @@ async def get_issue(
         comment_limit: Maximum number of comments.
         properties: Issue properties to return.
         update_history: Whether to update issue view history.
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the Jira issue object.
@@ -371,6 +384,10 @@ async def get_issue(
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
 
+    # Automatically include 'names' expansion when display names are requested
+    if use_display_names and (not expand or "names" not in expand):
+        expand = f"{expand},names" if expand else "names"
+
     issue = jira.get_issue(
         issue_key=issue_key,
         fields=fields_list,
@@ -379,7 +396,10 @@ async def get_issue(
         properties=properties.split(",") if properties else None,
         update_history=update_history,
     )
-    result = issue.to_simplified_dict()
+    if use_display_names:
+        result = issue.to_display_name_dict()
+    else:
+        result = issue.to_simplified_dict()
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 
@@ -451,6 +471,18 @@ async def search(
             default=None,
         ),
     ] = None,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Search Jira issues using JQL (Jira Query Language).
 
@@ -463,6 +495,7 @@ async def search(
         projects_filter: Comma-separated list of project keys to filter by.
         expand: Optional fields to expand.
         page_token: Pagination token from a previous search result (Cloud only).
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the search results including pagination info.
@@ -471,6 +504,10 @@ async def search(
     fields_list: str | list[str] | None = fields
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
+
+    # Automatically include 'names' expansion when display names are requested
+    if use_display_names and (not expand or "names" not in expand):
+        expand = f"{expand},names" if expand else "names"
 
     search_result = jira.search_issues(
         jql=jql,
@@ -481,7 +518,10 @@ async def search(
         projects_filter=projects_filter,
         page_token=page_token,
     )
-    result = search_result.to_simplified_dict()
+    if use_display_names:
+        result = search_result.to_display_name_dict()
+    else:
+        result = search_result.to_simplified_dict()
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -49,6 +49,14 @@ _GET_ISSUE_INCLUDE_SECTIONS = frozenset(
         "worklogs",
     }
 )
+_GET_ISSUE_INCLUDE_OUTPUT_KEYS: dict[str, str] = {
+    "remote_links": "remote_links",
+    "transitions": "transitions",
+    "watchers": "watchers",
+    "changelog": "changelogs",
+    "comments": "comments",
+    "worklogs": "worklogs",
+}
 _GET_ISSUE_INCLUDE_ALIASES = {
     "comment": "comments",
     "worklog": "worklogs",
@@ -547,6 +555,18 @@ async def get_issue(
             default=None,
         ),
     ] = None,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Get details of a specific Jira issue.
 
@@ -564,6 +584,7 @@ async def get_issue(
         properties: Issue properties to return.
         update_history: Whether to update issue view history.
         include: Comma-separated enrichment sections to inline.
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the Jira issue object.
@@ -586,6 +607,8 @@ async def get_issue(
     expand_additions = []
     if "changelog" in include_sections:
         expand_additions.append("changelog")
+    if use_display_names:
+        expand_additions.append("names")
     expand = _merge_expand(expand, expand_additions)
 
     # Fetch the issue (with augmented expand)
@@ -597,7 +620,15 @@ async def get_issue(
         properties=properties.split(",") if properties else None,
         update_history=update_history,
     )
-    result = issue.to_simplified_dict()
+    if use_display_names:
+        include_output_keys = {
+            _GET_ISSUE_INCLUDE_OUTPUT_KEYS[s]
+            for s in include_sections
+            if s in _GET_ISSUE_INCLUDE_OUTPUT_KEYS
+        }
+        result = issue.to_display_name_dict(extra_reserved_keys=include_output_keys)
+    else:
+        result = issue.to_simplified_dict()
 
     if "comments" in include_sections:
         result.setdefault("comments", [])
@@ -700,6 +731,18 @@ async def search(
             default=None,
         ),
     ] = None,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Search Jira issues using JQL (Jira Query Language).
 
@@ -712,6 +755,7 @@ async def search(
         projects_filter: Comma-separated list of project keys to filter by.
         expand: Optional fields to expand.
         page_token: Pagination token from a previous search result (Cloud only).
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the search results including pagination info.
@@ -720,6 +764,9 @@ async def search(
     fields_list: str | list[str] | None = fields
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
+
+    if use_display_names:
+        expand = _merge_expand(expand, ["names"])
 
     search_result = jira.search_issues(
         jql=jql,
@@ -730,7 +777,10 @@ async def search(
         projects_filter=projects_filter,
         page_token=page_token,
     )
-    result = search_result.to_simplified_dict()
+    if use_display_names:
+        result = search_result.to_display_name_dict()
+    else:
+        result = search_result.to_simplified_dict()
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/tests/e2e/cloud/test_mcp_tools_cloud.py
+++ b/tests/e2e/cloud/test_mcp_tools_cloud.py
@@ -75,6 +75,33 @@ class TestMCPJiraTools:
         assert data["key"] == cloud_instance.test_issue_key
 
     @pytest.mark.anyio
+    async def test_jira_get_issue_use_display_names(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        result = await call_tool(
+            mcp_client,
+            "jira_get_issue",
+            {
+                "issue_key": cloud_instance.test_issue_key,
+                "fields": "*all",
+                "use_display_names": True,
+            },
+        )
+        assert not result.is_error
+        assert result.content and isinstance(result.content[0], TextContent)
+        data = json.loads(result.content[0].text)
+        assert data["key"] == cloud_instance.test_issue_key
+        custom_fields = {
+            key: value
+            for key, value in data.items()
+            if isinstance(value, dict) and "field_id" in value
+        }
+        assert custom_fields
+        assert any(key != value["field_id"] for key, value in custom_fields.items())
+
+    @pytest.mark.anyio
     async def test_jira_search(
         self,
         mcp_client: Client,
@@ -93,6 +120,36 @@ class TestMCPJiraTools:
         data = json.loads(result.content[0].text)
         assert "issues" in data
         assert len(data["issues"]) > 0
+
+    @pytest.mark.anyio
+    async def test_jira_search_use_display_names(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        result = await call_tool(
+            mcp_client,
+            "jira_search",
+            {
+                "jql": f"project={cloud_instance.project_key}",
+                "fields": "*all",
+                "limit": 1,
+                "use_display_names": True,
+            },
+        )
+        assert not result.is_error
+        assert result.content and isinstance(result.content[0], TextContent)
+        data = json.loads(result.content[0].text)
+        assert len(data["issues"]) == 1
+        issue = data["issues"][0]
+        assert issue["key"].startswith(f"{cloud_instance.project_key}-")
+        custom_fields = {
+            key: value
+            for key, value in issue.items()
+            if isinstance(value, dict) and "field_id" in value
+        }
+        assert custom_fields
+        assert any(key != value["field_id"] for key, value in custom_fields.items())
 
     @pytest.mark.anyio
     async def test_jira_create_and_delete_issue(

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -74,6 +74,33 @@ class TestMCPJiraTools:
         assert data["key"] == dc_instance.test_issue_key
 
     @pytest.mark.anyio
+    async def test_jira_get_issue_use_display_names(
+        self,
+        mcp_client: Client,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        result = await call_tool(
+            mcp_client,
+            "jira_get_issue",
+            {
+                "issue_key": dc_instance.test_issue_key,
+                "fields": "*all",
+                "use_display_names": True,
+            },
+        )
+        assert not result.is_error
+        assert result.content and isinstance(result.content[0], TextContent)
+        data = json.loads(result.content[0].text)
+        assert data["key"] == dc_instance.test_issue_key
+        custom_fields = {
+            key: value
+            for key, value in data.items()
+            if isinstance(value, dict) and "field_id" in value
+        }
+        assert custom_fields
+        assert any(key != value["field_id"] for key, value in custom_fields.items())
+
+    @pytest.mark.anyio
     async def test_jira_get_issue_include_remote_links(
         self,
         mcp_client: Client,
@@ -114,6 +141,36 @@ class TestMCPJiraTools:
         data = json.loads(result.content[0].text)
         assert "issues" in data
         assert len(data["issues"]) > 0
+
+    @pytest.mark.anyio
+    async def test_jira_search_use_display_names(
+        self,
+        mcp_client: Client,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        result = await call_tool(
+            mcp_client,
+            "jira_search",
+            {
+                "jql": f"project={dc_instance.project_key}",
+                "fields": "*all",
+                "limit": 1,
+                "use_display_names": True,
+            },
+        )
+        assert not result.is_error
+        assert result.content and isinstance(result.content[0], TextContent)
+        data = json.loads(result.content[0].text)
+        assert len(data["issues"]) == 1
+        issue = data["issues"][0]
+        assert issue["key"].startswith(f"{dc_instance.project_key}-")
+        custom_fields = {
+            key: value
+            for key, value in issue.items()
+            if isinstance(value, dict) and "field_id" in value
+        }
+        assert custom_fields
+        assert any(key != value["field_id"] for key, value in custom_fields.items())
 
     @pytest.mark.anyio
     async def test_jira_create_and_delete_issue(

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1383,6 +1383,14 @@ class TestIssuesMixin:
         # Test with "*all" parameter
         issue = issues_mixin.get_issue("TEST-123", fields="*all")
 
+        issues_mixin.jira.get_issue.assert_called_once_with(
+            "TEST-123",
+            expand=None,
+            fields="*all",
+            properties=None,
+            update_history=True,
+        )
+
         # Check that all fields are included
         simplified = issue.to_simplified_dict()
         assert "summary" in simplified

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -1111,6 +1111,46 @@ class TestSearchMixin:
         assert result.next_page_token == "remaining_token_xyz"
         assert len(result.issues) == 2
 
+    def test_search_issues_cloud_preserves_names_map(
+        self,
+        search_mixin: SearchMixin,
+    ):
+        """Cloud v3 search keeps field display names for custom fields."""
+        search_mixin.config.is_cloud = True
+        search_mixin.config.projects_filter = None
+        search_mixin.config.url = "https://test.example.com"
+
+        response_page = {
+            "issues": [
+                {
+                    "id": "10001",
+                    "key": "TEST-1",
+                    "fields": {
+                        "summary": "Issue 1",
+                        "customfield_10001": 13,
+                    },
+                },
+            ],
+            "names": {"customfield_10001": "Story Points"},
+        }
+        search_mixin.jira.post = MagicMock(return_value=response_page)
+
+        result = search_mixin.search_issues(
+            "key = TEST-1",
+            fields="*all",
+            limit=1,
+            expand="names",
+        )
+
+        assert isinstance(result, JiraSearchResult)
+        assert result.issues[0].custom_fields["customfield_10001"]["name"] == (
+            "Story Points"
+        )
+        display_result = result.to_display_name_dict()
+        issue = display_result["issues"][0]
+        assert issue["Story Points"]["value"] == 13
+        assert "customfield_10001" not in issue
+
     def test_search_issues_cloud_no_remaining_token(
         self,
         search_mixin: SearchMixin,

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -773,3 +773,113 @@ class TestProcessCustomFieldValue:
         field = simplified["customfield_10200"]
         assert field["name"] == "Okapya Checklist"
         assert field["value"] == checklist_items
+
+
+class TestDisplayNameMethods:
+    """Tests for the additive display-name helper methods.
+
+    These methods sit on top of the existing JiraIssue model without
+    modifying any existing behavior.
+    """
+
+    @pytest.fixture()
+    def issue_with_names(self):
+        """Create a JiraIssue whose custom fields carry display names."""
+        api_data = {
+            "id": "100",
+            "key": "DN-1",
+            "fields": {
+                "summary": "Display name test",
+                "customfield_10001": "text value",
+                "customfield_10002": {"value": "Option A"},
+                "customfield_10003": [
+                    {"value": "Multi 1"},
+                    {"value": "Multi 2"},
+                ],
+                "customfield_10099": "orphan without a name",
+            },
+            "names": {
+                "customfield_10001": "Story Points",
+                "customfield_10002": "Severity",
+                "customfield_10003": "Affected Versions",
+            },
+        }
+        return JiraIssue.from_api_response(api_data, requested_fields="*all")
+
+    # -- get_custom_field_by_name -----------------------------------------
+
+    def test_get_custom_field_by_name_exact(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Story Points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_insensitive(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("story points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_sensitive_miss(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name(
+            "story points", case_sensitive=True
+        )
+        assert result is None
+
+    def test_get_custom_field_by_name_select(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Severity")
+        assert result == "Option A"
+
+    def test_get_custom_field_by_name_multiselect(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Affected Versions")
+        assert result == ["Multi 1", "Multi 2"]
+
+    def test_get_custom_field_by_name_not_found(self, issue_with_names):
+        assert issue_with_names.get_custom_field_by_name("Nonexistent") is None
+
+    # -- custom_fields_by_display_name property ---------------------------
+
+    def test_property_rekeys_by_display_name(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "Story Points" in by_name
+        assert "Severity" in by_name
+        assert "Affected Versions" in by_name
+
+    def test_property_includes_field_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert by_name["Story Points"]["field_id"] == "customfield_10001"
+        assert by_name["Severity"]["field_id"] == "customfield_10002"
+
+    def test_property_keeps_orphans_by_raw_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10099" in by_name
+        assert by_name["customfield_10099"]["field_id"] == "customfield_10099"
+
+    def test_property_does_not_mutate_original(self, issue_with_names):
+        _ = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10001" in issue_with_names.custom_fields
+
+    # -- to_display_name_dict ---------------------------------------------
+
+    def test_display_name_dict_rekeys_customs(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "Story Points" in d
+        assert "Severity" in d
+        assert "Affected Versions" in d
+        assert "customfield_10001" not in d
+        assert "customfield_10002" not in d
+
+    def test_display_name_dict_preserves_standard_fields(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["key"] == "DN-1"
+        assert d["summary"] == "Display name test"
+
+    def test_display_name_dict_includes_field_id(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["Story Points"]["field_id"] == "customfield_10001"
+
+    def test_display_name_dict_orphan_kept(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "customfield_10099" in d
+
+    def test_original_simplified_dict_unchanged(self, issue_with_names):
+        """to_simplified_dict must still use customfield_XXXXX keys."""
+        s = issue_with_names.to_simplified_dict()
+        assert "customfield_10001" in s
+        assert "Story Points" not in s

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -780,3 +780,194 @@ class TestProcessCustomFieldValue:
         field = simplified["customfield_10200"]
         assert field["name"] == "Okapya Checklist"
         assert field["value"] == checklist_items
+
+
+class TestDisplayNameMethods:
+    """Tests for the additive display-name helper methods.
+
+    These methods sit on top of the existing JiraIssue model without
+    modifying any existing behavior.
+    """
+
+    @pytest.fixture()
+    def issue_with_names(self):
+        """Create a JiraIssue whose custom fields carry display names."""
+        api_data = {
+            "id": "100",
+            "key": "DN-1",
+            "fields": {
+                "summary": "Display name test",
+                "customfield_10001": "text value",
+                "customfield_10002": {"value": "Option A"},
+                "customfield_10003": [
+                    {"value": "Multi 1"},
+                    {"value": "Multi 2"},
+                ],
+                "customfield_10099": "orphan without a name",
+            },
+            "names": {
+                "customfield_10001": "Story Points",
+                "customfield_10002": "Severity",
+                "customfield_10003": "Affected Versions",
+            },
+        }
+        return JiraIssue.from_api_response(api_data, requested_fields="*all")
+
+    # -- get_custom_field_by_name -----------------------------------------
+
+    def test_get_custom_field_by_name_exact(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Story Points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_insensitive(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("story points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_sensitive_miss(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name(
+            "story points", case_sensitive=True
+        )
+        assert result is None
+
+    def test_get_custom_field_by_name_select(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Severity")
+        assert result == "Option A"
+
+    def test_get_custom_field_by_name_multiselect(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Affected Versions")
+        assert result == ["Multi 1", "Multi 2"]
+
+    def test_get_custom_field_by_name_not_found(self, issue_with_names):
+        assert issue_with_names.get_custom_field_by_name("Nonexistent") is None
+
+    # -- custom_fields_by_display_name property ---------------------------
+
+    def test_property_rekeys_by_display_name(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "Story Points" in by_name
+        assert "Severity" in by_name
+        assert "Affected Versions" in by_name
+
+    def test_property_includes_field_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert by_name["Story Points"]["field_id"] == "customfield_10001"
+        assert by_name["Severity"]["field_id"] == "customfield_10002"
+
+    def test_property_keeps_orphans_by_raw_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10099" in by_name
+        assert by_name["customfield_10099"]["field_id"] == "customfield_10099"
+
+    def test_property_does_not_mutate_original(self, issue_with_names):
+        _ = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10001" in issue_with_names.custom_fields
+
+    def test_property_preserves_duplicate_display_names(self, issue_with_names):
+        issue_with_names.custom_fields["customfield_10004"] = {
+            "name": "Story Points",
+            "value": 8,
+        }
+
+        by_name = issue_with_names.custom_fields_by_display_name
+
+        assert by_name["Story Points"]["field_id"] == "customfield_10001"
+        assert by_name["customfield_10004"]["value"] == 8
+        assert len(by_name) == len(issue_with_names.custom_fields)
+
+    # -- to_display_name_dict ---------------------------------------------
+
+    def test_display_name_dict_rekeys_customs(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "Story Points" in d
+        assert "Severity" in d
+        assert "Affected Versions" in d
+        assert "customfield_10001" not in d
+        assert "customfield_10002" not in d
+
+    def test_display_name_dict_preserves_standard_fields(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["key"] == "DN-1"
+        assert d["summary"] == "Display name test"
+
+    def test_display_name_dict_includes_field_id(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["Story Points"]["field_id"] == "customfield_10001"
+
+    def test_display_name_dict_orphan_kept(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "customfield_10099" in d
+
+    def test_original_simplified_dict_unchanged(self, issue_with_names):
+        """to_simplified_dict must still use customfield_XXXXX keys."""
+        s = issue_with_names.to_simplified_dict()
+        assert "customfield_10001" in s
+        assert "Story Points" not in s
+
+    def test_display_name_dict_preserves_duplicate_names(self, issue_with_names):
+        issue_with_names.custom_fields["customfield_10004"] = {
+            "name": "Story Points",
+            "value": 8,
+        }
+
+        display_dict = issue_with_names.to_display_name_dict()
+
+        assert display_dict["Story Points"]["field_id"] == "customfield_10001"
+        assert display_dict["customfield_10004"]["value"] == 8
+        assert display_dict["customfield_10004"]["field_id"] == "customfield_10004"
+
+    def test_display_name_dict_preserves_standard_field_collision(
+        self, issue_with_names
+    ):
+        issue_with_names.custom_fields["customfield_10004"] = {
+            "name": "summary",
+            "value": "custom summary",
+        }
+
+        display_dict = issue_with_names.to_display_name_dict()
+
+        assert display_dict["summary"] == "Display name test"
+        assert display_dict["customfield_10004"]["value"] == "custom summary"
+
+    def test_display_name_dict_extra_reserved_keys(self, issue_with_names):
+        """Custom field named 'comments' must not claim that key when reserved."""
+        issue_with_names.custom_fields["customfield_10099"] = {
+            "name": "comments",
+            "value": "some value",
+        }
+
+        display_dict = issue_with_names.to_display_name_dict(
+            extra_reserved_keys={"comments"}
+        )
+
+        assert "customfield_10099" in display_dict
+        assert display_dict["customfield_10099"]["value"] == "some value"
+        assert display_dict["customfield_10099"]["field_id"] == "customfield_10099"
+
+    def test_display_name_dict_extra_reserved_keys_no_false_positives(
+        self, issue_with_names
+    ):
+        """Unrelated fields are still rekeyed even with extra_reserved_keys."""
+        display_dict = issue_with_names.to_display_name_dict(
+            extra_reserved_keys={"comments", "watchers"}
+        )
+
+        assert "Story Points" in display_dict
+        assert "Severity" in display_dict
+
+    def test_display_name_dict_strips_redundant_name(self, issue_with_names):
+        """The redundant 'name' field is removed from custom field entries."""
+        display_dict = issue_with_names.to_display_name_dict()
+
+        sp = display_dict["Story Points"]
+        assert "name" not in sp
+        assert sp["field_id"] == "customfield_10001"
+
+    def test_custom_fields_by_display_name_strips_redundant_name(
+        self, issue_with_names
+    ):
+        """The property variant also strips redundant 'name' entries."""
+        by_name = issue_with_names.custom_fields_by_display_name
+
+        sp = by_name["Story Points"]
+        assert "name" not in sp
+        assert sp["field_id"] == "customfield_10001"

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2430,3 +2430,100 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
     # return_limit=1 caps to first match
     assert len(result) == 1
     assert result[0] == "High"
+
+
+# ============================================================================
+# Display-Name Feature Tests
+# ============================================================================
+
+
+@pytest.mark.anyio
+async def test_get_issue_use_display_names(jira_client, mock_jira_fetcher):
+    """Test get_issue with use_display_names=True returns display-name keys."""
+    display_name_response = {
+        "key": "TEST-123",
+        "summary": "Test Issue Summary",
+        "status": {"name": "Open"},
+        "Story Points": {"value": 5, "field_id": "customfield_10243"},
+    }
+
+    def mock_get_issue_dn(
+        issue_key,
+        fields=None,
+        expand=None,
+        comment_limit=10,
+        properties=None,
+        update_history=True,
+    ):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test Issue Summary",
+            "status": {"name": "Open"},
+            "customfield_10243": 5,
+        }
+        mock_issue.to_display_name_dict.return_value = {
+            **display_name_response,
+            "key": issue_key,
+        }
+        return mock_issue
+
+    mock_jira_fetcher.get_issue.side_effect = mock_get_issue_dn
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "use_display_names": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert "Story Points" in content
+    assert "customfield_10243" not in content
+
+    mock_jira_fetcher.get_issue.assert_called_once()
+    call_kwargs = mock_jira_fetcher.get_issue.call_args
+    assert call_kwargs[1]["issue_key"] == "TEST-123"
+    assert call_kwargs[1]["expand"] == "names"
+
+
+@pytest.mark.anyio
+async def test_search_use_display_names(jira_client, mock_jira_fetcher):
+    """Test search with use_display_names=True returns display-name keys."""
+    display_name_issues = [
+        {
+            "key": "PROJ-123",
+            "summary": "First issue",
+            "Story Points": {"value": 3, "field_id": "customfield_10243"},
+        },
+    ]
+
+    def mock_search_dn(jql, **kwargs):
+        mock_search_result = MagicMock()
+        mock_search_result.to_simplified_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": [
+                {"key": "PROJ-123", "summary": "First issue", "customfield_10243": 3},
+            ],
+        }
+        mock_search_result.to_display_name_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": display_name_issues,
+        }
+        return mock_search_result
+
+    mock_jira_fetcher.search_issues.side_effect = mock_search_dn
+
+    response = await jira_client.call_tool(
+        "jira_search",
+        {"jql": "project = TEST", "use_display_names": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert content["issues"][0].get("Story Points") is not None
+    assert "customfield_10243" not in content["issues"][0]
+
+    mock_jira_fetcher.search_issues.assert_called_once()
+    call_kwargs = mock_jira_fetcher.search_issues.call_args
+    assert call_kwargs[1]["jql"] == "project = TEST"
+    assert call_kwargs[1]["expand"] == "names"

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -3269,3 +3269,237 @@ async def test_jira_move_issue_not_cloud(jira_client, mock_jira_fetcher):
             {"issue_key": "PROJ-123", "target_project_key": "OTHER"},
         )
     assert "Jira Cloud" in str(excinfo.value)
+
+
+# ============================================================================
+# Display-Name Feature Tests
+# ============================================================================
+
+
+@pytest.mark.anyio
+async def test_get_issue_use_display_names(jira_client, mock_jira_fetcher):
+    """Test get_issue with use_display_names=True returns display-name keys."""
+    display_name_response = {
+        "key": "TEST-123",
+        "summary": "Test Issue Summary",
+        "status": {"name": "Open"},
+        "Story Points": {"value": 5, "field_id": "customfield_10243"},
+    }
+
+    def mock_get_issue_dn(
+        issue_key,
+        fields=None,
+        expand=None,
+        comment_limit=10,
+        properties=None,
+        update_history=True,
+    ):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test Issue Summary",
+            "status": {"name": "Open"},
+            "customfield_10243": 5,
+        }
+        mock_issue.to_display_name_dict.return_value = {
+            **display_name_response,
+            "key": issue_key,
+        }
+        return mock_issue
+
+    mock_jira_fetcher.get_issue.side_effect = mock_get_issue_dn
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "use_display_names": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert "Story Points" in content
+    assert "customfield_10243" not in content
+
+    mock_jira_fetcher.get_issue.assert_called_once()
+    call_kwargs = mock_jira_fetcher.get_issue.call_args
+    assert call_kwargs[1]["issue_key"] == "TEST-123"
+    assert call_kwargs[1]["expand"] == "names"
+
+
+@pytest.mark.anyio
+async def test_search_use_display_names(jira_client, mock_jira_fetcher):
+    """Test search with use_display_names=True returns display-name keys."""
+    display_name_issues = [
+        {
+            "key": "PROJ-123",
+            "summary": "First issue",
+            "Story Points": {"value": 3, "field_id": "customfield_10243"},
+        },
+    ]
+
+    def mock_search_dn(jql, **kwargs):
+        mock_search_result = MagicMock()
+        mock_search_result.to_simplified_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": [
+                {"key": "PROJ-123", "summary": "First issue", "customfield_10243": 3},
+            ],
+        }
+        mock_search_result.to_display_name_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": display_name_issues,
+        }
+        return mock_search_result
+
+    mock_jira_fetcher.search_issues.side_effect = mock_search_dn
+
+    response = await jira_client.call_tool(
+        "jira_search",
+        {
+            "jql": "project = TEST",
+            "expand": "renderedFields",
+            "use_display_names": True,
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["issues"][0].get("Story Points") is not None
+    assert "customfield_10243" not in content["issues"][0]
+
+    mock_jira_fetcher.search_issues.assert_called_once()
+    call_kwargs = mock_jira_fetcher.search_issues.call_args
+    assert call_kwargs[1]["jql"] == "project = TEST"
+    assert call_kwargs[1]["expand"] == "renderedFields,names"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "include_key",
+    ["remote_links", "transitions", "watchers", "worklogs"],
+)
+async def test_display_name_collision_with_include_key_preserves_both(
+    jira_client, mock_jira_fetcher, include_key
+):
+    """Custom field whose display name collides with include output key falls back to raw ID."""
+    output_key_map = {
+        "remote_links": "remote_links",
+        "transitions": "transitions",
+        "watchers": "watchers",
+        "worklogs": "worklogs",
+    }
+    output_key = output_key_map[include_key]
+
+    def mock_get_issue_collision(
+        issue_key,
+        fields=None,
+        expand=None,
+        comment_limit=10,
+        properties=None,
+        update_history=True,
+    ):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test",
+            "status": {"name": "Open"},
+            "customfield_99999": {"name": output_key, "value": "custom"},
+        }
+
+        def display_name_dict(extra_reserved_keys=None):
+            if extra_reserved_keys and output_key in extra_reserved_keys:
+                return {
+                    "key": issue_key,
+                    "summary": "Test",
+                    "status": {"name": "Open"},
+                    "customfield_99999": {
+                        "value": "custom",
+                        "field_id": "customfield_99999",
+                    },
+                }
+            return {
+                "key": issue_key,
+                "summary": "Test",
+                "status": {"name": "Open"},
+                output_key: {"value": "custom", "field_id": "customfield_99999"},
+            }
+
+        mock_issue.to_display_name_dict.side_effect = display_name_dict
+        return mock_issue
+
+    mock_jira_fetcher.get_issue.side_effect = mock_get_issue_collision
+    mock_jira_fetcher.get_remote_issue_links.return_value = [{"url": "http://x"}]
+    mock_jira_fetcher.get_available_transitions.return_value = [{"name": "Done"}]
+    mock_jira_fetcher.get_issue_watchers.return_value = {"watchers": ["u1"]}
+    mock_jira_fetcher.get_worklogs.return_value = [{"time": "1h"}]
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "COL-1", "use_display_names": True, "include": include_key},
+    )
+    content = json.loads(response.content[0].text)
+
+    assert "customfield_99999" in content
+    assert content["customfield_99999"]["value"] == "custom"
+
+    assert output_key in content
+    assert content[output_key] != {"value": "custom", "field_id": "customfield_99999"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("include_key", ["comments", "changelog"])
+async def test_display_name_collision_with_setdefault_include_key(
+    jira_client, mock_jira_fetcher, include_key
+):
+    """Custom field whose display name matches a setdefault enrichment key falls back to raw ID."""
+    output_key_map = {"comments": "comments", "changelog": "changelogs"}
+    output_key = output_key_map[include_key]
+
+    def mock_get_issue_collision(
+        issue_key,
+        fields=None,
+        expand=None,
+        comment_limit=10,
+        properties=None,
+        update_history=True,
+    ):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test",
+            "status": {"name": "Open"},
+            "customfield_88888": {"name": output_key, "value": "custom"},
+        }
+
+        def display_name_dict(extra_reserved_keys=None):
+            if extra_reserved_keys and output_key in extra_reserved_keys:
+                return {
+                    "key": issue_key,
+                    "summary": "Test",
+                    "status": {"name": "Open"},
+                    "customfield_88888": {
+                        "value": "custom",
+                        "field_id": "customfield_88888",
+                    },
+                }
+            return {
+                "key": issue_key,
+                "summary": "Test",
+                "status": {"name": "Open"},
+                output_key: {"value": "custom", "field_id": "customfield_88888"},
+            }
+
+        mock_issue.to_display_name_dict.side_effect = display_name_dict
+        return mock_issue
+
+    mock_jira_fetcher.get_issue.side_effect = mock_get_issue_collision
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "COL-2", "use_display_names": True, "include": include_key},
+    )
+    content = json.loads(response.content[0].text)
+
+    assert "customfield_88888" in content
+    assert content["customfield_88888"]["value"] == "custom"
+
+    assert output_key in content


### PR DESCRIPTION
## Description

Adds an opt-in `use_display_names` parameter to `jira_get_issue` and `jira_search`.
When enabled, custom field keys use human-readable names such as `Story Points`
instead of opaque IDs such as `customfield_10243`. The tools automatically request
the Jira `names` expansion.

If a display name conflicts with a standard output key, another custom field, or a
requested `include` section, the custom field keeps its raw ID so no value is silently
lost.

Fixes #1154.

## Changes

- Add display-name lookup and serialization helpers to `JiraIssue` and `JiraSearchResult`.
- Preserve and combine field-name maps across Jira Cloud search pages.
- Preserve `fields="*all"` in `jira_get_issue` so custom fields reach the model.
- Add `use_display_names: bool = false` to `jira_get_issue` and `jira_search`.
- Merge the automatic `names` expansion with caller-provided expansions.
- Reserve requested `include` output keys during display-name selection.
- Add collision, client, server, Cloud E2E, and Data Center E2E regression coverage.
- Document the opt-in output and collision fallback.

## Verification

- `uv run pre-commit run --all-files` — passed (Ruff, formatting, mypy).
- Affected unit suites — 310 passed.
- `uv run pytest tests/integration/ --integration -q` — 8 passed, 15 skipped.
- Full Cloud E2E — 84 passed, 15 skipped.
- Full Data Center E2E — 96 passed, 100 Cloud-only tests skipped.
