### PR TITLE
feat(confluence): add content properties tools (get/set page display width and metadata)

### DIFF
--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -10,6 +10,7 @@ from .comments import CommentsMixin
 from .config import ConfluenceConfig
 from .labels import LabelsMixin
 from .pages import PagesMixin
+from .properties import PropertiesMixin
 from .search import SearchMixin
 from .spaces import SpacesMixin
 from .users import UsersMixin
@@ -24,6 +25,7 @@ class ConfluenceFetcher(
     UsersMixin,
     AnalyticsMixin,
     AttachmentsMixin,
+    PropertiesMixin,
 ):
     """Main entry point for Confluence operations, providing backward compatibility.
 
@@ -39,6 +41,7 @@ class ConfluenceFetcher(
     - UsersMixin: User operations
     - AnalyticsMixin: Page view analytics (Cloud only)
     - AttachmentsMixin: Attachment operations
+    - PropertiesMixin: Content property operations
     """
 
     pass

--- a/src/mcp_atlassian/confluence/properties.py
+++ b/src/mcp_atlassian/confluence/properties.py
@@ -1,0 +1,113 @@
+"""Module for Confluence content property operations."""
+
+import logging
+from typing import Any
+
+from .client import ConfluenceClient
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+class PropertiesMixin(ConfluenceClient):
+    """Mixin for Confluence content property operations."""
+
+    def get_content_properties(
+        self, page_id: str, key: str | None = None
+    ) -> dict[str, Any]:
+        """Get content properties for a Confluence page.
+
+        Args:
+            page_id: The ID of the page.
+            key: Optional property key. If provided, returns only that property.
+                If omitted, returns all properties as a ``{key: value}`` dict.
+
+        Returns:
+            Dict mapping property key(s) to their values.
+
+        Raises:
+            Exception: If the API request fails.
+        """
+        try:
+            base_url = self.confluence.url.rstrip("/")
+            if key:
+                url = f"{base_url}/rest/api/content/{page_id}/property/{key}"
+                response = self.confluence._session.get(url)
+                response.raise_for_status()
+                data: dict[str, Any] = response.json()
+                return {data["key"]: data["value"]}
+            else:
+                url = f"{base_url}/rest/api/content/{page_id}/property"
+                response = self.confluence._session.get(
+                    url, params={"expand": "version"}
+                )
+                response.raise_for_status()
+                data = response.json()
+                return {
+                    item["key"]: item["value"]
+                    for item in data.get("results", [])
+                }
+        except Exception as e:
+            logger.error(
+                f"Failed to get content properties for page {page_id}: {e}"
+            )
+            raise Exception(
+                f"Failed to get content properties for page {page_id}: {e}"
+            ) from e
+
+    def set_content_property(
+        self, page_id: str, key: str, value: Any
+    ) -> dict[str, Any]:
+        """Create or update a content property on a Confluence page.
+
+        Handles version increment automatically. Reads the current version before
+        writing, so callers do not need to manage version numbers.
+
+        If the property does not exist it is created (POST). If it already exists
+        it is updated (PUT) with ``version.number`` incremented by one.
+
+        Args:
+            page_id: The ID of the page.
+            key: Property key (e.g. ``content-appearance-published``).
+            value: Property value. Strings are passed as-is; dicts/lists are
+                serialised as JSON objects by the REST API.
+
+        Returns:
+            Dict with ``{key: value}`` of the created or updated property.
+
+        Raises:
+            Exception: If the API request fails.
+        """
+        try:
+            base_url = self.confluence.url.rstrip("/")
+            get_url = f"{base_url}/rest/api/content/{page_id}/property/{key}"
+            get_response = self.confluence._session.get(get_url)
+
+            if get_response.status_code == 404:
+                # Property does not exist — create it
+                post_url = f"{base_url}/rest/api/content/{page_id}/property"
+                body: dict[str, Any] = {"key": key, "value": value}
+                result_response = self.confluence._session.post(post_url, json=body)
+                result_response.raise_for_status()
+            else:
+                get_response.raise_for_status()
+                current: dict[str, Any] = get_response.json()
+                version_number = current.get("version", {}).get("number", 0) + 1
+                body = {
+                    "key": key,
+                    "value": value,
+                    "version": {"number": version_number},
+                }
+                put_url = f"{base_url}/rest/api/content/{page_id}/property/{key}"
+                result_response = self.confluence._session.put(put_url, json=body)
+                result_response.raise_for_status()
+
+            result: dict[str, Any] = result_response.json()
+            return {result["key"]: result["value"]}
+
+        except Exception as e:
+            logger.error(
+                f"Failed to set content property '{key}' on page {page_id}: {e}"
+            )
+            raise Exception(
+                f"Failed to set content property '{key}' on page {page_id}: {e}"
+            ) from e

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -2071,3 +2071,130 @@ async def get_page_images(
         ),
     )
     return contents
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_pages"},
+    annotations={"title": "Get Content Properties", "readOnlyHint": True},
+)
+async def get_content_properties(
+    ctx: Context,
+    page_id: Annotated[
+        str,
+        Field(
+            description=(
+                "Confluence page ID (numeric string from the page URL, "
+                "e.g. '123456789')."
+            )
+        ),
+    ],
+    key: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional property key to fetch a single property "
+                "(e.g. 'content-appearance-published'). "
+                "If omitted, all properties are returned."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Get content properties for a Confluence page.
+
+    Content properties are key-value metadata stored against a page that
+    control page-level behaviours such as display width
+    (``content-appearance-published`` / ``content-appearance-draft``),
+    editor version (``editor``), and arbitrary app metadata.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: Confluence page ID.
+        key: Optional property key. If provided only that property is returned.
+
+    Returns:
+        JSON object mapping property key(s) to their values.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    properties = confluence_fetcher.get_content_properties(page_id, key)
+    return json.dumps(properties, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Set Content Property", "destructiveHint": True},
+)
+@check_write_access
+async def set_content_property(
+    ctx: Context,
+    page_id: Annotated[
+        str,
+        Field(
+            description=(
+                "Confluence page ID (numeric string from the page URL, "
+                "e.g. '123456789')."
+            )
+        ),
+    ],
+    key: Annotated[
+        str,
+        Field(
+            description=(
+                "Property key to create or update. "
+                "Well-known keys: 'content-appearance-published', "
+                "'content-appearance-draft' (values: 'full-width' or 'fixed-width'), "
+                "'editor' (value: '{\"version\": 2}'). "
+                "Custom keys are also supported for app metadata."
+            )
+        ),
+    ],
+    value: Annotated[
+        str,
+        Field(
+            description=(
+                "Property value as a JSON string. "
+                "Examples: '\"full-width\"' for a string value, "
+                "'{\"version\": 2}' for an object value. "
+                "The version number is managed automatically."
+            )
+        ),
+    ],
+) -> str:
+    """Create or update a content property on a Confluence page.
+
+    Performs an upsert: creates the property if it does not exist, or updates
+    it if it does. The Confluence API version number is incremented automatically
+    so callers never need to manage it.
+
+    Common use cases:
+    - Switch page to full-width layout: key='content-appearance-published',
+      value='"full-width"'
+    - Switch page to fixed-width layout: key='content-appearance-published',
+      value='"fixed-width"'
+    - Set editor version: key='editor', value='{"version": 2}'
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: Confluence page ID.
+        key: Property key to create or update.
+        value: Property value as a JSON string.
+
+    Returns:
+        JSON object with the resulting ``{key: value}`` pair.
+
+    Raises:
+        ValueError: If the value is not valid JSON or in read-only mode.
+    """
+    import json as _json
+
+    try:
+        parsed_value = _json.loads(value)
+    except _json.JSONDecodeError as exc:
+        raise ValueError(
+            f"'value' must be a valid JSON string (e.g. '\"full-width\"' or "
+            f"'{{\"version\": 2}}'). Got: {value!r}"
+        ) from exc
+
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    result = confluence_fetcher.set_content_property(page_id, key, parsed_value)
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/tests/unit/confluence/test_properties.py
+++ b/tests/unit/confluence/test_properties.py
@@ -1,0 +1,199 @@
+"""Unit tests for the PropertiesMixin class."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.confluence.properties import PropertiesMixin
+
+
+def _make_response(status_code: int, json_data: object) -> MagicMock:
+    """Build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    if status_code >= 400:
+        from requests.exceptions import HTTPError
+
+        resp.raise_for_status.side_effect = HTTPError(
+            response=resp, request=MagicMock()
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestPropertiesMixin:
+    """Tests for PropertiesMixin."""
+
+    @pytest.fixture
+    def properties_mixin(self, confluence_client):
+        """Create a PropertiesMixin instance backed by the shared mock client."""
+        with patch(
+            "mcp_atlassian.confluence.properties.ConfluenceClient.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            mixin = PropertiesMixin()
+            mixin.confluence = confluence_client.confluence
+            mixin.config = confluence_client.config
+            mixin.preprocessor = confluence_client.preprocessor
+            # Attach a mock session with a recognisable base URL
+            mixin.confluence.url = "https://example.atlassian.net/wiki"
+            mixin.confluence._session = MagicMock()
+            return mixin
+
+    # ------------------------------------------------------------------
+    # get_content_properties — all properties
+    # ------------------------------------------------------------------
+
+    def test_get_all_properties_success(self, properties_mixin):
+        page_id = "123456789"
+        api_response = {
+            "results": [
+                {"key": "content-appearance-published", "value": "full-width"},
+                {"key": "content-appearance-draft", "value": "fixed-width"},
+            ]
+        }
+        properties_mixin.confluence._session.get.return_value = _make_response(
+            200, api_response
+        )
+
+        result = properties_mixin.get_content_properties(page_id)
+
+        properties_mixin.confluence._session.get.assert_called_once_with(
+            "https://example.atlassian.net/wiki/rest/api/content/123456789/property",
+            params={"expand": "version"},
+        )
+        assert result == {
+            "content-appearance-published": "full-width",
+            "content-appearance-draft": "fixed-width",
+        }
+
+    def test_get_all_properties_empty(self, properties_mixin):
+        properties_mixin.confluence._session.get.return_value = _make_response(
+            200, {"results": []}
+        )
+
+        result = properties_mixin.get_content_properties("123456789")
+
+        assert result == {}
+
+    # ------------------------------------------------------------------
+    # get_content_properties — single key
+    # ------------------------------------------------------------------
+
+    def test_get_single_property_success(self, properties_mixin):
+        page_id = "123456789"
+        key = "content-appearance-published"
+        api_response = {
+            "key": key,
+            "value": "full-width",
+            "version": {"number": 2},
+        }
+        properties_mixin.confluence._session.get.return_value = _make_response(
+            200, api_response
+        )
+
+        result = properties_mixin.get_content_properties(page_id, key=key)
+
+        properties_mixin.confluence._session.get.assert_called_once_with(
+            f"https://example.atlassian.net/wiki/rest/api/content/{page_id}/property/{key}"
+        )
+        assert result == {key: "full-width"}
+
+    def test_get_single_property_api_error(self, properties_mixin):
+        properties_mixin.confluence._session.get.return_value = _make_response(
+            500, {"message": "Internal Server Error"}
+        )
+
+        with pytest.raises(Exception, match="Failed to get content properties"):
+            properties_mixin.get_content_properties("123456789", key="some-key")
+
+    # ------------------------------------------------------------------
+    # set_content_property — create (404 on GET)
+    # ------------------------------------------------------------------
+
+    def test_set_property_creates_when_not_exists(self, properties_mixin):
+        page_id = "123456789"
+        key = "content-appearance-published"
+        value = "full-width"
+
+        get_resp = _make_response(404, {"message": "Not found"})
+        post_resp = _make_response(200, {"key": key, "value": value})
+        properties_mixin.confluence._session.get.return_value = get_resp
+        properties_mixin.confluence._session.post.return_value = post_resp
+
+        result = properties_mixin.set_content_property(page_id, key, value)
+
+        properties_mixin.confluence._session.post.assert_called_once_with(
+            f"https://example.atlassian.net/wiki/rest/api/content/{page_id}/property",
+            json={"key": key, "value": value},
+        )
+        assert result == {key: value}
+
+    # ------------------------------------------------------------------
+    # set_content_property — update (200 on GET, auto-version)
+    # ------------------------------------------------------------------
+
+    def test_set_property_updates_existing(self, properties_mixin):
+        page_id = "123456789"
+        key = "content-appearance-published"
+        old_value = "fixed-width"
+        new_value = "full-width"
+
+        get_resp = _make_response(
+            200,
+            {"key": key, "value": old_value, "version": {"number": 2}},
+        )
+        put_resp = _make_response(200, {"key": key, "value": new_value})
+        properties_mixin.confluence._session.get.return_value = get_resp
+        properties_mixin.confluence._session.put.return_value = put_resp
+
+        result = properties_mixin.set_content_property(page_id, key, new_value)
+
+        properties_mixin.confluence._session.put.assert_called_once_with(
+            f"https://example.atlassian.net/wiki/rest/api/content/{page_id}/property/{key}",
+            json={"key": key, "value": new_value, "version": {"number": 3}},
+        )
+        assert result == {key: new_value}
+
+    def test_set_property_version_starts_at_1_when_missing(self, properties_mixin):
+        """If the existing property has no version info, version should default to 1."""
+        page_id = "123456789"
+        key = "custom-key"
+
+        get_resp = _make_response(200, {"key": key, "value": "old"})
+        put_resp = _make_response(200, {"key": key, "value": "new"})
+        properties_mixin.confluence._session.get.return_value = get_resp
+        properties_mixin.confluence._session.put.return_value = put_resp
+
+        properties_mixin.set_content_property(page_id, key, "new")
+
+        call_kwargs = properties_mixin.confluence._session.put.call_args
+        assert call_kwargs.kwargs["json"]["version"]["number"] == 1
+
+    def test_set_property_api_error_on_put(self, properties_mixin):
+        page_id = "123456789"
+        key = "content-appearance-published"
+
+        get_resp = _make_response(
+            200, {"key": key, "value": "fixed-width", "version": {"number": 1}}
+        )
+        put_resp = _make_response(409, {"message": "Version conflict"})
+        properties_mixin.confluence._session.get.return_value = get_resp
+        properties_mixin.confluence._session.put.return_value = put_resp
+
+        with pytest.raises(Exception, match="Failed to set content property"):
+            properties_mixin.set_content_property(page_id, key, "full-width")
+
+    def test_set_property_api_error_on_post(self, properties_mixin):
+        page_id = "123456789"
+        key = "new-key"
+
+        get_resp = _make_response(404, {"message": "Not found"})
+        post_resp = _make_response(400, {"message": "Bad request"})
+        properties_mixin.confluence._session.get.return_value = get_resp
+        properties_mixin.confluence._session.post.return_value = post_resp
+
+        with pytest.raises(Exception, match="Failed to set content property"):
+            properties_mixin.set_content_property(page_id, key, "some-value")


### PR DESCRIPTION
## Description

Fixes #1171

Adds two new MCP tools for reading and writing **Confluence content properties** — key-value metadata stored against pages that control page-level behaviours such as display width, editor version, and custom app metadata.

The concrete use case that motivated this: there was no way to switch a Confluence page to **full-width layout** through mcp-atlassian. That requires writing the `content-appearance-published` and `content-appearance-draft` content properties, which previously required falling back to raw `curl` calls.

## Changes

- **`src/mcp_atlassian/confluence/properties.py`** — new `PropertiesMixin` with two methods:
  - `get_content_properties(page_id, key=None)` — returns all properties as `{key: value}`, or a single property when `key` is provided
  - `set_content_property(page_id, key, value)` — upserts a property with automatic version increment (GET current version → POST to create or PUT with `version + 1`), eliminating the `409 Conflict` footgun
- **`src/mcp_atlassian/confluence/__init__.py`** — adds `PropertiesMixin` to `ConfluenceFetcher`
- **`src/mcp_atlassian/servers/confluence.py`** — registers two new FastMCP tools:
  - `confluence_get_content_properties` (read, `readOnlyHint`)
  - `confluence_set_content_property` (write, `destructiveHint`, `@check_write_access`)
- **`tests/unit/confluence/test_properties.py`** — 9 unit tests covering: get all, get single, get error, create (404→POST), update (200→PUT with version increment), missing version defaults, PUT error, POST error

## Example usage

```python
# Set page to full-width
confluence_set_content_property(
    page_id="1491730434",
    key="content-appearance-published",
    value='"full-width"'
)

# Read all properties
confluence_get_content_properties(page_id="1491730434")
# → { "content-appearance-published": "full-width", "content-appearance-draft": "full-width" }
```

## Testing

- [x] Unit tests added — 9 tests, all pass (`uv run pytest tests/unit/confluence/test_properties.py -xvs`)
- [x] Full unit suite passes — 372 tests (`uv run pytest tests/unit/confluence/ -q`)
- [x] All pre-commit checks pass — ruff, ruff-format, mypy (`pre-commit run --all-files`)
- [x] Manual checks: pattern is consistent with existing `LabelsMixin` and `CommentsMixin`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).