### PR TITLE
feat(jira): add jira_get_remote_issue_links tool for reading remote/web links

### DIFF
--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -185,6 +185,67 @@ class LinksMixin(JiraClient):
             raise Exception(f"Error creating remote issue link: {error_msg}") from e
 
     @handle_auth_errors("Jira API")
+    def get_remote_issue_links(self, issue_key: str) -> list[dict[str, Any]]:
+        """Get all remote links for a Jira issue.
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123')
+
+        Returns:
+            List of remote link dicts with id, url, title, relationship, etc.
+
+        Raises:
+            ValueError: If issue_key is empty
+            MCPAtlassianAuthenticationError: If authentication fails
+                with the Jira API (401/403)
+            Exception: If there is an error retrieving remote links
+        """
+        if not issue_key:
+            raise ValueError("Issue key is required")
+
+        try:
+            if self.config.is_cloud:
+                endpoint = f"rest/api/3/issue/{issue_key}/remotelink"
+            else:
+                endpoint = f"rest/api/2/issue/{issue_key}/remotelink"
+            response = self.jira.get(endpoint)
+
+            if not isinstance(response, list):
+                logger.error(
+                    "Unexpected response type from remote links API: %s",
+                    type(response),
+                )
+                return []
+
+            results = []
+            for link in response:
+                obj = link.get("object", {})
+                result: dict[str, Any] = {
+                    "id": link.get("id"),
+                    "url": obj.get("url", ""),
+                    "title": obj.get("title", ""),
+                }
+                if obj.get("summary"):
+                    result["summary"] = obj["summary"]
+                if link.get("relationship"):
+                    result["relationship"] = link["relationship"]
+                application = link.get("application", {})
+                if application.get("name"):
+                    result["application"] = application["name"]
+                results.append(result)
+
+            return results
+        except HTTPError:
+            raise  # let decorator handle auth errors
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(
+                f"Error getting remote issue links: {error_msg}",
+                exc_info=True,
+            )
+            raise Exception(f"Error getting remote issue links: {error_msg}") from e
+
+    @handle_auth_errors("Jira API")
     def remove_issue_link(self, link_id: str) -> dict[str, Any]:
         """
         Remove a link between two issues.

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2121,6 +2121,44 @@ async def create_remote_issue_link(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_links"},
+    annotations={"title": "Get Remote Issue Links", "readOnlyHint": True},
+)
+async def get_remote_issue_links(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+) -> str:
+    """Get all remote/web links attached to a Jira issue.
+
+    Returns external links (web URLs, Confluence pages, GitHub PRs, etc.)
+    that have been added to the issue via remote links.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+
+    Returns:
+        JSON string with list of remote links (url, title, relationship, etc.).
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_remote_issue_links(issue_key)
+    return json.dumps(
+        {"issue_key": issue_key, "count": len(result), "remote_links": result},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_links"},
     annotations={"title": "Remove Issue Link", "destructiveHint": True},
 )

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -183,6 +183,96 @@ class TestLinksMixin:
         with pytest.raises(MCPAtlassianAuthenticationError):
             links_mixin.create_remote_issue_link(issue_key, link_data)
 
+    @pytest.mark.parametrize(
+        "url, api_version",
+        [
+            pytest.param(
+                "https://test.atlassian.net",
+                "3",
+                id="cloud",
+            ),
+            pytest.param(
+                "https://jira.example.com",
+                "2",
+                id="server",
+            ),
+        ],
+    )
+    def test_get_remote_issue_links_success(
+        self,
+        jira_config_factory,
+        mock_atlassian_jira,
+        url: str,
+        api_version: str,
+    ):
+        config = jira_config_factory(url=url)
+        mixin = LinksMixin(config=config)
+        mixin.jira = mock_atlassian_jira
+        issue_key = "PROJ-123"
+        mock_response = [
+            {
+                "id": 10000,
+                "object": {
+                    "url": "https://github.com/org/repo/pull/42",
+                    "title": "PR #42: Fix bug",
+                    "summary": "A pull request",
+                },
+                "relationship": "links to",
+                "application": {"type": "com.github", "name": "GitHub"},
+            },
+            {
+                "id": 10001,
+                "object": {
+                    "url": "https://example.com/docs",
+                    "title": "Documentation",
+                },
+            },
+        ]
+        mixin.jira.get.return_value = mock_response
+
+        result = mixin.get_remote_issue_links(issue_key)
+
+        assert len(result) == 2
+        assert result[0]["id"] == 10000
+        assert result[0]["url"] == "https://github.com/org/repo/pull/42"
+        assert result[0]["title"] == "PR #42: Fix bug"
+        assert result[0]["summary"] == "A pull request"
+        assert result[0]["relationship"] == "links to"
+        assert result[0]["application"] == "GitHub"
+        assert result[1]["id"] == 10001
+        assert result[1]["url"] == "https://example.com/docs"
+        assert result[1]["title"] == "Documentation"
+        assert "summary" not in result[1]
+        assert "relationship" not in result[1]
+        assert "application" not in result[1]
+        mixin.jira.get.assert_called_once_with(
+            f"rest/api/{api_version}/issue/PROJ-123/remotelink",
+        )
+
+    def test_get_remote_issue_links_empty(self, links_mixin):
+        links_mixin.jira.get.return_value = []
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == []
+
+    def test_get_remote_issue_links_missing_issue_key(self, links_mixin):
+        with pytest.raises(ValueError, match="Issue key is required"):
+            links_mixin.get_remote_issue_links("")
+
+    def test_get_remote_issue_links_unexpected_response(self, links_mixin):
+        links_mixin.jira.get.return_value = "not a list"
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == []
+
+    def test_get_remote_issue_links_authentication_error(self, links_mixin):
+        links_mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            links_mixin.get_remote_issue_links("PROJ-123")
+
     def test_remove_issue_link_success(self, links_mixin):
         link_id = "10000"
 

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 50, f"Expected 50 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

- Add `get_remote_issue_links()` method to `LinksMixin` to fetch remote links via `GET /rest/api/{2|3}/issue/{key}/remotelink`
- Register new `jira_get_remote_issue_links` read-only MCP tool in the `jira_links` toolset
- Add unit tests covering cloud/server API versions, empty responses, validation, unexpected response types, and auth errors

## Motivation

The server supports **creating** remote issue links (`jira_create_remote_issue_link`) but has no way to **read** them. Remote links (web links, GitHub PRs, Confluence pages, external docs) are stored separately from regular issue links and require a dedicated API call. This gap means AI agents cannot see external links attached to issues.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/jira/test_links.py` — 22 tests)
- [x] Pre-commit checks pass (ruff-format, ruff, mypy)
- [ ] Integration test with a real Jira instance containing remote links

🤖 Generated with [Claude Code](https://claude.com/claude-code)