### PR TITLE
fix(confluence): rewrite bare-filename img tags as Confluence attachment macros

### DIFF
--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -1,6 +1,7 @@
 """Confluence-specific text preprocessing module."""
 
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -84,7 +85,7 @@ class ConfluencePreprocessor(BasePreprocessor):
                 # Convert the element tree back to a string
                 storage_format = elements_to_string(root)
 
-                return str(storage_format)
+                return self._fix_attachment_images(str(storage_format))
             finally:
                 # Clean up the temporary directory
                 shutil.rmtree(temp_dir, ignore_errors=True)
@@ -102,4 +103,37 @@ class ConfluencePreprocessor(BasePreprocessor):
 
             return str(storage_format)
 
-    # Confluence-specific methods can be added here
+    @staticmethod
+    def _fix_attachment_images(storage_html: str) -> str:
+        """Replace bare-filename ``<img>`` tags with Confluence attachment macros.
+
+        Confluence Storage Format cannot resolve bare filenames in
+        ``<img src="filename.ext"/>``. Attachment references must use the
+        ``ac:image`` / ``ri:attachment`` macro instead. External URLs
+        (``http``/``https``/``data``) and absolute paths are left untouched.
+
+        Args:
+            storage_html: Confluence storage format HTML string.
+
+        Returns:
+            Storage HTML with bare-filename img tags replaced by attachment macros.
+        """
+
+        def _replace(match: re.Match) -> str:  # type: ignore[type-arg]
+            tag = match.group(0)
+            src_match = re.search(r'src="([^"]+)"', tag)
+            alt_match = re.search(r'alt="([^"]+)"', tag)
+            if not src_match:
+                return tag
+            src = src_match.group(1)
+            # Leave external URLs and absolute paths untouched
+            if src.startswith(("http://", "https://", "data:", "/")):
+                return tag
+            alt = alt_match.group(1) if alt_match else ""
+            return (
+                f'<ac:image ac:alt="{alt}">'
+                f'<ri:attachment ri:filename="{src}"/>'
+                f"</ac:image>"
+            )
+
+        return re.sub(r"<img\b[^>]*/?>", _replace, storage_html)

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -1,14 +1,16 @@
 """Confluence-specific text preprocessing module."""
 
 import logging
-import re
 import shutil
 import tempfile
 from pathlib import Path
+from urllib.parse import urlparse
 
+from bs4 import BeautifulSoup
 from md2conf.converter import (
     ConfluenceConverterOptions,
     ConfluenceStorageFormatConverter,
+    attachment_name,
     elements_to_string,
     markdown_to_html,
 )
@@ -101,7 +103,13 @@ class ConfluencePreprocessor(BasePreprocessor):
             # This creates a proper Confluence storage format document
             storage_format = f"""<p>{html_content}</p>"""
 
-            return str(storage_format)
+            return self._fix_attachment_images(str(storage_format))
+
+    @staticmethod
+    def _is_attachment_image_source(src: str) -> bool:
+        """Return whether an image source should resolve as an attachment."""
+        parsed_src = urlparse(src)
+        return not parsed_src.scheme and not src.startswith(("/", "#"))
 
     @staticmethod
     def _fix_attachment_images(storage_html: str) -> str:
@@ -118,22 +126,35 @@ class ConfluencePreprocessor(BasePreprocessor):
         Returns:
             Storage HTML with bare-filename img tags replaced by attachment macros.
         """
+        if "<img" not in storage_html.lower():
+            return storage_html
 
-        def _replace(match: re.Match) -> str:  # type: ignore[type-arg]
-            tag = match.group(0)
-            src_match = re.search(r'src="([^"]+)"', tag)
-            alt_match = re.search(r'alt="([^"]+)"', tag)
-            if not src_match:
-                return tag
-            src = src_match.group(1)
-            # Leave external URLs and absolute paths untouched
-            if src.startswith(("http://", "https://", "data:", "/")):
-                return tag
-            alt = alt_match.group(1) if alt_match else ""
-            return (
-                f'<ac:image ac:alt="{alt}">'
-                f'<ri:attachment ri:filename="{src}"/>'
-                f"</ac:image>"
-            )
+        soup = BeautifulSoup(storage_html, "html.parser")
+        rewritten = False
 
-        return re.sub(r"<img\b[^>]*/?>", _replace, storage_html)
+        for image in soup.find_all("img"):
+            src = image.get("src")
+            if not isinstance(src, str):
+                continue
+            if not ConfluencePreprocessor._is_attachment_image_source(src):
+                continue
+
+            attachment_image = soup.new_tag("ac:image")
+            alt = image.get("alt", "")
+            attachment_image["ac:alt"] = alt if isinstance(alt, str) else ""
+
+            for html_attr, confluence_attr in (
+                ("width", "ac:width"),
+                ("height", "ac:height"),
+            ):
+                value = image.get(html_attr)
+                if isinstance(value, str):
+                    attachment_image[confluence_attr] = value
+
+            attachment = soup.new_tag("ri:attachment")
+            attachment["ri:filename"] = attachment_name(src)
+            attachment_image.append(attachment)
+            image.replace_with(attachment_image)
+            rewritten = True
+
+        return str(soup) if rewritten else storage_html

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -592,6 +592,97 @@ More content.
     assert "<h2>" in result_with_anchors
 
 
+# Regression tests — bare-filename images produce "Preview unavailable"
+
+
+class TestFixAttachmentImages:
+    """Unit tests for ConfluencePreprocessor._fix_attachment_images."""
+
+    def setup_method(self):
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        self.fix = ConfluencePreprocessor._fix_attachment_images
+
+    def test_bare_filename_replaced_with_attachment_macro(self):
+        html = '<img src="chart.png" alt="Revenue chart"/>'
+        result = self.fix(html)
+        assert result == (
+            '<ac:image ac:alt="Revenue chart">'
+            '<ri:attachment ri:filename="chart.png"/>'
+            "</ac:image>"
+        )
+        assert "<img" not in result
+
+    def test_alt_text_preserved(self):
+        html = '<img alt="My diagram" src="diagram.svg"/>'
+        result = self.fix(html)
+        assert 'ac:alt="My diagram"' in result
+        assert 'ri:filename="diagram.svg"' in result
+
+    def test_missing_alt_defaults_to_empty_string(self):
+        html = '<img src="figure.png"/>'
+        result = self.fix(html)
+        assert 'ac:alt=""' in result
+        assert 'ri:filename="figure.png"' in result
+
+    def test_https_url_left_untouched(self):
+        html = '<img src="https://example.com/logo.png" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_http_url_left_untouched(self):
+        html = '<img src="http://example.com/img.jpg" alt="x"/>'
+        assert self.fix(html) == html
+
+    def test_data_uri_left_untouched(self):
+        html = '<img src="data:image/png;base64,abc123" alt="inline"/>'
+        assert self.fix(html) == html
+
+    def test_absolute_path_left_untouched(self):
+        html = '<img src="/images/logo.png" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_mixed_content_only_bare_filenames_rewritten(self):
+        html = (
+            '<img src="local.png" alt="local"/>'
+            '<img src="https://cdn.example.com/remote.png" alt="remote"/>'
+        )
+        result = self.fix(html)
+        assert "ri:filename" in result
+        assert "https://cdn.example.com/remote.png" in result
+        assert '<img src="local.png"' not in result
+
+    def test_no_img_tags_unchanged(self):
+        html = "<p>No images here</p>"
+        assert self.fix(html) == html
+
+
+def test_markdown_to_confluence_storage_attachment_image():
+    """Regression: bare-filename images must produce ac:image attachment macros."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    result = preprocessor.markdown_to_confluence_storage("![Revenue chart](chart.png)")
+    assert "ri:filename" in result, (
+        "Expected Confluence attachment macro, got: " + result
+    )
+    assert 'ri:filename="chart.png"' in result
+    assert "<img" not in result, (
+        "Raw <img> tag found — will show as 'Preview unavailable'"
+    )
+
+
+def test_markdown_to_confluence_storage_external_image_unchanged():
+    """External image URLs must not be rewritten to attachment macros."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    result = preprocessor.markdown_to_confluence_storage(
+        "![Logo](https://example.com/logo.png)"
+    )
+    assert "https://example.com/logo.png" in result
+    assert 'ri:filename="https://example.com/logo.png"' not in result
+
+
 # Issue #786 regression tests - Wiki Markup Corruption
 
 

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -592,7 +592,7 @@ More content.
     assert "<h2>" in result_with_anchors
 
 
-# Regression tests — bare-filename images produce "Preview unavailable"
+# Regression tests: bare-filename images produce "Preview unavailable"
 
 
 class TestFixAttachmentImages:
@@ -606,11 +606,8 @@ class TestFixAttachmentImages:
     def test_bare_filename_replaced_with_attachment_macro(self):
         html = '<img src="chart.png" alt="Revenue chart"/>'
         result = self.fix(html)
-        assert result == (
-            '<ac:image ac:alt="Revenue chart">'
-            '<ri:attachment ri:filename="chart.png"/>'
-            "</ac:image>"
-        )
+        assert 'ac:alt="Revenue chart"' in result
+        assert 'ri:filename="chart.png"' in result
         assert "<img" not in result
 
     def test_alt_text_preserved(self):
@@ -641,6 +638,31 @@ class TestFixAttachmentImages:
         html = '<img src="/images/logo.png" alt="logo"/>'
         assert self.fix(html) == html
 
+    def test_protocol_relative_url_left_untouched(self):
+        html = '<img src="//cdn.example.com/logo.png" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_anchor_reference_left_untouched(self):
+        html = '<img src="#inline-image" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_relative_path_uses_md2conf_attachment_name(self):
+        html = '<img src="images/chart 1.png" alt="Chart"/>'
+        result = self.fix(html)
+        assert 'ri:filename="images_chart_1.png"' in result
+
+    def test_xml_sensitive_values_are_escaped(self):
+        html = '<img src="chart & q.png" alt="A & B"/>'
+        result = self.fix(html)
+        assert 'ac:alt="A &amp; B"' in result
+        assert 'ri:filename="chart___q.png"' in result
+
+    def test_dimensions_are_preserved(self):
+        html = '<img src="chart.png" alt="Chart" width="600" height="400"/>'
+        result = self.fix(html)
+        assert 'ac:width="600"' in result
+        assert 'ac:height="400"' in result
+
     def test_mixed_content_only_bare_filenames_rewritten(self):
         html = (
             '<img src="local.png" alt="local"/>'
@@ -667,7 +689,7 @@ def test_markdown_to_confluence_storage_attachment_image():
     )
     assert 'ri:filename="chart.png"' in result
     assert "<img" not in result, (
-        "Raw <img> tag found — will show as 'Preview unavailable'"
+        "Raw <img> tag found - will show as 'Preview unavailable'"
     )
 
 


### PR DESCRIPTION
## Description

Fixes #1175

When converting markdown to Confluence storage format via `confluence_update_page` or `confluence_create_page` with `content_format="markdown"`, raw local image references such as:

```markdown
![Revenue chart](chart.png)
```

must be emitted as Confluence attachment image macros rather than bare `<img src="chart.png"/>` tags. Bare image filenames cannot be resolved by Confluence as page attachments and can render as "Preview unavailable".

## Changes

- Adds a guarded fallback in `ConfluencePreprocessor.markdown_to_confluence_storage` that rewrites any remaining local `<img>` tags to `ac:image` / `ri:attachment` storage macros.
- Uses parser-based rewriting instead of regex string interpolation, so XML-sensitive values are escaped correctly.
- Mirrors `md2conf` attachment filename sanitization for relative paths.
- Preserves alt text and image dimensions when fallback rewriting is needed.
- Leaves external URLs, data URIs, absolute paths, protocol-relative URLs, and anchor references unchanged.
- Adds regression coverage for the helper and the full markdown conversion path.

## Testing

- [x] `uv run pytest tests/unit/preprocessing/test_preprocessing.py -q` — 110 passed
- [x] `uv run pytest tests/unit/ -q` — 2643 passed, 5 skipped
- [x] `uv run pytest tests/integration/ -q` — 23 skipped
- [x] `uv run pytest tests/e2e/cloud --cloud-e2e -q` — 51 passed, 14 skipped
- [x] `uv run pre-commit run --all-files` — passed
- [ ] `uv run pytest tests/e2e/test_confluence_dc_operations.py tests/e2e/test_images_dc.py --dc-e2e -q` — local Confluence DC returned HTTP 403 on page creation; 4 failed, 4 passed, 3 skipped

## Checklist

- [x] Code follows project style guidelines.
- [x] Tests added/updated for changes.
- [x] Maintainer verification run against current `main`.
