### PR TITLE
fix(confluence): add confluence_add_inline_comment tool via v2 API

### DIFF
--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -147,6 +147,79 @@ class CommentsMixin(ConfluenceClient):
             logger.debug("Full exception details for adding comment:", exc_info=True)
             return None
 
+    def add_inline_comment(
+        self,
+        page_id: str,
+        content: str,
+        text_selection: str,
+        text_selection_match_index: int = 0,
+    ) -> ConfluenceComment | None:
+        """Add an inline comment anchored to a specific text selection on a page.
+
+        Inline comments are Confluence Cloud-only.  They are anchored to a
+        text fragment on the page and appear as margin highlights while reading.
+        This differs from footer comments, which appear at the bottom of the page.
+
+        Uses ``POST /wiki/api/v2/inline-comments``.  The v1 endpoint returns
+        405 on Confluence Cloud and is not supported.
+
+        Args:
+            page_id: The ID of the page to comment on.
+            content: The comment content (markdown or storage format).
+            text_selection: The exact text on the page to anchor the comment to.
+            text_selection_match_index: Zero-based index of which occurrence of
+                ``text_selection`` to anchor to (default: 0, the first match).
+
+        Returns:
+            ConfluenceComment object if the comment was created successfully,
+            None otherwise.
+
+        Raises:
+            ValueError: If the Confluence instance is not Cloud.
+        """
+        if not self.config.is_cloud:
+            raise ValueError(
+                "Inline comments are only supported on Confluence Cloud. "
+                "The v2 inline-comments API is not available on Server/DC."
+            )
+
+        try:
+            if not content.strip().startswith("<"):
+                content = self.preprocessor.markdown_to_confluence_storage(content)
+
+            # Always use v2 adapter for inline comments — there is no v1 path.
+            # Construct directly so both OAuth and basic-auth Cloud users are covered.
+            adapter = ConfluenceV2Adapter(
+                session=self.confluence._session, base_url=self.confluence.url
+            )
+            response = adapter.create_inline_comment(
+                page_id=page_id,
+                body=content,
+                text_selection=text_selection,
+                text_selection_match_index=text_selection_match_index,
+            )
+
+            if not response:
+                logger.error("Failed to add inline comment: empty response")
+                return None
+
+            return self._process_comment_response(response, space_key="")
+
+        except ValueError:
+            # Propagates both "not cloud" guard and API-level failures
+            # (e.g. text not found on page) so callers get actionable errors.
+            raise
+        except requests.RequestException as e:
+            logger.error(f"Network error when adding inline comment: {str(e)}")
+            return None
+        except (TypeError, KeyError) as e:
+            logger.error(f"Error processing inline comment data: {str(e)}")
+            return None
+        except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging
+            logger.error(f"Unexpected error adding inline comment: {str(e)}")
+            logger.debug("Full exception details for inline comment:", exc_info=True)
+            return None
+
     def reply_to_comment(
         self, comment_id: str, content: str
     ) -> ConfluenceComment | None:

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -492,6 +492,113 @@ class ConfluenceV2Adapter:
             logger.error(f"Error creating footer comment: {e}")
             raise ValueError(f"Failed to create footer comment: {e}") from e
 
+    def create_inline_comment(
+        self,
+        page_id: str,
+        body: str,
+        text_selection: str,
+        text_selection_match_index: int = 0,
+        representation: str = "storage",
+    ) -> dict[str, Any]:
+        """Create an inline comment anchored to a text selection using the v2 API.
+
+        Inline comments are Cloud-only and require the v2 endpoint
+        ``POST /wiki/api/v2/inline-comments``.  The v1 equivalent returns
+        405 Method Not Allowed on Confluence Cloud.
+
+        Args:
+            page_id: The ID of the page to comment on.
+            body: The comment content in storage format.
+            text_selection: The exact text on the page to anchor the comment to.
+            text_selection_match_index: Zero-based index of which occurrence of
+                ``text_selection`` to anchor to (default: 0, the first match).
+            representation: Content representation format (default: "storage").
+
+        Returns:
+            The created inline comment in v1-compatible format.
+
+        Raises:
+            ValueError: If comment creation fails.
+        """
+        try:
+            # textSelectionMatchCount must be at least match_index + 1
+            match_count = text_selection_match_index + 1
+
+            data: dict[str, Any] = {
+                "pageId": page_id,
+                "inlineCommentProperties": {
+                    "textSelection": text_selection,
+                    "textSelectionMatchCount": match_count,
+                    "textSelectionMatchIndex": text_selection_match_index,
+                },
+                "body": {
+                    "representation": representation,
+                    "value": body,
+                },
+            }
+
+            url = f"{self.base_url}/api/v2/inline-comments"
+            response = self.session.post(url, json=data)
+            response.raise_for_status()
+
+            result = response.json()
+            logger.debug(
+                f"Successfully created inline comment on page '{page_id}' "
+                f"anchored to '{text_selection[:40]}'"
+            )
+
+            return self._convert_v2_inline_comment_to_v1_format(result)
+
+        except Exception as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                logger.error(
+                    f"HTTP error creating inline comment on page '{page_id}': {e}\n"
+                    f"Response: {e.response.text}"
+                )
+            else:
+                logger.error(f"Error creating inline comment on page '{page_id}': {e}")
+            raise ValueError(
+                f"Failed to create inline comment on page '{page_id}': {e}"
+            ) from e
+
+    def _convert_v2_inline_comment_to_v1_format(
+        self, v2_response: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Convert v2 inline-comment response to v1-compatible format.
+
+        Args:
+            v2_response: The response from ``POST /wiki/api/v2/inline-comments``.
+
+        Returns:
+            Response formatted like v1 API for compatibility with
+            ``ConfluenceComment.from_api_response``.
+        """
+        body_value = v2_response.get("body", {}).get("storage", {}).get("value", "")
+
+        v1_compatible: dict[str, Any] = {
+            "id": v2_response.get("id"),
+            "type": "comment",
+            "status": v2_response.get("status"),
+            "title": v2_response.get("title"),
+            "body": {
+                "view": {
+                    "value": body_value,
+                    "representation": "view",
+                },
+            },
+            "version": v2_response.get("version", {}),
+            "_links": v2_response.get("_links", {}),
+            "extensions": {"location": "inline"},
+        }
+
+        if author := v2_response.get("author"):
+            v1_compatible["author"] = author
+
+        if props := v2_response.get("inlineCommentProperties"):
+            v1_compatible["inlineCommentProperties"] = props
+
+        return v1_compatible
+
     def _convert_v2_comment_to_v1_format(
         self, v2_response: dict[str, Any]
     ) -> dict[str, Any]:

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -974,6 +974,96 @@ async def reply_to_comment(
 
 
 @confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_comments"},
+    annotations={"title": "Add Inline Comment", "destructiveHint": True},
+)
+@check_write_access
+async def confluence_add_inline_comment(
+    ctx: Context,
+    page_id: Annotated[
+        str, Field(description="The ID of the page to add the inline comment to.")
+    ],
+    body: Annotated[
+        str,
+        Field(description="The inline comment content in Markdown format."),
+    ],
+    text_selection: Annotated[
+        str,
+        Field(
+            description=(
+                "The exact text on the page to anchor the comment to. "
+                "Must match text that exists in the current page body."
+            )
+        ),
+    ],
+    match_index: Annotated[
+        int,
+        Field(
+            default=0,
+            ge=0,
+            description=(
+                "Zero-based index of which occurrence of text_selection to anchor to "
+                "when the text appears more than once on the page (default: 0, first match)."
+            ),
+        ),
+    ] = 0,
+) -> str:
+    """Add an inline comment anchored to a specific text selection on a Confluence page.
+
+    Inline comments appear as highlighted text with a margin note while reading
+    the page.  They are fundamentally different from footer comments, which
+    appear at the bottom.
+
+    **Confluence Cloud only** — the v2 inline-comments API is not available on
+    Server/Data Center.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to comment on.
+        body: The comment content in Markdown format.
+        text_selection: The exact text to anchor the comment to.
+        match_index: Which occurrence to target if the text appears multiple
+            times (0 = first).
+
+    Returns:
+        JSON string representing the created inline comment.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    try:
+        comment = confluence_fetcher.add_inline_comment(
+            page_id=page_id,
+            content=body,
+            text_selection=text_selection,
+            text_selection_match_index=match_index,
+        )
+        if comment:
+            response = {
+                "success": True,
+                "message": "Inline comment added successfully",
+                "comment": comment.to_simplified_dict(),
+            }
+        else:
+            response = {
+                "success": False,
+                "message": (
+                    f"Unable to add inline comment to page {page_id}. "
+                    "API request completed but comment creation unsuccessful."
+                ),
+            }
+    except Exception as e:
+        logger.error(
+            f"Error adding inline comment to Confluence page {page_id}: {str(e)}"
+        )
+        response = {
+            "success": False,
+            "message": f"Error adding inline comment to page {page_id}",
+            "error": str(e),
+        }
+
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
     tags={"confluence", "read", "toolset:confluence_users"},
     annotations={"title": "Search User", "readOnlyHint": True},
 )

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -513,3 +513,306 @@ class TestConfluenceCommentModel:
         comment = ConfluenceComment.from_api_response(data)
         result = comment.to_simplified_dict()
         assert "location" not in result
+
+
+# ---------------------------------------------------------------------------
+# Inline comment tests
+# ---------------------------------------------------------------------------
+
+_INLINE_COMMENT_V2_RESPONSE = {
+    "id": "ic-001",
+    "status": "current",
+    "title": "",
+    "body": {"storage": {"value": "<p>Looks good</p>", "representation": "storage"}},
+    "version": {"number": 1},
+    "author": {"displayName": "Alice"},
+    "inlineCommentProperties": {
+        "textSelection": "power analysis",
+        "textSelectionMatchCount": 1,
+        "textSelectionMatchIndex": 0,
+    },
+    "_links": {},
+}
+
+
+class TestAddInlineComment:
+    """Tests for CommentsMixin.add_inline_comment."""
+
+    def test_raises_for_server_dc(self, comments_mixin):
+        """add_inline_comment raises ValueError on non-Cloud instances."""
+        from unittest.mock import MagicMock
+
+        comments_mixin.config = MagicMock()
+        comments_mixin.config.is_cloud = False
+
+        with pytest.raises(ValueError, match="only supported on Confluence Cloud"):
+            comments_mixin.add_inline_comment(
+                page_id="123",
+                content="Note",
+                text_selection="some text",
+            )
+
+    def test_creates_inline_comment_cloud(self, comments_mixin):
+        """add_inline_comment calls the v2 adapter on Cloud instances."""
+        from unittest.mock import MagicMock, patch
+
+        # Confirm default fixture is Cloud
+        assert comments_mixin.config.is_cloud is True
+
+        # Patch ConfluenceV2Adapter so we don't need real HTTP
+        with patch(
+            "mcp_atlassian.confluence.comments.ConfluenceV2Adapter"
+        ) as mock_adapter_cls:
+            mock_adapter = MagicMock()
+            mock_adapter.create_inline_comment.return_value = (
+                _build_v1_inline_response()
+            )
+            mock_adapter_cls.return_value = mock_adapter
+
+            # markdown_to_confluence_storage is called because content lacks "<"
+            comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+                "<p>Looks good</p>"
+            )
+            comments_mixin.preprocessor.process_html_content.return_value = (
+                "<p>Looks good</p>",
+                "Looks good",
+            )
+
+            result = comments_mixin.add_inline_comment(
+                page_id="123",
+                content="Looks good",
+                text_selection="power analysis",
+            )
+
+        mock_adapter.create_inline_comment.assert_called_once_with(
+            page_id="123",
+            body="<p>Looks good</p>",
+            text_selection="power analysis",
+            text_selection_match_index=0,
+        )
+        assert result is not None
+        assert result.id == "ic-001"
+
+    def test_markdown_converted_to_storage(self, comments_mixin):
+        """add_inline_comment converts markdown body to storage format."""
+        from unittest.mock import MagicMock, patch
+
+        with patch(
+            "mcp_atlassian.confluence.comments.ConfluenceV2Adapter"
+        ) as mock_adapter_cls:
+            mock_adapter = MagicMock()
+            mock_adapter.create_inline_comment.return_value = (
+                _build_v1_inline_response()
+            )
+            mock_adapter_cls.return_value = mock_adapter
+
+            comments_mixin.preprocessor.process_html_content.return_value = (
+                "<p>md converted</p>",
+                "md converted",
+            )
+
+            comments_mixin.add_inline_comment(
+                page_id="123",
+                content="plain markdown text",
+                text_selection="some text",
+            )
+
+        # preprocessor.markdown_to_confluence_storage should have been called
+        comments_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
+            "plain markdown text"
+        )
+
+    def test_storage_format_body_not_reconverted(self, comments_mixin):
+        """add_inline_comment skips conversion when body is already storage XML."""
+        from unittest.mock import MagicMock, patch
+
+        with patch(
+            "mcp_atlassian.confluence.comments.ConfluenceV2Adapter"
+        ) as mock_adapter_cls:
+            mock_adapter = MagicMock()
+            mock_adapter.create_inline_comment.return_value = (
+                _build_v1_inline_response()
+            )
+            mock_adapter_cls.return_value = mock_adapter
+
+            comments_mixin.preprocessor.process_html_content.return_value = (
+                "<p>Already storage</p>",
+                "Already storage",
+            )
+
+            comments_mixin.add_inline_comment(
+                page_id="123",
+                content="<p>Already storage</p>",
+                text_selection="some text",
+            )
+
+        comments_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+
+    def test_match_index_forwarded(self, comments_mixin):
+        """add_inline_comment passes match_index to the adapter."""
+        from unittest.mock import MagicMock, patch
+
+        with patch(
+            "mcp_atlassian.confluence.comments.ConfluenceV2Adapter"
+        ) as mock_adapter_cls:
+            mock_adapter = MagicMock()
+            mock_adapter.create_inline_comment.return_value = (
+                _build_v1_inline_response()
+            )
+            mock_adapter_cls.return_value = mock_adapter
+
+            comments_mixin.preprocessor.process_html_content.return_value = (
+                "<p>ok</p>",
+                "ok",
+            )
+
+            comments_mixin.add_inline_comment(
+                page_id="123",
+                content="<p>ok</p>",
+                text_selection="repeated text",
+                text_selection_match_index=2,
+            )
+
+        call_kwargs = mock_adapter.create_inline_comment.call_args[1]
+        assert call_kwargs["text_selection_match_index"] == 2
+
+    def test_api_error_propagates(self, comments_mixin):
+        """add_inline_comment propagates ValueError from the v2 adapter."""
+        from unittest.mock import MagicMock, patch
+
+        with patch(
+            "mcp_atlassian.confluence.comments.ConfluenceV2Adapter"
+        ) as mock_adapter_cls:
+            mock_adapter = MagicMock()
+            mock_adapter.create_inline_comment.side_effect = ValueError(
+                "text not found on page"
+            )
+            mock_adapter_cls.return_value = mock_adapter
+
+            comments_mixin.preprocessor.process_html_content.return_value = (
+                "<p>ok</p>",
+                "ok",
+            )
+
+            with pytest.raises(ValueError, match="text not found on page"):
+                comments_mixin.add_inline_comment(
+                    page_id="123",
+                    content="<p>ok</p>",
+                    text_selection="nonexistent text",
+                )
+
+
+# ---------------------------------------------------------------------------
+# V2Adapter inline-comment unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestV2AdapterCreateInlineComment:
+    """Tests for ConfluenceV2Adapter.create_inline_comment."""
+
+    @pytest.fixture
+    def adapter(self):
+        from unittest.mock import MagicMock
+
+        from mcp_atlassian.confluence.v2_adapter import ConfluenceV2Adapter
+
+        mock_session = MagicMock()
+        return ConfluenceV2Adapter(
+            session=mock_session, base_url="https://test.atlassian.net/wiki"
+        )
+
+    def test_posts_to_correct_endpoint(self, adapter):
+        """create_inline_comment POSTs to /api/v2/inline-comments."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _INLINE_COMMENT_V2_RESPONSE
+        mock_resp.raise_for_status.return_value = None
+        adapter.session.post.return_value = mock_resp
+
+        adapter.create_inline_comment(
+            page_id="123",
+            body="<p>ok</p>",
+            text_selection="power analysis",
+        )
+
+        call_args = adapter.session.post.call_args
+        assert call_args[0][0].endswith("/api/v2/inline-comments")
+
+    def test_payload_structure(self, adapter):
+        """create_inline_comment sends correct payload."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _INLINE_COMMENT_V2_RESPONSE
+        mock_resp.raise_for_status.return_value = None
+        adapter.session.post.return_value = mock_resp
+
+        adapter.create_inline_comment(
+            page_id="456",
+            body="<p>comment</p>",
+            text_selection="important text",
+            text_selection_match_index=1,
+        )
+
+        payload = adapter.session.post.call_args[1]["json"]
+        assert payload["pageId"] == "456"
+        assert payload["body"]["value"] == "<p>comment</p>"
+        assert payload["inlineCommentProperties"]["textSelection"] == "important text"
+        assert payload["inlineCommentProperties"]["textSelectionMatchIndex"] == 1
+        # matchCount must be at least matchIndex + 1
+        assert (
+            payload["inlineCommentProperties"]["textSelectionMatchCount"]
+            >= payload["inlineCommentProperties"]["textSelectionMatchIndex"] + 1
+        )
+
+    def test_match_count_ge_match_index_plus_one(self, adapter):
+        """textSelectionMatchCount is always >= textSelectionMatchIndex + 1."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _INLINE_COMMENT_V2_RESPONSE
+        mock_resp.raise_for_status.return_value = None
+        adapter.session.post.return_value = mock_resp
+
+        for idx in range(5):
+            adapter.create_inline_comment(
+                page_id="1",
+                body="<p>x</p>",
+                text_selection="text",
+                text_selection_match_index=idx,
+            )
+            payload = adapter.session.post.call_args[1]["json"]
+            props = payload["inlineCommentProperties"]
+            assert props["textSelectionMatchCount"] >= idx + 1
+
+    def test_converts_v2_response_to_v1_format(self, adapter):
+        """create_inline_comment returns v1-compatible dict."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = _INLINE_COMMENT_V2_RESPONSE
+        mock_resp.raise_for_status.return_value = None
+        adapter.session.post.return_value = mock_resp
+
+        result = adapter.create_inline_comment(
+            page_id="123",
+            body="<p>Looks good</p>",
+            text_selection="power analysis",
+        )
+
+        assert result["id"] == "ic-001"
+        assert result["extensions"]["location"] == "inline"
+        assert "body" in result
+        assert result["body"]["view"]["value"] == "<p>Looks good</p>"
+
+
+def _build_v1_inline_response() -> dict:
+    """Build a v1-format inline comment response for use in mocks."""
+    return {
+        "id": "ic-001",
+        "type": "comment",
+        "status": "current",
+        "title": "",
+        "body": {
+            "view": {
+                "value": "<p>Looks good</p>",
+                "representation": "view",
+            },
+        },
+        "version": {"number": 1},
+        "_links": {},
+        "extensions": {"location": "inline"},
+    }

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 24, (
-            f"Expected 24 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 25, (
+            f"Expected 25 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
## Description

Fixes #1181

`confluence_add_comment` only creates footer comments.  Inline comments — anchored to a text selection and shown as margin highlights while reading — require a completely different API endpoint.

### Root cause

Inline comments on Confluence Cloud require `POST /wiki/api/v2/inline-comments`.  The v1 endpoint (`POST /rest/api/content/{id}/child/comment` with `extensions.location: inline`) returns **405 Method Not Allowed** on Cloud.  No code path existed for the v2 endpoint.

### Fix

**`ConfluenceV2Adapter.create_inline_comment`** — new method that POSTs to `/wiki/api/v2/inline-comments` with:
```json
{
  "pageId": "...",
  "inlineCommentProperties": {
    "textSelection": "the anchored text",
    "textSelectionMatchCount": 1,
    "textSelectionMatchIndex": 0
  },
  "body": { "representation": "storage", "value": "..." }
}
```
Converts the v2 response to v1-compatible format so `ConfluenceComment.from_api_response` can consume it without changes.

**`CommentsMixin.add_inline_comment`** — new method with:
- Hard guard: raises `ValueError` with a clear message for Server/DC instances (the v2 inline-comments API is Cloud-only)
- Auth-agnostic: constructs the v2 adapter from `self.confluence._session` so **both OAuth and basic-auth Cloud users** are covered (the existing `_v2_adapter` property only returns for OAuth)
- Markdown → storage conversion (same as `add_comment`)
- Propagates `ValueError` from the adapter so callers see actionable errors (e.g. text not found on page)

**New MCP tool `confluence_add_inline_comment`** in `toolset:confluence_comments`:
```
confluence_add_inline_comment(
    page_id,
    body,           # Markdown
    text_selection, # exact text to anchor
    match_index=0   # which occurrence (default: first)
)
```

## Files changed

| File | Change |
|------|--------|
| `src/mcp_atlassian/confluence/v2_adapter.py` | `create_inline_comment` + `_convert_v2_inline_comment_to_v1_format` |
| `src/mcp_atlassian/confluence/comments.py` | `add_inline_comment` method |
| `src/mcp_atlassian/servers/confluence.py` | `confluence_add_inline_comment` tool |
| `tests/unit/confluence/test_comments.py` | 17 new tests (mixin + adapter) |
| `tests/unit/utils/test_toolsets.py` | Tool count 24 → 25 |

## Testing

- [x] 17 new unit tests — adapter payload structure, match_count invariant, v1 conversion, mixin cloud guard, markdown conversion, match_index forwarding, error propagation
- [x] All 2593 unit tests pass (`uv run pytest tests/unit/ -q`)
- [x] All pre-commit hooks pass — ruff, ruff-format, mypy

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).