### PR TITLE
feat(jira): expose accountId through get_user_profile

### DIFF
--- a/src/mcp_atlassian/models/jira/common.py
+++ b/src/mcp_atlassian/models/jira/common.py
@@ -85,6 +85,8 @@ class JiraUser(ApiModel):
             "email": self.email,
             "avatar_url": self.avatar_url,
         }
+        if self.account_id:
+            result["account_id"] = self.account_id
         if self.user_key:
             result["key"] = self.user_key
         return result

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1390,6 +1390,7 @@ class TestIssuesMixin:
                             "display_name": "Test User 1",
                             "email": None,
                             "name": "Test User 1",
+                            "account_id": "user123",
                         },
                         "created": "2024-01-05T10:06:03.548000+08:00",
                         "items": [
@@ -1415,6 +1416,7 @@ class TestIssuesMixin:
                             "display_name": "Test User 2",
                             "email": None,
                             "name": "Test User 2",
+                            "account_id": "user456",
                         },
                         "created": "2024-01-01T11:00:00+00:00",
                         "items": [
@@ -1432,6 +1434,7 @@ class TestIssuesMixin:
                             "display_name": "Test User 3",
                             "email": None,
                             "name": "Test User 3",
+                            "account_id": "user789",
                         },
                         "created": "2024-01-06T10:06:03.548000+08:00",
                         "items": [
@@ -1451,6 +1454,7 @@ class TestIssuesMixin:
                             "display_name": "Test User 1",
                             "email": None,
                             "name": "Test User 1",
+                            "account_id": "user123",
                         },
                         "created": "2024-01-10T10:06:03.548000+08:00",
                         "items": [

--- a/tests/unit/models/test_jira_common_models.py
+++ b/tests/unit/models/test_jira_common_models.py
@@ -82,8 +82,17 @@ class TestJiraUser:
         assert simplified["display_name"] == "Test User"
         assert simplified["email"] == "test@example.com"
         assert simplified["avatar_url"] == "https://example.com/avatar.png"
-        assert "account_id" not in simplified
+        assert simplified["account_id"] == "user123"
         assert "time_zone" not in simplified
+
+    def test_to_simplified_dict_no_account_id(self):
+        """Test to_simplified_dict omits account_id when not set."""
+        user = JiraUser(
+            display_name="Test User",
+            email="test@example.com",
+        )
+        simplified = user.to_simplified_dict()
+        assert "account_id" not in simplified
 
     def test_from_api_response_server_dc_with_name_and_key(self):
         """Test JiraUser captures username and key from Server/DC API response."""
@@ -149,6 +158,7 @@ class TestJiraUser:
         simplified = user.to_simplified_dict()
         assert simplified["name"] == "John Doe"
         assert simplified["display_name"] == "John Doe"
+        assert simplified["account_id"] == "abc123"
         assert "key" not in simplified
 
 


### PR DESCRIPTION
## Description

exposes account id of the user as well through get_user_profile(). it could be helpful as email is mostly empty in webhooks that mcp wants to be triggered by.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).