### PR TITLE
feat: expose Jira attachment upload as standalone MCP tools

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1038,6 +1038,96 @@ async def get_issue_images(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "attachments", "toolset:jira_attachments"},
+    annotations={"title": "Upload Attachment", "destructiveHint": True},
+)
+@check_write_access
+async def upload_attachment(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    file_path: Annotated[
+        str,
+        Field(
+            description=(
+                "Full path to the file to upload. Can be absolute "
+                "(e.g., '/home/user/document.pdf') or relative to the current "
+                "working directory. Example: './uploads/report.pdf'"
+            ),
+        ),
+    ],
+) -> str:
+    """Upload a single attachment to a Jira issue.
+
+    Uploads a file from the local filesystem to the specified Jira issue.
+    This is useful for:
+    - Attaching documents, screenshots, or logs to an issue
+    - Adding supporting files to bug reports or tasks
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        file_path: Path to the file to upload.
+
+    Returns:
+        JSON string with upload confirmation and attachment metadata.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.upload_attachment(issue_key=issue_key, file_path=file_path)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "attachments", "toolset:jira_attachments"},
+    annotations={"title": "Upload Multiple Attachments", "destructiveHint": True},
+)
+@check_write_access
+async def upload_attachments(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    file_paths: Annotated[
+        str,
+        Field(
+            description=(
+                "Comma-separated list of file paths to upload. Can be absolute "
+                "or relative paths. Example: './file1.pdf,./file2.png'"
+            ),
+        ),
+    ],
+) -> str:
+    """Upload multiple attachments to a Jira issue in a single operation.
+
+    More efficient than calling upload_attachment multiple times.
+    Useful for:
+    - Bulk uploading documentation assets
+    - Adding multiple related files to an issue at once
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        file_paths: Comma-separated list of file paths to upload.
+
+    Returns:
+        JSON string with upload results for each file.
+    """
+    jira = await get_jira_fetcher(ctx)
+    paths = [p.strip() for p in file_paths.split(",") if p.strip()]
+    result = jira.upload_attachments(issue_key=issue_key, file_paths=paths)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_agile"},
     annotations={"title": "Get Agile Boards", "readOnlyHint": True},
 )

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -392,6 +392,8 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         delete_issue,
         download_attachments,
         edit_comment,
+        upload_attachment,
+        upload_attachments,
         get_agile_boards,
         get_all_projects,
         get_board_issues,
@@ -457,6 +459,8 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(update_sprint)
     jira_sub_mcp.add_tool(add_issues_to_sprint)
     jira_sub_mcp.add_tool(batch_create_versions)
+    jira_sub_mcp.add_tool(upload_attachment)
+    jira_sub_mcp.add_tool(upload_attachments)
     test_mcp.mount(jira_sub_mcp, prefix="jira")
     return test_mcp
 
@@ -2430,3 +2434,71 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
     # return_limit=1 caps to first match
     assert len(result) == 1
     assert result[0] == "High"
+
+
+# ── jira_upload_attachment tests ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_upload_attachment(jira_client, mock_jira_fetcher):
+    """Test uploading a single attachment to a Jira issue."""
+    mock_jira_fetcher.upload_attachment.return_value = {
+        "success": True,
+        "issue_key": "TEST-123",
+        "filename": "report.pdf",
+        "size": 1024,
+        "id": "att456",
+    }
+
+    response = await jira_client.call_tool(
+        "jira_upload_attachment",
+        {
+            "issue_key": "TEST-123",
+            "file_path": "/path/to/report.pdf",
+        },
+    )
+
+    mock_jira_fetcher.upload_attachment.assert_called_once_with(
+        issue_key="TEST-123",
+        file_path="/path/to/report.pdf",
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["success"] is True
+    assert result_data["issue_key"] == "TEST-123"
+    assert result_data["filename"] == "report.pdf"
+    assert result_data["id"] == "att456"
+
+
+@pytest.mark.anyio
+async def test_upload_attachments(jira_client, mock_jira_fetcher):
+    """Test uploading multiple attachments to a Jira issue."""
+    mock_jira_fetcher.upload_attachments.return_value = {
+        "success": True,
+        "issue_key": "TEST-123",
+        "total": 2,
+        "uploaded": [
+            {"filename": "file1.pdf", "size": 1024, "id": "att1"},
+            {"filename": "file2.png", "size": 2048, "id": "att2"},
+        ],
+        "failed": [],
+    }
+
+    response = await jira_client.call_tool(
+        "jira_upload_attachments",
+        {
+            "issue_key": "TEST-123",
+            "file_paths": "/path/to/file1.pdf,/path/to/file2.png",
+        },
+    )
+
+    mock_jira_fetcher.upload_attachments.assert_called_once_with(
+        issue_key="TEST-123",
+        file_paths=["/path/to/file1.pdf", "/path/to/file2.png"],
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["success"] is True
+    assert result_data["total"] == 2
+    assert len(result_data["uploaded"]) == 2
+    assert len(result_data["failed"]) == 0

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -392,8 +392,6 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         delete_issue,
         download_attachments,
         edit_comment,
-        upload_attachment,
-        upload_attachments,
         get_agile_boards,
         get_all_projects,
         get_board_issues,
@@ -419,6 +417,8 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         transition_issue,
         update_issue,
         update_sprint,
+        upload_attachment,
+        upload_attachments,
     )
 
     jira_sub_mcp = FastMCP(name="TestJiraSubMCP")

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 51, f"Expected 51 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

- Add `jira_upload_attachment` tool for uploading a single file to a Jira issue
- Add `jira_upload_attachments` tool for batch uploading multiple files to a Jira issue
- Add corresponding unit tests for both tools

## Motivation

The backend `upload_attachment()` and `upload_attachments()` methods already exist in `AttachmentsMixin` (added in #168), but they were never exposed as standalone MCP tools in the server layer. Currently, Jira attachment upload is only accessible indirectly through the `jira_update_issue` tool's `attachments` parameter.

Meanwhile, the Confluence server already has dedicated `confluence_upload_attachment` and `confluence_upload_attachments` tools. This PR adds the equivalent Jira tools for parity.

## Changes

- **`src/mcp_atlassian/servers/jira.py`**: Added two new `@jira_mcp.tool` decorated functions following the existing Confluence upload tool pattern, with `@check_write_access` decorator and proper `Annotated` field descriptions.
- **`tests/unit/servers/test_jira_server.py`**: Added two test cases and registered the new tools in the test fixture.

## Test plan

- [x] `test_upload_attachment` — verifies single file upload calls backend correctly
- [x] `test_upload_attachments` — verifies comma-separated file paths are parsed and batch uploaded
- [x] Full test suite passes (88/88 tests)