### PR TITLE
fix: resolve issue type IDs for all types on localized Jira instances

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -605,7 +605,7 @@ class IssuesMixin(
                     "Provide issue_type like 'Task', 'Story', or 'Bug'."
                 )
 
-            # Handle Epic and Subtask issue type names across different languages
+            # Handle issue type names across different languages
             actual_issue_id = None
             if self._is_epic_issue_type(issue_type) and issue_type.lower() == "epic":
                 # If the user provided "Epic" but we need to find the localized name
@@ -620,6 +620,15 @@ class IssuesMixin(
                     actual_issue_id = subtask_type_id
                     logger.info(
                         f"Using localized Subtask issue type id: {subtask_type_id}"
+                    )
+            else:
+                # For all other issue types (Story, Task, Bug, etc.),
+                # resolve name to ID to support localized Jira instances
+                resolved_id = self._find_issue_type_id(project_key, issue_type)
+                if resolved_id:
+                    actual_issue_id = resolved_id
+                    logger.info(
+                        f"Resolved issue type '{issue_type}' to id: {resolved_id}"
                     )
 
             # Prepare fields
@@ -807,6 +816,39 @@ class IssuesMixin(
             return None
         except Exception as e:
             logger.warning(f"Could not get issue types for project {project_key}: {e}")
+            return None
+
+    def _find_issue_type_id(self, project_key: str, issue_type_name: str) -> str | None:
+        """
+        Find the issue type ID by name for a project.
+
+        Supports localized Jira instances where issue type names may differ
+        from the English defaults (e.g., Korean, Japanese, German).
+
+        Args:
+            project_key: The project key
+            issue_type_name: The issue type name to resolve
+
+        Returns:
+            The issue type ID if found, None otherwise
+        """
+        try:
+            issue_types = self.get_project_issue_types(project_key)
+            for issue_type in issue_types:
+                type_name = issue_type.get("name", "")
+                if type_name.lower() == issue_type_name.lower():
+                    return issue_type.get("id")
+            # Fallback: try untranslatedName if available
+            for issue_type in issue_types:
+                untranslated = issue_type.get("untranslatedName", "")
+                if untranslated and untranslated.lower() == issue_type_name.lower():
+                    return issue_type.get("id")
+            return None
+        except Exception as e:
+            logger.warning(
+                f"Could not resolve issue type '{issue_type_name}' "
+                f"for project {project_key}: {e}"
+            )
             return None
 
     def _prepare_epic_fields(

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -259,6 +259,9 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
             # The new createmeta endpoint returns paginated "values" array
             issue_types = meta.get("values", [])
             if not issue_types:
+                # Fallback: atlassian-python-api returns "issueTypes" key
+                issue_types = meta.get("issueTypes", [])
+            if not issue_types:
                 # Fallback for older response format
                 projects = meta.get("projects", [])
                 if projects and "issuetypes" in projects[0]:


### PR DESCRIPTION
## Problem

On localized Jira instances (e.g., Korean, Japanese, German), `create_issue()` fails with "Invalid issue type" for any type other than Epic or Subtask.

**Root cause (two issues):**

1. **`get_project_issue_types()`** checks for `"values"` key in the createmeta response, but `atlassian-python-api`'s `issue_createmeta_issuetypes()` returns `"issueTypes"` key — causing it to return an empty list.

2. **`create_issue()`** only resolves issue type name→ID for Epic and Subtask. For other types like Story, Task, or Bug, it sends `{"name": "스토리"}` directly, which Jira rejects because it expects the ID.

**Reproduction:** On a Korean Jira Cloud instance, call `create_issue(project_key="PROJ", issue_type="스토리", ...)` → fails with "선택한 이슈 유형이 올바르지 않습니다" (Invalid issue type).

## Fix

### `projects.py` — `get_project_issue_types()`
Add `"issueTypes"` key fallback between the existing `"values"` and `"projects"` fallbacks:

```python
issue_types = meta.get("values", [])
if not issue_types:
    issue_types = meta.get("issueTypes", [])  # <-- NEW
if not issue_types:
    # existing fallback for older format
```

### `issues.py` — `create_issue()` + `_find_issue_type_id()`
- Add `else` branch in `create_issue()` to resolve IDs for all non-Epic/Subtask issue types
- Add `_find_issue_type_id()` method that matches by `name` (case-insensitive) with `untranslatedName` fallback

## Testing

Verified on a Korean Jira Cloud instance (doosanrobotics.atlassian.net):
- `issue_createmeta_issuetypes("PAP")` returns `{"issueTypes": [...]}` (not `"values"`)
- After fix: `스토리` resolves to `id=10115`, issue created successfully
- Epic and Subtask resolution unchanged (existing code paths)