### PR TITLE
fix(jira): recognize legacy Cloud account IDs by shape

### DIFF
--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -121,7 +121,7 @@ class UsersMixin(JiraClient):
             ValueError: If the account ID could not be found.
         """
         # If it looks like an account ID already, return it
-        if assignee.startswith("5") and len(assignee) >= 10:
+        if re.match(r"^[0-9a-f]{24}$", assignee) or re.match(r"^\d+:", assignee):
             return assignee
 
         account_id = self._lookup_user_directly(assignee)

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -121,16 +121,16 @@ class UsersMixin(JiraClient):
             ValueError: If the account ID could not be found.
         """
         # If it looks like an account ID already, return it.
-        # Cloud account IDs come in two shapes: the legacy 24-char hex format
-        # (e.g. "5b10ac8d82e05b22cc7d4ef5") and the current "<digits>:<uuid>"
-        # format (e.g. "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d").
+        # Known unprefixed Cloud account IDs use a legacy 24-char hex format
+        # (e.g. "5b10ac8d82e05b22cc7d4ef5") or a "<digits>:<uuid>" format
+        # (e.g. "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d").
         # An explicit "accountid:" prefix is also accepted, matching the
-        # format documented in the create_issue/update_issue tool schemas.
+        # create_issue/update_issue tool schemas and supporting opaque IDs.
         if assignee.startswith("accountid:"):
             return assignee[len("accountid:") :]
-        if assignee.startswith("5") and len(assignee) >= 10:
+        if re.fullmatch(r"[0-9a-fA-F]{24}", assignee):
             return assignee
-        if re.match(r"^\d+:[0-9a-fA-F][0-9a-fA-F-]{7,}$", assignee):
+        if re.fullmatch(r"\d+:[0-9a-fA-F][0-9a-fA-F-]{7,}", assignee):
             return assignee
 
         account_id = self._lookup_user_directly(assignee)

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -146,27 +146,56 @@ class TestUsersMixin:
         # Verify self.jira.myself was called
         users_mixin.jira.myself.assert_called_once()
 
-    def test_get_account_id_already_account_id(self, users_mixin):
-        """Test that _get_account_id returns the input if it looks like an account ID."""
-        # Call the method with a string that looks like an account ID
-        account_id = users_mixin._get_account_id("5abcdef1234567890")
+    @pytest.mark.parametrize(
+        "account_id",
+        [
+            "5b10ac8d82e05b22cc7d4ef5",
+            "606b8fb83a516300764cb19d",
+            "aabbccdd11223344aabbccdd",
+            "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d",
+        ],
+    )
+    def test_get_account_id_already_account_id(self, users_mixin, account_id):
+        """Return recognized Cloud account ID formats without a user lookup."""
+        with (
+            patch.object(users_mixin, "_lookup_user_directly") as mock_direct,
+            patch.object(
+                users_mixin, "_lookup_user_by_permissions"
+            ) as mock_permissions,
+        ):
+            result = users_mixin._get_account_id(account_id)
 
-        # Verify result
-        assert account_id == "5abcdef1234567890"
-        # Verify no lookups were performed
-        users_mixin.jira.user_find_by_user_string.assert_not_called()
+        assert result == account_id
+        mock_direct.assert_not_called()
+        mock_permissions.assert_not_called()
 
-    def test_get_account_id_modern_cloud_format(self, users_mixin):
-        """Test that _get_account_id returns modern Cloud account IDs unchanged."""
-        # Call the method with a modern Atlassian Cloud account ID
-        account_id = users_mixin._get_account_id(
-            "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d"
-        )
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "5abcdef1234567890",
+            "712020:",
+            "john@example.com",
+            "John Smith",
+            "jsmith",
+        ],
+    )
+    def test_get_account_id_non_account_identifier_uses_lookup(
+        self, users_mixin, identifier
+    ):
+        """Resolve identifiers that do not match a known account ID format."""
+        with (
+            patch.object(
+                users_mixin, "_lookup_user_directly", return_value="resolved-id"
+            ) as mock_direct,
+            patch.object(
+                users_mixin, "_lookup_user_by_permissions"
+            ) as mock_permissions,
+        ):
+            result = users_mixin._get_account_id(identifier)
 
-        # Verify result
-        assert account_id == "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d"
-        # Verify no lookups were performed
-        users_mixin.jira.user_find_by_user_string.assert_not_called()
+        assert result == "resolved-id"
+        mock_direct.assert_called_once_with(identifier)
+        mock_permissions.assert_not_called()
 
     def test_get_account_id_strips_accountid_prefix(self, users_mixin):
         """Test that _get_account_id strips the accountid: prefix."""


### PR DESCRIPTION
## Summary

- recognize legacy 24-character hexadecimal Jira Cloud account IDs regardless of their first character
- preserve the modern `<digits>:<uuid>` form and documented `accountid:` prefix already supported on current `main`
- use full-shape matching so malformed IDs, email addresses, display names, and usernames still use normal user lookup
- add regression coverage for accepted account IDs and lookup fallbacks

## Background

`_get_account_id()` previously treated an unprefixed value as an account ID only when it started with `5` and had at least 10 characters. That rejected known legacy IDs such as `606b8fb83a516300764cb19d`, while also accepting malformed values such as the former 17-character test fixture.

The branch is rebased onto current `main`, which added the modern colon form and the explicit prefix for other opaque account IDs. This PR keeps both behaviors and replaces only the fragile legacy heuristic.

## Verification

- [x] `uv run pytest tests/unit/jira/test_users.py -xvs` — 69 passed
- [x] `uv run pytest tests/unit/ -xq` — 3,068 passed, 5 skipped
- [x] `uv run pytest tests/integration/ -xvs` — 23 environment-gated tests skipped as designed
- [x] `uv run pytest tests/e2e/cloud/ --cloud-e2e -xvs` — 82 passed, 15 skipped
- [x] `uv run pytest tests/e2e/ --dc-e2e -xvs` — 94 passed, 98 skipped
- [x] `uv run pre-commit run --all-files` — Ruff formatting/lint and mypy passed
