### PR TITLE
fix(utils): honor NO_PROXY env var when session proxies are explicitly set

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -127,6 +127,7 @@ class ConfluenceClient:
             client_cert=self.config.client_cert,
             client_key=self.config.client_key,
             client_key_password=self.config.client_key_password,
+            no_proxy=self.config.no_proxy,
         )
 
         # Proxy configuration

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -32,6 +32,7 @@ class ConfluenceClient:
             MCPAtlassianAuthenticationError: If OAuth authentication fails
         """
         self.config = config or ConfluenceConfig.from_env()
+        transport_url = self.config.url
 
         # Initialize the Confluence client based on auth type
         if self.config.auth_type == "oauth":
@@ -64,6 +65,7 @@ class ConfluenceClient:
                 # Cloud: use the Atlassian Cloud API URL
                 api_url = f"https://api.atlassian.com/ex/confluence/{self.config.oauth_config.cloud_id}"
                 is_cloud = True
+            transport_url = api_url
 
             # Initialize Confluence with the session
             self.confluence = Confluence(
@@ -112,10 +114,14 @@ class ConfluenceClient:
         if self.config.auth_type in ("pat", "oauth"):
             self.confluence._session.trust_env = False
 
+        if self.config.no_proxy and isinstance(self.config.no_proxy, str):
+            os.environ["NO_PROXY"] = self.config.no_proxy
+            log_config_param(logger, "Confluence", "NO_PROXY", self.config.no_proxy)
+
         # Configure SSL verification using the shared utility
         configure_ssl_verification(
             service_name="Confluence",
-            url=self.config.url,
+            url=transport_url,
             session=self.confluence._session,
             ssl_verify=self.config.ssl_verify,
             client_cert=self.config.client_cert,
@@ -137,9 +143,6 @@ class ConfluenceClient:
                 log_config_param(
                     logger, "Confluence", f"{k.upper()}_PROXY", v, sensitive=True
                 )
-        if self.config.no_proxy and isinstance(self.config.no_proxy, str):
-            os.environ["NO_PROXY"] = self.config.no_proxy
-            log_config_param(logger, "Confluence", "NO_PROXY", self.config.no_proxy)
 
         # Apply custom headers if configured
         if self.config.custom_headers:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -140,6 +140,7 @@ class JiraClient:
             client_cert=self.config.client_cert,
             client_key=self.config.client_key,
             client_key_password=self.config.client_key_password,
+            no_proxy=self.config.no_proxy,
         )
 
         # Proxy configuration

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -46,6 +46,7 @@ class JiraClient:
         """
         # Load configuration from environment variables if not provided
         self.config = config or JiraConfig.from_env()
+        transport_url = self.config.url
 
         # Initialize the Jira client based on auth type
         if self.config.auth_type == "oauth":
@@ -78,6 +79,7 @@ class JiraClient:
                 # Cloud: use the Atlassian Cloud API URL
                 api_url = f"https://api.atlassian.com/ex/jira/{self.config.oauth_config.cloud_id}"
                 is_cloud = True
+            transport_url = api_url
 
             # Initialize Jira with the session
             self.jira = Jira(
@@ -125,10 +127,14 @@ class JiraClient:
         if self.config.auth_type in ("pat", "oauth"):
             self.jira._session.trust_env = False
 
+        if self.config.no_proxy and isinstance(self.config.no_proxy, str):
+            os.environ["NO_PROXY"] = self.config.no_proxy
+            log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
+
         # Configure SSL verification using the shared utility
         configure_ssl_verification(
             service_name="Jira",
-            url=self.config.url,
+            url=transport_url,
             session=self.jira._session,
             ssl_verify=self.config.ssl_verify,
             client_cert=self.config.client_cert,
@@ -150,9 +156,6 @@ class JiraClient:
                 log_config_param(
                     logger, "Jira", f"{k.upper()}_PROXY", v, sensitive=True
                 )
-        if self.config.no_proxy and isinstance(self.config.no_proxy, str):
-            os.environ["NO_PROXY"] = self.config.no_proxy
-            log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
 
         # Apply custom headers if configured
         if self.config.custom_headers:

--- a/src/mcp_atlassian/utils/__init__.py
+++ b/src/mcp_atlassian/utils/__init__.py
@@ -20,7 +20,12 @@ from .media import (
 
 # Export OAuth utilities
 from .oauth import OAuthConfig, configure_oauth_session
-from .ssl import NoProxyAdapter, SSLIgnoreAdapter, configure_proxy_bypass, configure_ssl_verification
+from .ssl import (
+    NoProxyAdapter,
+    SSLIgnoreAdapter,
+    configure_proxy_bypass,
+    configure_ssl_verification,
+)
 from .urls import is_atlassian_cloud_url, resolve_relative_url, validate_url_for_ssrf
 
 # Export all utility functions for backward compatibility

--- a/src/mcp_atlassian/utils/__init__.py
+++ b/src/mcp_atlassian/utils/__init__.py
@@ -20,13 +20,15 @@ from .media import (
 
 # Export OAuth utilities
 from .oauth import OAuthConfig, configure_oauth_session
-from .ssl import SSLIgnoreAdapter, configure_ssl_verification
+from .ssl import NoProxyAdapter, SSLIgnoreAdapter, configure_proxy_bypass, configure_ssl_verification
 from .urls import is_atlassian_cloud_url, resolve_relative_url, validate_url_for_ssrf
 
 # Export all utility functions for backward compatibility
 __all__ = [
     "ATTACHMENT_MAX_BYTES",
+    "NoProxyAdapter",
     "SSLIgnoreAdapter",
+    "configure_proxy_bypass",
     "configure_ssl_verification",
     "is_atlassian_cloud_url",
     "is_image_attachment",

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -1,21 +1,79 @@
-"""SSL-related utility functions for MCP Atlassian."""
+"""SSL and proxy utility functions for MCP Atlassian."""
 
 import logging
+import os
 import ssl
 from typing import Any
 from urllib.parse import urlparse
 
+from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
+from requests.utils import should_bypass_proxies
 from urllib3.poolmanager import PoolManager
 
 logger = logging.getLogger("mcp-atlassian")
 
 
-class SSLIgnoreAdapter(HTTPAdapter):
-    """HTTP adapter that ignores SSL verification.
+class NoProxyAdapter(HTTPAdapter):
+    """HTTP adapter that respects NO_PROXY environment variable.
 
-    A custom transport adapter that disables SSL certificate verification for specific domains.
+    A custom transport adapter that ensures NO_PROXY is honored even when
+    proxies are explicitly configured on the session. By default, the requests
+    library only checks NO_PROXY during auto-detection from environment variables,
+    not when proxies are explicitly set on session.proxies.
+    """
+
+    def send(
+        self,
+        request: PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | None = None,
+        verify: bool | str = True,
+        cert: str | tuple[str, str] | None = None,
+        proxies: dict[str, str] | None = None,
+    ) -> Response:
+        """Send a request, respecting NO_PROXY environment variable.
+
+        This override ensures that NO_PROXY is respected even when proxies are
+        explicitly configured on the session.
+
+        Args:
+            request: The prepared request to send
+            stream: Whether to stream the response
+            timeout: Request timeout
+            verify: SSL verification setting
+            cert: Client certificate
+            proxies: Proxy configuration
+
+        Returns:
+            The response from the server
+        """
+        # Check if we should bypass proxies for this URL
+        no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+        if request.url and proxies and no_proxy and should_bypass_proxies(request.url, no_proxy):
+            logger.debug(
+                f"Bypassing proxy for {request.url} due to NO_PROXY setting: {no_proxy}"
+            )
+            proxies = None
+
+        return super().send(
+            request,
+            stream=stream,
+            timeout=timeout,
+            verify=verify,
+            cert=cert,
+            proxies=proxies,
+        )
+
+
+class SSLIgnoreAdapter(NoProxyAdapter):
+    """HTTP adapter that ignores SSL verification and respects NO_PROXY.
+
+    A custom transport adapter that:
+    1. Disables SSL certificate verification for specific domains
+    2. Respects NO_PROXY environment variable even when proxies are explicitly set
+
     This implementation ensures that both verify_mode is set to CERT_NONE and check_hostname
     is disabled, which is required for properly ignoring SSL certificates.
 
@@ -63,6 +121,67 @@ class SSLIgnoreAdapter(HTTPAdapter):
         """
         super().cert_verify(conn, url, verify=False, cert=cert)
 
+    def send(
+        self,
+        request: PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | None = None,
+        verify: bool | str = True,
+        cert: str | tuple[str, str] | None = None,
+        proxies: dict[str, str] | None = None,
+    ) -> Response:
+        """Send a request with SSL verification disabled.
+
+        Args:
+            request: The prepared request to send
+            stream: Whether to stream the response
+            timeout: Request timeout
+            verify: SSL verification setting (ignored, always False for this adapter)
+            cert: Client certificate
+            proxies: Proxy configuration
+
+        Returns:
+            The response from the server
+        """
+        # Let parent class handle NO_PROXY, but always disable SSL verification
+        return super().send(
+            request,
+            stream=stream,
+            timeout=timeout,
+            verify=False,  # Always disable SSL verification for this adapter
+            cert=cert,
+            proxies=proxies,
+        )
+
+
+def configure_proxy_bypass(
+    service_name: str,
+    url: str,
+    session: Session,
+) -> None:
+    """Configure the session to respect NO_PROXY environment variable.
+
+    This function mounts a custom adapter that ensures NO_PROXY is honored
+    even when proxies are explicitly configured on the session.
+
+    Args:
+        service_name: Name of the service for logging (e.g., "Confluence", "Jira")
+        url: The base URL of the service
+        session: The requests session to configure
+    """
+    no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+    if no_proxy:
+        logger.debug(
+            f"{service_name}: Configuring proxy bypass adapter for NO_PROXY={no_proxy}"
+        )
+        # Get the domain from the configured URL
+        domain = urlparse(url).netloc
+
+        # Mount the adapter to handle requests to this domain
+        adapter = NoProxyAdapter()
+        session.mount(f"https://{domain}", adapter)
+        session.mount(f"http://{domain}", adapter)
+
 
 def configure_ssl_verification(
     service_name: str,
@@ -77,7 +196,10 @@ def configure_ssl_verification(
 
     If SSL verification is disabled, this function will configure the session
     to use a custom SSL adapter that bypasses certificate validation for the
-    service's domain.
+    service's domain. This adapter also respects NO_PROXY.
+
+    If SSL verification is enabled but NO_PROXY is set, a proxy bypass adapter
+    is mounted to ensure NO_PROXY is respected.
 
     If client certificate paths are provided, they will be configured for
     mutual TLS authentication.
@@ -108,15 +230,25 @@ def configure_ssl_verification(
             f"with cert: {client_cert}"
         )
 
+    # Get the domain from the configured URL
+    domain = urlparse(url).netloc
+
     if not ssl_verify:
         logger.warning(
             f"{service_name} SSL verification disabled. This is insecure and should only be used in testing environments."
         )
 
-        # Get the domain from the configured URL
-        domain = urlparse(url).netloc
-
-        # Mount the adapter to handle requests to this domain
+        # Mount the SSL ignore adapter which also handles NO_PROXY
         adapter = SSLIgnoreAdapter()
         session.mount(f"https://{domain}", adapter)
         session.mount(f"http://{domain}", adapter)
+    else:
+        # Even with SSL verification enabled, we may need to handle NO_PROXY
+        no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+        if no_proxy:
+            logger.debug(
+                f"{service_name}: Mounting proxy bypass adapter for NO_PROXY={no_proxy}"
+            )
+            adapter = NoProxyAdapter()
+            session.mount(f"https://{domain}", adapter)
+            session.mount(f"http://{domain}", adapter)

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import ssl
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlparse
 
@@ -30,8 +31,8 @@ class NoProxyAdapter(HTTPAdapter):
         stream: bool = False,
         timeout: float | tuple[float, float] | None = None,
         verify: bool | str = True,
-        cert: str | tuple[str, str] | None = None,
-        proxies: dict[str, str] | None = None,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
     ) -> Response:
         """Send a request, respecting NO_PROXY environment variable.
 
@@ -51,7 +52,12 @@ class NoProxyAdapter(HTTPAdapter):
         """
         # Check if we should bypass proxies for this URL
         no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
-        if request.url and proxies and no_proxy and should_bypass_proxies(request.url, no_proxy):
+        if (
+            request.url
+            and proxies
+            and no_proxy
+            and should_bypass_proxies(request.url, no_proxy)
+        ):
             logger.debug(
                 f"Bypassing proxy for {request.url} due to NO_PROXY setting: {no_proxy}"
             )
@@ -127,8 +133,8 @@ class SSLIgnoreAdapter(NoProxyAdapter):
         stream: bool = False,
         timeout: float | tuple[float, float] | None = None,
         verify: bool | str = True,
-        cert: str | tuple[str, str] | None = None,
-        proxies: dict[str, str] | None = None,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
     ) -> Response:
         """Send a request with SSL verification disabled.
 

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -230,15 +230,13 @@ def configure_ssl_verification(
             f"with cert: {client_cert}"
         )
 
-    # Get the domain from the configured URL
-    domain = urlparse(url).netloc
-
     if not ssl_verify:
         logger.warning(
             f"{service_name} SSL verification disabled. This is insecure and should only be used in testing environments."
         )
 
         # Mount the SSL ignore adapter which also handles NO_PROXY
+        domain = urlparse(url).netloc
         adapter = SSLIgnoreAdapter()
         session.mount(f"https://{domain}", adapter)
         session.mount(f"http://{domain}", adapter)
@@ -249,6 +247,7 @@ def configure_ssl_verification(
             logger.debug(
                 f"{service_name}: Mounting proxy bypass adapter for NO_PROXY={no_proxy}"
             )
+            domain = urlparse(url).netloc
             adapter = NoProxyAdapter()
             session.mount(f"https://{domain}", adapter)
             session.mount(f"http://{domain}", adapter)

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -8,23 +8,27 @@ from typing import Any
 from urllib.parse import urlparse
 
 from requests import PreparedRequest, Response
-from requests.adapters import HTTPAdapter
 from requests.sessions import Session
 from requests.utils import should_bypass_proxies
 from urllib3.poolmanager import PoolManager
 
-from .ssrf_adapter import _PinnedHTTPConnectionPool, _PinnedHTTPSConnectionPool
+from .ssrf_adapter import (
+    SsrfPinningAdapter,
+    _PinnedHTTPConnectionPool,
+    _PinnedHTTPSConnectionPool,
+)
 
 logger = logging.getLogger("mcp-atlassian")
 
 
-class NoProxyAdapter(HTTPAdapter):
+class NoProxyAdapter(SsrfPinningAdapter):
     """HTTP adapter that respects NO_PROXY environment variable.
 
     A custom transport adapter that ensures NO_PROXY is honored even when
     proxies are explicitly configured on the session. By default, the requests
     library only checks NO_PROXY during auto-detection from environment variables,
-    not when proxies are explicitly set on session.proxies.
+    not when proxies are explicitly set on session.proxies. The adapter also
+    preserves the DNS-pinning SSRF protection used by the default transport.
 
     The no-proxy list is captured on the adapter when it is mounted. This keeps
     each mounted adapter bound to its own configuration, so multiple clients

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -23,7 +23,25 @@ class NoProxyAdapter(HTTPAdapter):
     proxies are explicitly configured on the session. By default, the requests
     library only checks NO_PROXY during auto-detection from environment variables,
     not when proxies are explicitly set on session.proxies.
+
+    The no-proxy list is captured on the adapter when it is mounted. This keeps
+    each mounted adapter bound to its own configuration, so multiple clients
+    running in the same process (e.g. Jira and Confluence with different
+    ``JIRA_NO_PROXY`` / ``CONFLUENCE_NO_PROXY`` values) cannot overwrite one
+    another via the shared process environment. When no value is captured, the
+    adapter falls back to the ``NO_PROXY`` environment variable.
     """
+
+    def __init__(self, *args: Any, no_proxy: str | None = None, **kwargs: Any) -> None:
+        """Initialize the adapter, capturing the configured no-proxy list.
+
+        Args:
+            no_proxy: The no-proxy list this adapter should honor. When omitted,
+                the adapter falls back to the ``NO_PROXY`` environment variable
+                at send time.
+        """
+        self._no_proxy = no_proxy
+        super().__init__(*args, **kwargs)
 
     def send(
         self,
@@ -50,8 +68,12 @@ class NoProxyAdapter(HTTPAdapter):
         Returns:
             The response from the server
         """
-        # Check if we should bypass proxies for this URL
-        no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+        # Check if we should bypass proxies for this URL. Prefer the value
+        # captured when the adapter was mounted so concurrent clients with
+        # different no-proxy lists stay isolated; fall back to the environment.
+        no_proxy = (
+            self._no_proxy or os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+        )
         if (
             request.url
             and proxies
@@ -164,18 +186,23 @@ def configure_proxy_bypass(
     service_name: str,
     url: str,
     session: Session,
+    no_proxy: str | None = None,
 ) -> None:
     """Configure the session to respect NO_PROXY environment variable.
 
     This function mounts a custom adapter that ensures NO_PROXY is honored
-    even when proxies are explicitly configured on the session.
+    even when proxies are explicitly configured on the session. The no-proxy
+    list is captured on the mounted adapter so it is not affected by later
+    changes to the process environment made by other clients.
 
     Args:
         service_name: Name of the service for logging (e.g., "Confluence", "Jira")
         url: The base URL of the service
         session: The requests session to configure
+        no_proxy: The no-proxy list to honor. Defaults to the ``NO_PROXY``
+            environment variable when not provided.
     """
-    no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+    no_proxy = no_proxy or os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
     if no_proxy:
         logger.debug(
             f"{service_name}: Configuring proxy bypass adapter for NO_PROXY={no_proxy}"
@@ -184,7 +211,7 @@ def configure_proxy_bypass(
         domain = urlparse(url).netloc
 
         # Mount the adapter to handle requests to this domain
-        adapter = NoProxyAdapter()
+        adapter = NoProxyAdapter(no_proxy=no_proxy)
         session.mount(f"https://{domain}", adapter)
         session.mount(f"http://{domain}", adapter)
 
@@ -197,6 +224,7 @@ def configure_ssl_verification(
     client_cert: str | None = None,
     client_key: str | None = None,
     client_key_password: str | None = None,
+    no_proxy: str | None = None,
 ) -> None:
     """Configure SSL verification and client certificates for a specific service.
 
@@ -218,7 +246,10 @@ def configure_ssl_verification(
         client_cert: Path to client certificate file (.pem)
         client_key: Path to client private key file (.pem)
         client_key_password: Password for encrypted private key (optional)
+        no_proxy: The no-proxy list to honor on the mounted adapter. Defaults to
+            the ``NO_PROXY`` environment variable when not provided.
     """
+    no_proxy = no_proxy or os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
     # Configure client certificate if provided (must be actual string paths)
     if isinstance(client_cert, str) and isinstance(client_key, str):
         # Encrypted private keys are not supported by the requests library
@@ -243,17 +274,16 @@ def configure_ssl_verification(
 
         # Mount the SSL ignore adapter which also handles NO_PROXY
         domain = urlparse(url).netloc
-        adapter = SSLIgnoreAdapter()
+        adapter = SSLIgnoreAdapter(no_proxy=no_proxy)
         session.mount(f"https://{domain}", adapter)
         session.mount(f"http://{domain}", adapter)
     else:
         # Even with SSL verification enabled, we may need to handle NO_PROXY
-        no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
         if no_proxy:
             logger.debug(
                 f"{service_name}: Mounting proxy bypass adapter for NO_PROXY={no_proxy}"
             )
             domain = urlparse(url).netloc
-            adapter = NoProxyAdapter()
+            adapter = NoProxyAdapter(no_proxy=no_proxy)
             session.mount(f"https://{domain}", adapter)
             session.mount(f"http://{domain}", adapter)

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -3,9 +3,12 @@
 import os
 from unittest.mock import MagicMock, patch
 
+from requests.sessions import Session
+
 from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.client import ConfluenceClient
 from mcp_atlassian.confluence.config import ConfluenceConfig
+from mcp_atlassian.utils.ssl import NoProxyAdapter
 
 
 def test_init_with_basic_auth():
@@ -239,6 +242,39 @@ def test_init_sets_proxies_and_no_proxy(monkeypatch):
     assert mock_session.proxies["https"] == "https://proxy:8443"
     assert mock_session.proxies["socks"] == "socks5://user:pass@proxy:1080"
     assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_init_configures_no_proxy_adapter_from_config(monkeypatch):
+    """Test that client no_proxy config is visible during SSL setup."""
+    mock_confluence = MagicMock()
+    mock_confluence._session = Session()
+    monkeypatch.setattr(
+        "mcp_atlassian.confluence.client.Confluence", lambda **kwargs: mock_confluence
+    )
+    monkeypatch.setattr(
+        "mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor",
+        lambda **kwargs: MagicMock(),
+    )
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+
+    config = ConfluenceConfig(
+        url="https://test.atlassian.net/wiki",
+        auth_type="basic",
+        username="user",
+        api_token="token",
+        https_proxy="https://proxy:8443",
+        no_proxy="test.atlassian.net",
+    )
+
+    ConfluenceClient(config=config)
+
+    assert os.environ["NO_PROXY"] == "test.atlassian.net"
+    assert mock_confluence._session.proxies["https"] == "https://proxy:8443"
+    assert isinstance(
+        mock_confluence._session.get_adapter("https://test.atlassian.net"),
+        NoProxyAdapter,
+    )
 
 
 def test_init_no_proxies(monkeypatch):

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -56,6 +56,7 @@ def test_init_with_basic_auth():
             client_cert=None,
             client_key=None,
             client_key_password=None,
+            no_proxy=None,
         )
 
 
@@ -103,6 +104,7 @@ def test_init_with_token_auth():
             client_cert=None,
             client_key=None,
             client_key_password=None,
+            no_proxy=None,
         )
 
 

--- a/tests/unit/confluence/test_client_oauth.py
+++ b/tests/unit/confluence/test_client_oauth.py
@@ -78,6 +78,10 @@ class TestConfluenceClientOAuth:
 
             # Verify SSL verification was configured
             mock_configure_ssl.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/confluence/{oauth_config.cloud_id}"
+            )
 
             # Verify preprocessor was initialized
             assert client.preprocessor == mock_preprocessor.return_value
@@ -131,6 +135,10 @@ class TestConfluenceClientOAuth:
 
             # Verify SSL verification was configured
             mock_configure_ssl.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/confluence/{byo_oauth_config.cloud_id}"
+            )
 
             # Verify preprocessor was initialized
             assert client.preprocessor == mock_preprocessor.return_value
@@ -358,6 +366,10 @@ class TestConfluenceClientOAuth:
 
             # Verify OAuth session was configured
             mock_configure_oauth.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/confluence/{mock_standard_oauth_config.cloud_id}"
+            )
 
     def test_from_env_with_byo_token_oauth(self):
         """Test creating client from env vars with BYO token OAuth config."""
@@ -398,6 +410,10 @@ class TestConfluenceClientOAuth:
                 == f"https://api.atlassian.com/ex/confluence/{mock_byo_oauth_config.cloud_id}"
             )
             mock_configure_oauth.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/confluence/{mock_byo_oauth_config.cloud_id}"
+            )
 
     def test_from_env_with_no_oauth_config_found(self):
         """Test client creation from env when no OAuth config is found by the utility."""

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -6,9 +6,11 @@ from typing import Literal
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from requests.sessions import Session
 
 from mcp_atlassian.jira.client import JiraClient
 from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.utils.ssl import NoProxyAdapter
 
 
 class DeepcopyMock(MagicMock):
@@ -275,6 +277,33 @@ def test_init_sets_proxies_and_no_proxy(monkeypatch):
     assert mock_session.proxies["https"] == "https://proxy:8443"
     assert mock_session.proxies["socks"] == "socks5://user:pass@proxy:1080"
     assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_init_configures_no_proxy_adapter_from_config(monkeypatch):
+    """Test that client no_proxy config is visible during SSL setup."""
+    mock_jira = MagicMock()
+    mock_jira._session = Session()
+    monkeypatch.setattr("mcp_atlassian.jira.client.Jira", lambda **kwargs: mock_jira)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+
+    config = JiraConfig(
+        url="https://test.atlassian.net",
+        auth_type="basic",
+        username="user",
+        api_token="pat",
+        http_proxy="http://proxy:8080",
+        no_proxy="test.atlassian.net",
+    )
+
+    JiraClient(config=config)
+
+    assert os.environ["NO_PROXY"] == "test.atlassian.net"
+    assert mock_jira._session.proxies["http"] == "http://proxy:8080"
+    assert isinstance(
+        mock_jira._session.get_adapter("https://test.atlassian.net"),
+        NoProxyAdapter,
+    )
 
 
 def test_init_no_proxies(monkeypatch):

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -58,6 +58,7 @@ def test_init_with_basic_auth():
             client_cert=None,
             client_key=None,
             client_key_password=None,
+            no_proxy=None,
         )
 
         assert client.config == config
@@ -100,6 +101,7 @@ def test_init_with_token_auth():
             client_cert=None,
             client_key=None,
             client_key_password=None,
+            no_proxy=None,
         )
 
         assert client.config == config

--- a/tests/unit/jira/test_client_oauth.py
+++ b/tests/unit/jira/test_client_oauth.py
@@ -75,6 +75,10 @@ class TestJiraClientOAuth:
 
             # Verify SSL verification was configured
             mock_configure_ssl.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/jira/{oauth_config.cloud_id}"
+            )
 
     def test_init_with_oauth_missing_cloud_id(self):
         """Test initializing the client with OAuth but missing cloud_id."""
@@ -199,6 +203,10 @@ class TestJiraClientOAuth:
 
             # Verify SSL verification was configured
             mock_configure_ssl.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/jira/{byo_oauth_config.cloud_id}"
+            )
 
     def test_init_with_byo_oauth_missing_cloud_id(self):
         """Test initializing with BYO OAuth but missing cloud_id."""
@@ -341,6 +349,10 @@ class TestJiraClientOAuth:
 
             # Verify OAuth session was configured
             mock_configure_oauth.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/jira/{mock_oauth_config.cloud_id}"
+            )
 
     def test_from_env_with_byo_token_oauth(self):
         """Test JiraClient.from_env() when BYO token OAuth config is found."""
@@ -390,6 +402,10 @@ class TestJiraClientOAuth:
                 == f"https://api.atlassian.com/ex/jira/{mock_byo_oauth_config.cloud_id}"
             )
             mock_configure_ssl.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == f"https://api.atlassian.com/ex/jira/{mock_byo_oauth_config.cloud_id}"
+            )
 
     def test_from_env_with_no_oauth_config_found(self):
         """Test JiraClient.from_env() when no OAuth config is found."""
@@ -439,7 +455,9 @@ class TestJiraClientOAuth:
                 "mcp_atlassian.jira.client.configure_oauth_session",
                 return_value=True,
             ),
-            patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+            patch(
+                "mcp_atlassian.jira.client.configure_ssl_verification"
+            ) as mock_configure_ssl,
         ):
             client = JiraClient(config=config)
 
@@ -448,6 +466,11 @@ class TestJiraClientOAuth:
             assert jira_kwargs["url"] == "https://jira.corp.example.com"
             assert jira_kwargs["cloud"] is False
             assert "session" in jira_kwargs
+            mock_configure_ssl.assert_called_once()
+            assert (
+                mock_configure_ssl.call_args.kwargs["url"]
+                == "https://jira.corp.example.com"
+            )
 
     def test_dc_oauth_rejects_missing_base_url_and_cloud_id(self):
         """Test JiraClient with OAuth but no cloud_id or base_url raises ValueError."""

--- a/tests/unit/jira/test_issue_creation_logic.py
+++ b/tests/unit/jira/test_issue_creation_logic.py
@@ -68,6 +68,8 @@ def issues_mixin():
     with patch("mcp_atlassian.jira.config.JiraConfig.from_env") as mock_from_env:
         mock_config = MagicMock()
         mock_config.is_cloud = True
+        mock_config.url = "https://test.atlassian.net"
+        mock_config.ssl_verify = True
         mock_from_env.return_value = mock_config
 
         mixin = ConcreteIssuesMixin()

--- a/tests/unit/utils/test_proxy.py
+++ b/tests/unit/utils/test_proxy.py
@@ -6,9 +6,8 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from requests.exceptions import ProxyError
-
 from requests import PreparedRequest
+from requests.exceptions import ProxyError
 from requests.sessions import Session
 
 from mcp_atlassian.confluence.client import ConfluenceClient
@@ -353,9 +352,7 @@ class TestNoProxyAdapter:
             _, kwargs = mock_send.call_args
             assert kwargs["proxies"] == proxies
 
-    def test_configure_proxy_bypass_mounts_adapter_when_no_proxy_set(
-        self, monkeypatch
-    ):
+    def test_configure_proxy_bypass_mounts_adapter_when_no_proxy_set(self, monkeypatch):
         """configure_proxy_bypass mounts NoProxyAdapter when NO_PROXY is set."""
         monkeypatch.setenv("NO_PROXY", "example.com")
         session = Session()

--- a/tests/unit/utils/test_proxy.py
+++ b/tests/unit/utils/test_proxy.py
@@ -8,10 +8,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 from requests.exceptions import ProxyError
 
+from requests import PreparedRequest
+from requests.sessions import Session
+
 from mcp_atlassian.confluence.client import ConfluenceClient
 from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.jira.client import JiraClient
 from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.utils.ssl import NoProxyAdapter, configure_proxy_bypass
 from tests.utils.base import BaseAuthTest
 from tests.utils.mocks import MockEnvironment
 
@@ -293,3 +297,79 @@ class TestProxyConfigurationEnhanced(BaseAuthTest):
                 assert os.environ.get("HTTP_PROXY") == "http://proxy.company.com:8080"
                 assert os.environ.get("HTTPS_PROXY") == "https://proxy.company.com:8443"
                 assert os.environ.get("NO_PROXY") == "localhost,127.0.0.1"
+
+
+class TestNoProxyAdapter:
+    """Tests for NoProxyAdapter and configure_proxy_bypass."""
+
+    def _make_request(self, url: str) -> PreparedRequest:
+        req = PreparedRequest()
+        req.url = url
+        return req
+
+    def test_clears_proxies_when_url_matches_no_proxy(self, monkeypatch):
+        """Proxies are cleared when the request URL matches NO_PROXY."""
+        monkeypatch.setenv("NO_PROXY", "internal.example.com")
+        adapter = NoProxyAdapter()
+        proxies = {"https": "https://proxy:8443"}
+
+        with patch.object(adapter.__class__.__bases__[0], "send") as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(
+                self._make_request("https://internal.example.com/api"),
+                proxies=proxies,
+            )
+            _, kwargs = mock_send.call_args
+            assert kwargs["proxies"] is None
+
+    def test_preserves_proxies_when_url_does_not_match_no_proxy(self, monkeypatch):
+        """Proxies are kept when the request URL is not in NO_PROXY."""
+        monkeypatch.setenv("NO_PROXY", "other.example.com")
+        adapter = NoProxyAdapter()
+        proxies = {"https": "https://proxy:8443"}
+
+        with patch.object(adapter.__class__.__bases__[0], "send") as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(
+                self._make_request("https://external.example.com/api"),
+                proxies=proxies,
+            )
+            _, kwargs = mock_send.call_args
+            assert kwargs["proxies"] == proxies
+
+    def test_no_effect_when_no_proxy_not_set(self, monkeypatch):
+        """Proxies are untouched when NO_PROXY is not set."""
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        adapter = NoProxyAdapter()
+        proxies = {"https": "https://proxy:8443"}
+
+        with patch.object(adapter.__class__.__bases__[0], "send") as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(
+                self._make_request("https://internal.example.com/api"),
+                proxies=proxies,
+            )
+            _, kwargs = mock_send.call_args
+            assert kwargs["proxies"] == proxies
+
+    def test_configure_proxy_bypass_mounts_adapter_when_no_proxy_set(
+        self, monkeypatch
+    ):
+        """configure_proxy_bypass mounts NoProxyAdapter when NO_PROXY is set."""
+        monkeypatch.setenv("NO_PROXY", "example.com")
+        session = Session()
+        configure_proxy_bypass("TestService", "https://example.com", session)
+        assert isinstance(session.get_adapter("https://example.com"), NoProxyAdapter)
+        assert isinstance(session.get_adapter("http://example.com"), NoProxyAdapter)
+
+    def test_configure_proxy_bypass_does_nothing_when_no_proxy_not_set(
+        self, monkeypatch
+    ):
+        """configure_proxy_bypass does not mount an adapter when NO_PROXY is absent."""
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        session = Session()
+        default_https_adapter = session.get_adapter("https://example.com")
+        configure_proxy_bypass("TestService", "https://example.com", session)
+        assert session.get_adapter("https://example.com") is default_https_adapter

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -7,7 +7,11 @@ import pytest
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
 
-from mcp_atlassian.utils.ssl import SSLIgnoreAdapter, configure_ssl_verification
+from mcp_atlassian.utils.ssl import (
+    NoProxyAdapter,
+    SSLIgnoreAdapter,
+    configure_ssl_verification,
+)
 
 
 def test_ssl_ignore_adapter_cert_verify():
@@ -90,9 +94,11 @@ def test_configure_ssl_verification_disabled():
             session.mount.assert_any_call("http://test.example.com", mock_adapter)
 
 
-def test_configure_ssl_verification_enabled():
-    """Test configure_ssl_verification when SSL verification is enabled."""
-    # Arrange
+def test_configure_ssl_verification_enabled(monkeypatch):
+    """Test configure_ssl_verification when SSL verification is enabled and NO_PROXY is absent."""
+    # Arrange — ensure NO_PROXY is absent so no proxy-bypass adapter is mounted
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
     service_name = "TestService"
     url = "https://test.example.com/path"
     session = MagicMock()  # Use MagicMock instead of actual Session
@@ -107,12 +113,14 @@ def test_configure_ssl_verification_enabled():
         assert session.mount.call_count == 0
 
 
-def test_configure_ssl_verification_enabled_with_real_session():
-    """Test SSL verification configuration when verification is enabled using a real Session."""
+def test_configure_ssl_verification_enabled_with_real_session(monkeypatch):
+    """Test SSL verification configuration when verification is enabled and NO_PROXY is absent."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
     session = Session()
     original_adapters_count = len(session.adapters)
 
-    # Configure with SSL verification enabled
+    # Configure with SSL verification enabled and no NO_PROXY
     configure_ssl_verification(
         service_name="Test",
         url="https://example.com",
@@ -120,7 +128,7 @@ def test_configure_ssl_verification_enabled_with_real_session():
         ssl_verify=True,
     )
 
-    # No adapters should be added when SSL verification is enabled
+    # No adapters should be added when SSL verification is enabled and NO_PROXY is absent
     assert len(session.adapters) == original_adapters_count
 
 
@@ -257,3 +265,58 @@ def test_configure_ssl_disabled_with_client_cert():
             assert session.cert == ("/path/to/cert.pem", "/path/to/key.pem")
             mock_adapter_class.assert_called_once()
             assert session.mount.call_count == 2
+
+
+def test_ssl_ignore_adapter_is_subclass_of_no_proxy_adapter():
+    """SSLIgnoreAdapter must inherit from NoProxyAdapter to pick up NO_PROXY logic."""
+    assert issubclass(SSLIgnoreAdapter, NoProxyAdapter)
+
+
+def test_ssl_ignore_adapter_send_forces_verify_false():
+    """SSLIgnoreAdapter.send() always passes verify=False to parent, ignoring the caller's value."""
+    adapter = SSLIgnoreAdapter()
+    request = MagicMock()
+    request.url = "https://external.example.com/api"
+
+    with patch.object(NoProxyAdapter, "send") as mock_super_send:
+        mock_super_send.return_value = MagicMock()
+        adapter.send(request, verify=True, proxies=None)
+        _, kwargs = mock_super_send.call_args
+        assert kwargs["verify"] is False
+
+
+def test_ssl_ignore_adapter_send_respects_no_proxy(monkeypatch):
+    """SSLIgnoreAdapter.send() honors NO_PROXY by clearing proxies for matching URLs."""
+    monkeypatch.setenv("NO_PROXY", "internal.example.com")
+    adapter = SSLIgnoreAdapter()
+    request = MagicMock()
+    request.url = "https://internal.example.com/api"
+    proxies = {"https": "https://proxy:8443"}
+
+    with patch.object(HTTPAdapter, "send") as mock_base_send:
+        mock_base_send.return_value = MagicMock()
+        adapter.send(request, proxies=proxies)
+        _, kwargs = mock_base_send.call_args
+        assert kwargs["proxies"] is None
+
+
+def test_configure_ssl_verification_enabled_with_no_proxy_mounts_adapter(monkeypatch):
+    """configure_ssl_verification mounts NoProxyAdapter when ssl_verify=True and NO_PROXY is set."""
+    monkeypatch.setenv("NO_PROXY", "test.example.com")
+    session = Session()
+    original_adapters_count = len(session.adapters)
+
+    configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com/path",
+        session=session,
+        ssl_verify=True,
+    )
+
+    assert len(session.adapters) == original_adapters_count + 2
+    assert isinstance(session.get_adapter("https://test.example.com"), NoProxyAdapter)
+    assert isinstance(session.get_adapter("http://test.example.com"), NoProxyAdapter)
+    # Must not be the stricter SSLIgnoreAdapter — SSL verification stays enabled
+    assert not isinstance(
+        session.get_adapter("https://test.example.com"), SSLIgnoreAdapter
+    )

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -12,6 +12,7 @@ from mcp_atlassian.utils.ssl import (
     SSLIgnoreAdapter,
     configure_ssl_verification,
 )
+from mcp_atlassian.utils.ssrf_adapter import SsrfPinningAdapter
 
 
 def test_ssl_ignore_adapter_cert_verify():
@@ -270,6 +271,12 @@ def test_configure_ssl_disabled_with_client_cert():
 def test_ssl_ignore_adapter_is_subclass_of_no_proxy_adapter():
     """SSLIgnoreAdapter must inherit from NoProxyAdapter to pick up NO_PROXY logic."""
     assert issubclass(SSLIgnoreAdapter, NoProxyAdapter)
+
+
+@pytest.mark.security_regression
+def test_no_proxy_adapter_preserves_ssrf_dns_pinning():
+    """A domain-specific NO_PROXY mount must not bypass DNS pinning."""
+    assert issubclass(NoProxyAdapter, SsrfPinningAdapter)
 
 
 def test_ssl_ignore_adapter_send_forces_verify_false():

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -300,6 +300,95 @@ def test_ssl_ignore_adapter_send_respects_no_proxy(monkeypatch):
         assert kwargs["proxies"] is None
 
 
+def test_no_proxy_adapter_prefers_captured_value_over_env(monkeypatch):
+    """A captured no-proxy list takes precedence over the process environment.
+
+    Regression for the multi-client blocker: the adapter must honor the list it
+    was mounted with rather than re-reading NO_PROXY at send time, so another
+    client overwriting the environment cannot change its behavior.
+    """
+    # Environment points at a different host than the adapter was configured for.
+    monkeypatch.setenv("NO_PROXY", "other.example.com")
+    adapter = NoProxyAdapter(no_proxy="internal.example.com")
+    request = MagicMock()
+    request.url = "https://internal.example.com/api"
+    proxies = {"https": "https://proxy:8443"}
+
+    with patch.object(HTTPAdapter, "send") as mock_base_send:
+        mock_base_send.return_value = MagicMock()
+        adapter.send(request, proxies=proxies)
+        _, kwargs = mock_base_send.call_args
+        # Bypassed because the captured list matches, despite the env not matching.
+        assert kwargs["proxies"] is None
+
+
+def test_no_proxy_adapter_falls_back_to_env_when_uncaptured(monkeypatch):
+    """With no captured value, the adapter still honors the NO_PROXY env var."""
+    monkeypatch.setenv("NO_PROXY", "internal.example.com")
+    adapter = NoProxyAdapter()
+    request = MagicMock()
+    request.url = "https://internal.example.com/api"
+    proxies = {"https": "https://proxy:8443"}
+
+    with patch.object(HTTPAdapter, "send") as mock_base_send:
+        mock_base_send.return_value = MagicMock()
+        adapter.send(request, proxies=proxies)
+        _, kwargs = mock_base_send.call_args
+        assert kwargs["proxies"] is None
+
+
+def test_two_adapters_with_different_no_proxy_lists_stay_isolated(monkeypatch):
+    """Two mounted adapters with different lists do not interfere with each other.
+
+    Simulates Jira and Confluence running in the same process: each adapter keeps
+    the no-proxy list it was mounted with even after the shared NO_PROXY env var is
+    later overwritten by the other client.
+    """
+    # Jira is configured first for jira.internal.
+    jira_adapter = NoProxyAdapter(no_proxy="jira.internal")
+    # Confluence is configured later and overwrites the shared environment.
+    confluence_adapter = NoProxyAdapter(no_proxy="confluence.internal")
+    monkeypatch.setenv("NO_PROXY", "confluence.internal")
+
+    proxies = {"https": "https://proxy:8443"}
+
+    def send_to(adapter, host):
+        request = MagicMock()
+        request.url = f"https://{host}/api"
+        with patch.object(HTTPAdapter, "send") as mock_base_send:
+            mock_base_send.return_value = MagicMock()
+            adapter.send(request, proxies=dict(proxies))
+            _, kwargs = mock_base_send.call_args
+            return kwargs["proxies"]
+
+    # Jira request to its own host bypasses the proxy...
+    assert send_to(jira_adapter, "jira.internal") is None
+    # ...and Jira does NOT bypass for the Confluence host, despite the env value.
+    assert send_to(jira_adapter, "confluence.internal") == proxies
+    # Confluence bypasses for its own host, not for Jira's.
+    assert send_to(confluence_adapter, "confluence.internal") is None
+    assert send_to(confluence_adapter, "jira.internal") == proxies
+
+
+def test_configure_ssl_verification_captures_no_proxy_on_adapter(monkeypatch):
+    """configure_ssl_verification passes the explicit no_proxy through to the adapter."""
+    # Env intentionally differs from the explicit argument.
+    monkeypatch.setenv("NO_PROXY", "env.example.com")
+    session = Session()
+
+    configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com/path",
+        session=session,
+        ssl_verify=True,
+        no_proxy="explicit.example.com",
+    )
+
+    adapter = session.get_adapter("https://test.example.com")
+    assert isinstance(adapter, NoProxyAdapter)
+    assert adapter._no_proxy == "explicit.example.com"
+
+
 def test_configure_ssl_verification_enabled_with_no_proxy_mounts_adapter(monkeypatch):
     """configure_ssl_verification mounts NoProxyAdapter when ssl_verify=True and NO_PROXY is set."""
     monkeypatch.setenv("NO_PROXY", "test.example.com")


### PR DESCRIPTION
## Description

The `requests` library ignores `NO_PROXY` when proxies are explicitly configured on `session.proxies`. This means hosts listed in `NO_PROXY` were still routed through the proxy when `HTTP_PROXY`/`HTTPS_PROXY` were set.

May fix #677.

## Changes

- Add `NoProxyAdapter` — an HTTP adapter that calls `should_bypass_proxies` on each request and clears proxies when the URL matches `NO_PROXY`
- Capture the no-proxy list on the adapter at mount time (threaded from each client's config through `configure_ssl_verification`/`configure_proxy_bypass`) instead of re-reading `NO_PROXY` per request, so Jira and Confluence with different `JIRA_NO_PROXY`/`CONFLUENCE_NO_PROXY` values stay isolated; the environment remains a fallback
- Preserve the DNS-pinning SSRF protection from the current transport when a domain-specific no-proxy adapter is mounted
- Add `configure_proxy_bypass()` — mounts `NoProxyAdapter` on a session when `NO_PROXY` is set
- `SSLIgnoreAdapter` now inherits from `NoProxyAdapter` so SSL-disabled sessions also respect `NO_PROXY`
- `configure_ssl_verification(ssl_verify=True)` mounts `NoProxyAdapter` when `NO_PROXY` is set
- Fix `urlparse(url)` being called unconditionally (broke fixtures passing mock URLs)
- Fix `send()` override signatures to match the supertype (`Mapping`, `bytes | str`) for mypy

## Testing

- [x] Unit tests added for `NoProxyAdapter`, `configure_proxy_bypass`, and the `NO_PROXY`-aware path in `configure_ssl_verification`
- [x] Regression proving two adapters with different no-proxy lists stay isolated even when the shared `NO_PROXY` environment variable is overwritten
- [x] Security regression proving the no-proxy adapter preserves DNS pinning
- [x] `uv run pytest tests/unit/ -q` — 3084 passed, 5 skipped
- [x] `uv run pytest tests/integration/ --integration -q` — 8 passed, 15 skipped
- [x] `uv run pytest tests/e2e --dc-e2e -q` — 94 passed, 98 skipped
- [x] `uv run pytest tests/e2e/cloud --cloud-e2e -q` — 81 passed, 15 skipped; one Atlassian Cloud HTTP 500 passed on immediate targeted rerun
- [x] `uv run pre-commit run --all-files` — formatting, Ruff, and mypy clean

## Checklist

- [x] Code follows project style guidelines.
- [x] Tests added/updated for changes.
- [x] Relevant unit, integration, Cloud, and Data Center verification completed.
