### PR TITLE
fix(jira): get field options for cascading select fields

### DIFF
--- a/src/mcp_atlassian/jira/field_options.py
+++ b/src/mcp_atlassian/jira/field_options.py
@@ -109,8 +109,8 @@ class FieldOptionsMixin(JiraClient):
             global_ctx = next((c for c in contexts if c.is_global_context), None)
             context_id = global_ctx.id if global_ctx else contexts[0].id
 
-        # Paginate through all options
-        all_options: list[FieldOption] = []
+        # Paginate through all option entries (Cloud returns a flat list).
+        raw_items: list[dict] = []
         start_at = 0
         max_results = 100
 
@@ -127,7 +127,7 @@ class FieldOptionsMixin(JiraClient):
                 values = response.get("values", [])
                 for item in values:
                     if isinstance(item, dict):
-                        all_options.append(FieldOption.from_api_response(item))
+                        raw_items.append(item)
 
                 total = response.get("total", len(values))
                 start_at += len(values)
@@ -141,7 +141,52 @@ class FieldOptionsMixin(JiraClient):
                 )
                 break
 
-        return all_options
+        # Build parent -> children mapping. Cloud main endpoint returns a
+        # flat list where child items include an "optionId" referencing
+        # their parent's id. Prefer calling the cascade-specific endpoint
+        # per parent to get authoritative child objects; fall back to
+        # grouping by optionId when cascade endpoint is unavailable.
+        items_by_id = {str(item.get("id", "")): item for item in raw_items}
+        parent_ids = [iid for iid, it in items_by_id.items() if not it.get("optionId")]
+
+        result: list[FieldOption] = []
+
+        for pid in parent_ids:
+            parent_item = items_by_id.get(pid, {})
+            # Attempt cascade-specific endpoint for this parent
+            child_items: list[dict] = []
+            try:
+                cascade_resp = self.jira.get(
+                    f"rest/api/3/field/{field_id}/context/{context_id}/option/{pid}/cascadingOption"
+                )
+                if isinstance(cascade_resp, dict):
+                    # endpoint may return values list or a single dict
+                    child_items = (
+                        cascade_resp.get("values")
+                        or cascade_resp.get("cascadingOptions")
+                        or []
+                    )
+                elif isinstance(cascade_resp, list):
+                    child_items = cascade_resp
+            except Exception:
+                # Ignore cascade endpoint failures and fall back below
+                child_items = []
+
+            # Fallback: group by flat-list "optionId"
+            if not child_items:
+                child_items = [it for it in raw_items if it.get("optionId") == pid]
+
+            # Build FieldOption objects
+            children = [
+                FieldOption.from_api_response(c)
+                for c in child_items
+                if isinstance(c, dict)
+            ]
+            parent_opt = FieldOption.from_api_response(parent_item)
+            parent_opt.child_options = children
+            result.append(parent_opt)
+
+        return result
 
     def _get_field_options_server(
         self,

--- a/src/mcp_atlassian/jira/field_options.py
+++ b/src/mcp_atlassian/jira/field_options.py
@@ -144,8 +144,10 @@ class FieldOptionsMixin(JiraClient):
         # Build parent -> children mapping. Cloud main endpoint returns a
         # flat list where child items include an "optionId" referencing
         # their parent's id. Prefer calling the cascade-specific endpoint
-        # per parent to get authoritative child objects; fall back to
-        # grouping by optionId when cascade endpoint is unavailable.
+        # per parent (with pagination) to get authoritative child objects;
+        # fall back to grouping by optionId only when that endpoint is
+        # unreachable (exception), so an explicitly empty cascade response
+        # is trusted and does not trigger the fallback.
         items_by_id = {str(item.get("id", "")): item for item in raw_items}
         parent_ids = [iid for iid, it in items_by_id.items() if not it.get("optionId")]
 
@@ -153,37 +155,53 @@ class FieldOptionsMixin(JiraClient):
 
         for pid in parent_ids:
             parent_item = items_by_id.get(pid, {})
-            # Attempt cascade-specific endpoint for this parent
             child_items: list[dict] = []
-            try:
-                cascade_resp = self.jira.get(
-                    f"rest/api/3/field/{field_id}/context/{context_id}/option/{pid}/cascadingOption"
-                )
-                if isinstance(cascade_resp, dict):
-                    # endpoint may return values list or a single dict
-                    child_items = (
-                        cascade_resp.get("values")
-                        or cascade_resp.get("cascadingOptions")
-                        or []
-                    )
-                elif isinstance(cascade_resp, list):
-                    child_items = cascade_resp
-            except Exception:
-                # Ignore cascade endpoint failures and fall back below
-                child_items = []
+            # True once the cascade endpoint responds (even with empty results),
+            # so an empty authoritative response is not confused with a failure.
+            cascade_fetched = False
+            cascade_start = 0
+            cascade_max = 100
 
-            # Fallback: group by flat-list "optionId"
-            if not child_items:
+            while True:
+                try:
+                    cascade_resp = self.jira.get(
+                        f"rest/api/3/field/{field_id}/context/{context_id}"
+                        f"/option/{pid}/cascadingOption",
+                        params={"startAt": cascade_start, "maxResults": cascade_max},
+                    )
+                    cascade_fetched = True
+
+                    if isinstance(cascade_resp, dict):
+                        page = cascade_resp.get("values")
+                        page_items: list[dict] = (
+                            [c for c in page if isinstance(c, dict)]
+                            if page is not None
+                            else []
+                        )
+                        child_items.extend(page_items)
+                        total = cascade_resp.get("total", len(page_items))
+                        cascade_start += len(page_items)
+                        if cascade_start >= total or not page_items:
+                            break
+                    else:
+                        break
+
+                except Exception as e:
+                    logger.debug(
+                        f"Cascade endpoint unavailable for field {field_id} "
+                        f"option {pid}: {e}. Falling back to flat-list grouping."
+                    )
+                    break
+
+            # Fallback: reconstruct hierarchy from flat-list "optionId" references,
+            # but only when the cascade endpoint was not reachable.
+            if not cascade_fetched:
                 child_items = [it for it in raw_items if it.get("optionId") == pid]
 
-            # Build FieldOption objects
-            children = [
-                FieldOption.from_api_response(c)
-                for c in child_items
-                if isinstance(c, dict)
-            ]
-            parent_opt = FieldOption.from_api_response(parent_item)
-            parent_opt.child_options = children
+            children = [FieldOption.from_api_response(c) for c in child_items]
+            parent_opt = FieldOption.from_api_response(parent_item).model_copy(
+                update={"child_options": children}
+            )
             result.append(parent_opt)
 
         return result

--- a/src/mcp_atlassian/jira/field_options.py
+++ b/src/mcp_atlassian/jira/field_options.py
@@ -278,10 +278,12 @@ class FieldOptionsMixin(JiraClient):
                 for entry in field_entries:
                     if isinstance(entry, dict) and entry.get("fieldId") == field_id:
                         allowed_values = entry.get("allowedValues", [])
+                        if not isinstance(allowed_values, list):
+                            return []
                         return [
                             FieldOption.from_api_response(item)
                             for item in allowed_values
-                            if isinstance(item, dict)
+                            if isinstance(item, dict | str)
                         ]
 
                 total = meta.get("total", len(field_entries))

--- a/src/mcp_atlassian/models/jira/field_option.py
+++ b/src/mcp_atlassian/models/jira/field_option.py
@@ -23,7 +23,9 @@ class FieldContext(ApiModel):
     is_any_issue_type: bool = False
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldContext":
+    def from_api_response(
+        cls, data: dict[str, Any] | str | None, **kwargs: Any
+    ) -> "FieldContext":
         """Create a FieldContext from a Jira API response.
 
         Args:
@@ -65,7 +67,9 @@ class FieldOption(ApiModel):
     child_options: list["FieldOption"] = Field(default_factory=list)
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldOption":
+    def from_api_response(
+        cls, data: dict[str, Any] | str | None, **kwargs: Any
+    ) -> "FieldOption":
         """Create a FieldOption from a Jira API response.
 
         Args:
@@ -74,14 +78,26 @@ class FieldOption(ApiModel):
         Returns:
             A FieldOption instance
         """
+        # Handle simple string values (some API shapes use strings for
+        # allowedValues/children). If `data` is a bare string, treat it
+        # as a value-only FieldOption.
+        if isinstance(data, str):
+            return cls(id="", value=data)
+
         if not data or not isinstance(data, dict):
             return cls(id="", value="")
 
-        children = [
-            cls.from_api_response(c)
-            for c in data.get("cascadingOptions", [])
-            if isinstance(c, dict)
-        ]
+        # Some APIs (Server/DC createmeta) return nested children under
+        # the key "children" while other shapes (legacy in-tests or
+        # cascade-specific endpoints) may use "cascadingOptions".
+        raw_children = data.get("cascadingOptions") or data.get("children") or []
+
+        children: list[FieldOption] = []
+        for c in raw_children:
+            if isinstance(c, dict):
+                children.append(cls.from_api_response(c))
+            elif isinstance(c, str):
+                children.append(cls(id="", value=c))
 
         return cls(
             id=str(data.get("id", data.get("optionId", ""))),

--- a/src/mcp_atlassian/models/jira/field_option.py
+++ b/src/mcp_atlassian/models/jira/field_option.py
@@ -87,17 +87,20 @@ class FieldOption(ApiModel):
         if not data or not isinstance(data, dict):
             return cls(id="", value="")
 
-        # Some APIs (Server/DC createmeta) return nested children under
-        # the key "children" while other shapes (legacy in-tests or
-        # cascade-specific endpoints) may use "cascadingOptions".
-        raw_children = data.get("cascadingOptions") or data.get("children") or []
+        # Server/DC createmeta uses "children"; Cloud/legacy uses
+        # "cascadingOptions". Use key presence so an explicit empty list
+        # is never mistaken for a missing key.
+        if "cascadingOptions" in data:
+            raw_children: list[Any] = data["cascadingOptions"]
+        elif "children" in data:
+            raw_children = data["children"]
+        else:
+            raw_children = []
 
         children: list[FieldOption] = []
         for c in raw_children:
             if isinstance(c, dict):
                 children.append(cls.from_api_response(c))
-            elif isinstance(c, str):
-                children.append(cls(id="", value=c))
 
         return cls(
             id=str(data.get("id", data.get("optionId", ""))),

--- a/src/mcp_atlassian/models/jira/field_option.py
+++ b/src/mcp_atlassian/models/jira/field_option.py
@@ -91,15 +91,16 @@ class FieldOption(ApiModel):
         # "cascadingOptions". Use key presence so an explicit empty list
         # is never mistaken for a missing key.
         if "cascadingOptions" in data:
-            raw_children: list[Any] = data["cascadingOptions"]
+            raw_children_data = data["cascadingOptions"]
         elif "children" in data:
-            raw_children = data["children"]
+            raw_children_data = data["children"]
         else:
-            raw_children = []
+            raw_children_data = []
 
+        raw_children = raw_children_data if isinstance(raw_children_data, list) else []
         children: list[FieldOption] = []
         for c in raw_children:
-            if isinstance(c, dict):
+            if isinstance(c, dict | str):
                 children.append(cls.from_api_response(c))
 
         return cls(

--- a/tests/unit/jira/test_field_options.py
+++ b/tests/unit/jira/test_field_options.py
@@ -339,22 +339,29 @@ class TestFieldOptionsMixin:
 
     def test_options_cloud_cascading(self, mixin):
         mixin.config.is_cloud = True
+        # Cloud main endpoint returns a flat list; children reference
+        # their parent via "optionId" or are available via the
+        # cascade-specific endpoint. Mock the main list followed by
+        # the cascade endpoint response for the parent.
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [
-                    {
-                        "id": "10200",
-                        "value": "Americas",
-                        "cascadingOptions": [
-                            {"id": "10201", "value": "US"},
-                            {"id": "10202", "value": "Canada"},
-                        ],
-                    }
-                ],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 1,
-            }
+            side_effect=[
+                # main options list (parent only)
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade-specific endpoint for parent 10200
+                {
+                    "values": [
+                        {"id": "10201", "value": "US"},
+                        {"id": "10202", "value": "Canada"},
+                    ]
+                },
+            ]
         )
 
         result = mixin.get_field_options("customfield_10020", context_id="10001")

--- a/tests/unit/jira/test_field_options.py
+++ b/tests/unit/jira/test_field_options.py
@@ -155,6 +155,45 @@ class TestFieldOptionModel:
         assert opt.child_options[0].value == "United States"
         assert opt.child_options[1].value == "Canada"
 
+    def test_children_key_server_dc(self):
+        """Server/DC createmeta uses 'children' instead of 'cascadingOptions'."""
+        data = {
+            "id": "10200",
+            "value": "North America",
+            "children": [
+                {"id": "10201", "value": "United States"},
+                {"id": "10202", "value": "Canada"},
+            ],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.value == "North America"
+        assert len(opt.child_options) == 2
+        assert opt.child_options[0].value == "United States"
+        assert opt.child_options[1].value == "Canada"
+
+    def test_cascading_options_empty_list_not_shadowed_by_children(self):
+        """An explicit empty cascadingOptions is not overridden by children."""
+        data = {
+            "id": "10200",
+            "value": "Parent",
+            "cascadingOptions": [],
+            "children": [{"id": "1", "value": "Should not appear"}],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.child_options == []
+
+    def test_cascading_options_key_takes_precedence_over_children(self):
+        """cascadingOptions wins when both keys are present."""
+        data = {
+            "id": "10200",
+            "value": "Parent",
+            "cascadingOptions": [{"id": "1", "value": "Cascade Child"}],
+            "children": [{"id": "2", "value": "Regular Child"}],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert len(opt.child_options) == 1
+        assert opt.child_options[0].value == "Cascade Child"
+
     def test_to_simplified_dict_with_children(self):
         opt = FieldOption(
             id="1",
@@ -369,6 +408,96 @@ class TestFieldOptionsMixin:
         assert result[0].value == "Americas"
         assert len(result[0].child_options) == 2
 
+    def test_options_cloud_cascading_cascade_pagination(self, mixin):
+        """Cascade endpoint paginates across multiple pages."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options list (one parent)
+                {
+                    "values": [{"id": "10200", "value": "Americas"}],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade endpoint page 1
+                {
+                    "values": [
+                        {"id": "10201", "value": "US"},
+                        {"id": "10202", "value": "Canada"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+                # cascade endpoint page 2
+                {
+                    "values": [{"id": "10203", "value": "Mexico"}],
+                    "startAt": 2,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 3
+        assert result[0].child_options[2].value == "Mexico"
+
+    def test_options_cloud_cascading_flat_list_fallback(self, mixin):
+        """When cascade endpoint is unreachable, fall back to optionId grouping."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options: parent + children as flat list with optionId
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                        {"id": "10201", "value": "US", "optionId": "10200"},
+                        {"id": "10202", "value": "Canada", "optionId": "10200"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 3,
+                },
+                # cascade endpoint unavailable
+                Exception("404 Not Found"),
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 2
+        assert {c.value for c in result[0].child_options} == {"US", "Canada"}
+
+    def test_options_cloud_cascading_empty_cascade_no_fallback(self, mixin):
+        """Empty cascade response is trusted; optionId fallback must not trigger."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options: parent + flat-list child (optionId present)
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                        {"id": "10201", "value": "US", "optionId": "10200"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 2,
+                },
+                # cascade endpoint responds but says no children
+                {"values": [], "total": 0},
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert result[0].child_options == []
+
     # -- get_field_options (Server/DC) --------------------------------------
 
     def test_options_server_with_params(self, mixin):
@@ -523,3 +652,44 @@ class TestFieldOptionsMixin:
         )
         assert len(result) == 1
         assert result[0].value == "Yes"
+
+    def test_options_server_cascading_children_key(self, mixin):
+        """Server/DC allowedValues with 'children' key for cascading select."""
+        mixin.config.is_cloud = False
+        mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Bug"}]
+        )
+        mixin.jira.issue_createmeta_fieldtypes = MagicMock(
+            return_value={
+                "maxResults": 50,
+                "startAt": 0,
+                "total": 1,
+                "isLast": True,
+                "values": [
+                    {
+                        "fieldId": "customfield_10020",
+                        "required": False,
+                        "name": "Region",
+                        "allowedValues": [
+                            {
+                                "id": "10200",
+                                "value": "Americas",
+                                "children": [
+                                    {"id": "10201", "value": "US"},
+                                    {"id": "10202", "value": "Canada"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        result = mixin.get_field_options(
+            "customfield_10020", project_key="TEST", issue_type="Bug"
+        )
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 2
+        assert result[0].child_options[0].value == "US"
+        assert result[0].child_options[1].value == "Canada"

--- a/tests/unit/jira/test_field_options.py
+++ b/tests/unit/jira/test_field_options.py
@@ -130,6 +130,13 @@ class TestFieldOptionModel:
                 "",
                 False,
             ),
+            (
+                "string_value",
+                "String option",
+                "",
+                "String option",
+                False,
+            ),
         ],
     )
     def test_from_api_response(
@@ -169,6 +176,24 @@ class TestFieldOptionModel:
         assert opt.value == "North America"
         assert len(opt.child_options) == 2
         assert opt.child_options[0].value == "United States"
+        assert opt.child_options[1].value == "Canada"
+
+    def test_children_key_with_string_children(self):
+        """String children are parsed as value-only child options."""
+        data = {
+            "id": "10200",
+            "value": "North America",
+            "children": [
+                "United States",
+                {"id": "10202", "value": "Canada"},
+            ],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.value == "North America"
+        assert len(opt.child_options) == 2
+        assert opt.child_options[0].id == ""
+        assert opt.child_options[0].value == "United States"
+        assert opt.child_options[1].id == "10202"
         assert opt.child_options[1].value == "Canada"
 
     def test_cascading_options_empty_list_not_shadowed_by_children(self):
@@ -693,3 +718,33 @@ class TestFieldOptionsMixin:
         assert len(result[0].child_options) == 2
         assert result[0].child_options[0].value == "US"
         assert result[0].child_options[1].value == "Canada"
+
+    def test_options_server_string_allowed_values(self, mixin):
+        """Server/DC allowedValues may contain simple string option entries."""
+        mixin.config.is_cloud = False
+        mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Bug"}]
+        )
+        mixin.jira.issue_createmeta_fieldtypes = MagicMock(
+            return_value={
+                "maxResults": 50,
+                "startAt": 0,
+                "total": 1,
+                "isLast": True,
+                "values": [
+                    {
+                        "fieldId": "customfield_10021",
+                        "allowedValues": ["US", "Canada"],
+                    }
+                ],
+            }
+        )
+
+        result = mixin.get_field_options(
+            "customfield_10021", project_key="TEST", issue_type="Bug"
+        )
+        assert len(result) == 2
+        assert result[0].id == ""
+        assert result[0].value == "US"
+        assert result[1].id == ""
+        assert result[1].value == "Canada"


### PR DESCRIPTION


## Description

Updates get_field_options to correctly handle the Jira api response for cascading select lists.

Fixes: #1186

## Changes



**Model fixes**

- FieldOption.from_api_response:
  - Accepts both cascadingOptions and children as child keys.
  - Handles string-valued option entries and string children (creates FieldOption for string entries).

**Cloud flow fixes**

- _get_field_options_cloud:
  - Collects the Cloud main endpoint flat list of options.
  - Identifies parent option IDs and, per parent, attempts the cascade-specific endpoint:
    - `GET /rest/api/3/field/{fieldId}/context/{contextId}/option/{optionId}/cascadingOption`
  - Falls back to grouping child items by optionId when cascade endpoint fails or returns nothing.
  - Attaches `child_options` to parent `FieldOption` objects.

**Server/DC fixes**

- Parser now recognizes nested children under `children` and parses string children.

**Tests**

- Updated cloud cascading unit test to mock realistic API shapes:
- Main flat options response, then cascade-specific endpoint returning children.
- Ran targeted and full test suites; all tests passed locally.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Executed tool using local server against Jira Data Center, sucessfully fetched custom cascade select list with multiple parent & child values

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
