### PR TITLE
fix: upgrade Alpine packages to resolve zlib CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN find /app/.venv -name '__pycache__' -type d -exec rm -rf {} + && \
 # Final stage
 FROM python:3.13-alpine
 
+# Upgrade base packages to pick up security fixes (zlib >= 1.3.2-r0)
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
+
 # Create a non-root user 'app'
 RUN adduser -D -h /home/app -s /bin/sh app
 WORKDIR /app


### PR DESCRIPTION
## Summary

Adds an \pk upgrade\ step in the final Docker stage to update \zlib\ from \1.3.1-r2\ to \>= 1.3.2-r0\, resolving two Snyk-reported vulnerabilities in the published Docker image.

## Vulnerabilities Fixed

- **Critical** – [SNYK-ALPINE323-ZLIB-15435528](https://security.snyk.io/vuln/SNYK-ALPINE323-ZLIB-15435528): Out-of-bounds Write in \zlib/zlib\
- **Medium** – [SNYK-ALPINE323-ZLIB-15435529](https://security.snyk.io/vuln/SNYK-ALPINE323-ZLIB-15435529): Improper Validation of Specified Quantity in Input in \zlib/zlib\

Both are introduced through the \python:3.13-alpine\ base image shipping \zlib@1.3.1-r2\ and are fixed in \1.3.2-r0\.

## Changes

- **\Dockerfile\**: Added \RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*\ in the final stage before user creation, ensuring all Alpine base packages (including zlib) are patched at build time.

Co-Authored-By: Oz <oz-agent@warp.dev>