### PR TITLE
fix: redact auth token in unsupported Authorization type log

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -667,7 +667,12 @@ class UserTokenMiddleware:
         elif auth_header.strip():
             # Non-empty but unsupported auth type
             auth_value = auth_header.strip()
-            auth_type = auth_value.split(" ", 1)[0] if " " in auth_value else auth_value
+            if " " in auth_value:
+                auth_type = auth_value.split(" ", 1)[0]
+            else:
+                # No space means no type prefix — likely a raw token.
+                # Redact to avoid leaking credentials in logs.
+                auth_type = "<redacted>"
             logger.warning(f"Unsupported Authorization type: {auth_type}")
             scope["state"]["auth_validation_error"] = (
                 "Unauthorized: Only 'Bearer <OAuthToken>', "

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -247,12 +247,13 @@ class TestUserTokenMiddleware:
 
     @pytest.mark.anyio
     async def test_unsupported_auth_type_returns_401(
-        self, middleware, mock_scope, mock_receive, mock_send
+        self, middleware, mock_scope, mock_receive, mock_send, caplog
     ):
         """Test that unsupported auth types (e.g., Digest) return 401 Unauthorized."""
         mock_scope["headers"] = [(b"authorization", b"Digest username=test")]
 
-        await middleware(mock_scope, mock_receive, mock_send)
+        with caplog.at_level(logging.WARNING, logger="mcp-atlassian.server.main"):
+            await middleware(mock_scope, mock_receive, mock_send)
 
         # Verify 401 response was sent
         assert mock_send.call_count == 2
@@ -269,6 +270,31 @@ class TestUserTokenMiddleware:
 
         # Verify app was NOT called
         middleware.app.assert_not_called()
+        assert "Unsupported Authorization type: Digest" in caplog.text
+        assert "username=test" not in caplog.text
+
+    @pytest.mark.anyio
+    async def test_raw_auth_token_is_redacted_in_warning(
+        self, middleware, mock_scope, mock_receive, mock_send, caplog
+    ):
+        """Test that raw Authorization values are redacted from warning logs."""
+        raw_token = "raw-token-without-prefix"
+        mock_scope["headers"] = [(b"authorization", raw_token.encode())]
+
+        with caplog.at_level(logging.WARNING, logger="mcp-atlassian.server.main"):
+            await middleware(mock_scope, mock_receive, mock_send)
+
+        assert mock_send.call_count == 2
+        start_call = mock_send.call_args_list[0][0][0]
+        assert start_call["status"] == 401
+
+        body_call = mock_send.call_args_list[1][0][0]
+        body = json.loads(body_call["body"].decode())
+        assert "Bearer" in body["error"]
+
+        middleware.app.assert_not_called()
+        assert "Unsupported Authorization type: <redacted>" in caplog.text
+        assert raw_token not in caplog.text
 
     @pytest.mark.anyio
     async def test_whitespace_only_auth_returns_401(


### PR DESCRIPTION
## Summary
- Prevents unsupported Authorization headers without a type prefix from logging the raw header value.
- Keeps unsupported headers with a prefix logging only the prefix, not credentials.
- Adds regression coverage for both warning-log paths.

## Verification
- `uv run pytest tests/unit/servers/test_main_server.py -xvs` (52 passed)
- `uv run pytest tests/integration --integration -xvs` (8 passed, 15 skipped: real API tests require `--use-real-data`)
- `uv run pytest tests/e2e/cloud/test_jira_auth_matrix.py tests/e2e/cloud/test_confluence_auth_matrix.py --cloud-e2e -xvs` (15 passed, 15 skipped: OAuth variant unavailable)
- `uv run pytest tests/e2e/test_jira_auth_matrix.py tests/e2e/test_confluence_auth_matrix.py --dc-e2e -xvs` (45 skipped: Jira DC not reachable at `http://localhost:8080`)
- `uv run pre-commit run --all-files`

Fixes #1134