### PR TITLE
feat(auth): add service account support via Cloud ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,23 @@ JIRA_API_TOKEN=your_jira_api_token_here
 CONFLUENCE_USERNAME=your.email@example.com
 CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 
+# --- METHOD 1b: SERVICE ACCOUNT (Atlassian Cloud - API Token with Cloud ID) ---
+# Service accounts use the api.atlassian.com gateway instead of direct instance URLs.
+# This is useful when AI agents should act under a dedicated bot identity.
+# 1. Create a service account at: https://admin.atlassian.com
+# 2. Generate an API token for the service account
+# 3. Get your Cloud ID from: https://your-company.atlassian.net/_edge/tenant_info
+#    (look for the "cloudId" field in the JSON response)
+# When CLOUD_ID is set, JIRA_URL/CONFLUENCE_URL are optional (the gateway URL is derived).
+#ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
+#JIRA_USERNAME=service-account@your-company.atlassian.net
+#JIRA_API_TOKEN=service_account_api_token
+#CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+#CONFLUENCE_API_TOKEN=service_account_api_token
+# You can also set per-service Cloud IDs if Jira and Confluence are on different sites:
+#JIRA_CLOUD_ID=your-jira-cloud-id
+#CONFLUENCE_CLOUD_ID=your-confluence-cloud-id
+
 # --- METHOD 2: PERSONAL ACCESS TOKEN (PAT) (Server / Data Center - Recommended) ---
 # Create PATs in your Jira/Confluence profile settings (usually under "Personal Access Tokens").
 #JIRA_PERSONAL_TOKEN=your_jira_personal_access_token

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@
 # =============================================
 # ESSENTIAL ATLASSIAN INSTANCE URLS
 # =============================================
-# REQUIRED: Replace with your Atlassian instance URLs.
+# REQUIRED except when a Cloud service-account Cloud ID is configured.
+# URLs are still recommended so generated Jira/Confluence links are clickable.
 # Example Cloud: https://your-company.atlassian.net
 # Example Server/DC: https://jira.your-internal-domain.com
 JIRA_URL=https://your-company.atlassian.net
@@ -41,7 +42,8 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # 2. Generate an API token and select the Jira/Confluence scopes it needs
 # 3. Copy the site's Cloud ID from Atlassian Administration, or get it from:
 #    https://your-company.atlassian.net/_edge/tenant_info (the "cloudId" field)
-# When CLOUD_ID is set, JIRA_URL/CONFLUENCE_URL are optional (the gateway URL is derived).
+# With a Cloud ID, JIRA_URL/CONFLUENCE_URL are optional for API calls.
+# Keep them when you want generated browser links to use your site domain.
 #ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
 #JIRA_USERNAME=bot@serviceaccount.atlassian.com
 #JIRA_API_TOKEN=service_account_api_token

--- a/.env.example
+++ b/.env.example
@@ -38,16 +38,17 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # Service accounts use the api.atlassian.com gateway instead of direct instance URLs.
 # This is useful when AI agents should act under a dedicated bot identity.
 # 1. Create a service account at: https://admin.atlassian.com
-# 2. Generate an API token for the service account
-# 3. Get your Cloud ID from: https://your-company.atlassian.net/_edge/tenant_info
-#    (look for the "cloudId" field in the JSON response)
+# 2. Generate an API token and select the Jira/Confluence scopes it needs
+# 3. Copy the site's Cloud ID from Atlassian Administration, or get it from:
+#    https://your-company.atlassian.net/_edge/tenant_info (the "cloudId" field)
 # When CLOUD_ID is set, JIRA_URL/CONFLUENCE_URL are optional (the gateway URL is derived).
 #ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
-#JIRA_USERNAME=service-account@your-company.atlassian.net
+#JIRA_USERNAME=bot@serviceaccount.atlassian.com
 #JIRA_API_TOKEN=service_account_api_token
-#CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+#CONFLUENCE_USERNAME=bot@serviceaccount.atlassian.com
 #CONFLUENCE_API_TOKEN=service_account_api_token
 # You can also set per-service Cloud IDs if Jira and Confluence are on different sites:
+# Per-service values take precedence over ATLASSIAN_CLOUD_ID.
 #JIRA_CLOUD_ID=your-jira-cloud-id
 #CONFLUENCE_CLOUD_ID=your-confluence-cloud-id
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Authentication"
-description: "Configure authentication for MCP Atlassian — API tokens, PATs, and OAuth 2.0"
+description: "Configure authentication for MCP Atlassian — API tokens, service accounts, PATs, and OAuth 2.0"
 ---
 
 MCP Atlassian supports three authentication methods depending on your Atlassian deployment type.
@@ -31,6 +31,36 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 CONFLUENCE_USERNAME=your.email@company.com
 CONFLUENCE_API_TOKEN=your_api_token
 ```
+
+## Service Account (Cloud)
+
+For AI agents and automations that should act under a dedicated bot identity instead of a personal account.
+
+<Steps>
+  <Step title="Create Service Account">
+    Go to [Atlassian Admin](https://admin.atlassian.com) → **Directory** → **Service accounts** and create a new service account
+  </Step>
+  <Step title="Generate API Token">
+    Generate an API token for the service account
+  </Step>
+  <Step title="Get Cloud ID">
+    Visit `https://your-company.atlassian.net/_edge/tenant_info` and copy the `cloudId` value from the JSON response
+  </Step>
+</Steps>
+
+**Environment variables:**
+```bash
+ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
+JIRA_USERNAME=service-account@your-company.atlassian.net
+JIRA_API_TOKEN=service_account_api_token
+CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+CONFLUENCE_API_TOKEN=service_account_api_token
+```
+
+<Note>
+When `ATLASSIAN_CLOUD_ID` is set, `JIRA_URL` and `CONFLUENCE_URL` are optional — the server routes requests through the `api.atlassian.com` gateway automatically.
+You can also use `JIRA_CLOUD_ID` and `CONFLUENCE_CLOUD_ID` separately if your Jira and Confluence are on different Cloud sites.
+</Note>
 
 ## Personal Access Token (Server/Data Center)
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -51,14 +51,16 @@ For AI agents and automations that should act under a dedicated bot identity ins
 **Environment variables:**
 ```bash
 ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
+JIRA_URL=https://your-company.atlassian.net
 JIRA_USERNAME=bot@serviceaccount.atlassian.com
 JIRA_API_TOKEN=service_account_api_token
+CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 CONFLUENCE_USERNAME=bot@serviceaccount.atlassian.com
 CONFLUENCE_API_TOKEN=service_account_api_token
 ```
 
 <Note>
-When `ATLASSIAN_CLOUD_ID` is set, `JIRA_URL` and `CONFLUENCE_URL` are optional — the server routes requests through the `api.atlassian.com` gateway automatically.
+When `ATLASSIAN_CLOUD_ID` is set, `JIRA_URL` and `CONFLUENCE_URL` are optional for API calls because the server routes requests through the `api.atlassian.com` gateway automatically. Keep the site URLs when you want generated browser links to be clickable.
 You can also use `JIRA_CLOUD_ID` and `CONFLUENCE_CLOUD_ID` separately if your Jira and Confluence are on different Cloud sites. Service-specific values take precedence over `ATLASSIAN_CLOUD_ID`.
 </Note>
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -41,25 +41,25 @@ For AI agents and automations that should act under a dedicated bot identity ins
     Go to [Atlassian Admin](https://admin.atlassian.com) → **Directory** → **Service accounts** and create a new service account
   </Step>
   <Step title="Generate API Token">
-    Generate an API token for the service account
+    Generate an API token for the service account and select the Jira or Confluence scopes it needs
   </Step>
   <Step title="Get Cloud ID">
-    Visit `https://your-company.atlassian.net/_edge/tenant_info` and copy the `cloudId` value from the JSON response
+    Copy the site ID from Atlassian Administration, or visit `https://your-company.atlassian.net/_edge/tenant_info` and copy the `cloudId` value
   </Step>
 </Steps>
 
 **Environment variables:**
 ```bash
 ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
-JIRA_USERNAME=service-account@your-company.atlassian.net
+JIRA_USERNAME=bot@serviceaccount.atlassian.com
 JIRA_API_TOKEN=service_account_api_token
-CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+CONFLUENCE_USERNAME=bot@serviceaccount.atlassian.com
 CONFLUENCE_API_TOKEN=service_account_api_token
 ```
 
 <Note>
 When `ATLASSIAN_CLOUD_ID` is set, `JIRA_URL` and `CONFLUENCE_URL` are optional — the server routes requests through the `api.atlassian.com` gateway automatically.
-You can also use `JIRA_CLOUD_ID` and `CONFLUENCE_CLOUD_ID` separately if your Jira and Confluence are on different Cloud sites.
+You can also use `JIRA_CLOUD_ID` and `CONFLUENCE_CLOUD_ID` separately if your Jira and Confluence are on different Cloud sites. Service-specific values take precedence over `ATLASSIAN_CLOUD_ID`.
 </Note>
 
 ## Personal Access Token (Server/Data Center)

--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -36,7 +36,7 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
     def _rest_base_url(self) -> str:
         """Return the REST API base URL, adding the Cloud ``/wiki`` prefix.
 
-        On Confluence Cloud, ``config.url`` is the bare site URL
+        On Confluence Cloud, ``config.api_url`` may be the bare site URL
         (``https://site.atlassian.net``) but the REST API is served under
         ``/wiki``. Hand-built URLs must include this prefix or requests 404.
         The ``endswith`` guard avoids producing ``/wiki/wiki`` when the
@@ -45,7 +45,7 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
         Returns:
             The base URL to use for direct REST API calls.
         """
-        base_url = self.config.url.rstrip("/")
+        base_url = self.config.api_url.rstrip("/")
         if self.config.is_cloud and not base_url.endswith("/wiki"):
             base_url = f"{base_url}/wiki"
         return base_url
@@ -81,7 +81,9 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             string when ``download_url`` is falsy.
         """
         resolved = (
-            resolve_relative_url(download_url, self.config.url) if download_url else ""
+            resolve_relative_url(download_url, self._rest_base_url())
+            if download_url
+            else ""
         )
         use_v1 = self.config.attachment_download_use_v1
         if use_v1 is None:

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -76,11 +76,11 @@ class ConfluenceClient:
         elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Confluence client with Token (PAT) auth. "
-                f"URL: {self.config.url}, "
+                f"URL: {self.config.api_url}, "
                 f"Token (masked): {mask_sensitive(str(self.config.personal_token))}"
             )
             self.confluence = Confluence(
-                url=self.config.url,
+                url=self.config.api_url,
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
@@ -89,12 +89,12 @@ class ConfluenceClient:
         else:  # basic auth
             logger.debug(
                 f"Initializing Confluence client with Basic auth. "
-                f"URL: {self.config.url}, Username: {self.config.username}, "
+                f"URL: {self.config.api_url}, Username: {self.config.username}, "
                 f"API Token present: {bool(self.config.api_token)}, "
                 f"Is Cloud: {self.config.is_cloud}"
             )
             self.confluence = Confluence(
-                url=self.config.url,
+                url=self.config.api_url,
                 username=self.config.username,
                 password=self.config.api_token,  # API token is used as password
                 cloud=self.config.is_cloud,

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -210,7 +210,7 @@ class ConfluenceClient:
         if self.config.auth_type == "oauth" and self.config.is_cloud:
             base_url = self.confluence.url.rstrip("/")
         else:
-            base_url = self.config.url.rstrip("/")
+            base_url = self.config.api_url.rstrip("/")
 
         if self.config.is_cloud and not base_url.endswith("/wiki"):
             base_url = f"{base_url}/wiki"

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -41,7 +41,9 @@ class ConfluenceClient:
             MCPAtlassianAuthenticationError: If OAuth authentication fails
         """
         self.config = config or ConfluenceConfig.from_env()
-        transport_url = self.config.url
+        transport_url = self.config.api_url
+        if not isinstance(transport_url, str):
+            transport_url = self.config.url
 
         # Initialize the Confluence client based on auth type
         if self.config.auth_type == "oauth":

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -40,6 +40,7 @@ class ConfluenceConfig:
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
     timeout: int = 75  # Connection timeout in seconds
+    cloud_id: str | None = None  # Atlassian Cloud ID (for service accounts)
 
     @property
     def is_cloud(self) -> bool:
@@ -49,6 +50,10 @@ class ConfluenceConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
+        # cloud_id set directly on config means Cloud (service account or explicit)
+        if self.cloud_id:
+            return True
+
         # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
@@ -71,6 +76,17 @@ class ConfluenceConfig:
         return is_atlassian_cloud_url(self.url) if self.url else False
 
     @property
+    def api_url(self) -> str:
+        """Get the effective API URL, using the Cloud gateway when cloud_id is set.
+
+        Returns:
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+        """
+        if self.cloud_id:
+            return f"https://api.atlassian.com/ex/confluence/{self.cloud_id}"
+        return self.url
+
+    @property
     def verify_ssl(self) -> bool:
         """Compatibility property for old code.
 
@@ -90,7 +106,11 @@ class ConfluenceConfig:
             ValueError: If any required environment variable is missing
         """
         url = os.getenv("CONFLUENCE_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        # cloud_id can substitute for URL (service accounts use api.atlassian.com)
+        has_cloud_id = bool(
+            os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+        )
+        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required CONFLUENCE_URL environment variable. "
                 "Set CONFLUENCE_URL to your Confluence base URL, for example "
@@ -110,7 +130,7 @@ class ConfluenceConfig:
         auth_type = None
 
         # Use the shared utility function directly
-        is_cloud = is_atlassian_cloud_url(url) if url else False
+        is_cloud = has_cloud_id or (is_atlassian_cloud_url(url) if url else False)
 
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
@@ -187,6 +207,9 @@ class ConfluenceConfig:
         ):
             timeout = int(os.getenv("CONFLUENCE_TIMEOUT", "75"))
 
+        # Cloud ID for service accounts (api.atlassian.com gateway)
+        cloud_id = os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -205,6 +228,7 @@ class ConfluenceConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cloud_id=cloud_id,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -50,6 +50,13 @@ class ConfluenceConfig:
     #   False -> always the legacy link
     attachment_download_use_v1: bool | None = None
 
+    def __post_init__(self) -> None:
+        """Normalize Cloud ID settings and derive a gateway URL when needed."""
+        if self.cloud_id is not None:
+            self.cloud_id = self.cloud_id.strip() or None
+        if (not self.url or not self.url.strip()) and self.cloud_id:
+            self.url = self.api_url
+
     @property
     def is_cloud(self) -> bool:
         """Check if this is a cloud instance.
@@ -88,10 +95,11 @@ class ConfluenceConfig:
         """Get the effective API URL, using the Cloud gateway when cloud_id is set.
 
         Returns:
-            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the
+            base URL.
         """
         if self.cloud_id:
-            return f"https://api.atlassian.com/ex/confluence/{self.cloud_id}"
+            return f"https://api.atlassian.com/ex/confluence/{self.cloud_id}/wiki"
         return self.url
 
     @property
@@ -114,10 +122,11 @@ class ConfluenceConfig:
             ValueError: If any required environment variable is missing
         """
         url = os.getenv("CONFLUENCE_URL")
+        cloud_id = (
+            os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID") or ""
+        ).strip() or None
         # cloud_id can substitute for URL (service accounts use api.atlassian.com)
-        has_cloud_id = bool(
-            os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
-        )
+        has_cloud_id = cloud_id is not None
         if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required CONFLUENCE_URL environment variable. "
@@ -214,9 +223,6 @@ class ConfluenceConfig:
             and os.getenv("CONFLUENCE_TIMEOUT", "").isdigit()
         ):
             timeout = int(os.getenv("CONFLUENCE_TIMEOUT", "75"))
-
-        # Cloud ID for service accounts (api.atlassian.com gateway)
-        cloud_id = os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
 
         # Unset or empty/whitespace -> None (auto); only an explicit value forces.
         _use_v1_raw = os.getenv("CONFLUENCE_ATTACHMENT_DOWNLOAD_USE_V1")

--- a/src/mcp_atlassian/confluence/permissions.py
+++ b/src/mcp_atlassian/confluence/permissions.py
@@ -28,7 +28,7 @@ class PermissionsMixin(ConfluenceClient):
         if self.config.auth_type == "oauth" and self.config.is_cloud:
             return str(self.confluence.url).rstrip("/")
 
-        base_url = self.config.url.rstrip("/")
+        base_url = self.config.api_url.rstrip("/")
         if self.config.is_cloud and not base_url.endswith("/wiki"):
             base_url = f"{base_url}/wiki"
         return base_url

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -90,11 +90,11 @@ class JiraClient:
         elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Jira client with Token (PAT) auth. "
-                f"URL: {self.config.url}, "
+                f"URL: {self.config.api_url}, "
                 f"Token (masked): {mask_sensitive(str(self.config.personal_token))}"
             )
             self.jira = Jira(
-                url=self.config.url,
+                url=self.config.api_url,
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
@@ -103,12 +103,12 @@ class JiraClient:
         else:  # basic auth
             logger.debug(
                 f"Initializing Jira client with Basic auth. "
-                f"URL: {self.config.url}, Username: {self.config.username}, "
+                f"URL: {self.config.api_url}, Username: {self.config.username}, "
                 f"API Token present: {bool(self.config.api_token)}, "
                 f"Is Cloud: {self.config.is_cloud}"
             )
             self.jira = Jira(
-                url=self.config.url,
+                url=self.config.api_url,
                 username=self.config.username,
                 password=self.config.api_token,
                 cloud=self.config.is_cloud,

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -55,7 +55,9 @@ class JiraClient:
         """
         # Load configuration from environment variables if not provided
         self.config = config or JiraConfig.from_env()
-        transport_url = self.config.url
+        transport_url = self.config.api_url
+        if not isinstance(transport_url, str):
+            transport_url = self.config.url
 
         # Initialize the Jira client based on auth type
         if self.config.auth_type == "oauth":

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -116,6 +116,7 @@ class JiraConfig:
     client_key_password: str | None = None  # Password for encrypted private key
     sla_config: SLAConfig | None = None  # Optional SLA configuration
     timeout: int = 75  # Connection timeout in seconds
+    cloud_id: str | None = None  # Atlassian Cloud ID (for service accounts)
 
     @property
     def is_cloud(self) -> bool:
@@ -125,6 +126,10 @@ class JiraConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
+        # cloud_id set directly on config means Cloud (service account or explicit)
+        if self.cloud_id:
+            return True
+
         # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
@@ -147,6 +152,17 @@ class JiraConfig:
         return is_atlassian_cloud_url(self.url) if self.url else False
 
     @property
+    def api_url(self) -> str:
+        """Get the effective API URL, using the Cloud gateway when cloud_id is set.
+
+        Returns:
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+        """
+        if self.cloud_id:
+            return f"https://api.atlassian.com/ex/jira/{self.cloud_id}"
+        return self.url
+
+    @property
     def verify_ssl(self) -> bool:
         """Compatibility property for old code.
 
@@ -166,7 +182,11 @@ class JiraConfig:
             ValueError: If required environment variables are missing or invalid
         """
         url = os.getenv("JIRA_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        # cloud_id can substitute for URL (service accounts use api.atlassian.com)
+        has_cloud_id = bool(
+            os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+        )
+        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required JIRA_URL environment variable. "
                 "Set JIRA_URL to your Jira base URL, for example "
@@ -184,7 +204,7 @@ class JiraConfig:
         auth_type = None
 
         # Use the shared utility function directly
-        is_cloud = is_atlassian_cloud_url(url) if url else False
+        is_cloud = has_cloud_id or (is_atlassian_cloud_url(url) if url else False)
 
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
@@ -262,6 +282,9 @@ class JiraConfig:
         if os.getenv("JIRA_TIMEOUT") and os.getenv("JIRA_TIMEOUT", "").isdigit():
             timeout = int(os.getenv("JIRA_TIMEOUT", "75"))
 
+        # Cloud ID for service accounts (api.atlassian.com gateway)
+        cloud_id = os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -281,6 +304,7 @@ class JiraConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cloud_id=cloud_id,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -118,6 +118,13 @@ class JiraConfig:
     timeout: int = 75  # Connection timeout in seconds
     cloud_id: str | None = None  # Atlassian Cloud ID (for service accounts)
 
+    def __post_init__(self) -> None:
+        """Normalize Cloud ID settings and derive a gateway URL when needed."""
+        if self.cloud_id is not None:
+            self.cloud_id = self.cloud_id.strip() or None
+        if (not self.url or not self.url.strip()) and self.cloud_id:
+            self.url = self.api_url
+
     @property
     def is_cloud(self) -> bool:
         """Check if this is a cloud instance.
@@ -156,7 +163,8 @@ class JiraConfig:
         """Get the effective API URL, using the Cloud gateway when cloud_id is set.
 
         Returns:
-            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the
+            base URL.
         """
         if self.cloud_id:
             return f"https://api.atlassian.com/ex/jira/{self.cloud_id}"
@@ -182,10 +190,11 @@ class JiraConfig:
             ValueError: If required environment variables are missing or invalid
         """
         url = os.getenv("JIRA_URL")
+        cloud_id = (
+            os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID") or ""
+        ).strip() or None
         # cloud_id can substitute for URL (service accounts use api.atlassian.com)
-        has_cloud_id = bool(
-            os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
-        )
+        has_cloud_id = cloud_id is not None
         if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required JIRA_URL environment variable. "
@@ -281,9 +290,6 @@ class JiraConfig:
         timeout = 75  # Default timeout
         if os.getenv("JIRA_TIMEOUT") and os.getenv("JIRA_TIMEOUT", "").isdigit():
             timeout = int(os.getenv("JIRA_TIMEOUT", "75"))
-
-        # Cloud ID for service accounts (api.atlassian.com gateway)
-        cloud_id = os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
 
         return cls(
             url=url or "",

--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -153,7 +153,7 @@ class DevelopmentMixin(JiraClient):
         # Use _session.get() directly: the dev-status endpoint is a plugin-specific
         # path (/rest/dev-status/1.0/...) not covered by the standard Jira client
         # wrappers. No higher-level wrapper method exists for this non-standard endpoint.
-        url = f"{self.config.url}/rest/dev-status/1.0/issue/detail"
+        url = f"{self.config.api_url}/rest/dev-status/1.0/issue/detail"
         http_response = self.jira._session.get(
             url, params=params, verify=self.config.ssl_verify
         )

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -240,7 +240,7 @@ class UsersMixin(JiraClient):
             Optional[str]: Account ID if found, None otherwise.
         """
         try:
-            url = f"{self.config.url}/rest/api/2/user/permission/search"
+            url = f"{self.config.api_url}/rest/api/2/user/permission/search"
             params = {"query": username, "permissions": "BROWSE"}
 
             auth = None

--- a/tests/e2e/cloud/conftest.py
+++ b/tests/e2e/cloud/conftest.py
@@ -51,6 +51,7 @@ class CloudInstanceInfo:
     test_page_id: str = ""
     oauth_access_token: str = ""
     oauth_cloud_id: str = ""
+    cloud_id: str = ""
 
     @classmethod
     def from_env(cls) -> CloudInstanceInfo:
@@ -348,6 +349,16 @@ def _make_jira_byo_oauth_config(info: CloudInstanceInfo) -> JiraConfig:
     )
 
 
+def _make_jira_cloud_id_config(info: CloudInstanceInfo) -> JiraConfig:
+    return JiraConfig(
+        url=info.jira_url,
+        auth_type="basic",
+        username=info.username,
+        api_token=info.api_token,
+        cloud_id=info.cloud_id,
+    )
+
+
 def _make_confluence_basic_config(
     info: CloudInstanceInfo,
 ) -> ConfluenceConfig:
@@ -369,6 +380,18 @@ def _make_confluence_byo_oauth_config(
             access_token=info.oauth_access_token,
             cloud_id=info.oauth_cloud_id,
         ),
+    )
+
+
+def _make_confluence_cloud_id_config(
+    info: CloudInstanceInfo,
+) -> ConfluenceConfig:
+    return ConfluenceConfig(
+        url=info.confluence_url,
+        auth_type="basic",
+        username=info.username,
+        api_token=info.api_token,
+        cloud_id=info.cloud_id,
     )
 
 
@@ -396,6 +419,15 @@ def cloud_instance() -> CloudInstanceInfo:
     if not _check_cloud_health(info):
         pytest.skip("Cloud instances not reachable or credentials invalid")
 
+    tenant_info = requests.get(
+        f"{info.jira_url.rstrip('/')}/_edge/tenant_info",
+        timeout=15,
+    )
+    tenant_info.raise_for_status()
+    info.cloud_id = str(tenant_info.json().get("cloudId", ""))
+    if not info.cloud_id:
+        raise RuntimeError("Cloud tenant info response did not include cloudId")
+
     info.test_issue_key = _find_or_create_test_issue(info)
     info.test_page_id = _find_or_create_test_page(info)
 
@@ -414,13 +446,19 @@ def auth_variants(
 ) -> list[AuthVariant]:
     """Session-scoped list of auth variants to test.
 
-    Always includes basic. Adds byo_oauth if OAuth env vars present.
+    Always includes direct basic auth and Cloud-ID gateway basic auth. Adds
+    byo_oauth if OAuth env vars are present.
     """
     variants = [
         AuthVariant(
             name="basic",
             jira_config=_make_jira_basic_config(cloud_instance),
             confluence_config=_make_confluence_basic_config(cloud_instance),
+        ),
+        AuthVariant(
+            name="cloud_id_gateway",
+            jira_config=_make_jira_cloud_id_config(cloud_instance),
+            confluence_config=_make_confluence_cloud_id_config(cloud_instance),
         ),
     ]
 

--- a/tests/e2e/cloud/test_confluence_auth_matrix.py
+++ b/tests/e2e/cloud/test_confluence_auth_matrix.py
@@ -1,4 +1,4 @@
-"""Confluence Cloud auth matrix tests -- read/write ops x 2 auth methods."""
+"""Confluence Cloud auth matrix tests across direct and gateway authentication."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from .conftest import AuthVariant, CloudInstanceInfo, CloudResourceTracker
 pytestmark = pytest.mark.cloud_e2e
 
 
-@pytest.fixture(params=["basic", "byo_oauth"])
+@pytest.fixture(params=["basic", "cloud_id_gateway", "byo_oauth"])
 def confluence_auth(
     request: pytest.FixtureRequest,
     auth_variants: list[AuthVariant],

--- a/tests/e2e/cloud/test_jira_auth_matrix.py
+++ b/tests/e2e/cloud/test_jira_auth_matrix.py
@@ -1,4 +1,4 @@
-"""Jira Cloud auth matrix tests -- read/write ops x 2 auth methods."""
+"""Jira Cloud auth matrix tests across direct and gateway authentication."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from .conftest import AuthVariant, CloudInstanceInfo, CloudResourceTracker
 pytestmark = pytest.mark.cloud_e2e
 
 
-@pytest.fixture(params=["basic", "byo_oauth"])
+@pytest.fixture(params=["basic", "cloud_id_gateway", "byo_oauth"])
 def jira_auth(
     request: pytest.FixtureRequest,
     auth_variants: list[AuthVariant],

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -1823,14 +1823,18 @@ class TestResolveAttachmentDownloadUrl:
     """
 
     def _make_mixin(
-        self, *, use_v1: bool | None, url: str = "https://example.atlassian.net/wiki"
+        self,
+        *,
+        use_v1: bool | None,
+        url: str = "https://example.atlassian.net/wiki",
+        cloud_id: str | None = None,
     ) -> AttachmentsMixin:
         with patch(
             "mcp_atlassian.confluence.attachments.ConfluenceClient.__init__",
             return_value=None,
         ):
             mixin = AttachmentsMixin()
-        config = ConfluenceConfig(url=url, auth_type="basic")
+        config = ConfluenceConfig(url=url, auth_type="basic", cloud_id=cloud_id)
         config.attachment_download_use_v1 = use_v1
         mixin.config = config
         return mixin
@@ -1908,6 +1912,20 @@ class TestResolveAttachmentDownloadUrl:
         )
         assert url == (
             "https://example.atlassian.net/wiki"
+            "/rest/api/content/123/child/attachment/att999/download"
+        )
+
+    def test_service_account_download_uses_gateway(self) -> None:
+        mixin = self._make_mixin(
+            use_v1=None,
+            url="https://example.atlassian.net/wiki",
+            cloud_id="cloud-123",
+        )
+        url = mixin._resolve_attachment_download_url(
+            "/download/attachments/123/foo.png", attachment_id="att999"
+        )
+        assert url == (
+            "https://api.atlassian.com/ex/confluence/cloud-123/wiki"
             "/rest/api/content/123/child/attachment/att999/download"
         )
 

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -459,3 +459,86 @@ def test_confluence_fetcher_mro_order():
     # Verify that attachment methods are accessible (the real test)
     assert hasattr(ConfluenceFetcher, "upload_attachment")
     assert hasattr(ConfluenceFetcher, "get_content_attachments")
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_basic_auth_with_cloud_id():
+    """Test that basic auth with cloud_id routes through api.atlassian.com."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="svc_token",
+        cloud_id="test-cloud-uuid",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            username="svc@company.atlassian.net",
+            password="svc_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_pat_auth_with_cloud_id():
+    """Test that PAT auth with cloud_id routes through api.atlassian.com."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="pat",
+        personal_token="test_pat",
+        cloud_id="test-cloud-uuid",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            token="test_pat",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_basic_auth_without_cloud_id_uses_direct_url():
+    """Test that basic auth without cloud_id uses the direct URL as before."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="basic",
+        username="user@example.com",
+        api_token="token",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://company.atlassian.net/wiki",
+            username="user@example.com",
+            password="token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -546,7 +546,7 @@ def test_confluence_client_custom_user_agent_overrides_default():
 # ---------------------------------------------------------------------------
 
 
-def test_init_basic_auth_with_cloud_id():
+def test_init_basic_auth_with_cloud_id() -> None:
     """Test that basic auth with cloud_id routes through api.atlassian.com."""
     config = ConfluenceConfig(
         url="https://company.atlassian.net/wiki",
@@ -559,21 +559,26 @@ def test_init_basic_auth_with_cloud_id():
     with (
         patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
         patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
-        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+        patch(
+            "mcp_atlassian.confluence.client.configure_ssl_verification"
+        ) as mock_configure_ssl,
     ):
         ConfluenceClient(config=config)
 
         mock_confluence.assert_called_once_with(
-            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid/wiki",
             username="svc@company.atlassian.net",
             password="svc_token",
             cloud=True,
             verify_ssl=True,
             timeout=75,
         )
+        assert mock_configure_ssl.call_args.kwargs["url"] == (
+            "https://api.atlassian.com/ex/confluence/test-cloud-uuid/wiki"
+        )
 
 
-def test_init_pat_auth_with_cloud_id():
+def test_init_pat_auth_with_cloud_id() -> None:
     """Test that PAT auth with cloud_id routes through api.atlassian.com."""
     config = ConfluenceConfig(
         url="https://company.atlassian.net/wiki",
@@ -590,7 +595,7 @@ def test_init_pat_auth_with_cloud_id():
         ConfluenceClient(config=config)
 
         mock_confluence.assert_called_once_with(
-            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid/wiki",
             token="test_pat",
             cloud=True,
             verify_ssl=True,
@@ -598,7 +603,7 @@ def test_init_pat_auth_with_cloud_id():
         )
 
 
-def test_init_basic_auth_without_cloud_id_uses_direct_url():
+def test_init_basic_auth_without_cloud_id_uses_direct_url() -> None:
     """Test that basic auth without cloud_id uses the direct URL as before."""
     config = ConfluenceConfig(
         url="https://company.atlassian.net/wiki",

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -329,3 +329,71 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://confluence.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_service_account_with_cloud_id():
+    """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "test-cloud-uuid",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.auth_type == "basic"
+        assert config.is_cloud is True
+        assert config.username == "svc@company.atlassian.net"
+
+
+def test_from_env_service_account_with_confluence_cloud_id():
+    """Test service-specific CONFLUENCE_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "global-cloud-id",
+            "CONFLUENCE_CLOUD_ID": "confluence-specific-cloud-id",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "confluence-specific-cloud-id"
+
+
+def test_from_env_service_account_no_url_required():
+    """Test that CONFLUENCE_URL is not required when cloud_id is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_CLOUD_ID": "test-cloud-uuid",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        # Should not raise ValueError about missing URL
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == ""
+
+
+def test_is_cloud_with_cloud_id_basic_auth():
+    """Test is_cloud returns True when cloud_id is set, regardless of URL."""
+    config = ConfluenceConfig(
+        url="",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -367,7 +367,7 @@ def test_from_env_oauth_enable_with_server_url():
 # ---------------------------------------------------------------------------
 
 
-def test_from_env_service_account_with_cloud_id():
+def test_from_env_service_account_with_cloud_id() -> None:
     """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
     with patch.dict(
         os.environ,
@@ -383,10 +383,13 @@ def test_from_env_service_account_with_cloud_id():
         assert config.auth_type == "basic"
         assert config.is_cloud is True
         assert config.username == "svc@company.atlassian.net"
+        assert config.url == (
+            "https://api.atlassian.com/ex/confluence/test-cloud-uuid/wiki"
+        )
 
 
-def test_from_env_service_account_with_confluence_cloud_id():
-    """Test service-specific CONFLUENCE_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+def test_from_env_service_account_with_confluence_cloud_id() -> None:
+    """Test CONFLUENCE_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
     with patch.dict(
         os.environ,
         {
@@ -399,10 +402,11 @@ def test_from_env_service_account_with_confluence_cloud_id():
     ):
         config = ConfluenceConfig.from_env()
         assert config.cloud_id == "confluence-specific-cloud-id"
+        assert config.api_url.endswith("/confluence/confluence-specific-cloud-id/wiki")
 
 
-def test_from_env_service_account_no_url_required():
-    """Test that CONFLUENCE_URL is not required when cloud_id is set."""
+def test_from_env_service_account_no_url_required() -> None:
+    """Test that cloud_id derives the gateway when CONFLUENCE_URL is absent."""
     with patch.dict(
         os.environ,
         {
@@ -412,13 +416,14 @@ def test_from_env_service_account_no_url_required():
         },
         clear=True,
     ):
-        # Should not raise ValueError about missing URL
         config = ConfluenceConfig.from_env()
         assert config.cloud_id == "test-cloud-uuid"
-        assert config.url == ""
+        assert config.url == (
+            "https://api.atlassian.com/ex/confluence/test-cloud-uuid/wiki"
+        )
 
 
-def test_is_cloud_with_cloud_id_basic_auth():
+def test_is_cloud_with_cloud_id_basic_auth() -> None:
     """Test is_cloud returns True when cloud_id is set, regardless of URL."""
     config = ConfluenceConfig(
         url="",
@@ -428,3 +433,6 @@ def test_is_cloud_with_cloud_id_basic_auth():
         cloud_id="test-cloud-uuid",
     )
     assert config.is_cloud is True
+    assert config.url == (
+        "https://api.atlassian.com/ex/confluence/test-cloud-uuid/wiki"
+    )

--- a/tests/unit/confluence/test_permissions.py
+++ b/tests/unit/confluence/test_permissions.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from requests.exceptions import HTTPError
 
+from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.confluence.permissions import PermissionsMixin
 
 
@@ -17,10 +18,10 @@ class TestPermissionsMixin:
         mixin = MagicMock(spec=PermissionsMixin)
         mixin.confluence = MagicMock()
         mixin.confluence.url = "https://company.atlassian.net/wiki"
-        mixin.config = MagicMock()
-        mixin.config.auth_type = "basic"
-        mixin.config.is_cloud = True
-        mixin.config.url = "https://company.atlassian.net"
+        mixin.config = ConfluenceConfig(
+            url="https://company.atlassian.net",
+            auth_type="basic",
+        )
 
         mixin._require_cloud_permissions_api = lambda *args, **kwargs: (
             PermissionsMixin._require_cloud_permissions_api(mixin, *args, **kwargs)
@@ -40,7 +41,7 @@ class TestPermissionsMixin:
 
     def test_check_content_permissions_requires_cloud(self, permissions_mixin):
         """Test that content permission checks require a Cloud instance."""
-        permissions_mixin.config.is_cloud = False
+        permissions_mixin.config.url = "https://confluence.example.com"
 
         with pytest.raises(ValueError, match="only available for Confluence Cloud"):
             permissions_mixin.check_content_permissions(
@@ -140,7 +141,7 @@ class TestPermissionsMixin:
 
     def test_get_space_permissions_requires_cloud(self, permissions_mixin):
         """Test that space permission checks require a Cloud instance."""
-        permissions_mixin.config.is_cloud = False
+        permissions_mixin.config.url = "https://confluence.example.com"
 
         with pytest.raises(ValueError, match="only available for Confluence Cloud"):
             permissions_mixin.get_space_permissions(space_id="1")
@@ -236,4 +237,14 @@ class TestPermissionsMixin:
 
         assert permissions_mixin._permissions_rest_base_url() == (
             "https://api.atlassian.com/ex/confluence/cloud-id"
+        )
+
+    def test_permissions_rest_base_url_uses_service_account_gateway(
+        self, permissions_mixin
+    ) -> None:
+        """Scoped service-account calls use the Cloud gateway URL."""
+        permissions_mixin.config.cloud_id = "cloud-id"
+
+        assert permissions_mixin._permissions_rest_base_url() == (
+            "https://api.atlassian.com/ex/confluence/cloud-id/wiki"
         )

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -396,3 +396,83 @@ def test_jira_client_basic_auth_preserves_trust_env():
         JiraClient(config=config)
 
         assert mock_session.trust_env is True
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_basic_auth_with_cloud_id():
+    """Test that basic auth with cloud_id routes through api.atlassian.com."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="basic",
+            username="svc@company.atlassian.net",
+            api_token="svc_token",
+            cloud_id="test-cloud-uuid",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://api.atlassian.com/ex/jira/test-cloud-uuid",
+            username="svc@company.atlassian.net",
+            password="svc_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_pat_auth_with_cloud_id():
+    """Test that PAT auth with cloud_id routes through api.atlassian.com."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="pat",
+            personal_token="test_pat",
+            cloud_id="test-cloud-uuid",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://api.atlassian.com/ex/jira/test-cloud-uuid",
+            token="test_pat",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_basic_auth_without_cloud_id_uses_direct_url():
+    """Test that basic auth without cloud_id uses the direct URL as before."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="basic",
+            username="user@example.com",
+            api_token="token",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://company.atlassian.net",
+            username="user@example.com",
+            password="token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -649,11 +649,13 @@ def test_update_version_rejects_non_dict_response() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_init_basic_auth_with_cloud_id():
+def test_init_basic_auth_with_cloud_id() -> None:
     """Test that basic auth with cloud_id routes through api.atlassian.com."""
     with (
         patch("mcp_atlassian.jira.client.Jira") as mock_jira,
-        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+        patch(
+            "mcp_atlassian.jira.client.configure_ssl_verification"
+        ) as mock_configure_ssl,
     ):
         config = JiraConfig(
             url="https://company.atlassian.net",
@@ -673,9 +675,12 @@ def test_init_basic_auth_with_cloud_id():
             verify_ssl=True,
             timeout=75,
         )
+        assert mock_configure_ssl.call_args.kwargs["url"] == (
+            "https://api.atlassian.com/ex/jira/test-cloud-uuid"
+        )
 
 
-def test_init_pat_auth_with_cloud_id():
+def test_init_pat_auth_with_cloud_id() -> None:
     """Test that PAT auth with cloud_id routes through api.atlassian.com."""
     with (
         patch("mcp_atlassian.jira.client.Jira") as mock_jira,
@@ -699,7 +704,7 @@ def test_init_pat_auth_with_cloud_id():
         )
 
 
-def test_init_basic_auth_without_cloud_id_uses_direct_url():
+def test_init_basic_auth_without_cloud_id_uses_direct_url() -> None:
     """Test that basic auth without cloud_id uses the direct URL as before."""
     with (
         patch("mcp_atlassian.jira.client.Jira") as mock_jira,

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -401,3 +401,99 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://jira.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_service_account_with_cloud_id():
+    """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.auth_type == "basic"
+        assert config.is_cloud is True
+        assert config.username == "svc@company.atlassian.net"
+
+
+def test_from_env_service_account_with_jira_cloud_id():
+    """Test service-specific JIRA_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "global-cloud-id",
+            "JIRA_CLOUD_ID": "jira-specific-cloud-id",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "jira-specific-cloud-id"
+
+
+def test_from_env_service_account_no_url_required():
+    """Test that JIRA_URL is not required when cloud_id is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        # Should not raise ValueError about missing URL
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == ""
+
+
+def test_from_env_service_account_with_url():
+    """Test service account config with both cloud_id and URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://company.atlassian.net",
+            "JIRA_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == "https://company.atlassian.net"
+        assert config.is_cloud is True
+
+
+def test_is_cloud_with_cloud_id_basic_auth():
+    """Test is_cloud returns True when cloud_id is set, regardless of URL."""
+    config = JiraConfig(
+        url="",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True
+
+    # Even with a server-like URL, cloud_id means Cloud
+    config = JiraConfig(
+        url="https://jira.example.com",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -408,7 +408,7 @@ def test_from_env_oauth_enable_with_server_url():
 # ---------------------------------------------------------------------------
 
 
-def test_from_env_service_account_with_cloud_id():
+def test_from_env_service_account_with_cloud_id() -> None:
     """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
     with patch.dict(
         os.environ,
@@ -424,10 +424,11 @@ def test_from_env_service_account_with_cloud_id():
         assert config.auth_type == "basic"
         assert config.is_cloud is True
         assert config.username == "svc@company.atlassian.net"
+        assert config.url == "https://api.atlassian.com/ex/jira/test-cloud-uuid"
 
 
-def test_from_env_service_account_with_jira_cloud_id():
-    """Test service-specific JIRA_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+def test_from_env_service_account_with_jira_cloud_id() -> None:
+    """Test JIRA_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
     with patch.dict(
         os.environ,
         {
@@ -440,10 +441,11 @@ def test_from_env_service_account_with_jira_cloud_id():
     ):
         config = JiraConfig.from_env()
         assert config.cloud_id == "jira-specific-cloud-id"
+        assert config.api_url.endswith("/jira/jira-specific-cloud-id")
 
 
-def test_from_env_service_account_no_url_required():
-    """Test that JIRA_URL is not required when cloud_id is set."""
+def test_from_env_service_account_no_url_required() -> None:
+    """Test that cloud_id derives the Jira gateway when JIRA_URL is absent."""
     with patch.dict(
         os.environ,
         {
@@ -453,13 +455,12 @@ def test_from_env_service_account_no_url_required():
         },
         clear=True,
     ):
-        # Should not raise ValueError about missing URL
         config = JiraConfig.from_env()
         assert config.cloud_id == "test-cloud-uuid"
-        assert config.url == ""
+        assert config.url == "https://api.atlassian.com/ex/jira/test-cloud-uuid"
 
 
-def test_from_env_service_account_with_url():
+def test_from_env_service_account_with_url() -> None:
     """Test service account config with both cloud_id and URL."""
     with patch.dict(
         os.environ,
@@ -477,7 +478,7 @@ def test_from_env_service_account_with_url():
         assert config.is_cloud is True
 
 
-def test_is_cloud_with_cloud_id_basic_auth():
+def test_is_cloud_with_cloud_id_basic_auth() -> None:
     """Test is_cloud returns True when cloud_id is set, regardless of URL."""
     config = JiraConfig(
         url="",
@@ -487,6 +488,7 @@ def test_is_cloud_with_cloud_id_basic_auth():
         cloud_id="test-cloud-uuid",
     )
     assert config.is_cloud is True
+    assert config.url == "https://api.atlassian.com/ex/jira/test-cloud-uuid"
 
     # Even with a server-like URL, cloud_id means Cloud
     config = JiraConfig(

--- a/tests/unit/jira/test_development.py
+++ b/tests/unit/jira/test_development.py
@@ -163,6 +163,28 @@ class TestDevelopmentMixin:
         assert result["branches"] == []
         assert result["commits"] == []
 
+    def test_get_issue_development_info_uses_service_account_gateway(
+        self, development_mixin
+    ) -> None:
+        """Scoped service-account dev-status calls use the Cloud gateway."""
+        development_mixin.config.cloud_id = "cloud-123"
+        development_mixin.jira.get_issue.return_value = {
+            "id": "12345",
+            "key": "TEST-123",
+        }
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = {"detail": []}
+        development_mixin.jira._session.get.return_value = mock_response
+
+        development_mixin.get_issue_development_info(
+            "TEST-123", application_type="stash", data_type="pullrequest"
+        )
+
+        assert development_mixin.jira._session.get.call_args.args[0] == (
+            "https://api.atlassian.com/ex/jira/cloud-123"
+            "/rest/dev-status/1.0/issue/detail"
+        )
+
     def test_get_issue_development_info_issue_not_found(self, development_mixin):
         """Test error when issue is not found."""
         development_mixin.jira.get_issue.return_value = {"key": "TEST-123"}

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -508,6 +508,23 @@ class TestUsersMixin:
             # Verify result
             assert account_id is None
 
+    def test_lookup_user_by_permissions_uses_service_account_gateway(
+        self, users_mixin
+    ) -> None:
+        """Scoped service-account requests use the Cloud API gateway."""
+        users_mixin.config.cloud_id = "cloud-123"
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock(status_code=200)
+            mock_response.json.return_value = {"users": []}
+            mock_get.return_value = mock_response
+
+            users_mixin._lookup_user_by_permissions("username")
+
+        assert mock_get.call_args.args[0] == (
+            "https://api.atlassian.com/ex/jira/cloud-123"
+            "/rest/api/2/user/permission/search"
+        )
+
     def test_lookup_user_by_permissions_jira_data_center(self, users_mixin):
         """Test _lookup_user_by_permissions when both 'key' and 'name' are available (Data Center)."""
         # Mock requests.get


### PR DESCRIPTION
## Description

Add Atlassian Cloud ID routing for scoped service-account API tokens so Jira and Confluence automation can run under a dedicated bot identity.

Fixes #781

## Changes

- Add shared and per-service Cloud ID configuration with service-specific precedence.
- Derive Jira and Confluence API gateway URLs when a Cloud ID is configured.
- Keep scoped-token requests on the gateway, including hand-built attachment, permission, user lookup, template, restriction, and development endpoints.
- Allow the site URLs to be omitted while recommending them for generated browser links.
- Document service-account setup, scoped tokens, and Cloud ID discovery.
- Add unit coverage and a live Cloud auth-matrix variant for Cloud ID gateway routing.

## Verification

- `pre-commit run --all-files`
- `uv run pytest -q tests/unit/` — 3179 passed, 5 skipped
- Live integration suite — 23 passed
- Cloud e2e — 101 passed, 15 skipped
- Data Center e2e — 98 passed, 117 skipped
