### PR TITLE
feat(ssl): enhance SSL compatibility for legacy corporate servers

### DIFF
--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -37,9 +37,14 @@ class SSLIgnoreAdapter(HTTPAdapter):
             pool_kwargs: Additional arguments for the pool manager
         """
         # Configure SSL context to disable verification completely
-        context = ssl.create_default_context()
+        # Use legacy mode for compatibility with older servers (TLS 1.0/1.1)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
+        # Enable all TLS versions for maximum compatibility
+        context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+        # Add legacy cipher suites for older corporate servers
+        context.set_ciphers('DEFAULT@SECLEVEL=0')
 
         self.poolmanager = PoolManager(
             num_pools=connections,

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -44,7 +44,7 @@ class SSLIgnoreAdapter(HTTPAdapter):
         # Enable all TLS versions for maximum compatibility
         context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
         # Add legacy cipher suites for older corporate servers
-        context.set_ciphers('DEFAULT@SECLEVEL=0')
+        context.set_ciphers("DEFAULT@SECLEVEL=0")
 
         self.poolmanager = PoolManager(
             num_pools=connections,

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -39,10 +39,10 @@ def test_ssl_ignore_adapter_init_poolmanager():
     # Create a mock for PoolManager that will be returned by constructor
     mock_pool_manager = MagicMock()
 
-    # Mock ssl.create_default_context
-    with patch("ssl.create_default_context") as mock_create_context:
+    # Mock ssl.SSLContext
+    with patch("ssl.SSLContext") as mock_ssl_context:
         mock_context = MagicMock()
-        mock_create_context.return_value = mock_context
+        mock_ssl_context.return_value = mock_context
 
         # Patch the PoolManager constructor
         with patch(
@@ -52,7 +52,7 @@ def test_ssl_ignore_adapter_init_poolmanager():
             adapter.init_poolmanager(5, 10, block=True)
 
             # Assert
-            mock_create_context.assert_called_once()
+            mock_ssl_context.assert_called_once_with(ssl.PROTOCOL_TLS_CLIENT)
             assert mock_context.check_hostname is False
             assert mock_context.verify_mode == ssl.CERT_NONE
 

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -56,6 +56,9 @@ def test_ssl_ignore_adapter_init_poolmanager():
             assert mock_context.check_hostname is False
             assert mock_context.verify_mode == ssl.CERT_NONE
 
+            # Verify the SSL context methods were called
+            mock_context.set_ciphers.assert_called_once_with("DEFAULT@SECLEVEL=0")
+
             # Verify PoolManager was called with our context
             mock_pool_manager_cls.assert_called_once()
             _, kwargs = mock_pool_manager_cls.call_args


### PR DESCRIPTION
## Description

This PR enhances SSL compatibility for legacy corporate servers that use outdated SSL/TLS configurations. Many enterprise Jira/Confluence instances still run on older servers that only support TLS 1.0/1.1 and legacy cipher suites. The current implementation with `ssl.create_default_context()` fails to connect to these servers, causing connection issues in corporate environments.

Fixes: #

## Changes

- Replace `ssl.create_default_context()` with `ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)` for better compatibility
- Add `context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED` to enable TLS 1.0/1.1 support
- Add `context.set_ciphers('DEFAULT@SECLEVEL=0')` to support legacy cipher suites
- Update unit test [test_ssl_ignore_adapter_init_poolmanager](tests/unit/utils/test_ssl.py:33:0-64:56) to mock the correct SSL context creation
- Add verification for new SSL configuration methods in tests

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Verified all SSL unit tests pass with the new implementation. Successfully tested against corporate Confluence instance with legacy SSL/TLS configuration.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
