### PR TITLE
feat(confluence): table layout, page width exposure, page restrictions, and copy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**81 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**84 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 80 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 84 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **81 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **84 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -81,7 +81,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
-| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_space_page_tree`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_diff` |
+| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_space_page_tree`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_copy_page`, `confluence_get_page_restrictions`, `confluence_set_page_restrictions`, `confluence_get_page_diff` |
 | `confluence_comments` | Yes | `confluence_get_comments`, `confluence_add_comment`, `confluence_reply_to_comment` |
 | `confluence_labels` | No | `confluence_get_labels`, `confluence_add_label` |
 | `confluence_users` | No | `confluence_search_user` |
@@ -93,7 +93,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (81 tools)
+# Enable all toolsets (84 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -41,12 +41,15 @@ Create a new Confluence page.
 |-----------|------|----------|-------------|
 | `space_key` | `string` | Yes | The key of the space to create the page in (usually a short uppercase code like 'DEV', 'TEAM', or 'DOC') |
 | `title` | `string` | Yes | The title of the page |
-| `content` | `string` | Yes | The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, storage format, or XHTML storage format |
+| `content` | `string` | No* | The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, storage format, or XHTML storage format |
+| `content_file` | `string` | No* | Absolute or relative filesystem path to read the page body from (UTF-8). Mutually exclusive with `content`. |
 | `parent_id` | `string` | No | (Optional) parent page ID. If provided, this page will be created as a child of the specified page |
 | `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' for Confluence XHTML storage format. Wiki format uses Confluence wiki markup syntax |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
 | `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at create time. |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
+| `page_width` | `string` | No | Page layout width. Options: 'full-width', 'default'. |
+| `table_layout` | `string` | No | Table width preset for Markdown tables. Options: 'full-width', 'wide', 'default'. |
 **Example:**
 
 ```json
@@ -56,6 +59,8 @@ Create a new Confluence page.
 <Tip>
 Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.
 </Tip>
+
+<Note>Exactly one of `content` or `content_file` must be provided.</Note>
 
 
 ---
@@ -72,7 +77,8 @@ Update an existing Confluence page.
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | The ID of the page to update |
 | `title` | `string` | Yes | The new title of the page |
-| `content` | `string` | Yes | The new content of the page. Format depends on content_format parameter |
+| `content` | `string` | No* | The new content of the page. Format depends on content_format parameter |
+| `content_file` | `string` | No* | Absolute or relative filesystem path to read the new page body from (UTF-8). Mutually exclusive with `content`. |
 | `is_minor_edit` | `boolean` | No | Whether this is a minor edit |
 | `version_comment` | `string` | No | Optional comment for this version |
 | `parent_id` | `string` | No | Optional the new parent page ID |
@@ -80,6 +86,8 @@ Update an existing Confluence page.
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
 | `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at update time. |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
+| `page_width` | `string` | No | Page layout width. Options: 'full-width', 'default'. Use an empty string to reset to default. |
+| `table_layout` | `string` | No | Table width preset for Markdown tables. Options: 'full-width', 'wide', 'default'. |
 **Example:**
 
 ```json
@@ -89,6 +97,8 @@ Update an existing Confluence page.
 <Tip>
 Set `is_minor_edit: true` to skip notification emails. The page version is auto-incremented.
 </Tip>
+
+<Note>Exactly one of `content` or `content_file` must be provided.</Note>
 
 
 ---
@@ -202,6 +212,62 @@ At least one of `target_parent_id` or `target_space_key` must be provided.
 Use `target_space_key` to move pages between spaces. Omit `target_parent_id` with a space key to move to the space root.
 </Tip>
 
+
+---
+
+### Copy Page
+
+Copy a Confluence page to a new location.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `source_page_id` | `string` | Yes | The ID of the page to copy |
+| `destination_space_key` | `string` | Yes | Space key for the new page |
+| `new_title` | `string` | Yes | Title for the copied page |
+| `destination_parent_id` | `string` | No | Parent page ID in the destination space. Omit to copy to the space root. |
+| `copy_attachments` | `boolean` | No | Whether to copy attachments. Supported on Confluence Cloud. |
+
+**Example:**
+
+```json
+{"source_page_id": "12345678", "destination_space_key": "DOCS", "new_title": "Copied Runbook", "destination_parent_id": "98765432"}
+```
+
+---
+
+### Get Page Restrictions
+
+Get view and edit restrictions for a Confluence page.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | `string` | Yes | The ID of the page |
+
+---
+
+### Set Page Restrictions
+
+Replace view and edit restrictions for a Confluence page.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | `string` | Yes | The ID of the page to restrict |
+| `read_users` | `array` | No | Account IDs (Cloud) or usernames (Server/DC) allowed to view the page |
+| `read_groups` | `array` | No | Group names allowed to view the page |
+| `edit_users` | `array` | No | Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page |
+| `edit_groups` | `array` | No | Group names allowed to edit the page |
+
+<Warning>Omitting all restriction lists or passing empty lists removes all page restrictions.</Warning>
 
 ---
 

--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -10,6 +10,7 @@ from .comments import CommentsMixin
 from .config import ConfluenceConfig
 from .labels import LabelsMixin
 from .pages import PagesMixin
+from .restrictions import RestrictionsMixin
 from .search import SearchMixin
 from .spaces import SpacesMixin
 from .users import UsersMixin
@@ -24,6 +25,7 @@ class ConfluenceFetcher(
     UsersMixin,
     AnalyticsMixin,
     AttachmentsMixin,
+    RestrictionsMixin,
 ):
     """Main entry point for Confluence operations, providing backward compatibility.
 

--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -41,6 +41,7 @@ class ConfluenceFetcher(
     - UsersMixin: User operations
     - AnalyticsMixin: Page view analytics (Cloud only)
     - AttachmentsMixin: Attachment operations
+    - RestrictionsMixin: Page restriction operations
     """
 
     pass
@@ -51,4 +52,5 @@ __all__ = [
     "ConfluenceConfig",
     "ConfluenceClient",
     "AnalyticsMixin",
+    "RestrictionsMixin",
 ]

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -166,6 +166,25 @@ class ConfluenceClient:
                     "continuing anyway"
                 )
 
+    def _v1_rest_base_url(self) -> str:
+        """Return the base URL for direct Confluence REST API v1 calls.
+
+        Confluence Cloud OAuth uses the Atlassian API gateway base URL stored on
+        the underlying client. V1 REST calls through that gateway require the
+        ``/wiki`` product prefix before ``/rest/api``.
+
+        Returns:
+            Base URL suitable for appending ``/rest/api/...``.
+        """
+        if self.config.auth_type == "oauth" and self.config.is_cloud:
+            base_url = self.confluence.url.rstrip("/")
+        else:
+            base_url = self.config.url.rstrip("/")
+
+        if self.config.is_cloud and not base_url.endswith("/wiki"):
+            base_url = f"{base_url}/wiki"
+        return base_url
+
     def _validate_authentication(self) -> None:
         """Validate authentication by making a simple API call."""
         try:

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -534,6 +534,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Create a new page in a Confluence space.
@@ -548,6 +549,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only)
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only)
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the new page's data
@@ -560,7 +562,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -629,6 +633,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Update an existing page in Confluence.
@@ -645,6 +650,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only). Pass empty string to remove emoji.
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only). Pass empty string to reset to default.
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the updated page's data
@@ -657,7 +663,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -1200,3 +1208,79 @@ class PagesMixin(ConfluenceClient):
             "to_version": to_version,
             "diff": diff_string,
         }
+
+    @handle_auth_errors("Confluence API")
+    def copy_page(
+        self,
+        source_page_id: str,
+        destination_space_key: str,
+        new_title: str,
+        destination_parent_id: str | None = None,
+        *,
+        copy_attachments: bool = True,
+    ) -> ConfluencePage:
+        """Copy a Confluence page to a new location.
+
+        On Confluence Cloud the native copy endpoint is used
+        (``POST /wiki/rest/api/content/{id}/copy``).  On Server/Data Center
+        the page body and title are fetched and a new page is created manually
+        (attachments are not copied in the Server/DC fallback path).
+
+        Args:
+            source_page_id: The ID of the page to copy.
+            destination_space_key: Space key for the new page.
+            new_title: Title of the new page.
+            destination_parent_id: Optional parent page ID in the destination space.
+                When omitted the new page is created at the space root.
+            copy_attachments: Whether to copy attachments (Cloud only, keyword-only).
+
+        Returns:
+            ConfluencePage model for the newly created copy.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the copy operation fails.
+        """
+        try:
+            if self.config.is_cloud:
+                payload: dict[str, object] = {
+                    "copyAttachments": copy_attachments,
+                    "copyPermissions": False,
+                    "copyProperties": False,
+                    "copyLabels": False,
+                    "pageTitle": new_title,
+                    "destination": {
+                        "type": "parent_page" if destination_parent_id else "space",
+                        "value": destination_parent_id or destination_space_key,
+                    },
+                }
+                result = self.confluence.post(
+                    f"rest/api/content/{source_page_id}/copy",
+                    data=payload,
+                )
+            else:
+                # Server/DC: manual GET + POST (no native copy endpoint)
+                source = self.confluence.get_page_by_id(
+                    source_page_id, expand="body.storage,version,space"
+                )
+                body = source.get("body", {}).get("storage", {}).get("value", "")
+                create_kwargs: dict[str, object] = {
+                    "space": destination_space_key,
+                    "title": new_title,
+                    "body": body,
+                    "representation": "storage",
+                }
+                if destination_parent_id:
+                    create_kwargs["parent_id"] = destination_parent_id
+                result = self.confluence.create_page(**create_kwargs)
+
+            new_page_id = result.get("id")
+            if not new_page_id:
+                raise ValueError("Copy response did not contain a page ID")
+
+            return self.get_page_content(new_page_id)
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error copying page {source_page_id}: {str(e)}")
+            raise Exception(f"Failed to copy page {source_page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -1556,8 +1556,10 @@ class PagesMixin(ConfluenceClient):
                     },
                 }
                 result = self.confluence.post(
-                    f"rest/api/content/{source_page_id}/copy",
+                    f"{self._v1_rest_base_url()}/rest/api/content/"
+                    f"{source_page_id}/copy",
                     data=payload,
+                    absolute=True,
                 )
             else:
                 # Server/DC: manual GET + POST (no native copy endpoint)

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -664,6 +664,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Create a new page in a Confluence space.
@@ -678,6 +679,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only)
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only)
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the new page's data
@@ -690,7 +692,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -759,6 +763,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Update an existing page in Confluence.
@@ -775,6 +780,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only). Pass empty string to remove emoji.
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only). Pass empty string to reset to default.
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the updated page's data
@@ -787,7 +793,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -1501,3 +1509,79 @@ class PagesMixin(ConfluenceClient):
             "to_version": to_version,
             "diff": diff_string,
         }
+
+    @handle_auth_errors("Confluence API")
+    def copy_page(
+        self,
+        source_page_id: str,
+        destination_space_key: str,
+        new_title: str,
+        destination_parent_id: str | None = None,
+        *,
+        copy_attachments: bool = True,
+    ) -> ConfluencePage:
+        """Copy a Confluence page to a new location.
+
+        On Confluence Cloud the native copy endpoint is used
+        (``POST /wiki/rest/api/content/{id}/copy``).  On Server/Data Center
+        the page body and title are fetched and a new page is created manually
+        (attachments are not copied in the Server/DC fallback path).
+
+        Args:
+            source_page_id: The ID of the page to copy.
+            destination_space_key: Space key for the new page.
+            new_title: Title of the new page.
+            destination_parent_id: Optional parent page ID in the destination space.
+                When omitted the new page is created at the space root.
+            copy_attachments: Whether to copy attachments (Cloud only, keyword-only).
+
+        Returns:
+            ConfluencePage model for the newly created copy.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the copy operation fails.
+        """
+        try:
+            if self.config.is_cloud:
+                payload: dict[str, object] = {
+                    "copyAttachments": copy_attachments,
+                    "copyPermissions": False,
+                    "copyProperties": False,
+                    "copyLabels": False,
+                    "pageTitle": new_title,
+                    "destination": {
+                        "type": "parent_page" if destination_parent_id else "space",
+                        "value": destination_parent_id or destination_space_key,
+                    },
+                }
+                result = self.confluence.post(
+                    f"rest/api/content/{source_page_id}/copy",
+                    data=payload,
+                )
+            else:
+                # Server/DC: manual GET + POST (no native copy endpoint)
+                source = self.confluence.get_page_by_id(
+                    source_page_id, expand="body.storage,version,space"
+                )
+                body = source.get("body", {}).get("storage", {}).get("value", "")
+                create_kwargs: dict[str, object] = {
+                    "space": destination_space_key,
+                    "title": new_title,
+                    "body": body,
+                    "representation": "storage",
+                }
+                if destination_parent_id:
+                    create_kwargs["parent_id"] = destination_parent_id
+                result = self.confluence.create_page(**create_kwargs)
+
+            new_page_id = result.get("id")
+            if not new_page_id:
+                raise ValueError("Copy response did not contain a page ID")
+
+            return self.get_page_content(new_page_id)
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error copying page {source_page_id}: {str(e)}")
+            raise Exception(f"Failed to copy page {source_page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/restrictions.py
+++ b/src/mcp_atlassian/confluence/restrictions.py
@@ -57,7 +57,9 @@ class RestrictionsMixin(ConfluenceClient):
                 users = restrictions.get("user", {})
                 if isinstance(users, dict):
                     for u in users.get("results", []):
-                        account_id = u.get("accountId") or u.get("username") or u.get("name")
+                        account_id = (
+                            u.get("accountId") or u.get("username") or u.get("name")
+                        )
                         if account_id:
                             result[op_key]["users"].append(account_id)
 
@@ -73,7 +75,9 @@ class RestrictionsMixin(ConfluenceClient):
             raise
         except Exception as e:
             logger.error(f"Error fetching restrictions for page {page_id}: {str(e)}")
-            raise Exception(f"Failed to get restrictions for page {page_id}: {str(e)}") from e
+            raise Exception(
+                f"Failed to get restrictions for page {page_id}: {str(e)}"
+            ) from e
 
     @handle_auth_errors("Confluence API")
     def set_page_restrictions(
@@ -158,4 +162,6 @@ class RestrictionsMixin(ConfluenceClient):
             raise
         except Exception as e:
             logger.error(f"Error setting restrictions for page {page_id}: {str(e)}")
-            raise Exception(f"Failed to set restrictions for page {page_id}: {str(e)}") from e
+            raise Exception(
+                f"Failed to set restrictions for page {page_id}: {str(e)}"
+            ) from e

--- a/src/mcp_atlassian/confluence/restrictions.py
+++ b/src/mcp_atlassian/confluence/restrictions.py
@@ -1,0 +1,161 @@
+"""Module for Confluence page restriction operations."""
+
+import json
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..utils.decorators import handle_auth_errors
+from .client import ConfluenceClient
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+class RestrictionsMixin(ConfluenceClient):
+    """Mixin for Confluence page restriction operations."""
+
+    @handle_auth_errors("Confluence API")
+    def get_page_restrictions(self, page_id: str) -> dict[str, Any]:
+        """Get view and edit restrictions for a Confluence page.
+
+        Returns the current restriction lists for the ``read`` and ``update``
+        operations.  An empty list for an operation means the page is
+        unrestricted for that operation (visible/editable by everyone).
+
+        Args:
+            page_id: The ID of the page to query.
+
+        Returns:
+            Dict with ``read`` and ``update`` keys, each containing:
+            ``{"users": [...account_ids...], "groups": [...group_names...]}``
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            data = self.confluence.get_all_restrictions_for_content(page_id)
+
+            result: dict[str, Any] = {
+                "read": {"users": [], "groups": []},
+                "update": {"users": [], "groups": []},
+            }
+
+            if not isinstance(data, dict):
+                return result
+
+            for operation, op_key in (("read", "read"), ("update", "update")):
+                op_data = data.get(operation, {})
+                if not isinstance(op_data, dict):
+                    continue
+
+                restrictions = op_data.get("restrictions", {})
+                if not isinstance(restrictions, dict):
+                    continue
+
+                users = restrictions.get("user", {})
+                if isinstance(users, dict):
+                    for u in users.get("results", []):
+                        account_id = u.get("accountId") or u.get("username") or u.get("name")
+                        if account_id:
+                            result[op_key]["users"].append(account_id)
+
+                groups = restrictions.get("group", {})
+                if isinstance(groups, dict):
+                    for g in groups.get("results", []):
+                        group_name = g.get("name")
+                        if group_name:
+                            result[op_key]["groups"].append(group_name)
+
+            return result
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error fetching restrictions for page {page_id}: {str(e)}")
+            raise Exception(f"Failed to get restrictions for page {page_id}: {str(e)}") from e
+
+    @handle_auth_errors("Confluence API")
+    def set_page_restrictions(
+        self,
+        page_id: str,
+        *,
+        read_users: list[str] | None = None,
+        read_groups: list[str] | None = None,
+        edit_users: list[str] | None = None,
+        edit_groups: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Set view and edit restrictions on a Confluence page.
+
+        Replaces all existing restrictions with the provided lists.
+        Passing empty lists for all parameters removes all restrictions
+        (makes the page unrestricted).
+
+        Confluence uses ``read`` for view access and ``update`` for edit
+        access.  Users are identified by account ID (Cloud) or username
+        (Server/DC); groups by group name.
+
+        Args:
+            page_id: The ID of the page to restrict.
+            read_users: Account IDs (Cloud) / usernames (Server/DC) that may view the page.
+            read_groups: Group names that may view the page.
+            edit_users: Account IDs / usernames that may edit the page.
+            edit_groups: Group names that may edit the page.
+
+        Returns:
+            Dict with the updated ``read`` and ``update`` restriction lists,
+            in the same format as :meth:`get_page_restrictions`.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            read_users = read_users or []
+            read_groups = read_groups or []
+            edit_users = edit_users or []
+            edit_groups = edit_groups or []
+
+            def _user_entry(account_id: str) -> dict[str, str]:
+                # Cloud uses accountId; Server/DC uses name/username
+                if self.config.is_cloud:
+                    return {"type": "known", "accountId": account_id}
+                return {"type": "known", "username": account_id}
+
+            def _group_entry(name: str) -> dict[str, str]:
+                return {"type": "group", "name": name}
+
+            payload = [
+                {
+                    "operation": "read",
+                    "restrictions": {
+                        "user": [_user_entry(u) for u in read_users],
+                        "group": [_group_entry(g) for g in read_groups],
+                    },
+                },
+                {
+                    "operation": "update",
+                    "restrictions": {
+                        "user": [_user_entry(u) for u in edit_users],
+                        "group": [_group_entry(g) for g in edit_groups],
+                    },
+                },
+            ]
+
+            # The atlassian library's put() only accepts dict|str for data;
+            # the restrictions endpoint expects a JSON array, so serialise manually.
+            self.confluence.put(
+                f"rest/api/content/{page_id}/restriction",
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+            )
+
+            return {
+                "read": {"users": read_users, "groups": read_groups},
+                "update": {"users": edit_users, "groups": edit_groups},
+            }
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error setting restrictions for page {page_id}: {str(e)}")
+            raise Exception(f"Failed to set restrictions for page {page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/restrictions.py
+++ b/src/mcp_atlassian/confluence/restrictions.py
@@ -1,6 +1,5 @@
 """Module for Confluence page restriction operations."""
 
-import json
 import logging
 from typing import Any
 
@@ -35,7 +34,11 @@ class RestrictionsMixin(ConfluenceClient):
             Exception: If the API call fails.
         """
         try:
-            data = self.confluence.get_all_restrictions_for_content(page_id)
+            data = self.confluence.get(
+                f"{self._v1_rest_base_url()}/rest/api/content/"
+                f"{page_id}/restriction/byOperation",
+                absolute=True,
+            )
 
             result: dict[str, Any] = {
                 "read": {"users": [], "groups": []},
@@ -146,13 +149,15 @@ class RestrictionsMixin(ConfluenceClient):
                 },
             ]
 
-            # The atlassian library's put() only accepts dict|str for data;
-            # the restrictions endpoint expects a JSON array, so serialise manually.
-            self.confluence.put(
-                f"rest/api/content/{page_id}/restriction",
-                data=json.dumps(payload),
-                headers={"Content-Type": "application/json"},
+            response = self.confluence._session.put(
+                f"{self._v1_rest_base_url()}/rest/api/content/{page_id}/restriction",
+                json=payload,
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
             )
+            response.raise_for_status()
 
             return {
                 "read": {"users": read_users, "groups": read_groups},

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -1,6 +1,7 @@
 """Confluence-specific text preprocessing module."""
 
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -36,8 +37,24 @@ class ConfluencePreprocessor(BasePreprocessor):
         """
         super().__init__(base_url=base_url)
 
+    # Table width (px) and layout name keyed by the caller-supplied table_layout value.
+    _TABLE_WIDTHS: dict[str, str] = {
+        "full-width": "1800",
+        "wide": "960",
+        "default": "760",
+    }
+    _TABLE_LAYOUTS: dict[str, str] = {
+        "full-width": "full-width",
+        "wide": "wide",
+        "default": "default",
+    }
+
     def markdown_to_confluence_storage(
-        self, markdown_content: str, *, enable_heading_anchors: bool = False
+        self,
+        markdown_content: str,
+        *,
+        enable_heading_anchors: bool = False,
+        table_layout: str | None = None,
     ) -> str:
         """
         Convert Markdown content to Confluence storage format (XHTML)
@@ -45,6 +62,9 @@ class ConfluencePreprocessor(BasePreprocessor):
         Args:
             markdown_content: Markdown text to convert
             enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False)
+            table_layout: Optional table width preset applied to all tables in the output.
+                Values: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px / Confluence default).
+                When None, tables retain the default 760 px width emitted by the converter.
 
         Returns:
             Confluence storage format (XHTML) string
@@ -82,9 +102,14 @@ class ConfluencePreprocessor(BasePreprocessor):
                 converter.visit(root)
 
                 # Convert the element tree back to a string
-                storage_format = elements_to_string(root)
+                storage_format = str(elements_to_string(root))
 
-                return str(storage_format)
+                if table_layout and table_layout in self._TABLE_WIDTHS:
+                    storage_format = self._apply_table_layout(
+                        storage_format, table_layout
+                    )
+
+                return storage_format
             finally:
                 # Clean up the temporary directory
                 shutil.rmtree(temp_dir, ignore_errors=True)
@@ -96,10 +121,40 @@ class ConfluencePreprocessor(BasePreprocessor):
             # Fall back to a simpler method if the conversion fails
             html_content = markdown_to_html(markdown_content)
 
-            # Use a different approach that doesn't rely on the HTML macro
             # This creates a proper Confluence storage format document
             storage_format = f"""<p>{html_content}</p>"""
 
             return str(storage_format)
 
-    # Confluence-specific methods can be added here
+    @classmethod
+    def _apply_table_layout(cls, storage_html: str, table_layout: str) -> str:
+        """Set table width and layout attributes in Confluence storage format.
+
+        The md2conf converter emits bare ``<table>`` tags with no width or
+        layout attributes.  Confluence renders these at its default narrow
+        width.  This method injects ``data-table-width`` and ``data-layout``
+        attributes so tables render at the requested width.
+
+        If attributes already exist (e.g. content edited via another tool)
+        they are replaced rather than duplicated.
+
+        Args:
+            storage_html: Confluence storage-format string to post-process.
+            table_layout: One of 'full-width', 'wide', or 'default'.
+
+        Returns:
+            Updated storage-format string with table width attributes set.
+        """
+        width = cls._TABLE_WIDTHS.get(table_layout, "760")
+        layout = cls._TABLE_LAYOUTS.get(table_layout, "default")
+        attrs = f'data-table-width="{width}" data-layout="{layout}"'
+
+        def _replace_table_tag(m: re.Match) -> str:
+            tag = m.group(0)
+            # Strip any existing data-table-width / data-layout attributes first
+            tag = re.sub(r'\s*data-table-width="[^"]*"', "", tag)
+            tag = re.sub(r'\s*data-layout="[^"]*"', "", tag)
+            # Inject new attributes after <table
+            return re.sub(r"^<table", f"<table {attrs}", tag)
+
+        return re.sub(r"<table\b[^>]*>", _replace_table_tag, storage_html)

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -1,6 +1,7 @@
 """Confluence-specific text preprocessing module."""
 
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -39,8 +40,24 @@ class ConfluencePreprocessor(BasePreprocessor):
         """
         super().__init__(base_url=base_url)
 
+    # Table width (px) and layout name keyed by the caller-supplied table_layout value.
+    _TABLE_WIDTHS: dict[str, str] = {
+        "full-width": "1800",
+        "wide": "960",
+        "default": "760",
+    }
+    _TABLE_LAYOUTS: dict[str, str] = {
+        "full-width": "full-width",
+        "wide": "wide",
+        "default": "default",
+    }
+
     def markdown_to_confluence_storage(
-        self, markdown_content: str, *, enable_heading_anchors: bool = False
+        self,
+        markdown_content: str,
+        *,
+        enable_heading_anchors: bool = False,
+        table_layout: str | None = None,
     ) -> str:
         """
         Convert Markdown content to Confluence storage format (XHTML)
@@ -48,6 +65,9 @@ class ConfluencePreprocessor(BasePreprocessor):
         Args:
             markdown_content: Markdown text to convert
             enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False)
+            table_layout: Optional table width preset applied to all tables in the output.
+                Values: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px / Confluence default).
+                When None, tables retain the default 760 px width emitted by the converter.
 
         Returns:
             Confluence storage format (XHTML) string
@@ -85,9 +105,15 @@ class ConfluencePreprocessor(BasePreprocessor):
                 converter.visit(root)
 
                 # Convert the element tree back to a string
-                storage_format = elements_to_string(root)
+                storage_format = self._fix_attachment_images(
+                    str(elements_to_string(root))
+                )
+                if table_layout in self._TABLE_WIDTHS:
+                    storage_format = self._apply_table_layout(
+                        storage_format, table_layout
+                    )
 
-                return self._fix_attachment_images(str(storage_format))
+                return storage_format
             finally:
                 # Clean up the temporary directory
                 shutil.rmtree(temp_dir, ignore_errors=True)
@@ -99,11 +125,47 @@ class ConfluencePreprocessor(BasePreprocessor):
             # Fall back to a simpler method if the conversion fails
             html_content = markdown_to_html(markdown_content)
 
-            # Use a different approach that doesn't rely on the HTML macro
             # This creates a proper Confluence storage format document
-            storage_format = f"""<p>{html_content}</p>"""
+            storage_format = self._fix_attachment_images(f"""<p>{html_content}</p>""")
+            if table_layout in self._TABLE_WIDTHS:
+                storage_format = self._apply_table_layout(
+                    storage_format, table_layout
+                )
 
-            return self._fix_attachment_images(str(storage_format))
+            return storage_format
+
+    @classmethod
+    def _apply_table_layout(cls, storage_html: str, table_layout: str) -> str:
+        """Set table width and layout attributes in Confluence storage format.
+
+        The md2conf converter emits bare ``<table>`` tags with no width or
+        layout attributes.  Confluence renders these at its default narrow
+        width.  This method injects ``data-table-width`` and ``data-layout``
+        attributes so tables render at the requested width.
+
+        If attributes already exist (e.g. content edited via another tool)
+        they are replaced rather than duplicated.
+
+        Args:
+            storage_html: Confluence storage-format string to post-process.
+            table_layout: One of 'full-width', 'wide', or 'default'.
+
+        Returns:
+            Updated storage-format string with table width attributes set.
+        """
+        width = cls._TABLE_WIDTHS.get(table_layout, "760")
+        layout = cls._TABLE_LAYOUTS.get(table_layout, "default")
+        attrs = f'data-table-width="{width}" data-layout="{layout}"'
+
+        def _replace_table_tag(m: re.Match) -> str:
+            tag = m.group(0)
+            # Strip any existing data-table-width / data-layout attributes first
+            tag = re.sub(r'\s*data-table-width="[^"]*"', "", tag)
+            tag = re.sub(r'\s*data-layout="[^"]*"', "", tag)
+            # Inject new attributes after <table
+            return re.sub(r"^<table", f"<table {attrs}", tag)
+
+        return re.sub(r"<table\b[^>]*>", _replace_table_tag, storage_html)
 
     @staticmethod
     def _is_attachment_image_source(src: str) -> bool:

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -40,7 +40,7 @@ class ConfluencePreprocessor(BasePreprocessor):
         """
         super().__init__(base_url=base_url)
 
-    # Table width (px) and layout name keyed by the caller-supplied table_layout value.
+    # Table width and layout keyed by the caller-supplied table_layout value.
     _TABLE_WIDTHS: dict[str, str] = {
         "full-width": "1800",
         "wide": "960",
@@ -108,7 +108,7 @@ class ConfluencePreprocessor(BasePreprocessor):
                 storage_format = self._fix_attachment_images(
                     str(elements_to_string(root))
                 )
-                if table_layout in self._TABLE_WIDTHS:
+                if table_layout is not None and table_layout in self._TABLE_WIDTHS:
                     storage_format = self._apply_table_layout(
                         storage_format, table_layout
                     )
@@ -127,10 +127,8 @@ class ConfluencePreprocessor(BasePreprocessor):
 
             # This creates a proper Confluence storage format document
             storage_format = self._fix_attachment_images(f"""<p>{html_content}</p>""")
-            if table_layout in self._TABLE_WIDTHS:
-                storage_format = self._apply_table_layout(
-                    storage_format, table_layout
-                )
+            if table_layout is not None and table_layout in self._TABLE_WIDTHS:
+                storage_format = self._apply_table_layout(storage_format, table_layout)
 
             return storage_format
 

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -571,6 +571,20 @@ async def create_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (Confluence default).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Create a new Confluence page.
 
@@ -584,6 +598,8 @@ async def create_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the created page object.
@@ -618,6 +634,8 @@ async def create_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     result = page.to_simplified_dict()
     if not include_content:
@@ -683,6 +701,20 @@ async def update_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (preserve existing).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Update an existing Confluence page.
 
@@ -698,6 +730,8 @@ async def update_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the updated page object.
@@ -734,6 +768,8 @@ async def update_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     page_data = updated_page.to_simplified_dict()
     if not include_content:
@@ -2071,3 +2107,167 @@ async def get_page_images(
         ),
     )
     return contents
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_pages"},
+    annotations={"title": "Get Page Restrictions", "readOnlyHint": True},
+)
+async def get_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page")],
+) -> str:
+    """Get view and edit restrictions for a Confluence page.
+
+    Returns the current restriction lists for the read (view) and update (edit)
+    operations.  An empty list means the page is unrestricted for that operation.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page.
+
+    Returns:
+        JSON string with ``read`` and ``update`` restriction lists, each
+        containing ``users`` (account IDs) and ``groups`` (group names).
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    restrictions = confluence_fetcher.get_page_restrictions(page_id=page_id)
+    return json.dumps(restrictions, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Set Page Restrictions", "destructiveHint": True},
+)
+@check_write_access
+async def set_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page to restrict")],
+    read_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to view the page. Empty list = unrestricted.",
+            default=None,
+        ),
+    ] = None,
+    read_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to view the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Set view and edit restrictions on a Confluence page.
+
+    Replaces all existing restrictions with the provided lists.  Omitting all
+    parameters (or passing empty lists) removes all restrictions.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to restrict.
+        read_users: Account IDs / usernames allowed to view the page.
+        read_groups: Group names allowed to view the page.
+        edit_users: Account IDs / usernames allowed to edit the page.
+        edit_groups: Group names allowed to edit the page.
+
+    Returns:
+        JSON string with the updated restriction lists.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    result = confluence_fetcher.set_page_restrictions(
+        page_id=page_id,
+        read_users=read_users,
+        read_groups=read_groups,
+        edit_users=edit_users,
+        edit_groups=edit_groups,
+    )
+    return json.dumps(
+        {"message": "Page restrictions updated successfully", "restrictions": result},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Copy Page", "destructiveHint": True},
+)
+@check_write_access
+async def copy_page(
+    ctx: Context,
+    source_page_id: Annotated[str, Field(description="The ID of the page to copy")],
+    destination_space_key: Annotated[
+        str,
+        Field(description="Space key for the new page (e.g. 'DEV', 'TEAM')"),
+    ],
+    new_title: Annotated[str, Field(description="Title for the new copied page")],
+    destination_parent_id: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Parent page ID in the destination space. When omitted the page is created at the space root.",
+            default=None,
+        ),
+        BeforeValidator(lambda x: str(x) if x is not None else None),
+    ] = None,
+    copy_attachments: Annotated[
+        bool,
+        Field(
+            description="(Optional) Whether to copy attachments to the new page. Defaults to true. Only supported on Confluence Cloud.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Copy a Confluence page to a new location.
+
+    On Confluence Cloud the native copy endpoint is used.  On Server/Data Center
+    the page body is fetched and a new page is created manually (attachments are
+    not copied in the Server/DC path).
+
+    Args:
+        ctx: The FastMCP context.
+        source_page_id: The ID of the page to copy.
+        destination_space_key: Space key for the new page.
+        new_title: Title for the new copied page.
+        destination_parent_id: Optional parent page ID in the destination space.
+        copy_attachments: Whether to copy attachments (Cloud only).
+
+    Returns:
+        JSON string representing the new page.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    page = confluence_fetcher.copy_page(
+        source_page_id=source_page_id,
+        destination_space_key=destination_space_key,
+        new_title=new_title,
+        destination_parent_id=destination_parent_id,
+        copy_attachments=copy_attachments,
+    )
+    return json.dumps(
+        {"message": "Page copied successfully", "page": page.to_simplified_dict()},
+        indent=2,
+        ensure_ascii=False,
+    )

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -637,14 +637,22 @@ async def create_page(
     page_width: Annotated[
         str | None,
         Field(
-            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (Confluence default).",
+            description=(
+                "(Optional) Page layout width. Options: 'full-width', "
+                "'default'. Defaults to null (Confluence default)."
+            ),
             default=None,
         ),
     ] = None,
     table_layout: Annotated[
         str | None,
         Field(
-            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            description=(
+                "(Optional) Table width preset applied to all markdown tables. "
+                "Options: 'full-width' (1800 px), 'wide' (960 px), "
+                "'default' (760 px). Only applies when content_format is "
+                "'markdown'."
+            ),
             default=None,
         ),
     ] = None,
@@ -802,14 +810,22 @@ async def update_page(
     page_width: Annotated[
         str | None,
         Field(
-            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (preserve existing).",
+            description=(
+                "(Optional) Page layout width. Options: 'full-width', "
+                "'default'. Defaults to null (preserve existing)."
+            ),
             default=None,
         ),
     ] = None,
     table_layout: Annotated[
         str | None,
         Field(
-            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            description=(
+                "(Optional) Table width preset applied to all markdown tables. "
+                "Options: 'full-width' (1800 px), 'wide' (960 px), "
+                "'default' (760 px). Only applies when content_format is "
+                "'markdown'."
+            ),
             default=None,
         ),
     ] = None,
@@ -2508,7 +2524,10 @@ async def set_page_restrictions(
     read_users: Annotated[
         list[str] | None,
         Field(
-            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to view the page. Empty list = unrestricted.",
+            description=(
+                "(Optional) Account IDs (Cloud) or usernames (Server/DC) "
+                "allowed to view the page. Empty list = unrestricted."
+            ),
             default=None,
         ),
     ] = None,
@@ -2522,7 +2541,10 @@ async def set_page_restrictions(
     edit_users: Annotated[
         list[str] | None,
         Field(
-            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page.",
+            description=(
+                "(Optional) Account IDs (Cloud) or usernames (Server/DC) "
+                "allowed to edit the page."
+            ),
             default=None,
         ),
     ] = None,
@@ -2584,7 +2606,10 @@ async def copy_page(
     destination_parent_id: Annotated[
         str | None,
         Field(
-            description="(Optional) Parent page ID in the destination space. When omitted the page is created at the space root.",
+            description=(
+                "(Optional) Parent page ID in the destination space. "
+                "When omitted the page is created at the space root."
+            ),
             default=None,
         ),
         BeforeValidator(lambda x: str(x) if x is not None else None),
@@ -2592,7 +2617,10 @@ async def copy_page(
     copy_attachments: Annotated[
         bool,
         Field(
-            description="(Optional) Whether to copy attachments to the new page. Defaults to true. Only supported on Confluence Cloud.",
+            description=(
+                "(Optional) Whether to copy attachments to the new page. "
+                "Defaults to true. Only supported on Confluence Cloud."
+            ),
             default=True,
         ),
     ] = True,

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -634,6 +634,20 @@ async def create_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (Confluence default).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Create a new Confluence page.
 
@@ -652,6 +666,8 @@ async def create_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the created page object.
@@ -692,6 +708,8 @@ async def create_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     result = page.to_simplified_dict()
     if not include_content:
@@ -781,6 +799,20 @@ async def update_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (preserve existing).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Update an existing Confluence page.
 
@@ -802,6 +834,8 @@ async def update_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the updated page object.
@@ -844,6 +878,8 @@ async def update_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     page_data = updated_page.to_simplified_dict()
     if not include_content:
@@ -2430,3 +2466,167 @@ async def get_page_images(
         ),
     )
     return contents
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_pages"},
+    annotations={"title": "Get Page Restrictions", "readOnlyHint": True},
+)
+async def get_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page")],
+) -> str:
+    """Get view and edit restrictions for a Confluence page.
+
+    Returns the current restriction lists for the read (view) and update (edit)
+    operations.  An empty list means the page is unrestricted for that operation.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page.
+
+    Returns:
+        JSON string with ``read`` and ``update`` restriction lists, each
+        containing ``users`` (account IDs) and ``groups`` (group names).
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    restrictions = confluence_fetcher.get_page_restrictions(page_id=page_id)
+    return json.dumps(restrictions, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Set Page Restrictions", "destructiveHint": True},
+)
+@check_write_access
+async def set_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page to restrict")],
+    read_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to view the page. Empty list = unrestricted.",
+            default=None,
+        ),
+    ] = None,
+    read_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to view the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Set view and edit restrictions on a Confluence page.
+
+    Replaces all existing restrictions with the provided lists.  Omitting all
+    parameters (or passing empty lists) removes all restrictions.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to restrict.
+        read_users: Account IDs / usernames allowed to view the page.
+        read_groups: Group names allowed to view the page.
+        edit_users: Account IDs / usernames allowed to edit the page.
+        edit_groups: Group names allowed to edit the page.
+
+    Returns:
+        JSON string with the updated restriction lists.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    result = confluence_fetcher.set_page_restrictions(
+        page_id=page_id,
+        read_users=read_users,
+        read_groups=read_groups,
+        edit_users=edit_users,
+        edit_groups=edit_groups,
+    )
+    return json.dumps(
+        {"message": "Page restrictions updated successfully", "restrictions": result},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Copy Page", "destructiveHint": True},
+)
+@check_write_access
+async def copy_page(
+    ctx: Context,
+    source_page_id: Annotated[str, Field(description="The ID of the page to copy")],
+    destination_space_key: Annotated[
+        str,
+        Field(description="Space key for the new page (e.g. 'DEV', 'TEAM')"),
+    ],
+    new_title: Annotated[str, Field(description="Title for the new copied page")],
+    destination_parent_id: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Parent page ID in the destination space. When omitted the page is created at the space root.",
+            default=None,
+        ),
+        BeforeValidator(lambda x: str(x) if x is not None else None),
+    ] = None,
+    copy_attachments: Annotated[
+        bool,
+        Field(
+            description="(Optional) Whether to copy attachments to the new page. Defaults to true. Only supported on Confluence Cloud.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Copy a Confluence page to a new location.
+
+    On Confluence Cloud the native copy endpoint is used.  On Server/Data Center
+    the page body is fetched and a new page is created manually (attachments are
+    not copied in the Server/DC path).
+
+    Args:
+        ctx: The FastMCP context.
+        source_page_id: The ID of the page to copy.
+        destination_space_key: Space key for the new page.
+        new_title: Title for the new copied page.
+        destination_parent_id: Optional parent page ID in the destination space.
+        copy_attachments: Whether to copy attachments (Cloud only).
+
+    Returns:
+        JSON string representing the new page.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    page = confluence_fetcher.copy_page(
+        source_page_id=source_page_id,
+        destination_space_key=destination_space_key,
+        new_title=new_title,
+        destination_parent_id=destination_parent_id,
+        copy_attachments=copy_attachments,
+    )
+    return json.dumps(
+        {"message": "Page copied successfully", "page": page.to_simplified_dict()},
+        indent=2,
+        ensure_ascii=False,
+    )

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -158,6 +158,108 @@ class TestConfluenceCloudPageHierarchy:
         assert any(page.id == child.id for page in children)
 
 
+class TestConfluenceCloudPageLayout:
+    """Page width and table layout handling."""
+
+    def test_markdown_table_layout_and_page_width(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Layout Test {uid}",
+            body="| Alpha | Beta |\n| --- | --- |\n| one | two |",
+            page_width="full-width",
+            table_layout="full-width",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        assert page.page_width == "full-width"
+
+        raw_page = confluence_fetcher.confluence.get_page_by_id(
+            page.id,
+            expand="body.storage,version",
+        )
+        storage_body = raw_page["body"]["storage"]["value"]
+        assert 'data-layout="full-width"' in storage_body
+        assert 'data-table-width="1800"' in storage_body
+
+
+class TestConfluenceCloudCopyAndRestrictions:
+    """Page copy and restriction operations."""
+
+    def test_copy_page(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        source = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Copy Source {uid}",
+            body=f"<p>Cloud copy source {uid}</p>",
+            is_markdown=False,
+            content_representation="storage",
+        )
+        resource_tracker.add_confluence_page(source.id)
+
+        copied = confluence_fetcher.copy_page(
+            source_page_id=source.id,
+            destination_space_key=cloud_instance.space_key,
+            new_title=f"Cloud E2E Copy Target {uid}",
+        )
+        resource_tracker.add_confluence_page(copied.id)
+
+        assert copied.id != source.id
+        assert copied.title == f"Cloud E2E Copy Target {uid}"
+        copied_raw = confluence_fetcher.get_page_content(
+            copied.id,
+            convert_to_markdown=False,
+        )
+        assert f"Cloud copy source {uid}" in (copied_raw.content or "")
+
+    def test_set_and_get_page_restrictions(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Restrictions Test {uid}",
+            body="<p>Restriction test.</p>",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        current_user = confluence_fetcher.confluence.get(
+            f"{confluence_fetcher._v1_rest_base_url()}/rest/api/user/current",
+            absolute=True,
+        )
+        account_id = current_user.get("accountId")
+        if not account_id:
+            pytest.skip("Current Cloud user response did not include accountId")
+
+        try:
+            result = confluence_fetcher.set_page_restrictions(
+                page.id,
+                read_users=[account_id],
+                edit_users=[account_id],
+            )
+            assert result["read"]["users"] == [account_id]
+            assert result["update"]["users"] == [account_id]
+
+            restrictions = confluence_fetcher.get_page_restrictions(page.id)
+            assert account_id in restrictions["read"]["users"]
+            assert account_id in restrictions["update"]["users"]
+        finally:
+            confluence_fetcher.set_page_restrictions(page.id)
+
+
 class TestConfluenceCloudLabels:
     """Label operations on Cloud."""
 

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -142,6 +142,100 @@ class TestConfluenceDCPageHierarchy:
         assert any(page.id == child.id for page in children)
 
 
+class TestConfluenceDCPageLayout:
+    """Page width and table layout handling."""
+
+    def test_markdown_table_layout_and_page_width(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        dc_instance: DCInstanceInfo,
+        resource_tracker: DCResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=dc_instance.space_key,
+            title=f"E2E Layout Test {uid}",
+            body="| Alpha | Beta |\n| --- | --- |\n| one | two |",
+            page_width="full-width",
+            table_layout="full-width",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        assert page.page_width == "full-width"
+
+        raw_page = confluence_fetcher.confluence.get_page_by_id(
+            page.id,
+            expand="body.storage,version",
+        )
+        storage_body = raw_page["body"]["storage"]["value"]
+        assert 'data-layout="full-width"' in storage_body
+        assert 'data-table-width="1800"' in storage_body
+
+
+class TestConfluenceDCCopyAndRestrictions:
+    """Page copy and restriction operations."""
+
+    def test_copy_page(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        dc_instance: DCInstanceInfo,
+        resource_tracker: DCResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        source = confluence_fetcher.create_page(
+            space_key=dc_instance.space_key,
+            title=f"E2E Copy Source {uid}",
+            body=f"<p>DC copy source {uid}</p>",
+            is_markdown=False,
+            content_representation="storage",
+        )
+        resource_tracker.add_confluence_page(source.id)
+
+        copied = confluence_fetcher.copy_page(
+            source_page_id=source.id,
+            destination_space_key=dc_instance.space_key,
+            new_title=f"E2E Copy Target {uid}",
+        )
+        resource_tracker.add_confluence_page(copied.id)
+
+        assert copied.id != source.id
+        assert copied.title == f"E2E Copy Target {uid}"
+        copied_raw = confluence_fetcher.get_page_content(
+            copied.id,
+            convert_to_markdown=False,
+        )
+        assert f"DC copy source {uid}" in (copied_raw.content or "")
+
+    def test_set_and_get_page_restrictions(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        dc_instance: DCInstanceInfo,
+        resource_tracker: DCResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=dc_instance.space_key,
+            title=f"E2E Restrictions Test {uid}",
+            body="<p>Restriction test.</p>",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        try:
+            result = confluence_fetcher.set_page_restrictions(
+                page.id,
+                read_users=[dc_instance.admin_username],
+                edit_users=[dc_instance.admin_username],
+            )
+            assert result["read"]["users"] == [dc_instance.admin_username]
+            assert result["update"]["users"] == [dc_instance.admin_username]
+
+            restrictions = confluence_fetcher.get_page_restrictions(page.id)
+            assert dc_instance.admin_username in restrictions["read"]["users"]
+            assert dc_instance.admin_username in restrictions["update"]["users"]
+        finally:
+            confluence_fetcher.set_page_restrictions(page.id)
+
+
 class TestConfluenceDCLabels:
     """Label operations."""
 

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -750,7 +750,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify create_page was called with the converted content
@@ -837,7 +837,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify update_page was called with the converted content

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -2857,6 +2857,117 @@ class TestPageWidth:
             assert page.page_width == "full-width"
 
 
+class TestCopyPage:
+    """Tests for copying Confluence pages."""
+
+    @pytest.fixture
+    def pages_mixin(self, confluence_client):
+        """Create a PagesMixin instance for testing."""
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceClient.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            mixin = PagesMixin()
+            mixin.confluence = confluence_client.confluence
+            mixin.config = confluence_client.config
+            mixin.preprocessor = confluence_client.preprocessor
+            return mixin
+
+    def test_copy_page_cloud_uses_native_copy_endpoint(self, pages_mixin):
+        """Cloud copies use the native v1 copy endpoint."""
+        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+        pages_mixin.config.auth_type = "basic"
+        pages_mixin.confluence.post.return_value = {"id": "copy-123"}
+
+        with patch.object(pages_mixin, "get_page_content") as mock_get_page:
+            mock_get_page.return_value = ConfluencePage(
+                id="copy-123",
+                title="Copied Page",
+            )
+
+            page = pages_mixin.copy_page(
+                source_page_id="source-123",
+                destination_space_key="DEST",
+                new_title="Copied Page",
+                destination_parent_id="parent-123",
+                copy_attachments=False,
+            )
+
+        pages_mixin.confluence.post.assert_called_once_with(
+            "https://example.atlassian.net/wiki/rest/api/content/source-123/copy",
+            data={
+                "copyAttachments": False,
+                "copyPermissions": False,
+                "copyProperties": False,
+                "copyLabels": False,
+                "pageTitle": "Copied Page",
+                "destination": {"type": "parent_page", "value": "parent-123"},
+            },
+            absolute=True,
+        )
+        mock_get_page.assert_called_once_with("copy-123")
+        assert page.id == "copy-123"
+
+    def test_copy_page_cloud_oauth_uses_gateway_wiki_path(self, pages_mixin):
+        """Cloud OAuth copy calls include /wiki on the API gateway URL."""
+        pages_mixin.config.auth_type = "oauth"
+        pages_mixin.confluence.url = "https://api.atlassian.com/ex/confluence/cloud-1"
+        pages_mixin.confluence.post.return_value = {"id": "copy-123"}
+
+        with patch.object(pages_mixin, "get_page_content") as mock_get_page:
+            mock_get_page.return_value = ConfluencePage(
+                id="copy-123",
+                title="Copied Page",
+            )
+
+            pages_mixin.copy_page(
+                source_page_id="source-123",
+                destination_space_key="DEST",
+                new_title="Copied Page",
+            )
+
+        assert (
+            pages_mixin.confluence.post.call_args.args[0]
+            == "https://api.atlassian.com/ex/confluence/cloud-1/wiki"
+            "/rest/api/content/source-123/copy"
+        )
+
+    def test_copy_page_server_dc_falls_back_to_create_page(self, pages_mixin):
+        """Server/DC copies fetch storage and create a new page manually."""
+        pages_mixin.config.url = "https://confluence.example.com"
+        pages_mixin.config.auth_type = "pat"
+        pages_mixin.confluence.get_page_by_id.return_value = {
+            "body": {"storage": {"value": "<p>Source</p>"}},
+        }
+        pages_mixin.confluence.create_page.return_value = {"id": "copy-456"}
+
+        with patch.object(pages_mixin, "get_page_content") as mock_get_page:
+            mock_get_page.return_value = ConfluencePage(
+                id="copy-456",
+                title="Copied Page",
+            )
+
+            page = pages_mixin.copy_page(
+                source_page_id="source-456",
+                destination_space_key="DEST",
+                new_title="Copied Page",
+                destination_parent_id="parent-456",
+            )
+
+        pages_mixin.confluence.get_page_by_id.assert_called_once_with(
+            "source-456", expand="body.storage,version,space"
+        )
+        pages_mixin.confluence.create_page.assert_called_once_with(
+            space="DEST",
+            title="Copied Page",
+            body="<p>Source</p>",
+            representation="storage",
+            parent_id="parent-456",
+        )
+        mock_get_page.assert_called_once_with("copy-456")
+        assert page.id == "copy-456"
+
+
 class TestPageHierarchy:
     """Tests for page hierarchy and navigation methods."""
 

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -1026,7 +1026,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify create_page was called with the converted content
@@ -1113,7 +1113,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify update_page was called with the converted content

--- a/tests/unit/confluence/test_restrictions.py
+++ b/tests/unit/confluence/test_restrictions.py
@@ -1,0 +1,165 @@
+"""Unit tests for Confluence page restriction operations."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.confluence.restrictions import RestrictionsMixin
+
+
+@pytest.fixture
+def restrictions_mixin(confluence_client):
+    """Return a RestrictionsMixin with a mocked Confluence client."""
+    with patch(
+        "mcp_atlassian.confluence.restrictions.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = RestrictionsMixin()
+        mixin.confluence = confluence_client.confluence
+        mixin.config = confluence_client.config
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+@pytest.fixture
+def restrictions_mixin_server_dc(confluence_client):
+    """Return a RestrictionsMixin configured as Server/DC."""
+    with patch(
+        "mcp_atlassian.confluence.restrictions.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = RestrictionsMixin()
+        mixin.confluence = confluence_client.confluence
+        # Use a MagicMock config so is_cloud can be set freely
+        mixin.config = MagicMock()
+        mixin.config.is_cloud = False
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+class TestGetPageRestrictions:
+    def test_get_restrictions_parses_users_and_groups(self, restrictions_mixin):
+        """get_page_restrictions extracts user account IDs and group names."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {
+            "read": {
+                "restrictions": {
+                    "user": {
+                        "results": [
+                            {"accountId": "user-111"},
+                            {"accountId": "user-222"},
+                        ]
+                    },
+                    "group": {
+                        "results": [
+                            {"name": "developers"},
+                        ]
+                    },
+                }
+            },
+            "update": {
+                "restrictions": {
+                    "user": {"results": [{"accountId": "user-111"}]},
+                    "group": {"results": []},
+                }
+            },
+        }
+
+        result = restrictions_mixin.get_page_restrictions("123")
+
+        assert result["read"]["users"] == ["user-111", "user-222"]
+        assert result["read"]["groups"] == ["developers"]
+        assert result["update"]["users"] == ["user-111"]
+        assert result["update"]["groups"] == []
+
+    def test_get_restrictions_empty_response(self, restrictions_mixin):
+        """get_page_restrictions handles an empty / unrestricted page gracefully."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {}
+
+        result = restrictions_mixin.get_page_restrictions("456")
+
+        assert result == {
+            "read": {"users": [], "groups": []},
+            "update": {"users": [], "groups": []},
+        }
+
+    def test_get_restrictions_api_error(self, restrictions_mixin):
+        """get_page_restrictions raises on API failure."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.side_effect = (
+            Exception("API error")
+        )
+
+        with pytest.raises(Exception, match="Failed to get restrictions for page 789"):
+            restrictions_mixin.get_page_restrictions("789")
+
+
+class TestSetPageRestrictions:
+    def test_set_restrictions_calls_put_with_correct_payload(self, restrictions_mixin):
+        """set_page_restrictions sends a correctly structured PUT payload."""
+        restrictions_mixin.confluence.put = MagicMock()
+
+        result = restrictions_mixin.set_page_restrictions(
+            "123",
+            read_users=["user-aaa"],
+            read_groups=["viewers"],
+            edit_users=["user-bbb"],
+            edit_groups=["editors"],
+        )
+
+        call_args = restrictions_mixin.confluence.put.call_args
+        assert call_args[0][0] == "rest/api/content/123/restriction"
+        # data is serialised as a JSON string
+        import json as _json
+
+        payload = _json.loads(call_args[1]["data"])
+
+        read_op = next(o for o in payload if o["operation"] == "read")
+        update_op = next(o for o in payload if o["operation"] == "update")
+
+        assert read_op["restrictions"]["user"][0]["accountId"] == "user-aaa"
+        assert read_op["restrictions"]["group"][0]["name"] == "viewers"
+        assert update_op["restrictions"]["user"][0]["accountId"] == "user-bbb"
+        assert update_op["restrictions"]["group"][0]["name"] == "editors"
+
+        assert result["read"]["users"] == ["user-aaa"]
+        assert result["update"]["groups"] == ["editors"]
+
+    def test_set_restrictions_empty_clears_all(self, restrictions_mixin):
+        """set_page_restrictions with no args sends empty restriction lists."""
+        import json as _json
+
+        restrictions_mixin.confluence.put = MagicMock()
+
+        result = restrictions_mixin.set_page_restrictions("123")
+
+        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        for op in payload:
+            assert op["restrictions"]["user"] == []
+            assert op["restrictions"]["group"] == []
+
+        assert result == {
+            "read": {"users": [], "groups": []},
+            "update": {"users": [], "groups": []},
+        }
+
+    def test_set_restrictions_server_dc_uses_username(self, restrictions_mixin_server_dc):
+        """set_page_restrictions uses 'username' key for Server/DC instances."""
+        import json as _json
+
+        restrictions_mixin = restrictions_mixin_server_dc
+        restrictions_mixin.confluence.put = MagicMock()
+
+        restrictions_mixin.set_page_restrictions("123", edit_users=["jdoe"])
+
+        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        update_op = next(o for o in payload if o["operation"] == "update")
+        user_entry = update_op["restrictions"]["user"][0]
+        assert "username" in user_entry
+        assert "accountId" not in user_entry
+        assert user_entry["username"] == "jdoe"
+
+    def test_set_restrictions_api_error(self, restrictions_mixin):
+        """set_page_restrictions raises on PUT failure."""
+        restrictions_mixin.confluence.put = MagicMock(side_effect=Exception("network error"))
+
+        with pytest.raises(Exception, match="Failed to set restrictions for page 999"):
+            restrictions_mixin.set_page_restrictions("999", read_users=["u1"])

--- a/tests/unit/confluence/test_restrictions.py
+++ b/tests/unit/confluence/test_restrictions.py
@@ -141,7 +141,9 @@ class TestSetPageRestrictions:
             "update": {"users": [], "groups": []},
         }
 
-    def test_set_restrictions_server_dc_uses_username(self, restrictions_mixin_server_dc):
+    def test_set_restrictions_server_dc_uses_username(
+        self, restrictions_mixin_server_dc
+    ):
         """set_page_restrictions uses 'username' key for Server/DC instances."""
         import json as _json
 
@@ -159,7 +161,9 @@ class TestSetPageRestrictions:
 
     def test_set_restrictions_api_error(self, restrictions_mixin):
         """set_page_restrictions raises on PUT failure."""
-        restrictions_mixin.confluence.put = MagicMock(side_effect=Exception("network error"))
+        restrictions_mixin.confluence.put = MagicMock(
+            side_effect=Exception("network error")
+        )
 
         with pytest.raises(Exception, match="Failed to set restrictions for page 999"):
             restrictions_mixin.set_page_restrictions("999", read_users=["u1"])

--- a/tests/unit/confluence/test_restrictions.py
+++ b/tests/unit/confluence/test_restrictions.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.confluence.restrictions import RestrictionsMixin
+from mcp_atlassian.utils.oauth import OAuthConfig
 
 
 @pytest.fixture
@@ -37,10 +39,35 @@ def restrictions_mixin_server_dc(confluence_client):
         return mixin
 
 
+@pytest.fixture
+def restrictions_mixin_cloud_oauth(confluence_client):
+    """Return a RestrictionsMixin configured for Confluence Cloud OAuth."""
+    with patch(
+        "mcp_atlassian.confluence.restrictions.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = RestrictionsMixin()
+        mixin.confluence = confluence_client.confluence
+        mixin.confluence.url = "https://api.atlassian.com/ex/confluence/cloud-123"
+        mixin.config = ConfluenceConfig(
+            url="https://example.atlassian.net/wiki",
+            auth_type="oauth",
+            oauth_config=OAuthConfig(
+                client_id="client-id",
+                client_secret="client-secret",
+                redirect_uri="http://localhost/callback",
+                scope="read:confluence-content.all write:confluence-content",
+                cloud_id="cloud-123",
+            ),
+        )
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
 class TestGetPageRestrictions:
     def test_get_restrictions_parses_users_and_groups(self, restrictions_mixin):
         """get_page_restrictions extracts user account IDs and group names."""
-        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {
+        restrictions_mixin.confluence.get.return_value = {
             "read": {
                 "restrictions": {
                     "user": {
@@ -66,6 +93,11 @@ class TestGetPageRestrictions:
 
         result = restrictions_mixin.get_page_restrictions("123")
 
+        restrictions_mixin.confluence.get.assert_called_once_with(
+            "https://example.atlassian.net/wiki/rest/api/content/"
+            "123/restriction/byOperation",
+            absolute=True,
+        )
         assert result["read"]["users"] == ["user-111", "user-222"]
         assert result["read"]["groups"] == ["developers"]
         assert result["update"]["users"] == ["user-111"]
@@ -73,7 +105,7 @@ class TestGetPageRestrictions:
 
     def test_get_restrictions_empty_response(self, restrictions_mixin):
         """get_page_restrictions handles an empty / unrestricted page gracefully."""
-        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {}
+        restrictions_mixin.confluence.get.return_value = {}
 
         result = restrictions_mixin.get_page_restrictions("456")
 
@@ -84,18 +116,31 @@ class TestGetPageRestrictions:
 
     def test_get_restrictions_api_error(self, restrictions_mixin):
         """get_page_restrictions raises on API failure."""
-        restrictions_mixin.confluence.get_all_restrictions_for_content.side_effect = (
-            Exception("API error")
-        )
+        restrictions_mixin.confluence.get.side_effect = Exception("API error")
 
         with pytest.raises(Exception, match="Failed to get restrictions for page 789"):
             restrictions_mixin.get_page_restrictions("789")
+
+    def test_get_restrictions_cloud_oauth_uses_gateway_wiki_path(
+        self, restrictions_mixin_cloud_oauth
+    ):
+        """Cloud OAuth v1 calls include the /wiki prefix on api.atlassian.com."""
+        restrictions_mixin_cloud_oauth.confluence.get.return_value = {}
+
+        restrictions_mixin_cloud_oauth.get_page_restrictions("123")
+
+        restrictions_mixin_cloud_oauth.confluence.get.assert_called_once_with(
+            "https://api.atlassian.com/ex/confluence/cloud-123/wiki"
+            "/rest/api/content/123/restriction/byOperation",
+            absolute=True,
+        )
 
 
 class TestSetPageRestrictions:
     def test_set_restrictions_calls_put_with_correct_payload(self, restrictions_mixin):
         """set_page_restrictions sends a correctly structured PUT payload."""
-        restrictions_mixin.confluence.put = MagicMock()
+        response = MagicMock()
+        restrictions_mixin.confluence._session.put.return_value = response
 
         result = restrictions_mixin.set_page_restrictions(
             "123",
@@ -105,12 +150,12 @@ class TestSetPageRestrictions:
             edit_groups=["editors"],
         )
 
-        call_args = restrictions_mixin.confluence.put.call_args
-        assert call_args[0][0] == "rest/api/content/123/restriction"
-        # data is serialised as a JSON string
-        import json as _json
-
-        payload = _json.loads(call_args[1]["data"])
+        call_args = restrictions_mixin.confluence._session.put.call_args
+        assert (
+            call_args.args[0]
+            == "https://example.atlassian.net/wiki/rest/api/content/123/restriction"
+        )
+        payload = call_args.kwargs["json"]
 
         read_op = next(o for o in payload if o["operation"] == "read")
         update_op = next(o for o in payload if o["operation"] == "update")
@@ -122,16 +167,15 @@ class TestSetPageRestrictions:
 
         assert result["read"]["users"] == ["user-aaa"]
         assert result["update"]["groups"] == ["editors"]
+        response.raise_for_status.assert_called_once_with()
 
     def test_set_restrictions_empty_clears_all(self, restrictions_mixin):
         """set_page_restrictions with no args sends empty restriction lists."""
-        import json as _json
-
-        restrictions_mixin.confluence.put = MagicMock()
+        restrictions_mixin.confluence._session.put.return_value = MagicMock()
 
         result = restrictions_mixin.set_page_restrictions("123")
 
-        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        payload = restrictions_mixin.confluence._session.put.call_args.kwargs["json"]
         for op in payload:
             assert op["restrictions"]["user"] == []
             assert op["restrictions"]["group"] == []
@@ -145,14 +189,12 @@ class TestSetPageRestrictions:
         self, restrictions_mixin_server_dc
     ):
         """set_page_restrictions uses 'username' key for Server/DC instances."""
-        import json as _json
-
         restrictions_mixin = restrictions_mixin_server_dc
-        restrictions_mixin.confluence.put = MagicMock()
+        restrictions_mixin.confluence._session.put.return_value = MagicMock()
 
         restrictions_mixin.set_page_restrictions("123", edit_users=["jdoe"])
 
-        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        payload = restrictions_mixin.confluence._session.put.call_args.kwargs["json"]
         update_op = next(o for o in payload if o["operation"] == "update")
         user_entry = update_op["restrictions"]["user"][0]
         assert "username" in user_entry
@@ -161,9 +203,25 @@ class TestSetPageRestrictions:
 
     def test_set_restrictions_api_error(self, restrictions_mixin):
         """set_page_restrictions raises on PUT failure."""
-        restrictions_mixin.confluence.put = MagicMock(
-            side_effect=Exception("network error")
+        restrictions_mixin.confluence._session.put.side_effect = Exception(
+            "network error"
         )
 
         with pytest.raises(Exception, match="Failed to set restrictions for page 999"):
             restrictions_mixin.set_page_restrictions("999", read_users=["u1"])
+
+    def test_set_restrictions_cloud_oauth_uses_gateway_wiki_path(
+        self, restrictions_mixin_cloud_oauth
+    ):
+        """Cloud OAuth restriction updates use the gateway v1 URL with /wiki."""
+        restrictions_mixin_cloud_oauth.confluence._session.put.return_value = (
+            MagicMock()
+        )
+
+        restrictions_mixin_cloud_oauth.set_page_restrictions("123")
+
+        assert (
+            restrictions_mixin_cloud_oauth.confluence._session.put.call_args.args[0]
+            == "https://api.atlassian.com/ex/confluence/cloud-123/wiki"
+            "/rest/api/content/123/restriction"
+        )

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -765,6 +765,73 @@ def function_{i}():
         assert "😀" in processed_markdown  # Emoji from numeric entity
 
 
+class TestTableLayout:
+    """Tests for table_layout post-processing in markdown_to_confluence_storage."""
+
+    MARKDOWN_WITH_TABLE = "| A | B |\n|---|---|\n| 1 | 2 |"
+
+    def test_table_layout_full_width(self, confluence_preprocessor):
+        """table_layout='full-width' sets data-table-width=1800 and data-layout=full-width."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="full-width"
+        )
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+
+    def test_table_layout_wide(self, confluence_preprocessor):
+        """table_layout='wide' sets data-table-width=960 and data-layout=wide."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="wide"
+        )
+        assert 'data-table-width="960"' in result
+        assert 'data-layout="wide"' in result
+
+    def test_table_layout_default(self, confluence_preprocessor):
+        """table_layout='default' adds 760 px width attribute."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="default"
+        )
+        assert 'data-table-width="760"' in result
+        assert 'data-layout="default"' in result
+
+    def test_table_layout_none_emits_bare_table(self, confluence_preprocessor):
+        """Omitting table_layout leaves the converter's bare <table> tag unchanged."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE
+        )
+        # md2conf produces a bare <table> with no width attributes
+        assert "data-table-width" not in result
+
+    def test_table_layout_unknown_value_is_ignored(self, confluence_preprocessor):
+        """An unrecognised table_layout value does not add width attributes."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="ultra-wide"
+        )
+        # Unrecognised value: no post-processing applied
+        assert "data-table-width" not in result
+
+    def test_apply_table_layout_injects_attrs_on_bare_tables(
+        self, confluence_preprocessor
+    ):
+        """_apply_table_layout adds attributes to bare <table> tags."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = "<table><tr><td>A</td></tr></table><table><tr><td>B</td></tr></table>"
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert result.count('data-table-width="1800"') == 2
+        assert result.count('data-layout="full-width"') == 2
+
+    def test_apply_table_layout_replaces_existing_attrs(self, confluence_preprocessor):
+        """_apply_table_layout replaces existing data-table-width/layout attrs."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = '<table data-table-width="760" data-layout="default"><tr><td>X</td></tr></table>'
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+        assert 'data-table-width="760"' not in result
+
+
 class TestContentProcessingInteroperability:
     """Test interoperability between Jira and Confluence content processing."""
 

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -817,6 +817,73 @@ def function_{i}():
         assert "😀" in processed_markdown  # Emoji from numeric entity
 
 
+class TestTableLayout:
+    """Tests for table_layout post-processing in markdown_to_confluence_storage."""
+
+    MARKDOWN_WITH_TABLE = "| A | B |\n|---|---|\n| 1 | 2 |"
+
+    def test_table_layout_full_width(self, confluence_preprocessor):
+        """table_layout='full-width' sets data-table-width=1800 and data-layout=full-width."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="full-width"
+        )
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+
+    def test_table_layout_wide(self, confluence_preprocessor):
+        """table_layout='wide' sets data-table-width=960 and data-layout=wide."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="wide"
+        )
+        assert 'data-table-width="960"' in result
+        assert 'data-layout="wide"' in result
+
+    def test_table_layout_default(self, confluence_preprocessor):
+        """table_layout='default' adds 760 px width attribute."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="default"
+        )
+        assert 'data-table-width="760"' in result
+        assert 'data-layout="default"' in result
+
+    def test_table_layout_none_emits_bare_table(self, confluence_preprocessor):
+        """Omitting table_layout leaves the converter's bare <table> tag unchanged."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE
+        )
+        # md2conf produces a bare <table> with no width attributes
+        assert "data-table-width" not in result
+
+    def test_table_layout_unknown_value_is_ignored(self, confluence_preprocessor):
+        """An unrecognised table_layout value does not add width attributes."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="ultra-wide"
+        )
+        # Unrecognised value: no post-processing applied
+        assert "data-table-width" not in result
+
+    def test_apply_table_layout_injects_attrs_on_bare_tables(
+        self, confluence_preprocessor
+    ):
+        """_apply_table_layout adds attributes to bare <table> tags."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = "<table><tr><td>A</td></tr></table><table><tr><td>B</td></tr></table>"
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert result.count('data-table-width="1800"') == 2
+        assert result.count('data-layout="full-width"') == 2
+
+    def test_apply_table_layout_replaces_existing_attrs(self, confluence_preprocessor):
+        """_apply_table_layout replaces existing data-table-width/layout attrs."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = '<table data-table-width="760" data-layout="default"><tr><td>X</td></tr></table>'
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+        assert 'data-table-width="760"' not in result
+
+
 class TestContentProcessingInteroperability:
     """Test interoperability between Jira and Confluence content processing."""
 

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -895,6 +895,8 @@ def test_page_content_file_parameters_preserve_positional_order():
         "include_content",
         "emoji",
         "content_file",
+        "page_width",
+        "table_layout",
     ]
 
     update_params = list(inspect.signature(confluence_server.update_page.fn).parameters)
@@ -911,6 +913,8 @@ def test_page_content_file_parameters_preserve_positional_order():
         "include_content",
         "emoji",
         "content_file",
+        "page_width",
+        "table_layout",
     ]
 
 

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 24, (
-            f"Expected 24 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 27, (
+            f"Expected 27 Confluence tools, got {len(confluence_tools)}"
         )

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 27, (
-            f"Expected 27 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 30, (
+            f"Expected 30 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
## Description

Fixes #1177.

Addresses four gaps in the markdown-to-Confluence pipeline and page-management toolset, originally found while using Confluence Cloud:

### Gap 1 - Expose `page_width` in create/update server tools

`PagesMixin.create_page` and `update_page` already accepted `page_width`, but the MCP tools did not expose it. Callers can now set full-width layout directly from `confluence_create_page` and `confluence_update_page`.

### Gap 3 - Preserve table layout on markdown writes

The md2conf converter emits bare `<table>` tags, which Confluence renders at the fixed-width default. `table_layout` is now available on create/update page calls and applies Confluence storage attributes for `full-width`, `wide`, or `default` markdown tables.

### Gap 4 - Page restriction tools

New tools:
- `confluence_get_page_restrictions`
- `confluence_set_page_restrictions`

The setter replaces read/update restrictions atomically. It uses account IDs on Cloud and usernames on Server/Data Center.

### Gap 5 - Page copy tool

New tool:
- `confluence_copy_page`

Cloud uses Confluence's native copy endpoint. Server/Data Center falls back to fetching the source storage body and creating a new page.

## Maintainer follow-up

- Rebased the PR onto current `main` and resolved conflicts with `content_file` support.
- Added direct v1 REST URL handling for Cloud OAuth gateway calls that require `/wiki` before `/rest/api`.
- Updated docs and tool counts for the three new Confluence page tools.
- Added Cloud and Server/Data Center e2e coverage for table layout/page width, page copy, and restrictions.

## Testing

- [x] `uv run pytest tests/unit/confluence/test_restrictions.py tests/unit/confluence/test_pages.py::TestCopyPage tests/unit/preprocessing/test_content_processing.py::TestTableLayout tests/unit/servers/test_confluence_server.py tests/unit/utils/test_toolsets.py -q`
- [x] `uv run pytest tests/unit/ -q` (2915 passed, 5 skipped)
- [x] `CONFLUENCE_URL="$CLOUD_E2E_CONFLUENCE_URL" CONFLUENCE_USERNAME="$CLOUD_E2E_USERNAME" CONFLUENCE_API_TOKEN="$CLOUD_E2E_API_TOKEN" CONFLUENCE_TEST_SPACE_KEY="$CLOUD_E2E_SPACE_KEY" uv run pytest tests/integration/test_real_api.py::TestRealConfluenceAPI -q --integration --use-real-data`
- [x] `uv run pytest tests/e2e/cloud/test_confluence_cloud_operations.py -q --cloud-e2e`
- [x] `uv run pytest tests/e2e/test_confluence_dc_operations.py -q --dc-e2e`
- [x] `uv run pre-commit run --all-files`
