### PR TITLE
ATLASSIAN_OAUTH_ENABLE check to require service URL

### DIFF
--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -109,16 +109,15 @@ def get_available_services(
             pat_env="CONFLUENCE_PERSONAL_TOKEN",
         )
 
-    if not confluence_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
-        confluence_is_setup = True
-        logger.info(
-            "Using Confluence minimal OAuth configuration "
-            "- expecting user-provided tokens via headers"
-        )
+        # OAuth enable check with known URL — expecting user-provided tokens via headers
+        if not confluence_is_setup and os.getenv(
+            "ATLASSIAN_OAUTH_ENABLE", ""
+        ).lower() in ("true", "1", "yes"):
+            confluence_is_setup = True
+            logger.info(
+                "Using Confluence OAuth with CONFLUENCE_URL "
+                "- expecting user-provided tokens via headers"
+            )
 
     if not confluence_is_setup:
         confluence_token = headers.get("X-Atlassian-Confluence-Personal-Token")
@@ -148,16 +147,17 @@ def get_available_services(
             pat_env="JIRA_PERSONAL_TOKEN",
         )
 
-    if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
-        jira_is_setup = True
-        logger.info(
-            "Using Jira minimal OAuth configuration "
-            "- expecting user-provided tokens via headers"
-        )
+        # OAuth enable check with known URL — expecting user-provided tokens via headers
+        if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+            "true",
+            "1",
+            "yes",
+        ):
+            jira_is_setup = True
+            logger.info(
+                "Using Jira OAuth with JIRA_URL "
+                "- expecting user-provided tokens via headers"
+            )
 
     if not jira_is_setup:
         jira_token = headers.get("X-Atlassian-Jira-Personal-Token")

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -86,8 +86,13 @@ def _check_service_auth(
 def get_available_services(
     headers: dict[str, str] | None = None,
 ) -> dict[str, bool | None]:
-    """Determine which services are available based on environment variables and optional headers."""
+    """Determine available services from environment variables and headers."""
     headers = headers or {}
+    oauth_enabled = os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
 
     confluence_url = os.getenv("CONFLUENCE_URL")
     confluence_is_setup = False
@@ -109,13 +114,10 @@ def get_available_services(
             pat_env="CONFLUENCE_PERSONAL_TOKEN",
         )
 
-        # OAuth enable check with known URL — expecting user-provided tokens via headers
-        if not confluence_is_setup and os.getenv(
-            "ATLASSIAN_OAUTH_ENABLE", ""
-        ).lower() in ("true", "1", "yes"):
+        if not confluence_is_setup and oauth_enabled:
             confluence_is_setup = True
             logger.info(
-                "Using Confluence OAuth with CONFLUENCE_URL "
+                "Using Confluence minimal OAuth configuration with CONFLUENCE_URL "
                 "- expecting user-provided tokens via headers"
             )
 
@@ -147,15 +149,10 @@ def get_available_services(
             pat_env="JIRA_PERSONAL_TOKEN",
         )
 
-        # OAuth enable check with known URL — expecting user-provided tokens via headers
-        if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-            "true",
-            "1",
-            "yes",
-        ):
+        if not jira_is_setup and oauth_enabled:
             jira_is_setup = True
             logger.info(
-                "Using Jira OAuth with JIRA_URL "
+                "Using Jira minimal OAuth configuration with JIRA_URL "
                 "- expecting user-provided tokens via headers"
             )
 
@@ -169,7 +166,8 @@ def get_available_services(
 
     if not confluence_is_setup:
         logger.info(
-            "Confluence is not configured or required environment variables are missing."
+            "Confluence is not configured or required environment variables "
+            "are missing."
         )
     if not jira_is_setup:
         logger.info(

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -436,7 +436,10 @@ class TestGetAvailableServicesWithHeaders:
             assert "Data Center" in caplog.text
 
     def test_oauth_enable_without_urls(self, caplog):
-        """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true without service URLs."""
+        """Test that ATLASSIAN_OAUTH_ENABLE=true without service URLs does NOT mark services as available.
+
+        The OAuth enable check is now scoped inside the URL check, so a URL is required.
+        """
         with MockEnvironment.clean_env():
             import os
 
@@ -444,17 +447,10 @@ class TestGetAvailableServicesWithHeaders:
 
             result = get_available_services()
             _assert_service_availability(
-                result, confluence_expected=True, jira_expected=True
+                result, confluence_expected=False, jira_expected=False
             )
-            assert_log_contains(
-                caplog,
-                "INFO",
-                "Using Confluence minimal OAuth configuration",
-            )
-            assert_log_contains(
-                caplog,
-                "INFO",
-                "Using Jira minimal OAuth configuration",
+            _assert_authentication_logs(
+                caplog, "not_configured", ["confluence", "jira"]
             )
 
     def test_oauth_enable_with_cloud_url_no_creds(self, caplog):
@@ -476,7 +472,25 @@ class TestGetAvailableServicesWithHeaders:
         ["true", "True", "TRUE", "1", "yes", "YES"],
     )
     def test_oauth_enable_value_variations(self, enable_value, caplog):
-        """Test various ATLASSIAN_OAUTH_ENABLE value formats."""
+        """Test various ATLASSIAN_OAUTH_ENABLE value formats with URLs present."""
+        with MockEnvironment.clean_env():
+            import os
+
+            os.environ["ATLASSIAN_OAUTH_ENABLE"] = enable_value
+            os.environ["CONFLUENCE_URL"] = "https://test.atlassian.net/wiki"
+            os.environ["JIRA_URL"] = "https://test.atlassian.net"
+
+            result = get_available_services()
+            _assert_service_availability(
+                result, confluence_expected=True, jira_expected=True
+            )
+
+    @pytest.mark.parametrize(
+        "enable_value",
+        ["true", "True", "TRUE", "1", "yes", "YES"],
+    )
+    def test_oauth_enable_without_urls_value_variations(self, enable_value, caplog):
+        """Test that ATLASSIAN_OAUTH_ENABLE without URLs returns False regardless of value format."""
         with MockEnvironment.clean_env():
             import os
 
@@ -484,7 +498,7 @@ class TestGetAvailableServicesWithHeaders:
 
             result = get_available_services()
             _assert_service_availability(
-                result, confluence_expected=True, jira_expected=True
+                result, confluence_expected=False, jira_expected=False
             )
 
     @pytest.mark.parametrize(

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -68,7 +68,9 @@ def _assert_authentication_logs(caplog, auth_type, services):
         "oauth": "OAuth 2.0 (3LO) authentication (Cloud)",
         "cloud_basic": "Cloud Basic Authentication (API Token)",
         "server": "Server/Data Center authentication (PAT or Basic Auth)",
-        "not_configured": "is not configured or required environment variables are missing",
+        "not_configured": (
+            "is not configured or required environment variables are missing"
+        ),
     }
 
     for service in services:
@@ -267,7 +269,7 @@ class TestGetAvailableServices:
 
 
 class TestGetAvailableServicesWithHeaders:
-    """Test cases for get_available_services function with header-based authentication."""
+    """Test get_available_services with header-based authentication."""
 
     def test_header_based_jira_authentication(self, caplog):
         """Test that Jira is available when header-based auth is provided."""
@@ -306,7 +308,7 @@ class TestGetAvailableServicesWithHeaders:
             )
 
     def test_header_based_both_services_authentication(self, caplog):
-        """Test that both services are available when both header-based auths are provided."""
+        """Test both services with both header-based authentication pairs."""
         headers = {
             "X-Atlassian-Jira-Url": "https://test.atlassian.net",
             "X-Atlassian-Jira-Personal-Token": "test-jira-pat-token",
@@ -436,10 +438,7 @@ class TestGetAvailableServicesWithHeaders:
             assert "Data Center" in caplog.text
 
     def test_oauth_enable_without_urls(self, caplog):
-        """Test that ATLASSIAN_OAUTH_ENABLE=true without service URLs does NOT mark services as available.
-
-        The OAuth enable check is now scoped inside the URL check, so a URL is required.
-        """
+        """Test that OAuth enable alone doesn't make services available."""
         with MockEnvironment.clean_env():
             import os
 
@@ -454,7 +453,7 @@ class TestGetAvailableServicesWithHeaders:
             )
 
     def test_oauth_enable_with_cloud_url_no_creds(self, caplog):
-        """Test BYOT OAuth mode — URL present but no credentials, ATLASSIAN_OAUTH_ENABLE=true."""
+        """Test BYOT OAuth mode with service URLs and no credentials."""
         with MockEnvironment.clean_env():
             import os
 
@@ -465,6 +464,39 @@ class TestGetAvailableServicesWithHeaders:
             result = get_available_services()
             _assert_service_availability(
                 result, confluence_expected=True, jira_expected=True
+            )
+
+    @pytest.mark.parametrize(
+        ("url_name", "url", "confluence_expected", "jira_expected"),
+        [
+            (
+                "CONFLUENCE_URL",
+                "https://test.atlassian.net/wiki",
+                True,
+                False,
+            ),
+            ("JIRA_URL", "https://test.atlassian.net", False, True),
+        ],
+    )
+    def test_oauth_enable_requires_matching_service_url(
+        self,
+        url_name,
+        url,
+        confluence_expected,
+        jira_expected,
+    ):
+        """Test that BYOT OAuth enables only services with matching URLs."""
+        with MockEnvironment.clean_env():
+            import os
+
+            os.environ["ATLASSIAN_OAUTH_ENABLE"] = "true"
+            os.environ[url_name] = url
+
+            result = get_available_services()
+            _assert_service_availability(
+                result,
+                confluence_expected=confluence_expected,
+                jira_expected=jira_expected,
             )
 
     @pytest.mark.parametrize(
@@ -490,7 +522,7 @@ class TestGetAvailableServicesWithHeaders:
         ["true", "True", "TRUE", "1", "yes", "YES"],
     )
     def test_oauth_enable_without_urls_value_variations(self, enable_value, caplog):
-        """Test that ATLASSIAN_OAUTH_ENABLE without URLs returns False regardless of value format."""
+        """Test accepted OAuth enable values without service URLs."""
         with MockEnvironment.clean_env():
             import os
 


### PR DESCRIPTION
When `ATLASSIAN_OAUTH_ENABLE=true` is set without a corresponding `CONFLUENCE_URL` or `JIRA_URL`, the service is incorrectly marked as available. This causes downstream failures when per-user fetchers are created without a base URL.

This is particularly problematic in multi-user or gateway deployments where only one service URL is configured and users provide credentials through authorization headers. Minimal OAuth availability is now scoped to each service URL, so configuring Confluence no longer exposes unusable Jira tools, and vice versa.

The regression coverage includes no URLs, both URLs, each individual service URL, accepted enable values, and disabled values.

## Testing

- `uv run pre-commit run --all-files`
- `uv run pytest tests/unit/ -q` (3270 passed, 5 skipped)
- `uv run pytest tests/integration/ -q` (23 environment-gated skips)
- `uv run pytest tests/e2e/cloud --cloud-e2e -q` (89 passed, 15 skipped)
- `uv run pytest tests/e2e/ --dc-e2e -q` (99 passed, 105 skipped)