### PR TITLE
fix(confluence): surface attachment upload API errors

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -484,10 +484,8 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             if minor_edit is not None:
                 data["minorEdit"] = str(minor_edit).lower()
 
-            # Use PUT to support creating new versions of existing attachments
-            # PUT will create a new attachment if it doesn't exist, OR create a new
-            # version if an attachment with the same filename already exists
-            response = self.confluence._session.put(
+            # POST creates a new attachment or a new version if same filename exists
+            response = self.confluence._session.post(
                 url, headers=headers, files=files, data=data
             )
             response.raise_for_status()
@@ -502,8 +500,11 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             return result
 
         except Exception as e:
-            logger.error(f"Direct API upload failed: {e}")
-            return None
+            logger.error(
+                f"Direct API upload failed: {type(e).__name__}: {e}", exc_info=True
+            )
+            # Propagate error details instead of swallowing them
+            raise
         finally:
             # Close file handles (only for actual file objects, not text fields like comment)
             if "files" in locals() and "file" in files:

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -104,13 +104,11 @@ class TestAttachmentsMixin:
 
         mock_response = Mock()
         if raise_error:
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.side_effect = raise_error
+            attachments_mixin.confluence._session.post.side_effect = raise_error
         else:
             mock_response.json.return_value = response_data
             mock_response.raise_for_status.return_value = None
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.return_value = mock_response
+            attachments_mixin.confluence._session.post.return_value = mock_response
 
         return mock_response
 
@@ -152,9 +150,8 @@ class TestAttachmentsMixin:
             assert result["id"] == "att12345"
 
             # Verify the REST API was called with correct parameters
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.assert_called_once()
-            call_args = attachments_mixin.confluence._session.put.call_args
+            attachments_mixin.confluence._session.post.assert_called_once()
+            call_args = attachments_mixin.confluence._session.post.call_args
 
             # Check URL
             assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
@@ -266,10 +263,9 @@ class TestAttachmentsMixin:
                 "123456", "/absolute/path/test_file.txt"
             )
 
-            # Assertions
+            # Assertions: exception is caught by upload_attachment and returned as failure dict
             assert result["success"] is False
-            # When direct API fails, we get generic failure message
-            assert "Failed to upload attachment" in result["error"]
+            assert "API Error" in result["error"]
 
     # Tests for upload_attachments method
 


### PR DESCRIPTION
## Summary

Carries forward the remaining error-propagation part of this PR after the Confluence attachment POST/versioning fixes landed on `main`.

- Logs direct attachment upload failures with exception type and traceback context.
- Re-raises direct upload exceptions so `upload_attachment()` returns the underlying API message instead of a generic `Failed to upload attachment ...` string.
- Keeps the current `main` upload path intact: POST, `X-Atlassian-Token: no-check`, Cloud `/wiki` base URL handling, and existing-attachment versioning fallback.

## Testing

- `uv run pytest tests/unit/confluence/test_attachments.py -xvs`
- `CONFLUENCE_URL="$CLOUD_E2E_CONFLUENCE_URL" CONFLUENCE_USERNAME="$CLOUD_E2E_USERNAME" CONFLUENCE_API_TOKEN="$CLOUD_E2E_API_TOKEN" CONFLUENCE_TEST_SPACE_KEY="$CLOUD_E2E_SPACE_KEY" uv run pytest tests/integration/test_real_api.py::TestRealConfluenceAPI::test_attachment_handling --integration --use-real-data -xvs`
- `uv run pytest tests/e2e/test_confluence_dc_operations.py::TestConfluenceDCAttachments::test_upload_attachment_creates_new_version --dc-e2e -xvs`
- `uv run pytest tests/e2e/cloud/test_confluence_cloud_operations.py::TestConfluenceCloudAttachments::test_upload_attachment_creates_new_version --cloud-e2e -xvs`
- `uv run pre-commit run --files src/mcp_atlassian/confluence/attachments.py tests/unit/confluence/test_attachments.py`

## Related

- Related to #1163.