### PR TITLE
feat: community true-up batch 3 — 10 PRs integrated and tested

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,23 @@ JIRA_API_TOKEN=your_jira_api_token_here
 CONFLUENCE_USERNAME=your.email@example.com
 CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 
+# --- METHOD 1b: SERVICE ACCOUNT (Atlassian Cloud - API Token with Cloud ID) ---
+# Service accounts use the api.atlassian.com gateway instead of direct instance URLs.
+# This is useful when AI agents should act under a dedicated bot identity.
+# 1. Create a service account at: https://admin.atlassian.com
+# 2. Generate an API token for the service account
+# 3. Get your Cloud ID from: https://your-company.atlassian.net/_edge/tenant_info
+#    (look for the "cloudId" field in the JSON response)
+# When CLOUD_ID is set, JIRA_URL/CONFLUENCE_URL are optional (the gateway URL is derived).
+#ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
+#JIRA_USERNAME=service-account@your-company.atlassian.net
+#JIRA_API_TOKEN=service_account_api_token
+#CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+#CONFLUENCE_API_TOKEN=service_account_api_token
+# You can also set per-service Cloud IDs if Jira and Confluence are on different sites:
+#JIRA_CLOUD_ID=your-jira-cloud-id
+#CONFLUENCE_CLOUD_ID=your-confluence-cloud-id
+
 # --- METHOD 2: PERSONAL ACCESS TOKEN (PAT) (Server / Data Center - Recommended) ---
 # Create PATs in your Jira/Confluence profile settings (usually under "Personal Access Tokens").
 #JIRA_PERSONAL_TOKEN=your_jira_personal_access_token

--- a/.env.example
+++ b/.env.example
@@ -239,3 +239,10 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 
 # Confluence-specific custom headers.
 #CONFLUENCE_CUSTOM_HEADERS=X-Confluence-Service=mcp-integration,X-Custom-Auth=confluence-token,X-ALB-Token=secret-token
+
+# --- Cookie Configuration (Advanced) ---
+# Raw cookie string attached to every Jira/Confluence request.
+# Useful behind SSO / reverse proxies that require session cookies.
+# Format: name=value pairs separated by "; " (exactly as a Cookie header).
+#JIRA_COOKIE=JSESSIONID=abc123; other_cookie=xyz
+#CONFLUENCE_COOKIE=JSESSIONID=abc123; other_cookie=xyz

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ playground/
 
 # Dev docs (local task documents)
 dev/
+docs/plans/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN find /app/.venv -name '__pycache__' -type d -exec rm -rf {} + && \
 # Final stage
 FROM python:3.13-alpine
 
+# Upgrade base packages to pick up security fixes (zlib >= 1.3.2-r0)
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
+
 # Create a non-root user 'app'
 RUN adduser -D -h /home/app -s /bin/sh app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,4 +1,28 @@
-# MCP Atlassian
+# MCP Atlassian (Community Fork)
+
+> **This is an actively maintained community fork of [`sooperset/mcp-atlassian`](https://github.com/sooperset/mcp-atlassian).**
+>
+> The upstream repository has a growing backlog of unmerged pull requests and
+> unresolved issues. This fork integrates vetted community PRs so users don't
+> have to wait — we monitor upstream issues and PRs and bring them in here
+> when they're ready. All changes are tracked with provenance back to the
+> original PRs and authors.
+>
+> **This is not a takeover.** We encourage contributors to submit PRs to
+> [upstream](https://github.com/sooperset/mcp-atlassian) first. This fork
+> exists to bridge the gap while the upstream maintainer catches up. When
+> upstream merges a PR, the duplicate here becomes a no-op on the next sync.
+>
+> **Branches:**
+> - `community/main` (default) — upstream + integrated community PRs
+> - `main` — clean mirror of upstream
+> - `team/main` — optional team-specific features (error recovery, extra tools, MCPB extension)
+>
+> **Want to help?** PRs welcome against `community/main`, or submit to
+> [upstream](https://github.com/sooperset/mcp-atlassian) — we'll pick it up
+> either way.
+
+---
 
 ![PyPI Version](https://img.shields.io/pypi/v/mcp-atlassian)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/mcp-atlassian)

--- a/docs/_overrides/confluence_get_page.yaml
+++ b/docs/_overrides/confluence_get_page.yaml
@@ -1,4 +1,4 @@
 example: |
   {"page_id": "12345678", "include_metadata": true}
 tips: |
-  Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date.
+  Content is returned in Markdown format by default. Set `convert_to_markdown` to `false` to retrieve exact Confluence storage XHTML when macro preservation matters, including embedded Jira card-vs-list rendering, task metadata, and page layout details. Use `include_metadata` for labels, version info, and last modified date.

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Authentication"
-description: "Configure authentication for MCP Atlassian — API tokens, PATs, and OAuth 2.0"
+description: "Configure authentication for MCP Atlassian — API tokens, service accounts, PATs, and OAuth 2.0"
 ---
 
 MCP Atlassian supports three authentication methods depending on your Atlassian deployment type.
@@ -31,6 +31,36 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 CONFLUENCE_USERNAME=your.email@company.com
 CONFLUENCE_API_TOKEN=your_api_token
 ```
+
+## Service Account (Cloud)
+
+For AI agents and automations that should act under a dedicated bot identity instead of a personal account.
+
+<Steps>
+  <Step title="Create Service Account">
+    Go to [Atlassian Admin](https://admin.atlassian.com) → **Directory** → **Service accounts** and create a new service account
+  </Step>
+  <Step title="Generate API Token">
+    Generate an API token for the service account
+  </Step>
+  <Step title="Get Cloud ID">
+    Visit `https://your-company.atlassian.net/_edge/tenant_info` and copy the `cloudId` value from the JSON response
+  </Step>
+</Steps>
+
+**Environment variables:**
+```bash
+ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
+JIRA_USERNAME=service-account@your-company.atlassian.net
+JIRA_API_TOKEN=service_account_api_token
+CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+CONFLUENCE_API_TOKEN=service_account_api_token
+```
+
+<Note>
+When `ATLASSIAN_CLOUD_ID` is set, `JIRA_URL` and `CONFLUENCE_URL` are optional — the server routes requests through the `api.atlassian.com` gateway automatically.
+You can also use `JIRA_CLOUD_ID` and `CONFLUENCE_CLOUD_ID` separately if your Jira and Confluence are on different Cloud sites.
+</Note>
 
 ## Personal Access Token (Server/Data Center)
 

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 72 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 73 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **72 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **73 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -81,7 +81,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
-| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_diff` |
+| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_diff` |
 | `confluence_comments` | Yes | `confluence_get_comments`, `confluence_add_comment`, `confluence_reply_to_comment` |
 | `confluence_labels` | No | `confluence_get_labels`, `confluence_add_label` |
 | `confluence_users` | No | `confluence_search_user` |
@@ -93,7 +93,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (72 tools)
+# Enable all toolsets (73 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -15,7 +15,7 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 | `title` | `string` | No | The exact title of the Confluence page. Use this with 'space_key' if 'page_id' is not known. |
 | `space_key` | `string` | No | The key of the Confluence space where the page resides (e.g., 'DEV', 'TEAM'). Required if using 'title'. |
 | `include_metadata` | `boolean` | No | Whether to include page metadata such as creation date, last update, version, and labels. |
-| `convert_to_markdown` | `boolean` | No | Whether to convert page to markdown (true) or keep it in raw HTML format (false). Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: using HTML significantly increases token usage in AI responses. |
+| `convert_to_markdown` | `boolean` | No | Whether to convert page to markdown (true) or return raw Confluence storage XHTML (false). Storage output preserves macros, embedded Jira render modes, page layout, and task metadata for safe round-tripping, but CAUTION: it significantly increases token usage in AI responses. |
 **Example:**
 
 ```json
@@ -23,7 +23,7 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 ```
 
 <Tip>
-Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date.
+Content is returned in Markdown format by default. Set `convert_to_markdown` to `false` to retrieve exact Confluence storage XHTML when macro preservation matters, including embedded Jira card-vs-list rendering, task metadata, and page layout details.
 </Tip>
 
 
@@ -41,9 +41,9 @@ Create a new Confluence page.
 |-----------|------|----------|-------------|
 | `space_key` | `string` | Yes | The key of the space to create the page in (usually a short uppercase code like 'DEV', 'TEAM', or 'DOC') |
 | `title` | `string` | Yes | The title of the page |
-| `content` | `string` | Yes | The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, or storage format |
+| `content` | `string` | Yes | The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, or storage format. Use storage when retransmitting macro-heavy pages or existing layout/render metadata. |
 | `parent_id` | `string` | No | (Optional) parent page ID. If provided, this page will be created as a child of the specified page |
-| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax |
+| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax. Choose `storage` when embedded macros, Jira cards/lists, task metadata, or page layout must round-trip unchanged. |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
 | `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at create time. |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
@@ -54,7 +54,7 @@ Create a new Confluence page.
 ```
 
 <Tip>
-Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.
+Use Markdown for content when authoring new text. Use `content_format: "storage"` when retransmitting existing Confluence storage XHTML so macro-heavy pages keep their render metadata. Specify `parent_id` to create as a child page.
 </Tip>
 
 
@@ -72,11 +72,11 @@ Update an existing Confluence page.
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | The ID of the page to update |
 | `title` | `string` | Yes | The new title of the page |
-| `content` | `string` | Yes | The new content of the page. Format depends on content_format parameter |
+| `content` | `string` | Yes | The new content of the page. Format depends on content_format parameter. Use storage when retransmitting macro-heavy pages or existing layout/render metadata. |
 | `is_minor_edit` | `boolean` | No | Whether this is a minor edit |
 | `version_comment` | `string` | No | Optional comment for this version |
 | `parent_id` | `string` | No | Optional the new parent page ID |
-| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax |
+| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax. Choose `storage` when embedded macros, Jira cards/lists, task metadata, or page layout must round-trip unchanged. |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
 | `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at update time. |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
@@ -87,7 +87,7 @@ Update an existing Confluence page.
 ```
 
 <Tip>
-Set `is_minor_edit: true` to skip notification emails. The page version is auto-incremented.
+Set `is_minor_edit: true` to skip notification emails. Use `content_format: "storage"` when updating existing macro-heavy pages so Confluence render metadata is retransmitted unchanged.
 </Tip>
 
 
@@ -169,7 +169,7 @@ Get a historical version of a specific Confluence page.
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | Confluence page ID (numeric ID, can be found in the page URL). For example, in 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', the page ID is '123456789'. |
 | `version` | `integer` | Yes | The version number of the page to retrieve |
-| `convert_to_markdown` | `boolean` | No | Whether to convert page to markdown (true) or keep it in raw HTML format (false). Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: using HTML significantly increases token usage in AI responses. |
+| `convert_to_markdown` | `boolean` | No | Whether to convert page to markdown (true) or return raw Confluence storage XHTML (false). Storage output preserves macros and task metadata for safe round-tripping, but CAUTION: it significantly increases token usage in AI responses. |
 
 ---
 

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -93,6 +93,40 @@ Set `is_minor_edit: true` to skip notification emails. The page version is auto-
 
 ---
 
+### Update Page Section
+
+Update a single section of a Confluence page without affecting the rest.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | `string` | Yes | The ID of the page to update |
+| `heading_text` | `string` | Yes | Exact text of the heading that starts the section to replace. Matching is case-sensitive. Use `confluence_get_page` with `convert_to_markdown=false` to inspect exact heading text when unsure. |
+| `new_content` | `string` | Yes | Replacement content for the section body. Do not include the heading itself — only the body beneath it. Format is controlled by `content_format`. |
+| `content_format` | `string` | No | Format of `new_content`. Options: `'markdown'` (default) or `'storage'` (raw Confluence storage XML). Use `'storage'` to insert macros or elements that markdown cannot express. |
+| `is_minor_edit` | `boolean` | No | Whether this is a minor edit |
+| `version_comment` | `string` | No | Optional comment for this version |
+
+**Example:**
+
+```json
+{"page_id": "12345678", "heading_text": "Weekly Update", "new_content": "- Shipped v2.1\n- Started v2.2 planning", "version_comment": "Weekly sync"}
+```
+
+<Tip>
+Use this instead of `confluence_update_page` when the page contains macros, layouts, task lists, or other Confluence-specific elements you don't want to lose. The tool fetches the page as raw storage XML, surgically replaces only the target section, and writes the full XML back — so everything outside the section is preserved exactly.
+</Tip>
+
+<Warning>
+`heading_text` must match the heading exactly as it appears in Confluence (case-sensitive, no surrounding emoji — emoji in headings are stripped automatically). If the heading is not found, a `ValueError` is raised.
+</Warning>
+
+
+---
+
 ### Delete Page
 
 Delete an existing Confluence page.

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -17,6 +17,7 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -25,6 +26,10 @@ Get details of a specific Jira issue including its Epic links and relationship i
 
 <Tip>
 Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
 </Tip>
 
 

--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -18,6 +18,7 @@ Search Jira issues using JQL (Jira Query Language).
 | `projects_filter` | `string` | No | (Optional) Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided. |
 | `expand` | `string` | No | (Optional) fields to expand. Examples: 'renderedFields', 'transitions', 'changelog' |
 | `page_token` | `string` | No | Pagination token from a previous search result. Cloud only — Server/DC uses `start_at` for pagination. |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -26,6 +27,10 @@ Search Jira issues using JQL (Jira Query Language).
 
 <Tip>
 Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
 </Tip>
 
 

--- a/scripts/oauth_authorize.py
+++ b/scripts/oauth_authorize.py
@@ -2,301 +2,68 @@
 """
 OAuth 2.0 Authorization Flow Helper for MCP Atlassian
 
-This script helps with the OAuth 2.0 (3LO) authorization flow for Atlassian Cloud:
+This script helps with the OAuth 2.0 (3LO) authorization flow for Atlassian Cloud
+and Server/Data Center:
 1. Opens a browser to the authorization URL
 2. Starts a local server to receive the callback with the authorization code
 3. Exchanges the authorization code for access and refresh tokens
 4. Saves the tokens for later use by MCP Atlassian
 
-Usage:
-    python oauth_authorize.py --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
-                             --redirect-uri http://localhost:8080/callback
-                             --scope "read:jira-work write:jira-work read:confluence-space.summary offline_access"
+Usage (Cloud):
+    python oauth_authorize.py \\
+        --client-id YOUR_CLIENT_ID \\
+        --client-secret YOUR_CLIENT_SECRET \\
+        --redirect-uri http://localhost:8080/callback \\
+        --scope "read:jira-work offline_access"
 
-IMPORTANT: The 'offline_access' scope is required for refresh tokens to work properly.
-Without this scope, tokens will expire quickly and authentication will fail.
+Usage (Server/Data Center):
+    python oauth_authorize.py \\
+        --base-url https://jira.local.example.com \\
+        --client-id YOUR_CLIENT_ID \\
+        --client-secret YOUR_CLIENT_SECRET \\
+        --redirect-uri http://localhost:8080/callback \\
+        --scope WRITE
 
 Environment variables can also be used:
-- ATLASSIAN_OAUTH_CLIENT_ID
-- ATLASSIAN_OAUTH_CLIENT_SECRET
+- ATLASSIAN_OAUTH_CLIENT_ID / JIRA_OAUTH_CLIENT_ID
+- ATLASSIAN_OAUTH_CLIENT_SECRET / JIRA_OAUTH_CLIENT_SECRET
 - ATLASSIAN_OAUTH_REDIRECT_URI
 - ATLASSIAN_OAUTH_SCOPE
+- JIRA_URL (for --base-url)
 """
 
 import argparse
-import http.server
 import logging
 import os
-import secrets
-import socketserver
 import sys
-import threading
-import time
-import urllib.parse
-import webbrowser
 
 # Add the parent directory to the path so we can import the package
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from src.mcp_atlassian.utils.oauth import OAuthConfig
+from src.mcp_atlassian.utils.oauth_setup import OAuthSetupArgs, run_oauth_flow
+from src.mcp_atlassian.utils.urls import is_atlassian_cloud_url
 
-# Configure logging (basicConfig should be called only once, ideally at the very start)
-# Adding lineno for better debugging.
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s - %(levelname)s - %(name)s - %(lineno)d - %(message)s",
     force=True,
 )
 
-
 logger = logging.getLogger("oauth-authorize")
 logger.setLevel(logging.DEBUG)
 logging.getLogger("mcp-atlassian.oauth").setLevel(logging.DEBUG)
-
-# Global variables for callback handling
-authorization_code = None
-received_state = None
-callback_received = False
-callback_error = None
-
-
-class CallbackHandler(http.server.BaseHTTPRequestHandler):
-    """HTTP request handler for OAuth callback."""
-
-    def do_GET(self) -> None:  # noqa: N802
-        """Handle GET requests (OAuth callback and favicon)."""
-        global authorization_code, callback_received, callback_error, received_state
-
-        parsed_path = urllib.parse.urlparse(self.path)
-        logger.debug(f"CallbackHandler received GET request for: {self.path}")
-
-        # Ignore favicon requests politely
-        if parsed_path.path == "/favicon.ico":
-            self.send_error(404, "File not found")
-            logger.debug("CallbackHandler: Ignored /favicon.ico request.")
-            return
-
-        # Process only /callback path
-        if parsed_path.path != "/callback":
-            self.send_error(404, "Not Found: Only /callback is supported.")
-            logger.warning(
-                f"CallbackHandler: Received request for unexpected path: {parsed_path.path}"
-            )
-            return
-
-        # Parse the query parameters from the URL
-        query = parsed_path.query
-        params = urllib.parse.parse_qs(query)
-
-        if "error" in params:
-            callback_error = params["error"][0]
-            callback_received = True
-            logger.error(f"Authorization error from callback: {callback_error}")
-            self._send_response(f"Authorization failed: {callback_error}")
-            return
-
-        if "code" in params:
-            authorization_code = params["code"][0]
-            if "state" in params:
-                received_state = params["state"][0]
-            callback_received = True
-            logger.info(
-                "Authorization code and state received successfully via callback."
-            )
-            self._send_response(
-                "Authorization successful! You can close this window now."
-            )
-        else:
-            logger.error("Invalid callback: 'code' or 'error' parameter missing.")
-            self._send_response(
-                "Invalid callback: Authorization code missing", status=400
-            )
-
-    def _send_response(self, message: str, status: int = 200) -> None:
-        """Send response to the browser."""
-        self.send_response(status)
-        self.send_header("Content-type", "text/html")
-        self.end_headers()
-
-        html = f"""
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <title>Atlassian OAuth Authorization</title>
-            <style>
-                body {{
-                    font-family: Arial, sans-serif;
-                    text-align: center;
-                    padding: 40px;
-                    max-width: 600px;
-                    margin: 0 auto;
-                }}
-                .message {{
-                    padding: 20px;
-                    border-radius: 5px;
-                    margin-bottom: 20px;
-                }}
-                .success {{
-                    background-color: #d4edda;
-                    color: #155724;
-                    border: 1px solid #c3e6cb;
-                }}
-                .error {{
-                    background-color: #f8d7da;
-                    color: #721c24;
-                    border: 1px solid #f5c6cb;
-                }}
-            </style>
-        </head>
-        <body>
-            <h1>Atlassian OAuth Authorization</h1>
-            <div class="message {"success" if status == 200 else "error"}">
-                <p>{message}</p>
-            </div>
-            <p>This window will automatically close in 5 seconds...</p>
-            <script>
-                setTimeout(function() {{
-                    window.close();
-                }}, 5000);
-            </script>
-        </body>
-        </html>
-        """
-        self.wfile.write(html.encode())
-
-    # Make the server quiet
-    def log_message(self, format: str, *args: str) -> None:
-        return
-
-
-def start_callback_server(port: int) -> socketserver.TCPServer:
-    """Start a local server to receive the OAuth callback."""
-    handler = CallbackHandler
-    httpd = socketserver.TCPServer(("", port), handler)
-    server_thread = threading.Thread(target=httpd.serve_forever)
-    server_thread.daemon = True
-    server_thread.start()
-    return httpd
-
-
-def wait_for_callback(timeout: int = 300) -> bool:
-    """Wait for the callback to be received."""
-    start_time = time.time()
-    while not callback_received and (time.time() - start_time) < timeout:
-        time.sleep(1)
-
-    if not callback_received:
-        logger.error(
-            f"Timed out waiting for authorization callback after {timeout} seconds"
-        )
-        return False
-
-    if callback_error:
-        logger.error(f"Authorization error: {callback_error}")
-        return False
-
-    return True
-
-
-def parse_redirect_uri(redirect_uri: str) -> tuple[str, int]:
-    """Parse the redirect URI to extract host and port."""
-    parsed = urllib.parse.urlparse(redirect_uri)
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    return parsed.hostname, port
-
-
-def run_oauth_flow(args: argparse.Namespace) -> bool:
-    """Run the OAuth 2.0 authorization flow."""
-    # Create OAuth configuration
-    oauth_config = OAuthConfig(
-        client_id=args.client_id,
-        client_secret=args.client_secret,
-        redirect_uri=args.redirect_uri,
-        scope=args.scope,
-    )
-
-    # Generate a random state for CSRF protection
-    state = secrets.token_urlsafe(16)
-
-    # Start local callback server if using localhost
-    hostname, port = parse_redirect_uri(args.redirect_uri)
-    httpd = None
-
-    if hostname and hostname.lower() in ["localhost", "127.0.0.1"]:
-        logger.info(f"Attempting to start local callback server on {hostname}:{port}")
-        try:
-            httpd = start_callback_server(port)
-        except OSError as e:
-            logger.error(f"Failed to start callback server: {e}")
-            logger.error(f"Make sure port {port} is available and not in use")
-            return False
-
-    # Get the authorization URL
-    auth_url = oauth_config.get_authorization_url(state=state)
-
-    # Open the browser for authorization
-    logger.info(f"Opening browser for authorization at {auth_url}")
-    webbrowser.open(auth_url)
-    logger.info(
-        "If the browser doesn't open automatically, please visit this URL manually."
-    )
-
-    # Wait for the callback
-    if not wait_for_callback():
-        if httpd:
-            httpd.shutdown()
-        return False
-
-    # Verify state to prevent CSRF attacks
-    if received_state != state:
-        logger.error(
-            f"State mismatch! Possible CSRF attack. Expected: {state}, Received: {received_state}"
-        )
-        if httpd:
-            httpd.shutdown()
-        return False
-    logger.info("CSRF state verified successfully.")
-
-    # Exchange the code for tokens
-    logger.info("Exchanging authorization code for tokens...")
-    if not authorization_code:
-        logger.error("Authorization code is missing, cannot exchange for tokens.")
-        if httpd:
-            httpd.shutdown()
-        return False
-
-    if oauth_config.exchange_code_for_tokens(authorization_code):
-        logger.info("🎉 OAuth authorization flow completed successfully!")
-
-        if oauth_config.cloud_id:
-            logger.info(f"Retrieved Cloud ID: {oauth_config.cloud_id}")
-            logger.info(
-                "\n💡 Tip: Add/update the following in your .env file or environment variables:"
-            )
-            logger.info(f"ATLASSIAN_OAUTH_CLIENT_ID={oauth_config.client_id}")
-            logger.info(f"ATLASSIAN_OAUTH_CLIENT_SECRET={oauth_config.client_secret}")
-            logger.info(f"ATLASSIAN_OAUTH_REDIRECT_URI={oauth_config.redirect_uri}")
-            logger.info(f"ATLASSIAN_OAUTH_SCOPE={oauth_config.scope}")
-            logger.info(f"ATLASSIAN_OAUTH_CLOUD_ID={oauth_config.cloud_id}")
-        else:
-            logger.warning(
-                "Cloud ID could not be obtained. Some API calls might require it."
-            )
-
-        if httpd:
-            httpd.shutdown()
-        return True
-    else:
-        logger.error("Failed to exchange authorization code for tokens")
-        if httpd:
-            httpd.shutdown()
-        return False
 
 
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
-        description="OAuth 2.0 Authorization Flow Helper for MCP Atlassian"
+        description="OAuth 2.0 Authorization Flow Helper for MCP Atlassian "
+        "(Cloud and Server/Data Center)"
+    )
+    parser.add_argument(
+        "--base-url",
+        help="Jira Server/DC instance URL (e.g., https://jira.local.example.com). "
+        "Omit for Atlassian Cloud.",
     )
     parser.add_argument("--client-id", help="OAuth Client ID")
     parser.add_argument("--client-secret", help="OAuth Client Secret")
@@ -309,14 +76,25 @@ def main() -> int:
     args = parser.parse_args()
 
     # Check for environment variables if arguments are not provided
+    if not args.base_url:
+        args.base_url = os.getenv("JIRA_URL")
     if not args.client_id:
-        args.client_id = os.getenv("ATLASSIAN_OAUTH_CLIENT_ID")
+        args.client_id = os.getenv("JIRA_OAUTH_CLIENT_ID") or os.getenv(
+            "ATLASSIAN_OAUTH_CLIENT_ID"
+        )
     if not args.client_secret:
-        args.client_secret = os.getenv("ATLASSIAN_OAUTH_CLIENT_SECRET")
+        args.client_secret = os.getenv("JIRA_OAUTH_CLIENT_SECRET") or os.getenv(
+            "ATLASSIAN_OAUTH_CLIENT_SECRET"
+        )
     if not args.redirect_uri:
         args.redirect_uri = os.getenv("ATLASSIAN_OAUTH_REDIRECT_URI")
     if not args.scope:
         args.scope = os.getenv("ATLASSIAN_OAUTH_SCOPE")
+
+    is_dc = bool(args.base_url) and not is_atlassian_cloud_url(args.base_url)
+
+    # Clear base_url for Cloud URLs so OAuthConfig treats it as Cloud
+    base_url: str | None = args.base_url if is_dc else None
 
     # Validate required arguments
     missing = []
@@ -334,18 +112,22 @@ def main() -> int:
         parser.print_help()
         return 1
 
-    # Check for offline_access scope
-    if args.scope and "offline_access" not in args.scope.split():
-        logger.warning("\n⚠️ WARNING: The 'offline_access' scope is missing!")
+    # Check for offline_access scope (Cloud only — DC doesn't use it)
+    if not is_dc and args.scope and "offline_access" not in args.scope.split():
         logger.warning(
-            "Without this scope, refresh tokens will not be issued and authentication will fail when tokens expire."
+            "The 'offline_access' scope is missing! Without it, refresh "
+            "tokens will not be issued and authentication will fail when "
+            "tokens expire. Consider adding 'offline_access' to your scope."
         )
-        logger.warning("Consider adding 'offline_access' to your scope string.")
-        proceed = input("Do you want to proceed anyway? (y/n): ")
-        if proceed.lower() != "y":
-            return 1
 
-    success = run_oauth_flow(args)
+    setup_args = OAuthSetupArgs(
+        client_id=args.client_id,
+        client_secret=args.client_secret,
+        redirect_uri=args.redirect_uri,
+        scope=args.scope,
+        base_url=base_url,
+    )
+    success = run_oauth_flow(setup_args)
     return 0 if success else 1
 
 

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -128,7 +128,7 @@ async def _run_stdio_with_stdin_guard(run_kwargs: dict[str, object]) -> None:
 @click.option(
     "--oauth-setup",
     is_flag=True,
-    help="Run OAuth 2.0 setup wizard for Atlassian Cloud",
+    help="Run OAuth 2.0 setup wizard (Cloud and Server/Data Center)",
 )
 @click.option(
     "--transport",

--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -10,6 +10,7 @@ from .comments import CommentsMixin
 from .config import ConfluenceConfig
 from .labels import LabelsMixin
 from .pages import PagesMixin
+from .restrictions import RestrictionsMixin
 from .search import SearchMixin
 from .spaces import SpacesMixin
 from .users import UsersMixin
@@ -24,6 +25,7 @@ class ConfluenceFetcher(
     UsersMixin,
     AnalyticsMixin,
     AttachmentsMixin,
+    RestrictionsMixin,
 ):
     """Main entry point for Confluence operations, providing backward compatibility.
 

--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -13,6 +13,7 @@ from .pages import PagesMixin
 from .restrictions import RestrictionsMixin
 from .search import SearchMixin
 from .spaces import SpacesMixin
+from .templates import TemplatesMixin
 from .users import UsersMixin
 
 
@@ -26,6 +27,7 @@ class ConfluenceFetcher(
     AnalyticsMixin,
     AttachmentsMixin,
     RestrictionsMixin,
+    TemplatesMixin,
 ):
     """Main entry point for Confluence operations, providing backward compatibility.
 
@@ -41,6 +43,8 @@ class ConfluenceFetcher(
     - UsersMixin: User operations
     - AnalyticsMixin: Page view analytics (Cloud only)
     - AttachmentsMixin: Attachment operations
+    - RestrictionsMixin: Page restriction operations
+    - TemplatesMixin: Template operations
     """
 
     pass

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -76,11 +76,11 @@ class ConfluenceClient:
         elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Confluence client with Token (PAT) auth. "
-                f"URL: {self.config.url}, "
+                f"URL: {self.config.api_url}, "
                 f"Token (masked): {mask_sensitive(str(self.config.personal_token))}"
             )
             self.confluence = Confluence(
-                url=self.config.url,
+                url=self.config.api_url,
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
@@ -89,12 +89,12 @@ class ConfluenceClient:
         else:  # basic auth
             logger.debug(
                 f"Initializing Confluence client with Basic auth. "
-                f"URL: {self.config.url}, Username: {self.config.username}, "
+                f"URL: {self.config.api_url}, Username: {self.config.username}, "
                 f"API Token present: {bool(self.config.api_token)}, "
                 f"Is Cloud: {self.config.is_cloud}"
             )
             self.confluence = Confluence(
-                url=self.config.url,
+                url=self.config.api_url,
                 username=self.config.username,
                 password=self.config.api_token,  # API token is used as password
                 cloud=self.config.is_cloud,

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -145,6 +145,11 @@ class ConfluenceClient:
         if self.config.custom_headers:
             self._apply_custom_headers()
 
+        # Apply cookie if configured
+        if self.config.cookie:
+            self.confluence._session.headers["Cookie"] = self.config.cookie
+            logger.debug("Applied configured cookie to Confluence session")
+
         # Import here to avoid circular imports
         from ..preprocessing.confluence import ConfluencePreprocessor
 

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -28,6 +28,23 @@ class CommentsMixin(ConfluenceClient):
             )
         return None
 
+    @property
+    def _inline_v2_adapter(self) -> ConfluenceV2Adapter | None:
+        """Get v2 API adapter for inline comment operations.
+
+        Inline comments require the v2 API on all Cloud instances because the
+        v1 ``POST /rest/api/content/`` endpoint does not support inline comment
+        creation on Confluence Cloud regardless of auth method.
+
+        Returns:
+            ConfluenceV2Adapter instance if this is a Cloud instance, None otherwise
+        """
+        if self.config.is_cloud:
+            return ConfluenceV2Adapter(
+                session=self.confluence._session, base_url=self.confluence.url
+            )
+        return None
+
     def get_page_comments(
         self, page_id: str, *, return_markdown: bool = True
     ) -> list[ConfluenceComment]:
@@ -65,6 +82,12 @@ class CommentsMixin(ConfluenceClient):
 
                 # Create a copy of the comment data to modify
                 modified_comment_data = comment_data.copy()
+                if "body" in modified_comment_data:
+                    modified_comment_data["body"] = modified_comment_data["body"].copy()
+                    if "view" in modified_comment_data["body"]:
+                        modified_comment_data["body"]["view"] = modified_comment_data[
+                            "body"
+                        ]["view"].copy()
 
                 # Modify the body value based on the return format
                 if "body" not in modified_comment_data:
@@ -206,6 +229,171 @@ class CommentsMixin(ConfluenceClient):
             logger.debug("Full exception details for comment reply:", exc_info=True)
             return None
 
+    def get_inline_comments(
+        self, page_id: str, *, return_markdown: bool = True
+    ) -> list[ConfluenceComment]:
+        """Get inline comments for a specific page.
+
+        Args:
+            page_id: The ID of the page to get inline comments from
+            return_markdown: When True, returns content in markdown format,
+                           otherwise returns raw HTML (keyword-only)
+
+        Returns:
+            List of ConfluenceComment models with location="inline"
+        """
+        try:
+            v2_adapter = self._inline_v2_adapter
+            if v2_adapter:
+                raw_comments = v2_adapter.get_inline_comments(page_id)
+                space_key = ""
+            else:
+                # v1: fetch all child comments then filter by location=inline
+                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
+                space_key = page.get("space", {}).get("key", "")
+                response = self.confluence.get_page_comments(
+                    content_id=page_id,
+                    expand="body.view.value,version,extensions.inlineProperties",
+                    depth="all",
+                )
+                raw_comments = [
+                    c
+                    for c in response.get("results", [])
+                    if c.get("extensions", {}).get("location") == "inline"
+                ]
+
+            comment_models = []
+            for comment_data in raw_comments:
+                body = comment_data.get("body", {}).get("view", {}).get("value", "")
+                processed_html, processed_markdown = (
+                    self.preprocessor.process_html_content(
+                        body, space_key=space_key, confluence_client=self.confluence
+                    )
+                )
+
+                modified_comment_data = comment_data.copy()
+                if "body" in modified_comment_data:
+                    modified_comment_data["body"] = modified_comment_data["body"].copy()
+                    if "view" in modified_comment_data["body"]:
+                        modified_comment_data["body"]["view"] = modified_comment_data[
+                            "body"
+                        ]["view"].copy()
+                if "body" not in modified_comment_data:
+                    modified_comment_data["body"] = {}
+                if "view" not in modified_comment_data["body"]:
+                    modified_comment_data["body"]["view"] = {}
+
+                modified_comment_data["body"]["view"]["value"] = (
+                    processed_markdown if return_markdown else processed_html
+                )
+
+                comment_models.append(
+                    ConfluenceComment.from_api_response(
+                        modified_comment_data, base_url=self.config.url
+                    )
+                )
+
+            return comment_models
+
+        except KeyError as e:
+            logger.error(f"Missing key in inline comment data: {str(e)}")
+            return []
+        except requests.RequestException as e:
+            logger.error(f"Network error when fetching inline comments: {str(e)}")
+            return []
+        except (ValueError, TypeError) as e:
+            logger.error(f"Error processing inline comment data: {str(e)}")
+            return []
+        except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging
+            logger.error(f"Unexpected error fetching inline comments: {str(e)}")
+            logger.debug("Full exception details for inline comments:", exc_info=True)
+            return []
+
+    def add_inline_comment(
+        self,
+        page_id: str,
+        content: str,
+        text_selection: str,
+        text_selection_match_count: int = 1,
+        text_selection_match_index: int = 0,
+    ) -> ConfluenceComment | None:
+        """Add an inline comment anchored to a text selection on a page.
+
+        For Cloud instances, uses the v2 API (POST /api/v2/inline-comments).
+        For Server/DC, uses the v1 API (POST /rest/api/content/).
+
+        Args:
+            page_id: The ID of the page to add the inline comment to
+            content: The comment content (Markdown or HTML/storage format)
+            text_selection: The text on the page to anchor the comment to
+            text_selection_match_count: How many times the text appears
+                on the page
+            text_selection_match_index: Zero-based index of which occurrence
+                to anchor to
+
+        Returns:
+            ConfluenceComment object if successful, None otherwise
+        """
+        try:
+            # Convert markdown to Confluence storage format if needed
+            if not content.strip().startswith("<"):
+                content = self.preprocessor.markdown_to_confluence_storage(content)
+
+            v2_adapter = self._inline_v2_adapter
+            if v2_adapter:
+                response = v2_adapter.create_inline_comment(
+                    page_id=page_id,
+                    body=content,
+                    text_selection=text_selection,
+                    text_selection_match_count=text_selection_match_count,
+                    text_selection_match_index=text_selection_match_index,
+                )
+                space_key = ""
+            else:
+                # v1 API: POST /rest/api/content/ with inline location
+                data: dict[str, Any] = {
+                    "type": "comment",
+                    "container": {
+                        "id": page_id,
+                        "type": "page",
+                    },
+                    "body": {
+                        "storage": {
+                            "value": content,
+                            "representation": "storage",
+                        },
+                    },
+                    "extensions": {
+                        "location": "inline",
+                        "inlineProperties": {
+                            "originalSelection": text_selection,
+                        },
+                    },
+                }
+                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
+                space_key = page.get("space", {}).get("key", "")
+                response = self.confluence.post("rest/api/content/", data=data)
+
+            if not response:
+                logger.error("Failed to add inline comment: empty response")
+                return None
+
+            return self._process_comment_response(response, space_key)
+
+        except requests.RequestException as e:
+            logger.error(f"Network error when adding inline comment: {str(e)}")
+            return None
+        except (ValueError, TypeError, KeyError) as e:
+            logger.error(f"Error processing inline comment data: {str(e)}")
+            return None
+        except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging
+            logger.error(f"Unexpected error adding inline comment: {str(e)}")
+            logger.debug(
+                "Full exception details for adding inline comment:",
+                exc_info=True,
+            )
+            return None
+
     def _process_comment_response(
         self, response: dict[str, Any], space_key: str
     ) -> ConfluenceComment:
@@ -225,6 +413,12 @@ class CommentsMixin(ConfluenceClient):
         )
 
         modified_response = response.copy()
+        if "body" in modified_response:
+            modified_response["body"] = modified_response["body"].copy()
+            if "view" in modified_response["body"]:
+                modified_response["body"]["view"] = modified_response["body"][
+                    "view"
+                ].copy()
         if "body" not in modified_response:
             modified_response["body"] = {}
         if "view" not in modified_response["body"]:

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -319,8 +319,10 @@ class CommentsMixin(ConfluenceClient):
     ) -> ConfluenceComment | None:
         """Add an inline comment anchored to a text selection on a page.
 
-        For Cloud instances, uses the v2 API (POST /api/v2/inline-comments).
-        For Server/DC, uses the v1 API (POST /rest/api/content/).
+        Inline comments are Cloud-only.  The v2 API
+        (``POST /wiki/api/v2/inline-comments``) is the only supported path;
+        the v1 endpoint returns 405 on Cloud and is not available on
+        Server/DC.
 
         Args:
             page_id: The ID of the page to add the inline comment to
@@ -333,57 +335,47 @@ class CommentsMixin(ConfluenceClient):
 
         Returns:
             ConfluenceComment object if successful, None otherwise
+
+        Raises:
+            ValueError: If the Confluence instance is not Cloud, or if the
+                API returns an actionable error (e.g. text not found).
         """
+        if not self.config.is_cloud:
+            raise ValueError(
+                "Inline comments are only supported on Confluence Cloud. "
+                "The v2 inline-comments API is not available on Server/DC."
+            )
+
         try:
             # Convert markdown to Confluence storage format if needed
             if not content.strip().startswith("<"):
                 content = self.preprocessor.markdown_to_confluence_storage(content)
 
             v2_adapter = self._inline_v2_adapter
-            if v2_adapter:
-                response = v2_adapter.create_inline_comment(
-                    page_id=page_id,
-                    body=content,
-                    text_selection=text_selection,
-                    text_selection_match_count=text_selection_match_count,
-                    text_selection_match_index=text_selection_match_index,
-                )
-                space_key = ""
-            else:
-                # v1 API: POST /rest/api/content/ with inline location
-                data: dict[str, Any] = {
-                    "type": "comment",
-                    "container": {
-                        "id": page_id,
-                        "type": "page",
-                    },
-                    "body": {
-                        "storage": {
-                            "value": content,
-                            "representation": "storage",
-                        },
-                    },
-                    "extensions": {
-                        "location": "inline",
-                        "inlineProperties": {
-                            "originalSelection": text_selection,
-                        },
-                    },
-                }
-                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
-                space_key = page.get("space", {}).get("key", "")
-                response = self.confluence.post("rest/api/content/", data=data)
+            if not v2_adapter:
+                logger.error("Failed to create v2 adapter for inline comments")
+                return None
+
+            response = v2_adapter.create_inline_comment(
+                page_id=page_id,
+                body=content,
+                text_selection=text_selection,
+                text_selection_match_count=text_selection_match_count,
+                text_selection_match_index=text_selection_match_index,
+            )
 
             if not response:
                 logger.error("Failed to add inline comment: empty response")
                 return None
 
-            return self._process_comment_response(response, space_key)
+            return self._process_comment_response(response, space_key="")
 
+        except ValueError:
+            raise
         except requests.RequestException as e:
             logger.error(f"Network error when adding inline comment: {str(e)}")
             return None
-        except (ValueError, TypeError, KeyError) as e:
+        except (TypeError, KeyError) as e:
             logger.error(f"Error processing inline comment data: {str(e)}")
             return None
         except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -41,6 +41,9 @@ class ConfluenceConfig:
     client_key_password: str | None = None  # Password for encrypted private key
     timeout: int = 75  # Connection timeout in seconds
     cookie: str | None = None  # Raw cookie string to attach to all requests
+    cloud_id: str | None = (
+        None  # Cloud ID — routes via api.atlassian.com (CONFLUENCE_CLOUD_ID > ATLASSIAN_CLOUD_ID)
+    )
 
     @property
     def is_cloud(self) -> bool:
@@ -50,6 +53,10 @@ class ConfluenceConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
+        # cloud_id set directly on config means Cloud (service account or explicit)
+        if self.cloud_id:
+            return True
+
         # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
@@ -72,6 +79,17 @@ class ConfluenceConfig:
         return is_atlassian_cloud_url(self.url) if self.url else False
 
     @property
+    def api_url(self) -> str:
+        """Get the effective API URL, using the Cloud gateway when cloud_id is set.
+
+        Returns:
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+        """
+        if self.cloud_id:
+            return f"https://api.atlassian.com/ex/confluence/{self.cloud_id}"
+        return self.url
+
+    @property
     def verify_ssl(self) -> bool:
         """Compatibility property for old code.
 
@@ -91,7 +109,11 @@ class ConfluenceConfig:
             ValueError: If any required environment variable is missing
         """
         url = os.getenv("CONFLUENCE_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        # cloud_id can substitute for URL (service accounts use api.atlassian.com)
+        has_cloud_id = bool(
+            os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+        )
+        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required CONFLUENCE_URL environment variable. "
                 "Set CONFLUENCE_URL to your Confluence base URL, for example "
@@ -111,7 +133,7 @@ class ConfluenceConfig:
         auth_type = None
 
         # Use the shared utility function directly
-        is_cloud = is_atlassian_cloud_url(url) if url else False
+        is_cloud = has_cloud_id or (is_atlassian_cloud_url(url) if url else False)
 
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
@@ -191,6 +213,9 @@ class ConfluenceConfig:
         # Cookie configuration
         cookie = os.getenv("CONFLUENCE_COOKIE")
 
+        # Cloud ID for service accounts (CONFLUENCE_CLOUD_ID takes precedence over ATLASSIAN_CLOUD_ID)
+        cloud_id = os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -210,6 +235,7 @@ class ConfluenceConfig:
             client_key_password=client_key_password,
             timeout=timeout,
             cookie=cookie,
+            cloud_id=cloud_id,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -40,6 +40,7 @@ class ConfluenceConfig:
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
     timeout: int = 75  # Connection timeout in seconds
+    cookie: str | None = None  # Raw cookie string to attach to all requests
 
     @property
     def is_cloud(self) -> bool:
@@ -187,6 +188,9 @@ class ConfluenceConfig:
         ):
             timeout = int(os.getenv("CONFLUENCE_TIMEOUT", "75"))
 
+        # Cookie configuration
+        cookie = os.getenv("CONFLUENCE_COOKIE")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -205,6 +209,7 @@ class ConfluenceConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cookie=cookie,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import requests
+from bs4 import BeautifulSoup, Tag
 from requests.exceptions import HTTPError
 
 from ..models.confluence import ConfluencePage
@@ -63,7 +64,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = v2_adapter.get_page(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
             else:
                 logger.debug(
@@ -72,7 +73,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = self.confluence.get_page_by_id(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
 
             # Check if API returned an error string
@@ -717,6 +718,135 @@ class PagesMixin(ConfluenceClient):
             logger.error(f"Error updating page {page_id}: {str(e)}")
             raise Exception(f"Failed to update page {page_id}: {str(e)}") from e
 
+    def update_page_section(
+        self,
+        page_id: str,
+        heading_text: str,
+        new_content: str,
+        *,
+        content_format: str = "markdown",
+        is_minor_edit: bool = False,
+        version_comment: str = "",
+    ) -> ConfluencePage:
+        """Update a single section of a Confluence page without affecting the rest.
+
+        Fetches the page in raw storage format, locates the section identified by
+        its heading text, replaces only the content between that heading and the
+        next heading of the same or higher level, and writes the modified storage
+        XML back. This is lossless: macros, layouts, mentions, and all other
+        Confluence-specific elements outside the target section are preserved.
+
+        Args:
+            page_id: The ID of the page to update.
+            heading_text: Exact text of the heading that starts the section to
+                replace. Matching is case-sensitive and whitespace-normalised.
+            new_content: Replacement content for the section body (excluding the
+                heading itself).
+            content_format: Format of new_content — ``'markdown'`` (default) or
+                ``'storage'``. When ``'markdown'``, the content is
+                converted to Confluence storage format before insertion.
+                (keyword-only)
+            is_minor_edit: Whether to flag the page version as a minor edit.
+                (keyword-only)
+            version_comment: Optional version comment. (keyword-only)
+
+        Returns:
+            Updated ``ConfluencePage`` with the section replaced.
+
+        Raises:
+            ValueError: If ``heading_text`` is not found on the page, or if
+                ``content_format`` is not one of the accepted values.
+            Exception: If retrieving or updating the page fails.
+        """
+        if content_format not in ("markdown", "storage"):
+            raise ValueError(
+                f"Invalid content_format '{content_format}'. "
+                "Must be 'markdown' or 'storage'."
+            )
+
+        # 1. Fetch raw storage XML — no markdown conversion so nothing is lost.
+        page = self.get_page_content(page_id, convert_to_markdown=False)
+        raw_storage = page.content or ""
+
+        # 2. Convert new_content to storage format when necessary.
+        if content_format == "markdown":
+            new_storage_fragment = self.preprocessor.markdown_to_confluence_storage(
+                new_content
+            )
+        else:
+            new_storage_fragment = new_content
+
+        # 3. Parse the full storage XML with BeautifulSoup.
+        soup = BeautifulSoup(raw_storage, "html.parser")
+
+        heading_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
+        target_heading: Tag | None = None
+        for tag in soup.find_all(heading_tags):
+            if (
+                isinstance(tag, Tag)
+                and tag.get_text(strip=True) == heading_text.strip()
+            ):
+                target_heading = tag
+                break
+
+        if target_heading is None:
+            raise ValueError(
+                f"Heading '{heading_text.strip()}' not found in page {page_id}. "
+                "Heading text must match exactly (case-sensitive)."
+            )
+
+        heading_level = int(target_heading.name[1])  # e.g. "h2" → 2
+
+        # 4. Collect all sibling nodes that belong to this section (between
+        #    this heading and the next heading of the same or higher level).
+        #    NavigableString nodes (whitespace, text) are included alongside
+        #    Tag nodes, so we type the list broadly.
+        siblings_to_remove: list = []
+        current = target_heading.next_sibling
+        while current is not None:
+            if isinstance(current, Tag) and current.name in heading_tags:
+                if int(current.name[1]) <= heading_level:
+                    break
+            siblings_to_remove.append(current)
+            current = current.next_sibling
+
+        # 5. Capture heading HTML, remove old section nodes, then splice in the
+        #    new fragment via string operations — avoids moving nodes between
+        #    BS4 trees which causes type and mutation issues.
+        heading_html = str(target_heading)
+        for node in siblings_to_remove:
+            node.extract()
+
+        pruned_html = str(soup)
+        heading_pos = pruned_html.find(heading_html)
+        if heading_pos == -1:
+            # Should not happen: heading was found by BS4 and serialised above.
+            # Guard against unexpected BS4 serialisation edge cases.
+            raise ValueError(
+                f"Internal error: could not locate heading '{heading_text.strip()}' "
+                "in serialised page HTML. Please report this as a bug."
+            )
+        insert_at = heading_pos + len(heading_html)
+        final_html = (
+            pruned_html[:insert_at] + new_storage_fragment + pruned_html[insert_at:]
+        )
+
+        # 7. Write the full modified storage XML back — no format conversion,
+        #    so every macro and element outside the section is untouched.
+        logger.debug(
+            f"Updating section '{heading_text}' on page {page_id} "
+            "using lossless storage-format write-back."
+        )
+        return self.update_page(
+            page_id=page_id,
+            title=page.title or "",
+            body=final_html,
+            is_markdown=False,
+            content_representation="storage",
+            is_minor_edit=is_minor_edit,
+            version_comment=version_comment,
+        )
+
     def get_page_children(
         self,
         page_id: str,
@@ -1031,7 +1161,7 @@ class PagesMixin(ConfluenceClient):
                 page = v2_adapter.get_page_by_version(
                     page_id=page_id,
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
             else:
                 logger.debug(
@@ -1043,7 +1173,7 @@ class PagesMixin(ConfluenceClient):
                     page_id=page_id,
                     status="historical",
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
 
             if isinstance(page, str):

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -335,6 +335,61 @@ class PagesMixin(ConfluenceClient):
             logger.debug(f"Error fetching page width for page {page_id}: {str(e)}")
             return None
 
+    def get_content_properties(
+        self, page_id: str, key: str | None = None
+    ) -> dict[str, Any]:
+        """Get content properties for a Confluence page.
+
+        Args:
+            page_id: The ID of the page.
+            key: Optional property key. If provided, returns only that property.
+                If omitted, returns all properties as a ``{key: value}`` dict.
+
+        Returns:
+            Dict mapping property key(s) to their values.
+        """
+        if key:
+            prop = self.confluence.get_page_property(page_id, key)
+            return {prop["key"]: prop["value"]}
+
+        properties = self.confluence.get_page_properties(page_id)
+        return {item["key"]: item["value"] for item in properties.get("results", [])}
+
+    def set_content_property(
+        self, page_id: str, key: str, value: Any
+    ) -> dict[str, Any]:
+        """Create or update a content property on a Confluence page.
+
+        Handles version increment automatically. Reads the current version
+        before writing, so callers do not need to manage version numbers.
+
+        Args:
+            page_id: The ID of the page.
+            key: Property key (e.g. ``content-appearance-published``).
+            value: Property value. Strings, dicts, and lists are all supported.
+
+        Returns:
+            Dict with ``{key: value}`` of the created or updated property.
+        """
+        property_data: dict[str, Any] = {"key": key, "value": value}
+
+        # Check if property exists (need version for update)
+        existing = None
+        try:
+            existing = self.confluence.get_page_property(page_id, key)
+        except Exception:  # noqa: BLE001, S110
+            # Property doesn't exist — will create it
+            pass
+
+        if existing and isinstance(existing, dict):
+            existing_version = existing.get("version", {}).get("number") or 0
+            property_data["version"] = {"number": existing_version + 1}
+            self.confluence.update_page_property(page_id, property_data)
+        else:
+            self.confluence.set_page_property(page_id, property_data)
+
+        return {key: value}
+
     def _set_page_width(self, page_id: str, width: str | None) -> bool:
         """Set the page layout width.
 
@@ -535,6 +590,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Create a new page in a Confluence space.
@@ -549,6 +605,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only)
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only)
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the new page's data
@@ -561,7 +618,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -630,6 +689,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Update an existing page in Confluence.
@@ -646,6 +706,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only). Pass empty string to remove emoji.
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only). Pass empty string to reset to default.
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the updated page's data
@@ -658,7 +719,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -1330,3 +1393,79 @@ class PagesMixin(ConfluenceClient):
             "to_version": to_version,
             "diff": diff_string,
         }
+
+    @handle_auth_errors("Confluence API")
+    def copy_page(
+        self,
+        source_page_id: str,
+        destination_space_key: str,
+        new_title: str,
+        destination_parent_id: str | None = None,
+        *,
+        copy_attachments: bool = True,
+    ) -> ConfluencePage:
+        """Copy a Confluence page to a new location.
+
+        On Confluence Cloud the native copy endpoint is used
+        (``POST /wiki/rest/api/content/{id}/copy``).  On Server/Data Center
+        the page body and title are fetched and a new page is created manually
+        (attachments are not copied in the Server/DC fallback path).
+
+        Args:
+            source_page_id: The ID of the page to copy.
+            destination_space_key: Space key for the new page.
+            new_title: Title of the new page.
+            destination_parent_id: Optional parent page ID in the destination space.
+                When omitted the new page is created at the space root.
+            copy_attachments: Whether to copy attachments (Cloud only, keyword-only).
+
+        Returns:
+            ConfluencePage model for the newly created copy.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the copy operation fails.
+        """
+        try:
+            if self.config.is_cloud:
+                payload: dict[str, object] = {
+                    "copyAttachments": copy_attachments,
+                    "copyPermissions": False,
+                    "copyProperties": False,
+                    "copyLabels": False,
+                    "pageTitle": new_title,
+                    "destination": {
+                        "type": "parent_page" if destination_parent_id else "space",
+                        "value": destination_parent_id or destination_space_key,
+                    },
+                }
+                result = self.confluence.post(
+                    f"rest/api/content/{source_page_id}/copy",
+                    data=payload,
+                )
+            else:
+                # Server/DC: manual GET + POST (no native copy endpoint)
+                source = self.confluence.get_page_by_id(
+                    source_page_id, expand="body.storage,version,space"
+                )
+                body = source.get("body", {}).get("storage", {}).get("value", "")
+                create_kwargs: dict[str, object] = {
+                    "space": destination_space_key,
+                    "title": new_title,
+                    "body": body,
+                    "representation": "storage",
+                }
+                if destination_parent_id:
+                    create_kwargs["parent_id"] = destination_parent_id
+                result = self.confluence.create_page(**create_kwargs)
+
+            new_page_id = result.get("id")
+            if not new_page_id:
+                raise ValueError("Copy response did not contain a page ID")
+
+            return self.get_page_content(new_page_id)
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error copying page {source_page_id}: {str(e)}")
+            raise Exception(f"Failed to copy page {source_page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -20,6 +20,32 @@ logger = logging.getLogger("mcp-atlassian")
 class PagesMixin(ConfluenceClient):
     """Mixin for Confluence page operations."""
 
+    def _render_page_content(
+        self,
+        content: str,
+        *,
+        convert_to_markdown: bool,
+        space_key: str = "",
+        content_id: str = "",
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> str:
+        """Render page content for the requested output mode.
+
+        When markdown conversion is disabled, return the exact Confluence storage
+        payload to preserve macros and task metadata for safe round-tripping.
+        """
+        if not convert_to_markdown:
+            return content
+
+        _, processed_markdown = self.preprocessor.process_html_content(
+            content,
+            space_key=space_key,
+            confluence_client=self.confluence,
+            content_id=content_id,
+            attachments=attachments,
+        )
+        return processed_markdown
+
     @property
     def _v2_adapter(self) -> ConfluenceV2Adapter | None:
         """Get v2 API adapter for OAuth authentication.
@@ -93,15 +119,13 @@ class PagesMixin(ConfluenceClient):
             page_attachments = (
                 page.get("children", {}).get("attachment", {}).get("results", [])
             )
-            processed_html, processed_markdown = self.preprocessor.process_html_content(
+            page_content = self._render_page_content(
                 content,
+                convert_to_markdown=convert_to_markdown,
                 space_key=space_key,
-                confluence_client=self.confluence,
                 content_id=page_id_str,
                 attachments=page_attachments,
             )
-
-            page_content = processed_markdown if convert_to_markdown else processed_html
 
             # Fetch page emoji and width from content properties
             emoji = self._get_page_emoji(page_id)
@@ -470,15 +494,12 @@ class PagesMixin(ConfluenceClient):
                     f"Page {page.get('id', 'unknown')} missing body.storage.value: {e}"
                 )
                 content = ""
-            processed_html, processed_markdown = self.preprocessor.process_html_content(
+            page_content = self._render_page_content(
                 content,
+                convert_to_markdown=convert_to_markdown,
                 space_key=space_key,
-                confluence_client=self.confluence,
                 content_id=str(page.get("id", "")),
             )
-
-            # Use the appropriate content format based on the convert_to_markdown flag
-            page_content = processed_markdown if convert_to_markdown else processed_html
 
             # Fetch page emoji and width from content properties
             emoji = self._get_page_emoji(str(page.get("id", "")))
@@ -546,15 +567,12 @@ class PagesMixin(ConfluenceClient):
                     f"Page {page.get('id', 'unknown')} missing body.storage.value: {e}"
                 )
                 content = ""
-            processed_html, processed_markdown = self.preprocessor.process_html_content(
+            page_content = self._render_page_content(
                 content,
+                convert_to_markdown=convert_to_markdown,
                 space_key=space_key,
-                confluence_client=self.confluence,
                 content_id=str(page.get("id", "")),
             )
-
-            # Use the appropriate content format based on the convert_to_markdown flag
-            page_content = processed_markdown if convert_to_markdown else processed_html
 
             # Ensure space information is included
             if "space" not in page:
@@ -729,6 +747,11 @@ class PagesMixin(ConfluenceClient):
                 final_body = body
                 representation = content_representation or "storage"
 
+            width_to_set = page_width if page_width else None
+            preserve_existing_width = page_width is None
+            if preserve_existing_width:
+                width_to_set = self._get_page_width(page_id)
+
             logger.debug(f"Updating page {page_id} with title '{title}'")
 
             # Use v2 API for OAuth authentication, v1 API for token/basic auth
@@ -770,9 +793,9 @@ class PagesMixin(ConfluenceClient):
                 self._set_page_emoji(page_id, emoji_to_set)
 
             # Set or remove the page width if provided
-            if page_width is not None:
-                # Empty string means reset to default, otherwise set it
-                width_to_set = page_width if page_width else None
+            if page_width is not None or width_to_set is not None:
+                # Empty string means reset to default, otherwise set it.
+                # When not explicitly provided, preserve the page's current width.
                 self._set_page_width(page_id, width_to_set)
 
             # After update, refresh the page data
@@ -986,16 +1009,15 @@ class PagesMixin(ConfluenceClient):
             for item in child_items:
                 # Only process content if we have "body" expanded
                 content_override = None
-                if "body" in item and convert_to_markdown:
+                if "body" in item:
                     content = item.get("body", {}).get("storage", {}).get("value", "")
                     if content:
-                        _, processed_markdown = self.preprocessor.process_html_content(
+                        content_override = self._render_page_content(
                             content,
+                            convert_to_markdown=convert_to_markdown,
                             space_key=space_key,
-                            confluence_client=self.confluence,
                             content_id=str(item.get("id", "")),
                         )
-                        content_override = processed_markdown
 
                 # Create the page model (works for both pages and folders)
                 page_model = ConfluencePage.from_api_response(
@@ -1255,15 +1277,13 @@ class PagesMixin(ConfluenceClient):
             page_attachments = (
                 page.get("children", {}).get("attachment", {}).get("results", [])
             )
-            processed_html, processed_markdown = self.preprocessor.process_html_content(
+            page_content = self._render_page_content(
                 content,
+                convert_to_markdown=convert_to_markdown,
                 space_key=space_key,
-                confluence_client=self.confluence,
                 content_id=str(page.get("id", "")),
                 attachments=page_attachments,
             )
-
-            page_content = processed_markdown if convert_to_markdown else processed_html
 
             emoji = self._get_page_emoji(page_id)
             return ConfluencePage.from_api_response(

--- a/src/mcp_atlassian/confluence/restrictions.py
+++ b/src/mcp_atlassian/confluence/restrictions.py
@@ -1,0 +1,167 @@
+"""Module for Confluence page restriction operations."""
+
+import json
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..utils.decorators import handle_auth_errors
+from .client import ConfluenceClient
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+class RestrictionsMixin(ConfluenceClient):
+    """Mixin for Confluence page restriction operations."""
+
+    @handle_auth_errors("Confluence API")
+    def get_page_restrictions(self, page_id: str) -> dict[str, Any]:
+        """Get view and edit restrictions for a Confluence page.
+
+        Returns the current restriction lists for the ``read`` and ``update``
+        operations.  An empty list for an operation means the page is
+        unrestricted for that operation (visible/editable by everyone).
+
+        Args:
+            page_id: The ID of the page to query.
+
+        Returns:
+            Dict with ``read`` and ``update`` keys, each containing:
+            ``{"users": [...account_ids...], "groups": [...group_names...]}``
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            data = self.confluence.get_all_restrictions_for_content(page_id)
+
+            result: dict[str, Any] = {
+                "read": {"users": [], "groups": []},
+                "update": {"users": [], "groups": []},
+            }
+
+            if not isinstance(data, dict):
+                return result
+
+            for operation, op_key in (("read", "read"), ("update", "update")):
+                op_data = data.get(operation, {})
+                if not isinstance(op_data, dict):
+                    continue
+
+                restrictions = op_data.get("restrictions", {})
+                if not isinstance(restrictions, dict):
+                    continue
+
+                users = restrictions.get("user", {})
+                if isinstance(users, dict):
+                    for u in users.get("results", []):
+                        account_id = (
+                            u.get("accountId") or u.get("username") or u.get("name")
+                        )
+                        if account_id:
+                            result[op_key]["users"].append(account_id)
+
+                groups = restrictions.get("group", {})
+                if isinstance(groups, dict):
+                    for g in groups.get("results", []):
+                        group_name = g.get("name")
+                        if group_name:
+                            result[op_key]["groups"].append(group_name)
+
+            return result
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error fetching restrictions for page {page_id}: {str(e)}")
+            raise Exception(
+                f"Failed to get restrictions for page {page_id}: {str(e)}"
+            ) from e
+
+    @handle_auth_errors("Confluence API")
+    def set_page_restrictions(
+        self,
+        page_id: str,
+        *,
+        read_users: list[str] | None = None,
+        read_groups: list[str] | None = None,
+        edit_users: list[str] | None = None,
+        edit_groups: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Set view and edit restrictions on a Confluence page.
+
+        Replaces all existing restrictions with the provided lists.
+        Passing empty lists for all parameters removes all restrictions
+        (makes the page unrestricted).
+
+        Confluence uses ``read`` for view access and ``update`` for edit
+        access.  Users are identified by account ID (Cloud) or username
+        (Server/DC); groups by group name.
+
+        Args:
+            page_id: The ID of the page to restrict.
+            read_users: Account IDs (Cloud) / usernames (Server/DC) that may view the page.
+            read_groups: Group names that may view the page.
+            edit_users: Account IDs / usernames that may edit the page.
+            edit_groups: Group names that may edit the page.
+
+        Returns:
+            Dict with the updated ``read`` and ``update`` restriction lists,
+            in the same format as :meth:`get_page_restrictions`.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            read_users = read_users or []
+            read_groups = read_groups or []
+            edit_users = edit_users or []
+            edit_groups = edit_groups or []
+
+            def _user_entry(account_id: str) -> dict[str, str]:
+                # Cloud uses accountId; Server/DC uses name/username
+                if self.config.is_cloud:
+                    return {"type": "known", "accountId": account_id}
+                return {"type": "known", "username": account_id}
+
+            def _group_entry(name: str) -> dict[str, str]:
+                return {"type": "group", "name": name}
+
+            payload = [
+                {
+                    "operation": "read",
+                    "restrictions": {
+                        "user": [_user_entry(u) for u in read_users],
+                        "group": [_group_entry(g) for g in read_groups],
+                    },
+                },
+                {
+                    "operation": "update",
+                    "restrictions": {
+                        "user": [_user_entry(u) for u in edit_users],
+                        "group": [_group_entry(g) for g in edit_groups],
+                    },
+                },
+            ]
+
+            # The atlassian library's put() only accepts dict|str for data;
+            # the restrictions endpoint expects a JSON array, so serialise manually.
+            self.confluence.put(
+                f"rest/api/content/{page_id}/restriction",
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+            )
+
+            return {
+                "read": {"users": read_users, "groups": read_groups},
+                "update": {"users": edit_users, "groups": edit_groups},
+            }
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error setting restrictions for page {page_id}: {str(e)}")
+            raise Exception(
+                f"Failed to set restrictions for page {page_id}: {str(e)}"
+            ) from e

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -80,7 +80,12 @@ class SearchMixin(ConfluenceClient):
         for page in search_result.results:
             # Get the excerpt from the original search results
             for result_item in results.get("results", []):
-                if result_item.get("content", {}).get("id") == page.id:
+                content_id = None
+                if result_item.get("content"):
+                    content_id = result_item["content"].get("id")
+                elif result_item.get("space"):
+                    content_id = str(result_item["space"].get("id", ""))
+                if content_id == page.id:
                     excerpt = result_item.get("excerpt", "")
                     if excerpt:
                         # Process the excerpt as HTML content

--- a/src/mcp_atlassian/confluence/templates.py
+++ b/src/mcp_atlassian/confluence/templates.py
@@ -1,0 +1,134 @@
+"""Module for Confluence template operations."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..utils.decorators import handle_auth_errors
+from .client import ConfluenceClient
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+class TemplatesMixin(ConfluenceClient):
+    """Mixin for Confluence template operations."""
+
+    @handle_auth_errors("Confluence API")
+    def list_page_templates(
+        self,
+        space_key: str | None = None,
+        limit: int = 25,
+    ) -> list[dict[str, Any]]:
+        """List page content templates, optionally scoped to a space.
+
+        When ``space_key`` is omitted, global templates are returned.  Pass a
+        space key to retrieve templates defined within that space.
+
+        Args:
+            space_key: Optional space key to filter templates.  ``None``
+                returns global templates.
+            limit: Maximum number of templates to return (default 25).
+
+        Returns:
+            List of template dicts, each containing at minimum:
+            ``templateId``, ``name``, ``templateType``, and ``description``.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            results: list[dict[str, Any]] = self.confluence.get_content_templates(
+                space=space_key,
+                limit=limit,
+            )
+            return results
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error listing templates: {str(e)}")
+            raise Exception(f"Failed to list page templates: {str(e)}") from e
+
+    @handle_auth_errors("Confluence API")
+    def get_page_template(self, template_id: str) -> dict[str, Any]:
+        """Get a single content template by ID, including its body.
+
+        Args:
+            template_id: The ID of the template to retrieve.
+
+        Returns:
+            Template dict containing ``templateId``, ``name``,
+            ``templateType``, ``description``, and ``body`` (storage format).
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails or the template is not found.
+        """
+        try:
+            return self.confluence.get_content_template(template_id)  # type: ignore[no-any-return]
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error fetching template {template_id}: {str(e)}")
+            raise Exception(f"Failed to get template {template_id}: {str(e)}") from e
+
+    @handle_auth_errors("Confluence API")
+    def create_page_from_template(
+        self,
+        space_key: str,
+        title: str,
+        template_id: str,
+        parent_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new Confluence page pre-populated with a template's body.
+
+        Fetches the template's storage-format body and creates a page with
+        that content.  The caller can rename the page and edit it afterwards.
+
+        Args:
+            space_key: Key of the space in which to create the page.
+            title: Title for the new page.
+            template_id: ID of the template whose body to use.
+            parent_id: Optional parent page ID.
+
+        Returns:
+            Dict with ``id``, ``title``, ``url``, and ``space_key`` of the
+            newly created page.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the template fetch or page creation fails.
+        """
+        try:
+            template = self.confluence.get_content_template(template_id)
+
+            body_obj = template.get("body", {})
+            # Templates store content under body.storage.value (same as pages)
+            body_value: str = body_obj.get("storage", {}).get("value", "")
+
+            result = self.confluence.create_page(
+                space=space_key,
+                title=title,
+                body=body_value,
+                parent_id=parent_id,
+                representation="storage",
+            )
+
+            page_id: str = result.get("id", "")
+            base_url = self.config.url.rstrip("/")
+            page_url = f"{base_url}/wiki/spaces/{space_key}/pages/{page_id}"
+
+            return {
+                "id": page_id,
+                "title": result.get("title", title),
+                "url": page_url,
+                "space_key": space_key,
+            }
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error creating page from template {template_id}: {str(e)}")
+            raise Exception(
+                f"Failed to create page from template {template_id}: {str(e)}"
+            ) from e

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -492,6 +492,148 @@ class ConfluenceV2Adapter:
             logger.error(f"Error creating footer comment: {e}")
             raise ValueError(f"Failed to create footer comment: {e}") from e
 
+    def get_inline_comments(
+        self,
+        page_id: str,
+        status: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get inline comments for a page using the v2 API.
+
+        Args:
+            page_id: The ID of the page to get inline comments from
+            status: Optional filter — "open" or "resolved"
+
+        Returns:
+            List of inline comments in v1-compatible format
+
+        Raises:
+            ValueError: If the API request fails
+        """
+        try:
+            url = f"{self.base_url}/api/v2/pages/{page_id}/inline-comments"
+            params: dict[str, Any] = {"body-format": "storage"}
+            if status:
+                params["status"] = status
+
+            response = self.session.get(url, params=params)
+            response.raise_for_status()
+
+            data = response.json()
+            results = data.get("results", [])
+            return [self._convert_v2_inline_comment_to_v1_format(r) for r in results]
+
+        except Exception as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                logger.error(
+                    f"HTTP error getting inline comments for page '{page_id}': {e}\n"
+                    f"Response: {e.response.text}"
+                )
+            else:
+                logger.error(f"Error getting inline comments for page '{page_id}': {e}")
+            raise ValueError(
+                f"Failed to get inline comments for page '{page_id}': {e}"
+            ) from e
+
+    def create_inline_comment(
+        self,
+        *,
+        page_id: str,
+        body: str,
+        text_selection: str,
+        text_selection_match_count: int = 1,
+        text_selection_match_index: int = 0,
+        representation: str = "storage",
+    ) -> dict[str, Any]:
+        """Create an inline comment anchored to a text selection using the v2 API.
+
+        Args:
+            page_id: The ID of the page to add the inline comment to
+            body: The comment content
+            text_selection: The text on the page to anchor the comment to
+            text_selection_match_count: Total number of times the text
+                appears on the page
+            text_selection_match_index: Zero-based index of which occurrence
+                to anchor to
+            representation: Content representation format (default: "storage")
+
+        Returns:
+            The created inline comment data in v1-compatible format
+
+        Raises:
+            ValueError: If creation fails
+        """
+        try:
+            data: dict[str, Any] = {
+                "pageId": page_id,
+                "body": {
+                    "representation": representation,
+                    "value": body,
+                },
+                "inlineCommentProperties": {
+                    "textSelection": text_selection,
+                    "textSelectionMatchCount": text_selection_match_count,
+                    "textSelectionMatchIndex": text_selection_match_index,
+                },
+            }
+
+            url = f"{self.base_url}/api/v2/inline-comments"
+            response = self.session.post(url, json=data)
+            response.raise_for_status()
+
+            result = response.json()
+            logger.debug("Successfully created inline comment with v2 API")
+
+            return self._convert_v2_inline_comment_to_v1_format(result)
+
+        except Exception as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                logger.error(
+                    f"HTTP error creating inline comment: {e}\n"
+                    f"Response: {e.response.text}"
+                )
+            else:
+                logger.error(f"Error creating inline comment: {e}")
+            raise ValueError(f"Failed to create inline comment: {e}") from e
+
+    def _convert_v2_inline_comment_to_v1_format(
+        self, v2_response: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Convert v2 inline comment response to v1-compatible format.
+
+        Args:
+            v2_response: The response from the v2 inline-comments API
+
+        Returns:
+            Response formatted like v1 API for compatibility
+        """
+        body_value = v2_response.get("body", {}).get("storage", {}).get("value", "")
+
+        v1_compatible: dict[str, Any] = {
+            "id": v2_response.get("id"),
+            "type": "comment",
+            "status": v2_response.get("status"),
+            "title": v2_response.get("title"),
+            "body": {
+                "view": {
+                    "value": body_value,
+                    "representation": "view",
+                },
+            },
+            "version": v2_response.get("version", {}),
+            "_links": v2_response.get("_links", {}),
+            "extensions": {"location": "inline"},
+            "created": v2_response.get("version", {}).get("createdAt", ""),
+            "updated": v2_response.get("version", {}).get("createdAt", ""),
+        }
+
+        if author := v2_response.get("author"):
+            v1_compatible["author"] = author
+
+        if inline_props := v2_response.get("inlineCommentProperties"):
+            v1_compatible["inlineCommentProperties"] = inline_props
+
+        return v1_compatible
+
     def _convert_v2_comment_to_v1_format(
         self, v2_response: dict[str, Any]
     ) -> dict[str, Any]:
@@ -521,6 +663,8 @@ class ConfluenceV2Adapter:
             },
             "version": v2_response.get("version", {}),
             "_links": v2_response.get("_links", {}),
+            "created": v2_response.get("version", {}).get("createdAt", ""),
+            "updated": v2_response.get("version", {}).get("createdAt", ""),
         }
 
         # Map v2 author to v1 format

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -90,11 +90,11 @@ class JiraClient:
         elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Jira client with Token (PAT) auth. "
-                f"URL: {self.config.url}, "
+                f"URL: {self.config.api_url}, "
                 f"Token (masked): {mask_sensitive(str(self.config.personal_token))}"
             )
             self.jira = Jira(
-                url=self.config.url,
+                url=self.config.api_url,
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
@@ -103,12 +103,12 @@ class JiraClient:
         else:  # basic auth
             logger.debug(
                 f"Initializing Jira client with Basic auth. "
-                f"URL: {self.config.url}, Username: {self.config.username}, "
+                f"URL: {self.config.api_url}, Username: {self.config.username}, "
                 f"API Token present: {bool(self.config.api_token)}, "
                 f"Is Cloud: {self.config.is_cloud}"
             )
             self.jira = Jira(
-                url=self.config.url,
+                url=self.config.api_url,
                 username=self.config.username,
                 password=self.config.api_token,
                 cloud=self.config.is_cloud,

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -158,6 +158,11 @@ class JiraClient:
         if self.config.custom_headers:
             self._apply_custom_headers()
 
+        # Apply cookie if configured
+        if self.config.cookie:
+            self.jira._session.headers["Cookie"] = self.config.cookie
+            logger.debug("Applied configured cookie to Jira session")
+
         # Initialize the text preprocessor for text processing capabilities
         self.preprocessor = JiraPreprocessor(
             base_url=self.config.url,

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -117,6 +117,9 @@ class JiraConfig:
     sla_config: SLAConfig | None = None  # Optional SLA configuration
     timeout: int = 75  # Connection timeout in seconds
     cookie: str | None = None  # Raw cookie string to attach to all requests
+    cloud_id: str | None = (
+        None  # Cloud ID — routes via api.atlassian.com (JIRA_CLOUD_ID > ATLASSIAN_CLOUD_ID)
+    )
 
     @property
     def is_cloud(self) -> bool:
@@ -126,6 +129,10 @@ class JiraConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
+        # cloud_id set directly on config means Cloud (service account or explicit)
+        if self.cloud_id:
+            return True
+
         # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
@@ -148,6 +155,17 @@ class JiraConfig:
         return is_atlassian_cloud_url(self.url) if self.url else False
 
     @property
+    def api_url(self) -> str:
+        """Get the effective API URL, using the Cloud gateway when cloud_id is set.
+
+        Returns:
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+        """
+        if self.cloud_id:
+            return f"https://api.atlassian.com/ex/jira/{self.cloud_id}"
+        return self.url
+
+    @property
     def verify_ssl(self) -> bool:
         """Compatibility property for old code.
 
@@ -167,7 +185,11 @@ class JiraConfig:
             ValueError: If required environment variables are missing or invalid
         """
         url = os.getenv("JIRA_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        # cloud_id can substitute for URL (service accounts use api.atlassian.com)
+        has_cloud_id = bool(
+            os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+        )
+        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required JIRA_URL environment variable. "
                 "Set JIRA_URL to your Jira base URL, for example "
@@ -185,7 +207,7 @@ class JiraConfig:
         auth_type = None
 
         # Use the shared utility function directly
-        is_cloud = is_atlassian_cloud_url(url) if url else False
+        is_cloud = has_cloud_id or (is_atlassian_cloud_url(url) if url else False)
 
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
@@ -266,6 +288,9 @@ class JiraConfig:
         # Cookie configuration
         cookie = os.getenv("JIRA_COOKIE")
 
+        # Cloud ID for service accounts (JIRA_CLOUD_ID takes precedence over ATLASSIAN_CLOUD_ID)
+        cloud_id = os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -286,6 +311,7 @@ class JiraConfig:
             client_key_password=client_key_password,
             timeout=timeout,
             cookie=cookie,
+            cloud_id=cloud_id,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -116,6 +116,7 @@ class JiraConfig:
     client_key_password: str | None = None  # Password for encrypted private key
     sla_config: SLAConfig | None = None  # Optional SLA configuration
     timeout: int = 75  # Connection timeout in seconds
+    cookie: str | None = None  # Raw cookie string to attach to all requests
 
     @property
     def is_cloud(self) -> bool:
@@ -262,6 +263,9 @@ class JiraConfig:
         if os.getenv("JIRA_TIMEOUT") and os.getenv("JIRA_TIMEOUT", "").isdigit():
             timeout = int(os.getenv("JIRA_TIMEOUT", "75"))
 
+        # Cookie configuration
+        cookie = os.getenv("JIRA_COOKIE")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -281,6 +285,7 @@ class JiraConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cookie=cookie,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -26,7 +26,9 @@ class DevelopmentMixin(JiraClient):
         Args:
             issue_key: The issue key (e.g., PROJECT-123)
             application_type: Filter by application type
-                (e.g., 'stash', 'github', 'bitbucket').
+                (e.g., 'stash', 'GitHub', 'bitbucket').
+                Values are case-sensitive (the dev-status API
+                returns empty results or 500 errors on mismatch).
                 If None, tries common application types.
             data_type: Filter by data type
                 (e.g., 'pullrequest', 'branch', 'repository').
@@ -65,8 +67,9 @@ class DevelopmentMixin(JiraClient):
                 )
 
             # Otherwise, try common application types and merge results
-            # Common types: stash (Bitbucket Server), bitbucket, github, gitlab
-            app_types = ["stash", "bitbucket", "github", "gitlab"]
+            # Values are case-sensitive — the dev-status API requires the
+            # exact casing registered by each DVCS connector plugin.
+            app_types = ["stash", "bitbucket", "GitHub", "GitLab"]
             # Data types to try for each app type
             data_types = ["pullrequest", "branch", "repository"]
             merged_result: dict[str, Any] = {
@@ -132,7 +135,7 @@ class DevelopmentMixin(JiraClient):
         Args:
             issue_key: The issue key
             issue_id: The numeric issue ID
-            application_type: The application type (stash, github, etc.)
+            application_type: The application type (stash, GitHub, etc.) — case-sensitive
             data_type: Optional data type filter
 
         Returns:

--- a/src/mcp_atlassian/jira/field_options.py
+++ b/src/mcp_atlassian/jira/field_options.py
@@ -109,8 +109,8 @@ class FieldOptionsMixin(JiraClient):
             global_ctx = next((c for c in contexts if c.is_global_context), None)
             context_id = global_ctx.id if global_ctx else contexts[0].id
 
-        # Paginate through all options
-        all_options: list[FieldOption] = []
+        # Paginate through all option entries (Cloud returns a flat list).
+        raw_items: list[dict] = []
         start_at = 0
         max_results = 100
 
@@ -127,7 +127,7 @@ class FieldOptionsMixin(JiraClient):
                 values = response.get("values", [])
                 for item in values:
                     if isinstance(item, dict):
-                        all_options.append(FieldOption.from_api_response(item))
+                        raw_items.append(item)
 
                 total = response.get("total", len(values))
                 start_at += len(values)
@@ -141,7 +141,70 @@ class FieldOptionsMixin(JiraClient):
                 )
                 break
 
-        return all_options
+        # Build parent -> children mapping. Cloud main endpoint returns a
+        # flat list where child items include an "optionId" referencing
+        # their parent's id. Prefer calling the cascade-specific endpoint
+        # per parent (with pagination) to get authoritative child objects;
+        # fall back to grouping by optionId only when that endpoint is
+        # unreachable (exception), so an explicitly empty cascade response
+        # is trusted and does not trigger the fallback.
+        items_by_id = {str(item.get("id", "")): item for item in raw_items}
+        parent_ids = [iid for iid, it in items_by_id.items() if not it.get("optionId")]
+
+        result: list[FieldOption] = []
+
+        for pid in parent_ids:
+            parent_item = items_by_id.get(pid, {})
+            child_items: list[dict] = []
+            # True once the cascade endpoint responds (even with empty results),
+            # so an empty authoritative response is not confused with a failure.
+            cascade_fetched = False
+            cascade_start = 0
+            cascade_max = 100
+
+            while True:
+                try:
+                    cascade_resp = self.jira.get(
+                        f"rest/api/3/field/{field_id}/context/{context_id}"
+                        f"/option/{pid}/cascadingOption",
+                        params={"startAt": cascade_start, "maxResults": cascade_max},
+                    )
+                    cascade_fetched = True
+
+                    if isinstance(cascade_resp, dict):
+                        page = cascade_resp.get("values")
+                        page_items: list[dict] = (
+                            [c for c in page if isinstance(c, dict)]
+                            if page is not None
+                            else []
+                        )
+                        child_items.extend(page_items)
+                        total = cascade_resp.get("total", len(page_items))
+                        cascade_start += len(page_items)
+                        if cascade_start >= total or not page_items:
+                            break
+                    else:
+                        break
+
+                except Exception as e:
+                    logger.debug(
+                        f"Cascade endpoint unavailable for field {field_id} "
+                        f"option {pid}: {e}. Falling back to flat-list grouping."
+                    )
+                    break
+
+            # Fallback: reconstruct hierarchy from flat-list "optionId" references,
+            # but only when the cascade endpoint was not reachable.
+            if not cascade_fetched:
+                child_items = [it for it in raw_items if it.get("optionId") == pid]
+
+            children = [FieldOption.from_api_response(c) for c in child_items]
+            parent_opt = FieldOption.from_api_response(parent_item).model_copy(
+                update={"child_options": children}
+            )
+            result.append(parent_opt)
+
+        return result
 
     def _get_field_options_server(
         self,

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -605,7 +605,7 @@ class IssuesMixin(
                     "Provide issue_type like 'Task', 'Story', or 'Bug'."
                 )
 
-            # Handle Epic and Subtask issue type names across different languages
+            # Handle issue type names across different languages
             actual_issue_id = None
             if self._is_epic_issue_type(issue_type) and issue_type.lower() == "epic":
                 # If the user provided "Epic" but we need to find the localized name
@@ -620,6 +620,15 @@ class IssuesMixin(
                     actual_issue_id = subtask_type_id
                     logger.info(
                         f"Using localized Subtask issue type id: {subtask_type_id}"
+                    )
+            else:
+                # For all other issue types (Story, Task, Bug, etc.),
+                # resolve name to ID to support localized Jira instances
+                resolved_id = self._find_issue_type_id(project_key, issue_type)
+                if resolved_id:
+                    actual_issue_id = resolved_id
+                    logger.info(
+                        f"Resolved issue type '{issue_type}' to id: {resolved_id}"
                     )
 
             # Prepare fields
@@ -807,6 +816,39 @@ class IssuesMixin(
             return None
         except Exception as e:
             logger.warning(f"Could not get issue types for project {project_key}: {e}")
+            return None
+
+    def _find_issue_type_id(self, project_key: str, issue_type_name: str) -> str | None:
+        """
+        Find the issue type ID by name for a project.
+
+        Supports localized Jira instances where issue type names may differ
+        from the English defaults (e.g., Korean, Japanese, German).
+
+        Args:
+            project_key: The project key
+            issue_type_name: The issue type name to resolve
+
+        Returns:
+            The issue type ID if found, None otherwise
+        """
+        try:
+            issue_types = self.get_project_issue_types(project_key)
+            for issue_type in issue_types:
+                type_name = issue_type.get("name", "")
+                if type_name.lower() == issue_type_name.lower():
+                    return issue_type.get("id")
+            # Fallback: try untranslatedName if available
+            for issue_type in issue_types:
+                untranslated = issue_type.get("untranslatedName", "")
+                if untranslated and untranslated.lower() == issue_type_name.lower():
+                    return issue_type.get("id")
+            return None
+        except Exception as e:
+            logger.warning(
+                f"Could not resolve issue type '{issue_type_name}' "
+                f"for project {project_key}: {e}"
+            )
             return None
 
     def _prepare_epic_fields(

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -986,6 +986,14 @@ class IssuesMixin(
                 logger.debug(f"Identified field '{key}' as standard system field ID.")
 
             if api_field_id:
+                # Allow None values to pass through for clearing fields
+                if value is None:
+                    fields[api_field_id] = None
+                    logger.debug(
+                        f"Setting field '{api_field_id}' to None from kwarg '{key}' (clearing field)."
+                    )
+                    continue
+
                 # Get the full field definition for formatting context if needed
                 field_definition = self.get_field_by_id(
                     api_field_id
@@ -1050,6 +1058,7 @@ class IssuesMixin(
                 - assignee: New assignee for the issue
                 - parent: Parent issue key (str or {"key": "..."} dict)
                 - epicKey/epic_link/epicLink: Epic link alias
+                Pass None to clear a field (e.g., priority=None).
 
         Returns:
             JiraIssue model representing the updated issue
@@ -1162,6 +1171,46 @@ class IssuesMixin(
             error_msg = str(e)
             logger.error(f"Error updating issue {issue_key}: {error_msg}")
             raise ValueError(f"Failed to update issue {issue_key}: {error_msg}") from e
+
+    def assign_issue(
+        self,
+        issue_key: str,
+        assignee: str | None,
+    ) -> JiraIssue:
+        """
+        Assign a Jira issue to a user using the dedicated assignment endpoint.
+
+        Unlike update_issue (which sets assignee via the fields update and is
+        silently ignored by some Jira configurations), this method calls
+        PUT /rest/api/3/issue/{key}/assignee directly.
+
+        Pass None or empty string to unassign.
+
+        Args:
+            issue_key: The key of the issue to assign (e.g., 'PROJ-123')
+            assignee: User identifier (email, display name, or account ID).
+                      Pass None or "" to unassign.
+
+        Returns:
+            JiraIssue model representing the updated issue
+
+        Raises:
+            ValueError: If the user cannot be resolved or assignment fails
+        """
+        try:
+            if assignee is None or assignee == "":
+                # Unassign: the atlassian-python-api accepts None for unassignment
+                self.jira.assign_issue(issue_key, None)
+            else:
+                account_id = self._get_account_id(assignee)
+                self.jira.assign_issue(issue_key, account_id)
+
+            # Return the updated issue
+            return self.get_issue(issue_key)
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error assigning issue {issue_key}: {error_msg}")
+            raise ValueError(f"Failed to assign issue {issue_key}: {error_msg}") from e
 
     def _update_issue_with_status(
         self, issue_key: str, fields: dict[str, Any]

--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -188,26 +188,64 @@ class LinksMixin(JiraClient):
     def get_remote_issue_links(self, issue_key: str) -> list[dict[str, Any]]:
         """Get remote links (web links, Confluence links) for an issue.
 
+        Returns a simplified list of remote link dicts with fields useful
+        for LLM consumption: ``id``, ``url``, ``title``, and optionally
+        ``summary``, ``relationship``, ``application``, and ``resolved``.
+
         Args:
             issue_key: The issue key (e.g., 'PROJ-123')
 
         Returns:
-            List of remote link data dictionaries
+            List of simplified remote link dicts
 
         Raises:
+            ValueError: If issue_key is empty
             MCPAtlassianAuthenticationError: If authentication fails
         """
+        if not issue_key:
+            raise ValueError("Issue key is required")
+
         try:
             if self.config.is_cloud:
                 endpoint = f"rest/api/3/issue/{issue_key}/remotelink"
             else:
                 endpoint = f"rest/api/2/issue/{issue_key}/remotelink"
-            result = self.jira.get(endpoint)
-            if isinstance(result, list):
-                return result
-            if isinstance(result, dict):
-                return result.get("remoteLinks", [result])
-            return []
+            response = self.jira.get(endpoint)
+
+            # Normalise response to a list of raw link dicts
+            if isinstance(response, list):
+                raw_links = response
+            elif isinstance(response, dict):
+                raw_links = response.get("remoteLinks", [response])
+            else:
+                logger.error(
+                    "Unexpected response type from remote links API: %s",
+                    type(response),
+                )
+                return []
+
+            # Extract LLM-relevant fields, drop API noise
+            results: list[dict[str, Any]] = []
+            for link in raw_links:
+                obj = link.get("object", {})
+                result: dict[str, Any] = {
+                    "id": link.get("id"),
+                    "url": obj.get("url", ""),
+                    "title": obj.get("title", ""),
+                }
+                if obj.get("summary"):
+                    result["summary"] = obj["summary"]
+                if link.get("relationship"):
+                    result["relationship"] = link["relationship"]
+                application = link.get("application", {})
+                if application.get("name"):
+                    result["application"] = application["name"]
+                status = obj.get("status", {})
+                if status.get("resolved") is not None:
+                    result["resolved"] = status["resolved"]
+                results.append(result)
+
+            return results
         except HTTPError:
             raise  # let decorator handle auth errors
         except Exception as e:

--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -185,6 +185,41 @@ class LinksMixin(JiraClient):
             raise Exception(f"Error creating remote issue link: {error_msg}") from e
 
     @handle_auth_errors("Jira API")
+    def get_remote_issue_links(self, issue_key: str) -> list[dict[str, Any]]:
+        """Get remote links (web links, Confluence links) for an issue.
+
+        Args:
+            issue_key: The issue key (e.g., 'PROJ-123')
+
+        Returns:
+            List of remote link data dictionaries
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails
+        """
+        try:
+            if self.config.is_cloud:
+                endpoint = f"rest/api/3/issue/{issue_key}/remotelink"
+            else:
+                endpoint = f"rest/api/2/issue/{issue_key}/remotelink"
+            result = self.jira.get(endpoint)
+            if isinstance(result, list):
+                return result
+            if isinstance(result, dict):
+                return result.get("remoteLinks", [result])
+            return []
+        except HTTPError:
+            raise  # let decorator handle auth errors
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(
+                f"Error getting remote links for {issue_key}: {error_msg}",
+                exc_info=True,
+            )
+            msg = f"Error getting remote links for {issue_key}: {error_msg}"
+            raise Exception(msg) from e
+
+    @handle_auth_errors("Jira API")
     def remove_issue_link(self, link_id: str) -> dict[str, Any]:
         """
         Remove a link between two issues.

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -256,8 +256,9 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
                 logger.error(msg)
                 raise TypeError(msg)
 
-            # The new createmeta endpoint returns paginated "values" array
-            issue_types = meta.get("values", [])
+            # The new createmeta endpoint returns paginated "values" array;
+            # some API versions return "issueTypes" instead of "values"
+            issue_types = meta.get("values", meta.get("issueTypes", []))
             if not issue_types:
                 # Fallback for older response format
                 projects = meta.get("projects", [])
@@ -269,6 +270,40 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
         except Exception as e:
             logger.error(
                 f"Error getting issue types for project {project_key}: {str(e)}"
+            )
+            return []
+
+    def get_create_fields(
+        self, project_key: str, issue_type_id: str
+    ) -> list[dict[str, Any]]:
+        """Get all fields available when creating an issue of a given type.
+
+        Uses the non-deprecated ``issue_createmeta_fieldtypes`` endpoint to
+        return field metadata for the specified project and issue type.
+
+        Args:
+            project_key: The project key (e.g., 'PROJ')
+            issue_type_id: The issue type ID (from get_project_issue_types)
+
+        Returns:
+            List of field metadata dicts with fieldId, name, required,
+            schema, etc.
+        """
+        try:
+            meta = self.jira.issue_createmeta_fieldtypes(
+                project=project_key, issue_type_id=issue_type_id
+            )
+            if not isinstance(meta, dict):
+                msg = (
+                    f"Unexpected return type from "
+                    f"issue_createmeta_fieldtypes: {type(meta)}"
+                )
+                logger.error(msg)
+                raise TypeError(msg)
+            return meta.get("values", meta.get("fields", []))
+        except Exception as e:
+            logger.error(
+                f"Error getting create fields for {project_key}/{issue_type_id}: {e}"
             )
             return []
 

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -260,6 +260,9 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
             # some API versions return "issueTypes" instead of "values"
             issue_types = meta.get("values", meta.get("issueTypes", []))
             if not issue_types:
+                # Fallback: atlassian-python-api returns "issueTypes" key
+                issue_types = meta.get("issueTypes", [])
+            if not issue_types:
                 # Fallback for older response format
                 projects = meta.get("projects", [])
                 if projects and "issuetypes" in projects[0]:

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -120,8 +120,14 @@ class UsersMixin(JiraClient):
         Raises:
             ValueError: If the account ID could not be found.
         """
-        # If it looks like an account ID already, return it
-        if assignee.startswith("5") and len(assignee) >= 10:
+        # If it looks like an account ID already, return it.
+        # Atlassian account IDs come in two formats:
+        #   - 24-char hex string: e.g. 606b8fb83a516300764cb19d
+        #   - digits:uuid: e.g. 712020:96a182bb-ee48-4240-8465-a7236ccfce2a
+        if re.fullmatch(r"[0-9a-f]{24}", assignee) or re.fullmatch(
+            r"\d+:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+            assignee,
+        ):
             return assignee
 
         account_id = self._lookup_user_directly(assignee)

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -385,6 +385,11 @@ class UsersMixin(JiraClient):
                 fails.
             Exception: For other API errors.
         """
+        # Handle 'me' as a special case — resolve to current user's account ID
+        if identifier.lower() == "me":
+            resolved_id = self.get_current_user_account_id()
+            return self.get_user_profile_by_identifier(resolved_id)
+
         api_kwargs = self._determine_user_api_params(identifier)
 
         try:

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -200,6 +200,11 @@ class ConfluencePage(ApiModel, TimestampMixin):
             if not updated and version and version.when:
                 updated = version.when
 
+            # Fall back to history.createdBy if no top-level author
+            if not author:
+                if created_by := history.get("createdBy"):
+                    author = ConfluenceUser.from_api_response(created_by)
+
         # Construct URL if base_url is provided
         url = None
         if base_url := kwargs.get("base_url"):

--- a/src/mcp_atlassian/models/confluence/search.py
+++ b/src/mcp_atlassian/models/confluence/search.py
@@ -53,6 +53,17 @@ class ConfluenceSearchResult(ApiModel, TimestampMixin):
             # In Confluence search, the content is nested inside the result item
             if content := item.get("content"):
                 results.append(ConfluencePage.from_api_response(content, **kwargs))
+            elif space_data := item.get("space"):
+                # Space-type results: map to ConfluencePage for uniform return type
+                space_as_page = {
+                    "id": str(space_data.get("id", "")),
+                    "title": space_data.get("name", item.get("title", "")),
+                    "space": space_data,
+                    "type": "space",
+                }
+                results.append(
+                    ConfluencePage.from_api_response(space_as_page, **kwargs)
+                )
 
         return cls(
             total_size=data.get("totalSize", 0),

--- a/src/mcp_atlassian/models/jira/field_option.py
+++ b/src/mcp_atlassian/models/jira/field_option.py
@@ -23,7 +23,9 @@ class FieldContext(ApiModel):
     is_any_issue_type: bool = False
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldContext":
+    def from_api_response(
+        cls, data: dict[str, Any] | str | None, **kwargs: Any
+    ) -> "FieldContext":
         """Create a FieldContext from a Jira API response.
 
         Args:
@@ -65,7 +67,9 @@ class FieldOption(ApiModel):
     child_options: list["FieldOption"] = Field(default_factory=list)
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldOption":
+    def from_api_response(
+        cls, data: dict[str, Any] | str | None, **kwargs: Any
+    ) -> "FieldOption":
         """Create a FieldOption from a Jira API response.
 
         Args:
@@ -74,14 +78,29 @@ class FieldOption(ApiModel):
         Returns:
             A FieldOption instance
         """
+        # Handle simple string values (some API shapes use strings for
+        # allowedValues/children). If `data` is a bare string, treat it
+        # as a value-only FieldOption.
+        if isinstance(data, str):
+            return cls(id="", value=data)
+
         if not data or not isinstance(data, dict):
             return cls(id="", value="")
 
-        children = [
-            cls.from_api_response(c)
-            for c in data.get("cascadingOptions", [])
-            if isinstance(c, dict)
-        ]
+        # Server/DC createmeta uses "children"; Cloud/legacy uses
+        # "cascadingOptions". Use key presence so an explicit empty list
+        # is never mistaken for a missing key.
+        if "cascadingOptions" in data:
+            raw_children: list[Any] = data["cascadingOptions"]
+        elif "children" in data:
+            raw_children = data["children"]
+        else:
+            raw_children = []
+
+        children: list[FieldOption] = []
+        for c in raw_children:
+            if isinstance(c, dict):
+                children.append(cls.from_api_response(c))
 
         return cls(
             id=str(data.get("id", data.get("optionId", ""))),

--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -761,6 +761,95 @@ class JiraIssue(ApiModel, TimestampMixin):
 
         return None, None
 
+    def get_custom_field_by_name(
+        self, display_name: str, *, case_sensitive: bool = False
+    ) -> Any:
+        """Look up a custom field value by its human-readable display name.
+
+        This is a convenience wrapper over the internal ``custom_fields`` dict
+        (which is keyed by ``customfield_XXXXX``).  It searches the ``name``
+        entry stored inside each value object, so the underlying data structure
+        is completely untouched.
+
+        Args:
+            display_name: The human-readable name of the field
+                (e.g. ``"Story Points"``, ``"Severity"``).
+            case_sensitive: If *False* (default) the comparison is
+                case-insensitive.
+
+        Returns:
+            The processed field value if found, or *None*.
+        """
+        target = display_name if case_sensitive else display_name.lower()
+        for field_data in self.custom_fields.values():
+            if not isinstance(field_data, dict):
+                continue
+            stored_name = field_data.get("name")
+            if stored_name is None:
+                continue
+            candidate = stored_name if case_sensitive else stored_name.lower()
+            if candidate == target:
+                return self._process_custom_field_value(field_data.get("value"))
+        return None
+
+    @property
+    def custom_fields_by_display_name(self) -> dict[str, Any]:
+        """Return ``custom_fields`` re-keyed by display name.
+
+        Fields that do not carry a ``name`` entry keep their original
+        ``customfield_XXXXX`` key so nothing is silently dropped.
+
+        Each value retains the upstream structure
+        (``{"value": …, "name": …}``) with an additional ``"field_id"`` key
+        for reverse-lookup convenience.
+
+        Returns:
+            A **new** dict — the original ``custom_fields`` is never mutated.
+        """
+        result: dict[str, Any] = {}
+        for field_id, field_data in self.custom_fields.items():
+            if not isinstance(field_data, dict):
+                result[field_id] = field_data
+                continue
+            display_key = field_data.get("name", field_id)
+            entry = {**field_data, "field_id": field_id}
+            result[display_key] = entry
+        return result
+
+    def to_display_name_dict(self) -> dict[str, Any]:
+        """Like ``to_simplified_dict`` but with custom fields keyed by display name.
+
+        Standard fields (summary, status, etc.) are identical to
+        ``to_simplified_dict()``.  Only the custom-field section changes:
+        each ``customfield_XXXXX`` key is replaced by its human-readable
+        name when one is available.
+
+        Returns:
+            A simplified dict suitable for tool / API output where custom
+            fields use human-friendly keys.
+        """
+        base = self.to_simplified_dict()
+
+        rekeyed_customs: dict[str, Any] = {}
+        removed_keys: list[str] = []
+
+        for key, value in base.items():
+            if not key.startswith("customfield_"):
+                continue
+            removed_keys.append(key)
+            if isinstance(value, dict) and "name" in value:
+                display_key = value["name"]
+                entry = {**value, "field_id": key}
+                rekeyed_customs[display_key] = entry
+            else:
+                rekeyed_customs[key] = value
+
+        for k in removed_keys:
+            del base[k]
+
+        base.update(rekeyed_customs)
+        return base
+
     def _get_epic_name(self) -> str | None:
         """Get the epic name from custom fields if available."""
         # Try each pattern in order

--- a/src/mcp_atlassian/models/jira/search.py
+++ b/src/mcp_atlassian/models/jira/search.py
@@ -49,9 +49,15 @@ class JiraSearchResult(ApiModel):
 
         issues = []
         issues_data = data.get("issues", [])
+        # The 'names' map (field ID → display name) lives at the top level
+        # of search responses.  Propagate it into each issue dict so that
+        # JiraIssue.from_api_response can populate display names.
+        top_level_names = data.get("names")
         if isinstance(issues_data, list):
             for issue_data in issues_data:
                 if issue_data:
+                    if top_level_names and isinstance(issue_data, dict):
+                        issue_data = {**issue_data, "names": top_level_names}
                     requested_fields = kwargs.get("requested_fields")
                     issues.append(
                         JiraIssue.from_api_response(
@@ -108,6 +114,18 @@ class JiraSearchResult(ApiModel):
             "start_at": self.start_at,
             "max_results": self.max_results,
             "issues": [issue.to_simplified_dict() for issue in self.issues],
+        }
+        if self.next_page_token is not None:
+            result["next_page_token"] = self.next_page_token
+        return result
+
+    def to_display_name_dict(self) -> dict[str, Any]:
+        """Like ``to_simplified_dict`` but with display-name keys on each issue."""
+        result: dict[str, Any] = {
+            "total": self.total,
+            "start_at": self.start_at,
+            "max_results": self.max_results,
+            "issues": [issue.to_display_name_dict() for issue in self.issues],
         }
         if self.next_page_token is not None:
             result["next_page_token"] = self.next_page_token

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -55,16 +55,21 @@ class ConfluencePreprocessor(BasePreprocessor):
         *,
         enable_heading_anchors: bool = False,
         table_layout: str | None = None,
+        apply_task_lists: bool = True,
     ) -> str:
         """
         Convert Markdown content to Confluence storage format (XHTML)
 
         Args:
             markdown_content: Markdown text to convert
-            enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False)
+            enable_heading_anchors: Whether to enable automatic heading anchor
+                generation (default: False)
             table_layout: Optional table width preset applied to all tables in the output.
                 Values: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px / Confluence default).
                 When None, tables retain the default 760 px width emitted by the converter.
+            apply_task_lists: Whether to convert GFM task-list items
+                (``- [ ]`` / ``- [x]``) to Confluence ``ac:task-list`` macros
+                (default: True)
 
         Returns:
             Confluence storage format (XHTML) string
@@ -108,6 +113,9 @@ class ConfluencePreprocessor(BasePreprocessor):
                     storage_format = self._apply_table_layout(
                         storage_format, table_layout
                     )
+
+                if apply_task_lists:
+                    storage_format = self._apply_task_lists(storage_format)
 
                 return self._fix_attachment_images(storage_format)
             finally:
@@ -193,3 +201,55 @@ class ConfluencePreprocessor(BasePreprocessor):
             return re.sub(r"^<table", f"<table {attrs}", tag)
 
         return re.sub(r"<table\b[^>]*>", _replace_table_tag, storage_html)
+
+    @classmethod
+    def _apply_task_lists(cls, storage_html: str) -> str:
+        """Convert GFM-style task list items to Confluence ac:task-list macros.
+
+        md2conf renders GFM task list items (``- [ ]`` / ``- [x]``) as plain
+        ``<ul><li>`` elements with the checkbox marker as literal text.
+        Confluence needs ``<ac:task-list>`` / ``<ac:task>`` elements to render
+        interactive checkboxes.
+
+        Only converts ``<ul>`` blocks whose every ``<li>`` begins with a
+        checkbox marker; mixed lists (some items without a checkbox prefix)
+        are left unchanged.  Nested ``<ul>`` elements are not traversed to
+        avoid partial matches.
+
+        Args:
+            storage_html: Confluence storage-format string to post-process.
+
+        Returns:
+            Updated storage-format string with task lists converted.
+        """
+        task_item_re = re.compile(r"^\[( |x|X)\]\s*(.*)", re.DOTALL)
+
+        def _replace_ul(m: re.Match) -> str:
+            ul_html = m.group(0)
+            items = re.findall(r"<li>(.*?)</li>", ul_html, re.DOTALL)
+            if not items:
+                return ul_html
+
+            task_matches = [task_item_re.match(item) for item in items]
+            if not all(task_matches):
+                return ul_html  # mixed list — leave as-is
+
+            parts = ["<ac:task-list>"]
+            for tm in task_matches:
+                if tm is None:  # should not happen given all(task_matches) above
+                    continue
+                status = "complete" if tm.group(1).lower() == "x" else "incomplete"
+                body = tm.group(2).strip()
+                parts.append(
+                    f"<ac:task>"
+                    f"<ac:task-status>{status}</ac:task-status>"
+                    f"<ac:task-body>{body}</ac:task-body>"
+                    f"</ac:task>"
+                )
+            parts.append("</ac:task-list>")
+            return "".join(parts)
+
+        # Only match <ul> blocks with no nested <ul> to avoid partial tag matches.
+        return re.sub(
+            r"<ul>(?:(?!<ul>).)*?</ul>", _replace_ul, storage_html, flags=re.DOTALL
+        )

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -1,6 +1,7 @@
 """Confluence-specific text preprocessing module."""
 
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -36,8 +37,24 @@ class ConfluencePreprocessor(BasePreprocessor):
         """
         super().__init__(base_url=base_url)
 
+    # Table width (px) and layout name keyed by the caller-supplied table_layout value.
+    _TABLE_WIDTHS: dict[str, str] = {
+        "full-width": "1800",
+        "wide": "960",
+        "default": "760",
+    }
+    _TABLE_LAYOUTS: dict[str, str] = {
+        "full-width": "full-width",
+        "wide": "wide",
+        "default": "default",
+    }
+
     def markdown_to_confluence_storage(
-        self, markdown_content: str, *, enable_heading_anchors: bool = False
+        self,
+        markdown_content: str,
+        *,
+        enable_heading_anchors: bool = False,
+        table_layout: str | None = None,
     ) -> str:
         """
         Convert Markdown content to Confluence storage format (XHTML)
@@ -45,6 +62,9 @@ class ConfluencePreprocessor(BasePreprocessor):
         Args:
             markdown_content: Markdown text to convert
             enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False)
+            table_layout: Optional table width preset applied to all tables in the output.
+                Values: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px / Confluence default).
+                When None, tables retain the default 760 px width emitted by the converter.
 
         Returns:
             Confluence storage format (XHTML) string
@@ -82,9 +102,14 @@ class ConfluencePreprocessor(BasePreprocessor):
                 converter.visit(root)
 
                 # Convert the element tree back to a string
-                storage_format = elements_to_string(root)
+                storage_format = str(elements_to_string(root))
 
-                return str(storage_format)
+                if table_layout and table_layout in self._TABLE_WIDTHS:
+                    storage_format = self._apply_table_layout(
+                        storage_format, table_layout
+                    )
+
+                return self._fix_attachment_images(storage_format)
             finally:
                 # Clean up the temporary directory
                 shutil.rmtree(temp_dir, ignore_errors=True)
@@ -96,10 +121,75 @@ class ConfluencePreprocessor(BasePreprocessor):
             # Fall back to a simpler method if the conversion fails
             html_content = markdown_to_html(markdown_content)
 
-            # Use a different approach that doesn't rely on the HTML macro
             # This creates a proper Confluence storage format document
             storage_format = f"""<p>{html_content}</p>"""
 
             return str(storage_format)
 
-    # Confluence-specific methods can be added here
+    @staticmethod
+    def _fix_attachment_images(storage_html: str) -> str:
+        """Replace bare-filename ``<img>`` tags with Confluence attachment macros.
+
+        Confluence Storage Format cannot resolve bare filenames in
+        ``<img src="filename.ext"/>``. Attachment references must use the
+        ``ac:image`` / ``ri:attachment`` macro instead. External URLs
+        (``http``/``https``/``data``) and absolute paths are left untouched.
+
+        Args:
+            storage_html: Confluence storage format HTML string.
+
+        Returns:
+            Storage HTML with bare-filename img tags replaced by attachment macros.
+        """
+
+        def _replace(match: re.Match) -> str:  # type: ignore[type-arg]
+            tag = match.group(0)
+            src_match = re.search(r'src="([^"]+)"', tag)
+            alt_match = re.search(r'alt="([^"]+)"', tag)
+            if not src_match:
+                return tag
+            src = src_match.group(1)
+            # Leave external URLs and absolute paths untouched
+            if src.startswith(("http://", "https://", "data:", "/")):
+                return tag
+            alt = alt_match.group(1) if alt_match else ""
+            return (
+                f'<ac:image ac:alt="{alt}">'
+                f'<ri:attachment ri:filename="{src}"/>'
+                f"</ac:image>"
+            )
+
+        return re.sub(r"<img\b[^>]*/?>", _replace, storage_html)
+
+    @classmethod
+    def _apply_table_layout(cls, storage_html: str, table_layout: str) -> str:
+        """Set table width and layout attributes in Confluence storage format.
+
+        The md2conf converter emits bare ``<table>`` tags with no width or
+        layout attributes.  Confluence renders these at its default narrow
+        width.  This method injects ``data-table-width`` and ``data-layout``
+        attributes so tables render at the requested width.
+
+        If attributes already exist (e.g. content edited via another tool)
+        they are replaced rather than duplicated.
+
+        Args:
+            storage_html: Confluence storage-format string to post-process.
+            table_layout: One of 'full-width', 'wide', or 'default'.
+
+        Returns:
+            Updated storage-format string with table width attributes set.
+        """
+        width = cls._TABLE_WIDTHS.get(table_layout, "760")
+        layout = cls._TABLE_LAYOUTS.get(table_layout, "default")
+        attrs = f'data-table-width="{width}" data-layout="{layout}"'
+
+        def _replace_table_tag(m: re.Match) -> str:
+            tag = m.group(0)
+            # Strip any existing data-table-width / data-layout attributes first
+            tag = re.sub(r'\s*data-table-width="[^"]*"', "", tag)
+            tag = re.sub(r'\s*data-layout="[^"]*"', "", tag)
+            # Inject new attributes after <table
+            return re.sub(r"^<table", f"<table {attrs}", tag)
+
+        return re.sub(r"<table\b[^>]*>", _replace_table_tag, storage_html)

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -172,9 +172,9 @@ async def get_page(
         bool,
         Field(
             description=(
-                "Whether to convert page to markdown (true) or keep it in raw HTML format (false). "
-                "Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: "
-                "using HTML significantly increases token usage in AI responses."
+                "Whether to convert page to markdown (true) or return raw Confluence storage XHTML (false). "
+                "Storage output preserves macros, embedded Jira render modes, page layout, and task metadata "
+                "for safe round-tripping, but CAUTION: it significantly increases token usage in AI responses."
             ),
             default=True,
         ),
@@ -602,7 +602,11 @@ async def create_page(
     content: Annotated[
         str,
         Field(
-            description="The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, or storage format"
+            description=(
+                "The content of the page. Format depends on content_format parameter. "
+                "Can be Markdown (default), wiki markup, or storage format. Use storage "
+                "when retransmitting macro-heavy pages or existing layout/render metadata."
+            )
         ),
     ],
     parent_id: Annotated[
@@ -616,7 +620,12 @@ async def create_page(
     content_format: Annotated[
         str,
         Field(
-            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax",
+            description=(
+                "(Optional) The format of the content parameter. Options: 'markdown' "
+                "(default), 'wiki', or 'storage'. Wiki format uses Confluence wiki "
+                "markup syntax. Choose 'storage' when embedded macros, Jira cards/lists, "
+                "task metadata, or page layout must round-trip unchanged."
+            ),
             default="markdown",
         ),
     ] = "markdown",
@@ -729,7 +738,11 @@ async def update_page(
     content: Annotated[
         str,
         Field(
-            description="The new content of the page. Format depends on content_format parameter"
+            description=(
+                "The new content of the page. Format depends on content_format parameter. "
+                "Use storage when retransmitting macro-heavy pages or existing layout/render "
+                "metadata."
+            )
         ),
     ],
     is_minor_edit: Annotated[
@@ -746,7 +759,12 @@ async def update_page(
     content_format: Annotated[
         str,
         Field(
-            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax",
+            description=(
+                "(Optional) The format of the content parameter. Options: 'markdown' "
+                "(default), 'wiki', or 'storage'. Wiki format uses Confluence wiki "
+                "markup syntax. Choose 'storage' when embedded macros, Jira cards/lists, "
+                "task metadata, or page layout must round-trip unchanged."
+            ),
             default="markdown",
         ),
     ] = "markdown",
@@ -1468,9 +1486,9 @@ async def get_page_history(
         bool,
         Field(
             description=(
-                "Whether to convert page to markdown (true) or keep it in raw HTML format (false). "
-                "Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: "
-                "using HTML significantly increases token usage in AI responses."
+                "Whether to convert page to markdown (true) or return raw Confluence storage XHTML (false). "
+                "Storage output preserves macros and task metadata for safe round-tripping, but CAUTION: "
+                "it significantly increases token usage in AI responses."
             ),
             default=True,
         ),
@@ -2694,3 +2712,154 @@ async def copy_page(
         indent=2,
         ensure_ascii=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# Template tools
+# ---------------------------------------------------------------------------
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_templates"},
+    annotations={"title": "List Page Templates", "readOnlyHint": True},
+)
+async def confluence_list_page_templates(
+    ctx: Context,
+    space_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Optional space key to list templates defined in that space. "
+                "When omitted, global templates are returned."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(
+            default=25,
+            ge=1,
+            le=200,
+            description="Maximum number of templates to return.",
+        ),
+    ] = 25,
+) -> str:
+    """List Confluence page content templates.
+
+    Returns template metadata (ID, name, description, type) without the
+    full body.  Use confluence_get_page_template to fetch a template's body.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    try:
+        results = confluence_fetcher.list_page_templates(
+            space_key=space_key,
+            limit=limit,
+        )
+        simplified = [
+            {
+                "templateId": t.get("templateId", ""),
+                "name": t.get("name", ""),
+                "templateType": t.get("templateType", ""),
+                "description": (t.get("description") or {}).get("value", ""),
+            }
+            for t in results
+        ]
+        return json.dumps(
+            {"templates": simplified, "total": len(simplified)},
+            indent=2,
+            ensure_ascii=False,
+        )
+    except MCPAtlassianAuthenticationError as e:
+        logger.error(f"Authentication error listing templates: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Error listing templates: {e}")
+        raise
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_templates"},
+    annotations={"title": "Get Page Template", "readOnlyHint": True},
+)
+async def confluence_get_page_template(
+    ctx: Context,
+    template_id: Annotated[
+        str,
+        Field(description="The ID of the template to retrieve."),
+    ],
+) -> str:
+    """Get a Confluence page template by ID, including its storage-format body."""
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    try:
+        template = confluence_fetcher.get_page_template(template_id)
+        body_value = template.get("body", {}).get("storage", {}).get("value", "")
+        return json.dumps(
+            {
+                "templateId": template.get("templateId", ""),
+                "name": template.get("name", ""),
+                "templateType": template.get("templateType", ""),
+                "description": (template.get("description") or {}).get("value", ""),
+                "body": body_value,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    except MCPAtlassianAuthenticationError as e:
+        logger.error(f"Authentication error fetching template {template_id}: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching template {template_id}: {e}")
+        raise
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_templates"},
+    annotations={"title": "Create Page from Template", "destructiveHint": False},
+)
+@check_write_access
+async def confluence_create_page_from_template(
+    ctx: Context,
+    space_key: Annotated[
+        str,
+        Field(description="Key of the space in which to create the page."),
+    ],
+    title: Annotated[
+        str,
+        Field(description="Title for the new page."),
+    ],
+    template_id: Annotated[
+        str,
+        Field(description="ID of the template to use as the page body."),
+    ],
+    parent_id: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Optional ID of the parent page.",
+        ),
+    ] = None,
+) -> str:
+    """Create a new Confluence page pre-populated with a template's body.
+
+    Fetches the named template and creates a page with its storage-format
+    content.  The page can be edited afterwards via confluence_update_page.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    try:
+        result = confluence_fetcher.create_page_from_template(
+            space_key=space_key,
+            title=title,
+            template_id=template_id,
+            parent_id=parent_id,
+        )
+        return json.dumps(result, indent=2, ensure_ascii=False)
+    except MCPAtlassianAuthenticationError as e:
+        logger.error(f"Authentication error creating page from template: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Error creating page from template {template_id}: {e}")
+        raise

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -185,7 +185,7 @@ async def get_page(
             description=(
                 "(Optional) Comma-separated sections to inline in the response, "
                 "avoiding extra tool calls. Supported: "
-                "comments, labels, views"
+                "comments, labels, views, properties"
             ),
             default=None,
         ),
@@ -200,7 +200,7 @@ async def get_page(
         space_key: The key of the space. Must be used with 'title'.
         include_metadata: Whether to include page metadata.
         convert_to_markdown: Convert content to markdown (true) or keep raw HTML (false).
-        include: Comma-separated enrichments to inline (comments, labels, views).
+        include: Comma-separated enrichments to inline (comments, labels, views, properties).
 
     Returns:
         JSON string representing the page content and/or metadata, or an error
@@ -300,6 +300,17 @@ async def get_page(
                     resolved_page_id,
                 )
                 result["views"] = {}
+
+        if "properties" in sections:
+            try:
+                props = confluence_fetcher.get_content_properties(resolved_page_id)
+                result["properties"] = props
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to inline properties for page %s",
+                    resolved_page_id,
+                )
+                result["properties"] = {}
 
     return json.dumps(result, indent=2, ensure_ascii=False)
 
@@ -630,6 +641,20 @@ async def create_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (Confluence default).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Create a new Confluence page.
 
@@ -643,6 +668,8 @@ async def create_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the created page object.
@@ -677,6 +704,8 @@ async def create_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     result = page.to_simplified_dict()
     if not include_content:
@@ -742,6 +771,20 @@ async def update_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (preserve existing).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Update an existing Confluence page.
 
@@ -757,6 +800,8 @@ async def update_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the updated page object.
@@ -793,6 +838,8 @@ async def update_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     page_data = updated_page.to_simplified_dict()
     if not include_content:
@@ -2405,3 +2452,245 @@ async def get_page_images(
         ),
     )
     return contents
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Set Content Property", "destructiveHint": True},
+)
+@check_write_access
+async def set_content_property(
+    ctx: Context,
+    page_id: Annotated[
+        str,
+        Field(
+            description=(
+                "Confluence page ID (numeric string from the page URL, "
+                "e.g. '123456789')."
+            )
+        ),
+    ],
+    key: Annotated[
+        str,
+        Field(
+            description=(
+                "Property key to create or update. "
+                "Well-known keys: 'content-appearance-published', "
+                "'content-appearance-draft' (values: 'full-width' or 'fixed-width'), "
+                "'editor' (value: '{\"version\": 2}'). "
+                "Custom keys are also supported for app metadata."
+            )
+        ),
+    ],
+    value: Annotated[
+        str,
+        Field(
+            description=(
+                "Property value as a JSON string. "
+                "Examples: '\"full-width\"' for a string value, "
+                "'{\"version\": 2}' for an object value. "
+                "The version number is managed automatically."
+            )
+        ),
+    ],
+) -> str:
+    """Create or update a content property on a Confluence page.
+
+    Performs an upsert: creates the property if it does not exist, or updates
+    it if it does. The Confluence API version number is incremented automatically
+    so callers never need to manage it.
+
+    Common use cases:
+    - Switch page to full-width layout: key='content-appearance-published',
+      value='"full-width"'
+    - Switch page to fixed-width layout: key='content-appearance-published',
+      value='"fixed-width"'
+    - Set editor version: key='editor', value='{"version": 2}'
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: Confluence page ID.
+        key: Property key to create or update.
+        value: Property value as a JSON string.
+
+    Returns:
+        JSON object with the resulting ``{key: value}`` pair.
+
+    Raises:
+        ValueError: If the value is not valid JSON or in read-only mode.
+    """
+    try:
+        parsed_value = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"'value' must be a valid JSON string (e.g. '\"full-width\"' or "
+            f"'{{\"version\": 2}}'). Got: {value!r}"
+        ) from exc
+
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    result = confluence_fetcher.set_content_property(page_id, key, parsed_value)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_pages"},
+    annotations={"title": "Get Page Restrictions", "readOnlyHint": True},
+)
+async def get_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page")],
+) -> str:
+    """Get view and edit restrictions for a Confluence page.
+
+    Returns the current restriction lists for the read (view) and update (edit)
+    operations.  An empty list means the page is unrestricted for that operation.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page.
+
+    Returns:
+        JSON string with ``read`` and ``update`` restriction lists, each
+        containing ``users`` (account IDs) and ``groups`` (group names).
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    restrictions = confluence_fetcher.get_page_restrictions(page_id=page_id)
+    return json.dumps(restrictions, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Set Page Restrictions", "destructiveHint": True},
+)
+@check_write_access
+async def set_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page to restrict")],
+    read_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to view the page. Empty list = unrestricted.",
+            default=None,
+        ),
+    ] = None,
+    read_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to view the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Set view and edit restrictions on a Confluence page.
+
+    Replaces all existing restrictions with the provided lists.  Omitting all
+    parameters (or passing empty lists) removes all restrictions.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to restrict.
+        read_users: Account IDs / usernames allowed to view the page.
+        read_groups: Group names allowed to view the page.
+        edit_users: Account IDs / usernames allowed to edit the page.
+        edit_groups: Group names allowed to edit the page.
+
+    Returns:
+        JSON string with the updated restriction lists.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    result = confluence_fetcher.set_page_restrictions(
+        page_id=page_id,
+        read_users=read_users,
+        read_groups=read_groups,
+        edit_users=edit_users,
+        edit_groups=edit_groups,
+    )
+    return json.dumps(
+        {"message": "Page restrictions updated successfully", "restrictions": result},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Copy Page", "destructiveHint": True},
+)
+@check_write_access
+async def copy_page(
+    ctx: Context,
+    source_page_id: Annotated[str, Field(description="The ID of the page to copy")],
+    destination_space_key: Annotated[
+        str,
+        Field(description="Space key for the new page (e.g. 'DEV', 'TEAM')"),
+    ],
+    new_title: Annotated[str, Field(description="Title for the new copied page")],
+    destination_parent_id: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Parent page ID in the destination space. When omitted the page is created at the space root.",
+            default=None,
+        ),
+        BeforeValidator(lambda x: str(x) if x is not None else None),
+    ] = None,
+    copy_attachments: Annotated[
+        bool,
+        Field(
+            description="(Optional) Whether to copy attachments to the new page. Defaults to true. Only supported on Confluence Cloud.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Copy a Confluence page to a new location.
+
+    On Confluence Cloud the native copy endpoint is used.  On Server/Data Center
+    the page body is fetched and a new page is created manually (attachments are
+    not copied in the Server/DC path).
+
+    Args:
+        ctx: The FastMCP context.
+        source_page_id: The ID of the page to copy.
+        destination_space_key: Space key for the new page.
+        new_title: Title for the new copied page.
+        destination_parent_id: Optional parent page ID in the destination space.
+        copy_attachments: Whether to copy attachments (Cloud only).
+
+    Returns:
+        JSON string representing the new page.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    page = confluence_fetcher.copy_page(
+        source_page_id=source_page_id,
+        destination_space_key=destination_space_key,
+        new_title=new_title,
+        destination_parent_id=destination_parent_id,
+        copy_attachments=copy_attachments,
+    )
+    return json.dumps(
+        {"message": "Page copied successfully", "page": page.to_simplified_dict()},
+        indent=2,
+        ensure_ascii=False,
+    )

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -179,6 +179,17 @@ async def get_page(
             default=True,
         ),
     ] = True,
+    include: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated sections to inline in the response, "
+                "avoiding extra tool calls. Supported: "
+                "comments, labels, views"
+            ),
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Get content of a specific Confluence page by its ID, or by its title and space key.
 
@@ -189,9 +200,11 @@ async def get_page(
         space_key: The key of the space. Must be used with 'title'.
         include_metadata: Whether to include page metadata.
         convert_to_markdown: Convert content to markdown (true) or keep raw HTML (false).
+        include: Comma-separated enrichments to inline (comments, labels, views).
 
     Returns:
-        JSON string representing the page content and/or metadata, or an error if not found or parameters are invalid.
+        JSON string representing the page content and/or metadata, or an error
+        if not found or parameters are invalid.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
     page_object = None
@@ -237,10 +250,56 @@ async def get_page(
             ensure_ascii=False,
         )
 
+    result: dict
     if include_metadata:
         result = {"metadata": page_object.to_simplified_dict()}
     else:
         result = {"content": {"value": page_object.content}}
+
+    # Inline requested enrichments to avoid extra tool calls
+    if include:
+        sections = {s.strip().lower() for s in include.split(",")}
+        resolved_page_id = str(page_object.id)
+
+        if "comments" in sections:
+            try:
+                comments = confluence_fetcher.get_page_comments(
+                    resolved_page_id,
+                )
+                result["comments"] = [
+                    comment.to_simplified_dict() for comment in comments
+                ]
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to inline comments for page %s",
+                    resolved_page_id,
+                )
+                result["comments"] = []
+
+        if "labels" in sections:
+            try:
+                labels = confluence_fetcher.get_page_labels(resolved_page_id)
+                result["labels"] = [label.to_simplified_dict() for label in labels]
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to inline labels for page %s",
+                    resolved_page_id,
+                )
+                result["labels"] = []
+
+        if "views" in sections:
+            try:
+                views = confluence_fetcher.get_page_views(
+                    page_id=resolved_page_id, include_title=False
+                )
+                result["views"] = views.to_simplified_dict()
+            except Exception:  # noqa: BLE001
+                # Graceful degradation for Server/DC (analytics API unavailable)
+                logger.debug(
+                    "Views unavailable for page %s (expected on Server/DC)",
+                    resolved_page_id,
+                )
+                result["views"] = {}
 
     return json.dumps(result, indent=2, ensure_ascii=False)
 
@@ -747,6 +806,104 @@ async def update_page(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Update Page Section", "destructiveHint": True},
+)
+@check_write_access
+async def update_page_section(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page to update")],
+    heading_text: Annotated[
+        str,
+        Field(
+            description=(
+                "Exact text of the heading that starts the section to replace. "
+                "Matching is case-sensitive. Use confluence_get_page with "
+                "convert_to_markdown=false to inspect exact heading text when unsure."
+            )
+        ),
+    ],
+    new_content: Annotated[
+        str,
+        Field(
+            description=(
+                "Replacement content for the section body. "
+                "Do NOT include the heading itself — only the body beneath it. "
+                "Format is controlled by content_format."
+            )
+        ),
+    ],
+    content_format: Annotated[
+        str,
+        Field(
+            description=(
+                "(Optional) Format of new_content. "
+                "Options: 'markdown' (default) or 'storage' (raw Confluence storage XML). "
+                "Use 'storage' to insert macros or elements that markdown cannot express."
+            ),
+            default="markdown",
+        ),
+    ] = "markdown",
+    is_minor_edit: Annotated[
+        bool, Field(description="Whether this is a minor edit", default=False)
+    ] = False,
+    version_comment: Annotated[
+        str | None,
+        Field(description="Optional comment for this version", default=None),
+    ] = None,
+) -> str:
+    """Update a single section of a Confluence page without affecting the rest.
+
+    Replaces only the content beneath a named heading, leaving all other
+    sections, macros, layouts, and Confluence-specific elements completely
+    intact. This avoids the data loss that occurs when a full page is
+    downloaded as Markdown, edited, and re-uploaded.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to update.
+        heading_text: Exact heading text identifying the section to replace.
+        new_content: New body content for the section (heading not included).
+        content_format: Format of new_content ('markdown' or 'storage').
+        is_minor_edit: Whether to flag this as a minor edit.
+        version_comment: Optional version comment.
+
+    Returns:
+        JSON string representing the updated page metadata.
+
+    Raises:
+        ValueError: If Confluence client is not configured, heading is not
+            found, or content_format is invalid.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    if content_format not in ("markdown", "storage"):
+        raise ValueError(
+            f"Invalid content_format '{content_format}'. Must be 'markdown' or 'storage'."
+        )
+
+    updated_page = confluence_fetcher.update_page_section(
+        page_id=page_id,
+        heading_text=heading_text,
+        new_content=new_content,
+        content_format=content_format,
+        is_minor_edit=is_minor_edit,
+        version_comment=version_comment or "",
+    )
+
+    page_data = updated_page.to_simplified_dict()
+    page_data.pop("content", None)
+    return json.dumps(
+        {
+            "message": f"Section '{heading_text}' updated successfully",
+            "page": page_data,
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
     annotations={"title": "Delete Page", "destructiveHint": True},
 )
 @check_write_access
@@ -974,6 +1131,143 @@ async def reply_to_comment(
 
 
 @confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_comments"},
+    annotations={"title": "Get Inline Comments", "readOnlyHint": True},
+)
+async def get_inline_comments(
+    ctx: Context,
+    page_id: Annotated[
+        str, Field(description="The ID of the page to get inline comments from")
+    ],
+) -> str:
+    """Get all inline comments for a Confluence page.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to get inline comments from.
+
+    Returns:
+        JSON string with a list of inline comments.
+
+    Raises:
+        ValueError: If Confluence client is unavailable.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    try:
+        comments = confluence_fetcher.get_inline_comments(page_id)
+        response = {
+            "success": True,
+            "page_id": page_id,
+            "count": len(comments),
+            "comments": [c.to_simplified_dict() for c in comments],
+        }
+    except Exception as e:
+        logger.error(
+            f"Error getting inline comments for Confluence page {page_id}: {str(e)}"
+        )
+        response = {
+            "success": False,
+            "message": f"Error getting inline comments for page {page_id}",
+            "error": str(e),
+        }
+
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_comments"},
+    annotations={"title": "Add Inline Comment", "destructiveHint": True},
+)
+@check_write_access
+async def add_inline_comment(
+    ctx: Context,
+    page_id: Annotated[
+        str, Field(description="The ID of the page to add the inline comment to")
+    ],
+    body: Annotated[str, Field(description="The comment content in Markdown format")],
+    text_selection: Annotated[
+        str,
+        Field(
+            description=(
+                "The exact text on the page to anchor the inline comment to. "
+                "Must match text that exists in the page content."
+            )
+        ),
+    ],
+    text_selection_match_count: Annotated[
+        int,
+        Field(
+            description=(
+                "Total number of times the selected text appears on the page. "
+                "Defaults to 1."
+            ),
+            ge=1,
+        ),
+    ] = 1,
+    text_selection_match_index: Annotated[
+        int,
+        Field(
+            description=(
+                "Zero-based index of which occurrence of the text to anchor to. "
+                "Defaults to 0 (first occurrence)."
+            ),
+            ge=0,
+        ),
+    ] = 0,
+) -> str:
+    """Add an inline comment anchored to a specific text selection on a Confluence page.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to add the inline comment to.
+        body: The comment content in Markdown format.
+        text_selection: The exact text on the page to anchor the comment to.
+        text_selection_match_count: Total occurrences of the selected text on the page.
+        text_selection_match_index: Zero-based index of which occurrence to anchor to.
+
+    Returns:
+        JSON string representing the created inline comment.
+
+    Raises:
+        ValueError: If in read-only mode or Confluence client is unavailable.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    try:
+        comment = confluence_fetcher.add_inline_comment(
+            page_id=page_id,
+            content=body,
+            text_selection=text_selection,
+            text_selection_match_count=text_selection_match_count,
+            text_selection_match_index=text_selection_match_index,
+        )
+        if comment:
+            response = {
+                "success": True,
+                "message": "Inline comment added successfully",
+                "comment": comment.to_simplified_dict(),
+            }
+        else:
+            response = {
+                "success": False,
+                "message": (
+                    f"Unable to add inline comment to page {page_id}. "
+                    "API request completed but comment creation unsuccessful."
+                ),
+            }
+    except Exception as e:
+        logger.error(
+            f"Error adding inline comment to Confluence page {page_id}: {str(e)}"
+        )
+        response = {
+            "success": False,
+            "message": f"Error adding inline comment to page {page_id}",
+            "error": str(e),
+        }
+
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
     tags={"confluence", "read", "toolset:confluence_users"},
     annotations={"title": "Search User", "readOnlyHint": True},
 )
@@ -1058,6 +1352,46 @@ async def search_user(
             indent=2,
             ensure_ascii=False,
         )
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_users"},
+    annotations={"title": "Get User Details", "readOnlyHint": True},
+)
+async def get_user_details(
+    ctx: Context,
+    identifier: Annotated[
+        str,
+        Field(
+            description=(
+                "User identifier: accountId (Cloud), username (Server/DC), "
+                "or 'me' for the currently authenticated user."
+            )
+        ),
+    ],
+) -> str:
+    """Get Confluence user details by identifier.
+
+    Fetches the full profile for a specific user. Use 'me' to get the
+    currently authenticated user's profile.
+
+    Args:
+        ctx: The FastMCP context.
+        identifier: accountId (Cloud), username (Server/DC), or 'me'.
+
+    Returns:
+        JSON string with user details (accountId, displayName, email, etc.).
+    """
+    confluence = await get_confluence_fetcher(ctx)
+
+    if identifier.lower() == "me":
+        result = confluence.get_current_user_info()
+    elif confluence.config.is_cloud:
+        result = confluence.get_user_details_by_accountid(identifier)
+    else:
+        result = confluence.get_user_details_by_username(identifier)
+
+    return json.dumps(result, indent=2, ensure_ascii=False)
 
 
 @confluence_mcp.tool(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -344,33 +344,88 @@ async def get_issue(
     update_history: Annotated[
         bool,
         Field(
-            description="Whether to update the issue view history for the requesting user",
+            description=(
+                "Whether to update the issue view history for the requesting user"
+            ),
             default=True,
         ),
     ] = True,
+    include: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated sections to inline "
+                "in the response, avoiding extra tool calls. "
+                "Supported: remote_links, transitions, "
+                "watchers, changelog"
+            ),
+            default=None,
+        ),
+    ] = None,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
-    """Get details of a specific Jira issue including its Epic links and relationship information.
+    """Get details of a specific Jira issue.
+
+    Includes Epic links and relationship information. Use the
+    ``include`` parameter to inline enrichments (remote_links,
+    transitions, watchers, changelog) so that separate tool calls
+    are not needed.
 
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
-        fields: Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'), a single field as a string (e.g., 'duedate'), '*all' for all fields, or omitted for essentials.
+        fields: Comma-separated fields to return.
         expand: Optional fields to expand.
         comment_limit: Maximum number of comments.
         properties: Issue properties to return.
         update_history: Whether to update issue view history.
+        include: Comma-separated enrichment sections to inline.
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the Jira issue object.
 
     Raises:
-        ValueError: If the Jira client is not configured or available.
+        ValueError: If the Jira client is not configured.
     """
     jira = await get_jira_fetcher(ctx)
     fields_list: str | list[str] | None = fields
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
 
+    # Parse include sections
+    include_sections: set[str] = set()
+    if include:
+        include_sections = {s.strip().lower() for s in include.split(",")}
+
+    # Some enrichments piggyback on Jira's expand mechanism
+    if include_sections & {"transitions", "changelog"}:
+        expand_additions = []
+        if "transitions" in include_sections:
+            expand_additions.append("transitions")
+        if "changelog" in include_sections:
+            expand_additions.append("changelog")
+        if expand:
+            expand = f"{expand},{','.join(expand_additions)}"
+        else:
+            expand = ",".join(expand_additions)
+
+    # Automatically include 'names' expansion when display names are requested
+    if use_display_names and (not expand or "names" not in expand):
+        expand = f"{expand},names" if expand else "names"
+
+    # Fetch the issue (with augmented expand)
     issue = jira.get_issue(
         issue_key=issue_key,
         fields=fields_list,
@@ -379,7 +434,23 @@ async def get_issue(
         properties=properties.split(",") if properties else None,
         update_history=update_history,
     )
-    result = issue.to_simplified_dict()
+    if use_display_names:
+        result = issue.to_display_name_dict()
+    else:
+        result = issue.to_simplified_dict()
+
+    # Enrichments that require separate API calls
+    if "remote_links" in include_sections:
+        try:
+            result["remote_links"] = jira.get_remote_issue_links(issue_key)
+        except Exception:  # noqa: BLE001
+            result["remote_links"] = []
+
+    if "watchers" in include_sections:
+        try:
+            result["watchers"] = jira.get_issue_watchers(issue_key)
+        except Exception:  # noqa: BLE001
+            result["watchers"] = {}
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 
@@ -451,6 +522,18 @@ async def search(
             default=None,
         ),
     ] = None,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Search Jira issues using JQL (Jira Query Language).
 
@@ -463,6 +546,7 @@ async def search(
         projects_filter: Comma-separated list of project keys to filter by.
         expand: Optional fields to expand.
         page_token: Pagination token from a previous search result (Cloud only).
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the search results including pagination info.
@@ -471,6 +555,10 @@ async def search(
     fields_list: str | list[str] | None = fields
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
+
+    # Automatically include 'names' expansion when display names are requested
+    if use_display_names and (not expand or "names" not in expand):
+        expand = f"{expand},names" if expand else "names"
 
     search_result = jira.search_issues(
         jql=jql,
@@ -481,7 +569,10 @@ async def search(
         projects_filter=projects_filter,
         page_token=page_token,
     )
-    result = search_result.to_simplified_dict()
+    if use_display_names:
+        result = search_result.to_display_name_dict()
+    else:
+        result = search_result.to_simplified_dict()
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 
@@ -1692,6 +1783,62 @@ async def update_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_issues"},
+    annotations={"title": "Assign Issue", "readOnlyHint": False},
+)
+@check_write_access
+async def assign_issue(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    assignee: Annotated[
+        str | None,
+        Field(
+            description=(
+                "User identifier to assign (email, display name, or account ID). "
+                "Pass null or empty string to unassign the issue."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Assign a Jira issue to a user using the dedicated assignment endpoint.
+
+    This is more reliable than setting assignee via update_issue, which is
+    silently ignored by some Jira configurations. Uses PUT /issue/{key}/assignee.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        assignee: User identifier (email, display name, or account ID).
+                  Pass None or empty string to unassign.
+
+    Returns:
+        JSON string representing the updated issue object.
+
+    Raises:
+        ValueError: If in read-only mode, Jira client unavailable, or user not found.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        issue = jira.assign_issue(issue_key=issue_key, assignee=assignee)
+        result = issue.to_simplified_dict()
+        return json.dumps(
+            {"message": f"Issue {issue_key} assigned successfully", "issue": result},
+            indent=2,
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error(f"Error assigning issue {issue_key}: {str(e)}", exc_info=True)
+        raise ValueError(f"Failed to assign issue {issue_key}: {str(e)}")
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_issues"},
     annotations={"title": "Delete Issue", "destructiveHint": True},
 )
 @check_write_access
@@ -2371,6 +2518,81 @@ async def add_issues_to_sprint(
         "issue_keys": keys_list,
     }
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_projects"},
+    annotations={"title": "Get Project Issue Types", "readOnlyHint": True},
+)
+async def get_project_issue_types(
+    ctx: Context,
+    project_key: Annotated[
+        str,
+        Field(
+            description="Jira project key (e.g., 'PROJ', 'JTEST')",
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+) -> str:
+    """Get available issue types for a Jira project.
+
+    Returns the list of issue types (Bug, Task, Story, Epic, etc.) that can
+    be created in the specified project. Use the returned issue type IDs with
+    get_create_fields to discover what fields each type requires.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: The project key.
+
+    Returns:
+        JSON string with list of issue types (id, name, description, subtask).
+    """
+    jira = await get_jira_fetcher(ctx)
+    types = jira.get_project_issue_types(project_key)
+    return json.dumps(types, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_projects"},
+    annotations={"title": "Get Create Fields", "readOnlyHint": True},
+)
+async def get_create_fields(
+    ctx: Context,
+    project_key: Annotated[
+        str,
+        Field(
+            description="Jira project key (e.g., 'PROJ', 'JTEST')",
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+    issue_type_id: Annotated[
+        str,
+        Field(
+            description=(
+                "The issue type ID (from get_project_issue_types). "
+                "Example: '10002' for Task."
+            )
+        ),
+    ],
+) -> str:
+    """Get fields available for creating an issue of a specific type.
+
+    Returns all fields (required and optional) for the given project and
+    issue type, including field names, IDs, whether they're required, and
+    their schema. Use this to discover what data is needed before calling
+    create_issue.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: The project key.
+        issue_type_id: The issue type ID.
+
+    Returns:
+        JSON string with list of field metadata (fieldId, name, required, schema).
+    """
+    jira = await get_jira_fetcher(ctx)
+    fields = jira.get_create_fields(project_key, issue_type_id)
+    return json.dumps(fields, indent=2, ensure_ascii=False)
 
 
 @jira_mcp.tool(
@@ -3164,8 +3386,8 @@ async def get_issue_development_info(
         str | None,
         Field(
             description=(
-                "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "(Optional) Filter by application type (case-sensitive). "
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'GitLab'"
             )
         ),
     ] = None,
@@ -3229,8 +3451,8 @@ async def get_issues_development_info(
         str | None,
         Field(
             description=(
-                "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "(Optional) Filter by application type (case-sensitive). "
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'GitLab'"
             )
         ),
     ] = None,

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -760,11 +760,12 @@ class UserTokenMiddleware:
         elif auth_header.strip():
             # Non-empty but unsupported auth type
             auth_value = auth_header.strip()
-            auth_type = (
-                auth_value.split(" ", 1)[0]
-                if " " in auth_value
-                else f"(masked) {mask_sensitive(auth_value)}"
-            )
+            if " " in auth_value:
+                auth_type = auth_value.split(" ", 1)[0]
+            else:
+                # No space means no type prefix — likely a raw token.
+                # Redact to avoid leaking credentials in logs (OWASP/CWE-532).
+                auth_type = "<redacted>"
             logger.warning(f"Unsupported Authorization type: {auth_type}")
             scope["state"]["auth_validation_error"] = (
                 "Unauthorized: Only 'Bearer <OAuthToken>', "

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -1,6 +1,8 @@
 """Main FastMCP server setup for Atlassian integration."""
 
+import asyncio
 import base64
+import functools
 import json
 import logging
 import os
@@ -34,6 +36,7 @@ from mcp_atlassian.utils.oauth import (
     CLOUD_TOKEN_URL,
     DC_AUTHORIZE_PATH,
     DC_TOKEN_PATH,
+    OAuthConfig,
 )
 from mcp_atlassian.utils.token_verifier import AtlassianOpaqueTokenVerifier
 from mcp_atlassian.utils.tools import get_enabled_tools, should_include_tool
@@ -118,6 +121,74 @@ async def health_check(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok"})
 
 
+async def _try_auto_oauth(
+    config: JiraConfig | ConfluenceConfig,
+    service_name: str,
+) -> bool:
+    """Attempt an automatic browser-based OAuth flow when credentials are
+    present but no stored tokens exist.
+
+    If the config does not need auto-OAuth (wrong auth type, missing creds, or
+    tokens already present), returns False without running the flow.
+
+    The blocking ``run_oauth_flow`` call (which waits for a browser callback
+    via ``time.sleep``) is offloaded to a thread so the async event loop is
+    not blocked during server startup.
+
+    Args:
+        config: The Jira or Confluence config to check and optionally run flow for.
+        service_name: Display name for logging (e.g. "Jira", "Confluence").
+
+    Returns:
+        True if the flow succeeded and tokens were stored, False otherwise.
+    """
+    if config.auth_type != "oauth":
+        return False
+    oauth_cfg = config.oauth_config
+    if not (
+        isinstance(oauth_cfg, OAuthConfig)
+        and bool(oauth_cfg.client_id)
+        and bool(oauth_cfg.client_secret)
+        and not oauth_cfg.access_token
+        and not oauth_cfg.refresh_token
+    ):
+        return False
+
+    from mcp_atlassian.utils.oauth_setup import OAuthSetupArgs, run_oauth_flow
+
+    logger.info(
+        "%s OAuth credentials found but no stored tokens. "
+        "Initiating browser authorization flow...",
+        service_name,
+    )
+    args = OAuthSetupArgs(
+        client_id=oauth_cfg.client_id,
+        client_secret=oauth_cfg.client_secret,
+        redirect_uri=oauth_cfg.redirect_uri,
+        scope=oauth_cfg.scope,
+        base_url=oauth_cfg.base_url,
+    )
+    try:
+        loop = asyncio.get_running_loop()
+        success = await loop.run_in_executor(
+            None, functools.partial(run_oauth_flow, args)
+        )
+        if success:
+            logger.info("%s OAuth browser flow completed successfully.", service_name)
+            return True
+    except Exception:
+        logger.exception(
+            "%s OAuth browser flow raised an unexpected error.", service_name
+        )
+
+    logger.error(
+        "%s OAuth browser flow failed. %s tools may be unavailable.",
+        service_name,
+        service_name,
+    )
+    return False
+
+
 @asynccontextmanager
 async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict[str, Any]]:
     logger.info("Main Atlassian MCP server lifespan starting...")
@@ -133,13 +204,21 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict[str,
         try:
             jira_config = JiraConfig.from_env()
             if jira_config.is_auth_configured():
+                if await _try_auto_oauth(jira_config, "Jira"):
+                    jira_config = JiraConfig.from_env()
                 loaded_jira_config = jira_config
                 logger.info(
                     "Jira configuration loaded and authentication is configured."
                 )
+            elif await _try_auto_oauth(jira_config, "Jira"):
+                jira_config = JiraConfig.from_env()
+                if jira_config.is_auth_configured():
+                    loaded_jira_config = jira_config
+                    logger.info("Jira configuration loaded after OAuth browser flow.")
             else:
                 logger.warning(
-                    "Jira URL found, but authentication is not fully configured. Jira tools will be unavailable."
+                    "Jira URL found, but authentication is not fully "
+                    "configured. Jira tools will be unavailable."
                 )
         except Exception as e:
             logger.error(f"Failed to load Jira configuration: {e}", exc_info=True)
@@ -148,16 +227,30 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict[str,
         try:
             confluence_config = ConfluenceConfig.from_env()
             if confluence_config.is_auth_configured():
+                if await _try_auto_oauth(confluence_config, "Confluence"):
+                    confluence_config = ConfluenceConfig.from_env()
                 loaded_confluence_config = confluence_config
                 logger.info(
                     "Confluence configuration loaded and authentication is configured."
                 )
+            elif await _try_auto_oauth(confluence_config, "Confluence"):
+                confluence_config = ConfluenceConfig.from_env()
+                if confluence_config.is_auth_configured():
+                    loaded_confluence_config = confluence_config
+                    logger.info(
+                        "Confluence configuration loaded after OAuth browser flow."
+                    )
             else:
                 logger.warning(
-                    "Confluence URL found, but authentication is not fully configured. Confluence tools will be unavailable."
+                    "Confluence URL found, but authentication is not "
+                    "fully configured. Confluence tools will be "
+                    "unavailable."
                 )
         except Exception as e:
-            logger.error(f"Failed to load Confluence configuration: {e}", exc_info=True)
+            logger.error(
+                f"Failed to load Confluence configuration: {e}",
+                exc_info=True,
+            )
 
     app_context = MainAppContext(
         full_jira_config=loaded_jira_config,
@@ -667,7 +760,11 @@ class UserTokenMiddleware:
         elif auth_header.strip():
             # Non-empty but unsupported auth type
             auth_value = auth_header.strip()
-            auth_type = auth_value.split(" ", 1)[0] if " " in auth_value else auth_value
+            auth_type = (
+                auth_value.split(" ", 1)[0]
+                if " " in auth_value
+                else f"(masked) {mask_sensitive(auth_value)}"
+            )
             logger.warning(f"Unsupported Authorization type: {auth_type}")
             scope["state"]["auth_validation_error"] = (
                 "Unauthorized: Only 'Bearer <OAuthToken>', "

--- a/src/mcp_atlassian/utils/__init__.py
+++ b/src/mcp_atlassian/utils/__init__.py
@@ -20,13 +20,20 @@ from .media import (
 
 # Export OAuth utilities
 from .oauth import OAuthConfig, configure_oauth_session
-from .ssl import SSLIgnoreAdapter, configure_ssl_verification
+from .ssl import (
+    NoProxyAdapter,
+    SSLIgnoreAdapter,
+    configure_proxy_bypass,
+    configure_ssl_verification,
+)
 from .urls import is_atlassian_cloud_url, resolve_relative_url, validate_url_for_ssrf
 
 # Export all utility functions for backward compatibility
 __all__ = [
     "ATTACHMENT_MAX_BYTES",
+    "NoProxyAdapter",
     "SSLIgnoreAdapter",
+    "configure_proxy_bypass",
     "configure_ssl_verification",
     "is_atlassian_cloud_url",
     "is_image_attachment",

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -109,16 +109,15 @@ def get_available_services(
             pat_env="CONFLUENCE_PERSONAL_TOKEN",
         )
 
-    if not confluence_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
-        confluence_is_setup = True
-        logger.info(
-            "Using Confluence minimal OAuth configuration "
-            "- expecting user-provided tokens via headers"
-        )
+        # OAuth enable check with known URL — expecting user-provided tokens via headers
+        if not confluence_is_setup and os.getenv(
+            "ATLASSIAN_OAUTH_ENABLE", ""
+        ).lower() in ("true", "1", "yes"):
+            confluence_is_setup = True
+            logger.info(
+                "Using Confluence OAuth with CONFLUENCE_URL "
+                "- expecting user-provided tokens via headers"
+            )
 
     if not confluence_is_setup:
         confluence_token = headers.get("X-Atlassian-Confluence-Personal-Token")
@@ -148,16 +147,17 @@ def get_available_services(
             pat_env="JIRA_PERSONAL_TOKEN",
         )
 
-    if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
-        jira_is_setup = True
-        logger.info(
-            "Using Jira minimal OAuth configuration "
-            "- expecting user-provided tokens via headers"
-        )
+        # OAuth enable check with known URL — expecting user-provided tokens via headers
+        if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+            "true",
+            "1",
+            "yes",
+        ):
+            jira_is_setup = True
+            logger.info(
+                "Using Jira OAuth with JIRA_URL "
+                "- expecting user-provided tokens via headers"
+            )
 
     if not jira_is_setup:
         jira_token = headers.get("X-Atlassian-Jira-Personal-Token")

--- a/src/mcp_atlassian/utils/oauth_setup.py
+++ b/src/mcp_atlassian/utils/oauth_setup.py
@@ -1,7 +1,8 @@
 """
 OAuth 2.0 Authorization Flow Helper for MCP Atlassian
 
-This module helps with the OAuth 2.0 (3LO) authorization flow for Atlassian Cloud:
+This module helps with the OAuth 2.0 (3LO) authorization flow for Atlassian Cloud
+and Server/Data Center:
 1. Opens a browser to the authorization URL
 2. Starts a local server to receive the callback with the authorization code
 3. Exchanges the authorization code for access and refresh tokens
@@ -19,6 +20,7 @@ import webbrowser
 from dataclasses import dataclass
 
 from ..utils.oauth import OAuthConfig
+from ..utils.urls import is_atlassian_cloud_url
 
 # Configure logging
 logger = logging.getLogger("mcp-atlassian.oauth-setup")
@@ -205,6 +207,7 @@ class OAuthSetupArgs:
     client_secret: str
     redirect_uri: str
     scope: str
+    base_url: str | None = None
 
 
 def run_oauth_flow(args: OAuthSetupArgs) -> bool:
@@ -222,6 +225,7 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
         client_secret=args.client_secret,
         redirect_uri=args.redirect_uri,
         scope=args.scope,
+        base_url=args.base_url,
     )
 
     # Generate a random state for CSRF protection
@@ -270,94 +274,18 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
     if oauth_config.exchange_code_for_tokens(authorization_code):
         logger.info("✅ OAuth authorization successful!")
         logger.info("Access token obtained successfully.")
-        logger.info("Refresh token saved successfully.")
-
-        if oauth_config.cloud_id:
-            logger.info(f"Cloud ID: {oauth_config.cloud_id}")
-
-            # Print environment variable information more clearly
-            logger.info("\n=== IMPORTANT: ENVIRONMENT VARIABLES ===")
-            logger.info(
-                "Your tokens have been securely stored in your system keyring and backup file."
-            )
-            logger.info(
-                "However, to use them in your application, you need these environment variables:"
-            )
-            logger.info("")
-            logger.info(
-                "Add the following to your .env file or set as environment variables:"
-            )
-            logger.info("------------------------------------------------------------")
-            logger.info(f"ATLASSIAN_OAUTH_CLIENT_ID={oauth_config.client_id}")
-            logger.info("ATLASSIAN_OAUTH_CLIENT_SECRET=<redacted>")
-            logger.info(f"ATLASSIAN_OAUTH_REDIRECT_URI={oauth_config.redirect_uri}")
-            logger.info(f"ATLASSIAN_OAUTH_SCOPE={oauth_config.scope}")
-            logger.info(f"ATLASSIAN_OAUTH_CLOUD_ID={oauth_config.cloud_id}")
-            logger.info("------------------------------------------------------------")
-            logger.info("")
-            logger.info(
-                "Note: The tokens themselves are not set as environment variables for security reasons."
-            )
-            logger.info(
-                "They are stored securely in your system keyring and will be loaded automatically."
-            )
-            logger.info(
-                f"Token storage location (backup): ~/.mcp-atlassian/oauth-{oauth_config.client_id}.json"
+        if oauth_config.refresh_token:
+            logger.info("Refresh token saved successfully.")
+        elif oauth_config.is_data_center:
+            logger.warning(
+                "No refresh token received. DC tokens may expire "
+                "and require re-authentication."
             )
 
-            # Generate VS Code configuration JSON snippet
-            import json
-
-            vscode_config = {
-                "mcpServers": {
-                    "mcp-atlassian": {
-                        "command": "docker",
-                        "args": [
-                            "run",
-                            "--rm",
-                            "-i",
-                            "-p",
-                            "8080:8080",
-                            "-e",
-                            "CONFLUENCE_URL",
-                            "-e",
-                            "JIRA_URL",
-                            "-e",
-                            "ATLASSIAN_OAUTH_CLIENT_ID",
-                            "-e",
-                            "ATLASSIAN_OAUTH_CLIENT_SECRET",
-                            "-e",
-                            "ATLASSIAN_OAUTH_REDIRECT_URI",
-                            "-e",
-                            "ATLASSIAN_OAUTH_SCOPE",
-                            "-e",
-                            "ATLASSIAN_OAUTH_CLOUD_ID",
-                            "ghcr.io/sooperset/mcp-atlassian:latest",
-                        ],
-                        "env": {
-                            "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
-                            "JIRA_URL": "https://your-company.atlassian.net",
-                            "ATLASSIAN_OAUTH_CLIENT_ID": oauth_config.client_id,
-                            "ATLASSIAN_OAUTH_CLIENT_SECRET": "<redacted - set via environment variable>",
-                            "ATLASSIAN_OAUTH_REDIRECT_URI": oauth_config.redirect_uri,
-                            "ATLASSIAN_OAUTH_SCOPE": oauth_config.scope,
-                            "ATLASSIAN_OAUTH_CLOUD_ID": oauth_config.cloud_id,
-                        },
-                    }
-                }
-            }
-
-            # Pretty print the VS Code configuration JSON
-            vscode_json = json.dumps(vscode_config, indent=4)
-
-            logger.info("\n=== VS CODE CONFIGURATION ===")
-            logger.info("Add the following to your VS Code settings.json file:")
-            logger.info("------------------------------------------------------------")
-            logger.info(vscode_json)
-            logger.info("------------------------------------------------------------")
-            logger.info(
-                "\nNote: If you already have an 'mcp' configuration in settings.json, merge this with your existing configuration."
-            )
+        if oauth_config.is_data_center:
+            _log_dc_success(oauth_config)
+        elif oauth_config.cloud_id:
+            _log_cloud_success(oauth_config)
         else:
             logger.error("Failed to obtain cloud ID!")
 
@@ -369,6 +297,184 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
         if httpd:
             httpd.shutdown()
         return False
+
+
+def _log_cloud_success(oauth_config: OAuthConfig) -> None:
+    """Log success output for Cloud OAuth flows."""
+    import json
+
+    logger.info(f"Cloud ID: {oauth_config.cloud_id}")
+
+    logger.info("\n=== IMPORTANT: ENVIRONMENT VARIABLES ===")
+    logger.info(
+        "Your tokens have been securely stored in your system keyring and backup file."
+    )
+    logger.info(
+        "However, to use them in your application, you need "
+        "these environment variables:"
+    )
+    logger.info("")
+    logger.info("Add the following to your .env file or set as environment variables:")
+    logger.info("------------------------------------------------------------")
+    logger.info(f"ATLASSIAN_OAUTH_CLIENT_ID={oauth_config.client_id}")
+    logger.info("ATLASSIAN_OAUTH_CLIENT_SECRET=<redacted>")
+    logger.info(f"ATLASSIAN_OAUTH_REDIRECT_URI={oauth_config.redirect_uri}")
+    logger.info(f"ATLASSIAN_OAUTH_SCOPE={oauth_config.scope}")
+    logger.info(f"ATLASSIAN_OAUTH_CLOUD_ID={oauth_config.cloud_id}")
+    logger.info("------------------------------------------------------------")
+    logger.info("")
+    logger.info(
+        "Note: The tokens themselves are not set as environment variables "
+        "for security reasons."
+    )
+    logger.info(
+        "They are stored securely in your system keyring and will be "
+        "loaded automatically."
+    )
+    logger.info(
+        f"Token storage location (backup): "
+        f"~/.mcp-atlassian/oauth-{oauth_config.client_id}.json"
+    )
+
+    vscode_config = {
+        "mcpServers": {
+            "mcp-atlassian": {
+                "command": "docker",
+                "args": [
+                    "run",
+                    "--rm",
+                    "-i",
+                    "-p",
+                    "8080:8080",
+                    "-e",
+                    "CONFLUENCE_URL",
+                    "-e",
+                    "JIRA_URL",
+                    "-e",
+                    "ATLASSIAN_OAUTH_CLIENT_ID",
+                    "-e",
+                    "ATLASSIAN_OAUTH_CLIENT_SECRET",
+                    "-e",
+                    "ATLASSIAN_OAUTH_REDIRECT_URI",
+                    "-e",
+                    "ATLASSIAN_OAUTH_SCOPE",
+                    "-e",
+                    "ATLASSIAN_OAUTH_CLOUD_ID",
+                    "ghcr.io/sooperset/mcp-atlassian:latest",
+                ],
+                "env": {
+                    "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+                    "JIRA_URL": "https://your-company.atlassian.net",
+                    "ATLASSIAN_OAUTH_CLIENT_ID": oauth_config.client_id,
+                    "ATLASSIAN_OAUTH_CLIENT_SECRET": (
+                        "<redacted - set via environment variable>"
+                    ),
+                    "ATLASSIAN_OAUTH_REDIRECT_URI": oauth_config.redirect_uri,
+                    "ATLASSIAN_OAUTH_SCOPE": oauth_config.scope,
+                    "ATLASSIAN_OAUTH_CLOUD_ID": oauth_config.cloud_id,
+                },
+            }
+        }
+    }
+
+    vscode_json = json.dumps(vscode_config, indent=4)
+
+    logger.info("\n=== VS CODE CONFIGURATION ===")
+    logger.info("Add the following to your VS Code settings.json file:")
+    logger.info("------------------------------------------------------------")
+    logger.info(vscode_json)
+    logger.info("------------------------------------------------------------")
+    logger.info(
+        "\nNote: If you already have an 'mcp' configuration in settings.json, "
+        "merge this with your existing configuration."
+    )
+
+
+def _log_dc_success(oauth_config: OAuthConfig) -> None:
+    """Log success output for Data Center OAuth flows."""
+    import json
+
+    base_url = oauth_config.base_url or ""
+
+    logger.info(f"Instance URL: {base_url}")
+
+    logger.info("\n=== IMPORTANT: ENVIRONMENT VARIABLES ===")
+    logger.info(
+        "Your tokens have been securely stored in your system keyring and backup file."
+    )
+    logger.info(
+        "However, to use them in your application, you need these "
+        "environment variables:"
+    )
+    logger.info("")
+    logger.info("Add the following to your .env file or set as environment variables:")
+    logger.info("------------------------------------------------------------")
+    logger.info(f"JIRA_URL={base_url}")
+    logger.info(f"JIRA_OAUTH_CLIENT_ID={oauth_config.client_id}")
+    logger.info("JIRA_OAUTH_CLIENT_SECRET=<redacted>")
+    logger.info(f"ATLASSIAN_OAUTH_REDIRECT_URI={oauth_config.redirect_uri}")
+    logger.info(f"ATLASSIAN_OAUTH_SCOPE={oauth_config.scope}")
+    logger.info("------------------------------------------------------------")
+    logger.info("")
+    logger.info(
+        "Note: The tokens themselves are not set as environment variables "
+        "for security reasons."
+    )
+    logger.info(
+        "They are stored securely in your system keyring and will be "
+        "loaded automatically."
+    )
+    logger.info(
+        f"Token storage location (backup): "
+        f"~/.mcp-atlassian/oauth-{oauth_config.client_id}.json"
+    )
+
+    vscode_config = {
+        "mcpServers": {
+            "mcp-atlassian": {
+                "command": "docker",
+                "args": [
+                    "run",
+                    "--rm",
+                    "-i",
+                    "-p",
+                    "8080:8080",
+                    "-e",
+                    "JIRA_URL",
+                    "-e",
+                    "JIRA_OAUTH_CLIENT_ID",
+                    "-e",
+                    "JIRA_OAUTH_CLIENT_SECRET",
+                    "-e",
+                    "ATLASSIAN_OAUTH_REDIRECT_URI",
+                    "-e",
+                    "ATLASSIAN_OAUTH_SCOPE",
+                    "ghcr.io/sooperset/mcp-atlassian:latest",
+                ],
+                "env": {
+                    "JIRA_URL": base_url,
+                    "JIRA_OAUTH_CLIENT_ID": oauth_config.client_id,
+                    "JIRA_OAUTH_CLIENT_SECRET": (
+                        "<redacted - set via environment variable>"
+                    ),
+                    "ATLASSIAN_OAUTH_REDIRECT_URI": oauth_config.redirect_uri,
+                    "ATLASSIAN_OAUTH_SCOPE": oauth_config.scope,
+                },
+            }
+        }
+    }
+
+    vscode_json = json.dumps(vscode_config, indent=4)
+
+    logger.info("\n=== VS CODE CONFIGURATION ===")
+    logger.info("Add the following to your VS Code settings.json file:")
+    logger.info("------------------------------------------------------------")
+    logger.info(vscode_json)
+    logger.info("------------------------------------------------------------")
+    logger.info(
+        "\nNote: If you already have an 'mcp' configuration in settings.json, "
+        "merge this with your existing configuration."
+    )
 
 
 def _prompt_for_input(
@@ -394,20 +500,64 @@ def _prompt_for_input(
 
 
 def run_oauth_setup() -> int:
-    """Run the OAuth 2.0 setup wizard interactively."""
+    """Run the OAuth 2.0 setup wizard interactively.
+
+    Supports both Atlassian Cloud and Server/Data Center instances.
+    The wizard auto-detects Cloud vs DC based on the instance URL provided.
+    """
     print("\n=== Atlassian OAuth 2.0 Setup Wizard ===")
     print(
-        "This wizard will guide you through setting up OAuth 2.0 authentication for MCP Atlassian."
+        "This wizard will guide you through setting up OAuth 2.0 "
+        "authentication for MCP Atlassian."
     )
-    print("\nYou need to have created an OAuth 2.0 app in your Atlassian account.")
-    print("You can create one at: https://developer.atlassian.com/console/myapps/")
+    print("\nSupported platforms: Atlassian Cloud and Server/Data Center")
+
+    # Determine instance URL to detect Cloud vs DC
+    instance_url = _prompt_for_input(
+        "Instance URL (e.g. https://company.atlassian.net or "
+        "https://jira.local.example.com)",
+        "JIRA_URL",
+    )
+
+    is_dc = bool(instance_url) and not is_atlassian_cloud_url(instance_url)
+    base_url: str | None = instance_url if is_dc else None
+
+    if is_dc:
+        print(f"\nDetected Server/Data Center instance: {instance_url}")
+        print(
+            "You need to configure an Application Link (OAuth 2.0) in your "
+            "Jira instance."
+        )
+        print(
+            "Go to: Administration > Application Links > Create link "
+            "(Incoming) with OAuth 2.0"
+        )
+    else:
+        print("\nDetected Atlassian Cloud instance.")
+        print("You need to have created an OAuth 2.0 app in your Atlassian account.")
+        print("You can create one at: https://developer.atlassian.com/console/myapps/")
+
     print("\nPlease provide the following information:\n")
 
-    # Check for environment variables first
-    client_id = _prompt_for_input("OAuth Client ID", "ATLASSIAN_OAUTH_CLIENT_ID")
+    # For DC, prefer service-specific env vars, fall back to global ones
+    client_id_env = "ATLASSIAN_OAUTH_CLIENT_ID"
+    client_secret_env = "ATLASSIAN_OAUTH_CLIENT_SECRET"  # noqa: S105
+    if is_dc:
+        client_id_env = (
+            "JIRA_OAUTH_CLIENT_ID"
+            if os.getenv("JIRA_OAUTH_CLIENT_ID")
+            else "ATLASSIAN_OAUTH_CLIENT_ID"
+        )
+        client_secret_env = (
+            "JIRA_OAUTH_CLIENT_SECRET"
+            if os.getenv("JIRA_OAUTH_CLIENT_SECRET")
+            else "ATLASSIAN_OAUTH_CLIENT_SECRET"
+        )
+
+    client_id = _prompt_for_input("OAuth Client ID", client_id_env)
 
     client_secret = _prompt_for_input(
-        "OAuth Client Secret", "ATLASSIAN_OAUTH_CLIENT_SECRET", is_secret=True
+        "OAuth Client Secret", client_secret_env, is_secret=True
     )
 
     default_redirect = os.getenv(
@@ -418,9 +568,13 @@ def run_oauth_setup() -> int:
         or default_redirect
     )
 
+    dc_default_scope = "WRITE"
+    cloud_default_scope = (
+        "read:jira-work write:jira-work read:confluence-space.summary offline_access"
+    )
     default_scope = os.getenv(
         "ATLASSIAN_OAUTH_SCOPE",
-        "read:jira-work write:jira-work read:confluence-space.summary offline_access",
+        dc_default_scope if is_dc else cloud_default_scope,
     )
     scope = (
         _prompt_for_input("OAuth Scopes (space-separated)", "ATLASSIAN_OAUTH_SCOPE")
@@ -441,6 +595,7 @@ def run_oauth_setup() -> int:
         client_secret=client_secret,
         redirect_uri=redirect_uri,
         scope=scope,
+        base_url=base_url,
     )
 
     success = run_oauth_flow(args)

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -1,21 +1,85 @@
-"""SSL-related utility functions for MCP Atlassian."""
+"""SSL and proxy utility functions for MCP Atlassian."""
 
 import logging
+import os
 import ssl
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlparse
 
+from requests import PreparedRequest, Response
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
+from requests.utils import should_bypass_proxies
 from urllib3.poolmanager import PoolManager
 
 logger = logging.getLogger("mcp-atlassian")
 
 
-class SSLIgnoreAdapter(HTTPAdapter):
-    """HTTP adapter that ignores SSL verification.
+class NoProxyAdapter(HTTPAdapter):
+    """HTTP adapter that respects NO_PROXY environment variable.
 
-    A custom transport adapter that disables SSL certificate verification for specific domains.
+    A custom transport adapter that ensures NO_PROXY is honored even when
+    proxies are explicitly configured on the session. By default, the requests
+    library only checks NO_PROXY during auto-detection from environment variables,
+    not when proxies are explicitly set on session.proxies.
+    """
+
+    def send(
+        self,
+        request: PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | None = None,
+        verify: bool | str = True,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
+    ) -> Response:
+        """Send a request, respecting NO_PROXY environment variable.
+
+        This override ensures that NO_PROXY is respected even when proxies are
+        explicitly configured on the session.
+
+        Args:
+            request: The prepared request to send
+            stream: Whether to stream the response
+            timeout: Request timeout
+            verify: SSL verification setting
+            cert: Client certificate
+            proxies: Proxy configuration
+
+        Returns:
+            The response from the server
+        """
+        # Check if we should bypass proxies for this URL
+        no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+        if (
+            request.url
+            and proxies
+            and no_proxy
+            and should_bypass_proxies(request.url, no_proxy)
+        ):
+            logger.debug(
+                f"Bypassing proxy for {request.url} due to NO_PROXY setting: {no_proxy}"
+            )
+            proxies = None
+
+        return super().send(
+            request,
+            stream=stream,
+            timeout=timeout,
+            verify=verify,
+            cert=cert,
+            proxies=proxies,
+        )
+
+
+class SSLIgnoreAdapter(NoProxyAdapter):
+    """HTTP adapter that ignores SSL verification and respects NO_PROXY.
+
+    A custom transport adapter that:
+    1. Disables SSL certificate verification for specific domains
+    2. Respects NO_PROXY environment variable even when proxies are explicitly set
+
     This implementation ensures that both verify_mode is set to CERT_NONE and check_hostname
     is disabled, which is required for properly ignoring SSL certificates.
 
@@ -63,6 +127,67 @@ class SSLIgnoreAdapter(HTTPAdapter):
         """
         super().cert_verify(conn, url, verify=False, cert=cert)
 
+    def send(
+        self,
+        request: PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | None = None,
+        verify: bool | str = True,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
+    ) -> Response:
+        """Send a request with SSL verification disabled.
+
+        Args:
+            request: The prepared request to send
+            stream: Whether to stream the response
+            timeout: Request timeout
+            verify: SSL verification setting (ignored, always False for this adapter)
+            cert: Client certificate
+            proxies: Proxy configuration
+
+        Returns:
+            The response from the server
+        """
+        # Let parent class handle NO_PROXY, but always disable SSL verification
+        return super().send(
+            request,
+            stream=stream,
+            timeout=timeout,
+            verify=False,  # Always disable SSL verification for this adapter
+            cert=cert,
+            proxies=proxies,
+        )
+
+
+def configure_proxy_bypass(
+    service_name: str,
+    url: str,
+    session: Session,
+) -> None:
+    """Configure the session to respect NO_PROXY environment variable.
+
+    This function mounts a custom adapter that ensures NO_PROXY is honored
+    even when proxies are explicitly configured on the session.
+
+    Args:
+        service_name: Name of the service for logging (e.g., "Confluence", "Jira")
+        url: The base URL of the service
+        session: The requests session to configure
+    """
+    no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+    if no_proxy:
+        logger.debug(
+            f"{service_name}: Configuring proxy bypass adapter for NO_PROXY={no_proxy}"
+        )
+        # Get the domain from the configured URL
+        domain = urlparse(url).netloc
+
+        # Mount the adapter to handle requests to this domain
+        adapter = NoProxyAdapter()
+        session.mount(f"https://{domain}", adapter)
+        session.mount(f"http://{domain}", adapter)
+
 
 def configure_ssl_verification(
     service_name: str,
@@ -77,7 +202,10 @@ def configure_ssl_verification(
 
     If SSL verification is disabled, this function will configure the session
     to use a custom SSL adapter that bypasses certificate validation for the
-    service's domain.
+    service's domain. This adapter also respects NO_PROXY.
+
+    If SSL verification is enabled but NO_PROXY is set, a proxy bypass adapter
+    is mounted to ensure NO_PROXY is respected.
 
     If client certificate paths are provided, they will be configured for
     mutual TLS authentication.
@@ -113,10 +241,19 @@ def configure_ssl_verification(
             f"{service_name} SSL verification disabled. This is insecure and should only be used in testing environments."
         )
 
-        # Get the domain from the configured URL
+        # Mount the SSL ignore adapter which also handles NO_PROXY
         domain = urlparse(url).netloc
-
-        # Mount the adapter to handle requests to this domain
         adapter = SSLIgnoreAdapter()
         session.mount(f"https://{domain}", adapter)
         session.mount(f"http://{domain}", adapter)
+    else:
+        # Even with SSL verification enabled, we may need to handle NO_PROXY
+        no_proxy = os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
+        if no_proxy:
+            logger.debug(
+                f"{service_name}: Mounting proxy bypass adapter for NO_PROXY={no_proxy}"
+            )
+            domain = urlparse(url).netloc
+            adapter = NoProxyAdapter()
+            session.mount(f"https://{domain}", adapter)
+            session.mount(f"http://{domain}", adapter)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -135,6 +135,11 @@ CONFLUENCE_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Attachment upload, download, and management",
         default=False,
     ),
+    "confluence_templates": ToolsetDefinition(
+        name="confluence_templates",
+        description="Page template listing and page creation from templates",
+        default=False,
+    ),
 }
 
 # --- Combined registry ---

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -137,3 +137,93 @@ class TestConfluenceCloudComments:
 
         comments = confluence_fetcher.get_page_comments(page.id)
         assert len(comments) > 0
+
+
+class TestConfluenceDateMacro:
+    """Date macros in storage format are preserved in page content.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/897
+    """
+
+    def test_date_macro_preserved_in_page_content(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        storage_body = (
+            "<p>Meeting date: "
+            '<ac:structured-macro ac:name="date">'
+            '<ac:parameter ac:name="date">2026-02-04</ac:parameter>'
+            "</ac:structured-macro>"
+            "</p>"
+        )
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Date Macro Test {uid}",
+            body=storage_body,
+            is_markdown=False,
+            content_representation="storage",
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        content = fetched.content or ""
+        assert "2026-02-04" in content or "Feb" in content or "February" in content, (
+            f"Date macro value missing from content. Got: {content[:500]}"
+        )
+
+
+class TestConfluencePageAncestors:
+    """get_page_content should populate the ancestors field.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/1131
+    Root cause: 'ancestors' not included in expand params in get_page_content().
+    """
+
+    def test_child_page_has_ancestors(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        parent = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Ancestor Parent {uid}",
+            body="<p>Parent page.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(parent.id)
+
+        child = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Ancestor Child {uid}",
+            body="<p>Child page.</p>",
+            is_markdown=False,
+            parent_id=parent.id,
+        )
+        resource_tracker.add_confluence_page(child.id)
+
+        fetched = confluence_fetcher.get_page_content(child.id)
+        assert len(fetched.ancestors) > 0, (
+            "ancestors is empty — 'ancestors' missing from expand params"
+        )
+        parent_ids = [a.get("id") for a in fetched.ancestors]
+        assert parent.id in parent_ids, (
+            f"parent {parent.id} not in ancestors: {parent_ids}"
+        )
+
+        # Verify to_simplified_dict() — this is what the MCP tool returns
+        simplified = fetched.to_simplified_dict()
+        assert "ancestors" in simplified, (
+            "ancestors missing from to_simplified_dict() output"
+        )
+        simplified_parent_ids = [a["id"] for a in simplified["ancestors"]]
+        assert parent.id in simplified_parent_ids, (
+            f"parent {parent.id} not in simplified ancestors: {simplified['ancestors']}"
+        )
+        # Each ancestor should have id and title
+        for ancestor in simplified["ancestors"]:
+            assert "id" in ancestor, f"ancestor missing 'id': {ancestor}"
+            assert "title" in ancestor, f"ancestor missing 'title': {ancestor}"

--- a/tests/e2e/cloud/test_confluence_dates.py
+++ b/tests/e2e/cloud/test_confluence_dates.py
@@ -1,0 +1,60 @@
+"""E2E tests for Confluence page date fields (upstream #965)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluencePageDateFields:
+    """ConfluencePage.created and .updated fields are always empty.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/965
+    Same root cause as #607: 'history' not included in expand params.
+    Test FAILS until history is added to expand in pages.py.
+    """
+
+    def test_page_created_date_populated(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Date fields test {uid}",
+            body="<p>Testing date fields.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.created, (
+            "ConfluencePage.created is empty — 'history' missing from expand params"
+        )
+
+    def test_page_updated_date_populated(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Updated date test {uid}",
+            body="<p>Testing updated date field.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.updated, (
+            "ConfluencePage.updated is empty — 'history' missing from expand params"
+        )

--- a/tests/e2e/cloud/test_confluence_page_include.py
+++ b/tests/e2e/cloud/test_confluence_page_include.py
@@ -1,0 +1,67 @@
+"""get_page include param: inline comments, labels, views.
+
+Regression for https://github.com/sooperset/mcp-atlassian/issues/1103
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestGetPageIncludeEnrichments:
+    """get_page include param inlines comments, labels, views.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/1103
+    """
+
+    def test_include_comments(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Include comments test {uid}",
+            body="<p>Testing include param.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        # Add a comment
+        confluence_fetcher.add_comment(page.id, "Test comment for include")
+
+        # Verify comments can be retrieved
+        comments = confluence_fetcher.get_page_comments(page.id)
+        assert len(comments) >= 1
+
+    def test_include_labels(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Include labels test {uid}",
+            body="<p>Testing labels include.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        # Add a label
+        confluence_fetcher.add_page_label(page.id, "test-label")
+
+        # Verify labels can be retrieved
+        labels = confluence_fetcher.get_page_labels(page.id)
+        assert len(labels) >= 1

--- a/tests/e2e/cloud/test_confluence_page_metadata.py
+++ b/tests/e2e/cloud/test_confluence_page_metadata.py
@@ -1,0 +1,74 @@
+"""E2E tests for Confluence page metadata fields (upstream #607)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluencePageMetadata:
+    """Page metadata fields (created, updated, author) are populated.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/607
+    Root cause: get_page_content() missing 'history' in expand params.
+    Fix: add 'history' to expand string in pages.py lines 66 and 75.
+    Branch sits here until fix is implemented — test currently FAILS.
+    """
+
+    def test_page_has_created_date(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Metadata Test {uid}",
+            body="<p>Testing metadata retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.created, "created date is empty — 'history' missing from expand"
+
+    def test_page_has_last_modified(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Modified Test {uid}",
+            body="<p>Testing metadata retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.updated, "updated date is empty — 'history' missing from expand"
+
+    def test_page_has_author(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Author Test {uid}",
+            body="<p>Testing author retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.author is not None, "author is None — not returned by API"

--- a/tests/e2e/cloud/test_confluence_space_search.py
+++ b/tests/e2e/cloud/test_confluence_space_search.py
@@ -1,0 +1,27 @@
+"""E2E: CQL space-type search returns results (regression #907)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluenceCQLSpaceSearch:
+    """CQL type=space searches return results (not empty list).
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/907
+    Root cause: search.py excerpt-matching uses 'content' key but space
+    results use 'space' key — no match found, results silently empty.
+    """
+
+    def test_cql_type_space_returns_results(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+    ) -> None:
+        results = confluence_fetcher.search(cql="type=space", limit=10)
+        assert len(results) > 0, (
+            "CQL type=space returned no results — space result processing broken"
+        )

--- a/tests/e2e/cloud/test_confluence_user_details.py
+++ b/tests/e2e/cloud/test_confluence_user_details.py
@@ -1,0 +1,28 @@
+"""E2E: get user details via Confluence API (regression #654)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluenceGetUserDetails:
+    """Get user details by identifier or 'me'.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/654
+    The underlying methods existed but weren't exposed as MCP tools.
+    """
+
+    def test_get_current_user_via_me(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+    ) -> None:
+        result = confluence_fetcher.get_current_user_info()
+        assert result is not None
+        assert isinstance(result, dict)
+        assert result.get("displayName") or result.get("accountId"), (
+            "get_current_user_info returned no identifying fields"
+        )

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -199,3 +199,65 @@ class TestJiraCloudTransitions:
 
         updated = jira_fetcher.get_issue(issue.key)
         assert updated.status is not None
+
+
+class TestJiraRemoteIssueLinks:
+    """Remote issue links (web links and Confluence links) on Jira issues.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/240
+    Feature was requested: add web links and Confluence links to Jira issues.
+    Already implemented via create_remote_issue_link in links.py.
+    """
+
+    def test_create_web_link(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Remote link test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        link_data = {
+            "object": {
+                "url": f"https://example.com/doc-{uid}",
+                "title": f"Test Documentation {uid}",
+            }
+        }
+        result = jira_fetcher.create_remote_issue_link(issue.key, link_data)
+        assert result.get("success") is True, "Remote link was not created"
+        assert result.get("link_url") == f"https://example.com/doc-{uid}"
+
+    def test_create_confluence_link(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Confluence link test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        # Link to a Confluence page (URL format)
+        confluence_url = (
+            cloud_instance.jira_url.rstrip("/") + "/wiki/spaces/MCPTEST/overview"
+        )
+        link_data = {
+            "object": {
+                "url": confluence_url,
+                "title": "MCP Test Space",
+                "summary": "Linked from upstream issue #240 regression test",
+            }
+        }
+        result = jira_fetcher.create_remote_issue_link(issue.key, link_data)
+        assert result.get("success") is True, "Confluence remote link was not created"
+        assert "MCPTEST" in result.get("link_url", "")

--- a/tests/e2e/cloud/test_jira_issue_creation_workflow.py
+++ b/tests/e2e/cloud/test_jira_issue_creation_workflow.py
@@ -1,0 +1,87 @@
+"""Agent issue-creation workflow: discover types, fields, create issue.
+
+Regression for https://github.com/sooperset/mcp-atlassian/issues/460
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestAgentIssueCreationWorkflow:
+    """Acceptance test: agent can discover types, fields, and create an issue.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/460
+    Proves the full agent workflow: discover issue types -> discover required
+    fields -> create issue with correct data. Without these tools, agents
+    need 5-6 calls and often fail due to missing field information.
+    """
+
+    def test_discover_issue_types(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """Agent can discover what issue types a project supports."""
+        types = jira_fetcher.get_project_issue_types(cloud_instance.project_key)
+        assert len(types) > 0, "No issue types returned"
+        names = [t.get("name") for t in types]
+        assert "Task" in names or "Bug" in names, f"Expected common types, got: {names}"
+
+    def test_discover_create_fields(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """Agent can discover what fields are needed for an issue type."""
+        types = jira_fetcher.get_project_issue_types(cloud_instance.project_key)
+        task_type = next((t for t in types if t["name"] == "Task"), types[0])
+
+        fields = jira_fetcher.get_create_fields(
+            cloud_instance.project_key, task_type["id"]
+        )
+        assert len(fields) > 0, "No fields returned"
+        field_ids = [f.get("fieldId") for f in fields]
+        assert "summary" in field_ids, "summary field not in create fields"
+
+    def test_full_agent_workflow_discover_and_create(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        """Full workflow: discover types -> discover fields -> create issue."""
+        uid = uuid.uuid4().hex[:8]
+
+        # Step 1: Discover issue types
+        types = jira_fetcher.get_project_issue_types(cloud_instance.project_key)
+        assert len(types) > 0
+
+        # Step 2: Pick Task
+        task_type = next(t for t in types if t["name"] == "Task")
+
+        # Step 3: Discover fields
+        fields = jira_fetcher.get_create_fields(
+            cloud_instance.project_key, task_type["id"]
+        )
+        required_fields = [f for f in fields if f.get("required")]
+        # summary and issuetype should be required
+        required_ids = [f["fieldId"] for f in required_fields]
+        assert "summary" in required_ids or "issuetype" in required_ids
+
+        # Step 4: Create issue using discovered metadata
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Agent workflow test {uid}",
+            issue_type=task_type["name"],
+        )
+        resource_tracker.add_jira_issue(issue.key)
+        assert issue.key.startswith(cloud_instance.project_key)

--- a/tests/e2e/cloud/test_jira_issue_include.py
+++ b/tests/e2e/cloud/test_jira_issue_include.py
@@ -1,0 +1,88 @@
+"""get_issue include param: inline enrichments in one call.
+
+Regression for https://github.com/sooperset/mcp-atlassian/issues/857
+and https://github.com/sooperset/mcp-atlassian/issues/1101
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestGetIssueIncludeEnrichments:
+    """get_issue include param inlines enrichments in one call.
+
+    Regression for github.com/sooperset/mcp-atlassian/issues/857
+    and github.com/sooperset/mcp-atlassian/issues/1101
+    """
+
+    def test_get_remote_issue_links(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Include test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        jira_fetcher.create_remote_issue_link(
+            issue.key,
+            {
+                "object": {
+                    "url": f"https://example.com/{uid}",
+                    "title": "Test Link",
+                }
+            },
+        )
+
+        links = jira_fetcher.get_remote_issue_links(issue.key)
+        assert isinstance(links, list)
+        assert len(links) >= 1
+
+    def test_get_transitions(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Transitions test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        transitions = jira_fetcher.get_transitions(issue.key)
+        assert isinstance(transitions, list)
+        assert len(transitions) > 0
+
+    def test_get_watchers(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Watchers test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        watchers = jira_fetcher.get_issue_watchers(issue.key)
+        assert isinstance(watchers, dict)

--- a/tests/e2e/cloud/test_jira_user_profile_me.py
+++ b/tests/e2e/cloud/test_jira_user_profile_me.py
@@ -1,0 +1,31 @@
+"""E2E: get_user_profile handles 'me' identifier (regression #596)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+
+from .conftest import CloudInstanceInfo
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestJiraUserProfileMe:
+    """get_user_profile_by_identifier should handle 'me' without crashing.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/596
+    Bug: calling get_user_profile with 'me' crashes with unhelpful error.
+    """
+
+    def test_get_user_profile_with_me_identifier(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """get_user_profile_by_identifier('me') returns current user."""
+        result = jira_fetcher.get_user_profile_by_identifier("me")
+        assert result is not None, "'me' identifier returned None"
+        assert result.account_id or result.display_name, (
+            "User profile missing account_id and display_name"
+        )

--- a/tests/e2e/cloud/test_jira_watchers.py
+++ b/tests/e2e/cloud/test_jira_watchers.py
@@ -1,0 +1,58 @@
+"""E2E tests for Jira Cloud watcher operations (upstream #483)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestJiraCloudWatchers:
+    """Watcher operations on Cloud — regression for upstream #483.
+
+    Proves that add_watcher, remove_watcher, and get_issue_watchers
+    exist and operate correctly against a real Jira Cloud instance.
+    """
+
+    def test_watcher_lifecycle(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        """add_watcher, get_issue_watchers, remove_watcher round-trip."""
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Cloud E2E Watcher Test {uid}",
+            issue_type="Task",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        # Get the current user's account ID so we can add/remove ourselves
+        account_id = jira_fetcher.get_current_user_account_id()
+        assert account_id, "Expected a non-empty account ID for the current user"
+
+        # Add the current user as a watcher
+        add_result = jira_fetcher.add_watcher(issue.key, account_id)
+        assert add_result["success"] is True
+        assert add_result["issue_key"] == issue.key
+
+        # Confirm the watcher count increased after adding
+        watchers_result = jira_fetcher.get_issue_watchers(issue.key)
+        assert watchers_result["issue_key"] == issue.key
+        assert isinstance(watchers_result["watchers"], list)
+        assert watchers_result["watcher_count"] >= 1, (
+            "Expected at least 1 watcher after add_watcher call"
+        )
+
+        # Remove the current user as a watcher
+        remove_result = jira_fetcher.remove_watcher(issue.key, account_id=account_id)
+        assert remove_result["success"] is True
+        assert remove_result["issue_key"] == issue.key

--- a/tests/fixtures/confluence_mocks.py
+++ b/tests/fixtures/confluence_mocks.py
@@ -598,3 +598,82 @@ MOCK_COMMENT_REPLY_V2_RESPONSE = {
         "webui": "/spaces/TEST/pages/12345?focusedCommentId=222333444",
     },
 }
+
+# ============================================================================
+# Inline Comment Mock Data
+# ============================================================================
+
+MOCK_INLINE_COMMENT_V1_RESPONSE = {
+    "id": "333444555",
+    "type": "comment",
+    "status": "current",
+    "title": "Inline Comment",
+    "container": {
+        "id": "12345",
+        "type": "page",
+        "status": "current",
+        "title": "Test Page",
+    },
+    "body": {
+        "view": {
+            "value": "<p>This is an inline comment</p>",
+            "representation": "view",
+        },
+    },
+    "version": {
+        "by": {
+            "type": "known",
+            "accountId": "user123",
+            "displayName": "Test User",
+        },
+        "when": "2024-01-03T10:00:00.000Z",
+        "number": 1,
+    },
+    "extensions": {
+        "location": "inline",
+        "inlineProperties": {
+            "originalSelection": "some text to anchor",
+        },
+    },
+    "_links": {
+        "webui": "/spaces/TEST/pages/12345?focusedCommentId=333444555",
+        "self": "https://example.atlassian.net/wiki/rest/api/content/333444555",
+    },
+}
+
+MOCK_INLINE_COMMENT_V2_RESPONSE = {
+    "id": "444555666",
+    "status": "open",
+    "pageId": "12345",
+    "inlineCommentProperties": {
+        "textSelection": "some text to anchor",
+        "textSelectionMatchCount": 1,
+        "textSelectionMatchIndex": 0,
+        "resolved": False,
+    },
+    "body": {
+        "storage": {
+            "value": "<p>This is a v2 inline comment</p>",
+            "representation": "storage",
+        },
+    },
+    "version": {
+        "number": 1,
+        "createdAt": "2024-01-03T10:00:00.000Z",
+    },
+    "author": {
+        "type": "known",
+        "accountId": "user123",
+        "displayName": "Test User",
+    },
+    "_links": {
+        "webui": "/spaces/TEST/pages/12345?focusedCommentId=444555666",
+    },
+}
+
+MOCK_INLINE_COMMENTS_V2_LIST_RESPONSE = {
+    "results": [MOCK_INLINE_COMMENT_V2_RESPONSE],
+    "_links": {
+        "self": "https://example.atlassian.net/wiki/api/v2/pages/12345/inline-comments",
+    },
+}

--- a/tests/unit/confluence/conftest.py
+++ b/tests/unit/confluence/conftest.py
@@ -7,6 +7,7 @@ framework to provide efficient, reusable test fixtures with session-scoped cachi
 """
 
 import os
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -168,8 +169,10 @@ def mock_atlassian_confluence(
         confluence_instance.get_all_spaces.return_value = MOCK_SPACES_RESPONSE
 
         # Set up common return values using both legacy mocks and new factories
-        confluence_instance.get_page_by_id.return_value = MOCK_PAGE_RESPONSE
-        confluence_instance.get_page_by_title.return_value = MOCK_PAGE_RESPONSE
+        confluence_instance.get_page_by_id.return_value = deepcopy(MOCK_PAGE_RESPONSE)
+        confluence_instance.get_page_by_title.return_value = deepcopy(
+            MOCK_PAGE_RESPONSE
+        )
         confluence_instance.get_all_pages_from_space.return_value = (
             MOCK_PAGES_FROM_SPACE_RESPONSE
         )
@@ -382,7 +385,7 @@ def oauth_confluence_client(mock_preprocessor):
                 mock_confluence_instance.get_all_spaces.return_value = (
                     MOCK_SPACES_RESPONSE
                 )
-                mock_confluence_instance.get_page_by_id.return_value = (
+                mock_confluence_instance.get_page_by_id.return_value = deepcopy(
                     MOCK_PAGE_RESPONSE
                 )
                 mock_confluence_instance.create_page.return_value = (

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -459,3 +459,86 @@ def test_confluence_fetcher_mro_order():
     # Verify that attachment methods are accessible (the real test)
     assert hasattr(ConfluenceFetcher, "upload_attachment")
     assert hasattr(ConfluenceFetcher, "get_content_attachments")
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_basic_auth_with_cloud_id():
+    """Test that basic auth with cloud_id routes through api.atlassian.com."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="svc_token",
+        cloud_id="test-cloud-uuid",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            username="svc@company.atlassian.net",
+            password="svc_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_pat_auth_with_cloud_id():
+    """Test that PAT auth with cloud_id routes through api.atlassian.com."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="pat",
+        personal_token="test_pat",
+        cloud_id="test-cloud-uuid",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            token="test_pat",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_basic_auth_without_cloud_id_uses_direct_url():
+    """Test that basic auth without cloud_id uses the direct URL as before."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="basic",
+        username="user@example.com",
+        api_token="token",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://company.atlassian.net/wiki",
+            username="user@example.com",
+            password="token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -1,6 +1,6 @@
 """Unit tests for the CommentsMixin class."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import requests
@@ -669,34 +669,12 @@ class TestGetInlineComments:
 class TestAddInlineComment:
     """Tests for add_inline_comment method."""
 
-    def test_add_inline_comment_v1_success(self, comments_mixin_dc):
-        """add_inline_comment v1 (Server/DC) posts with inline location."""
-        page_id = "12345"
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
-        }
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
-            "<p>Inline comment</p>"
-        )
-        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
-        comments_mixin_dc.preprocessor.process_html_content.return_value = (
-            "<p>Inline comment</p>",
-            "Inline comment",
-        )
-
-        result = comments_mixin_dc.add_inline_comment(
-            page_id, "Inline comment", "some text to anchor"
-        )
-
-        assert result is not None
-        assert result.location == "inline"
-        call_args = comments_mixin_dc.confluence.post.call_args
-        assert call_args[0][0] == "rest/api/content/"
-        data = call_args[1]["data"]
-        assert data["extensions"]["location"] == "inline"
-        assert data["extensions"]["inlineProperties"]["originalSelection"] == (
-            "some text to anchor"
-        )
+    def test_add_inline_comment_raises_for_server_dc(self, comments_mixin_dc):
+        """add_inline_comment raises ValueError on Server/DC (Cloud-only API)."""
+        with pytest.raises(ValueError, match="only supported on Confluence Cloud"):
+            comments_mixin_dc.add_inline_comment(
+                "12345", "Inline comment", "some text to anchor"
+            )
 
     def test_add_inline_comment_v2_cloud_success(self, comments_mixin):
         """add_inline_comment uses v2 API on Cloud (any auth type)."""
@@ -750,52 +728,76 @@ class TestAddInlineComment:
         # v1 API should not be called
         comments_mixin.confluence.post.assert_not_called()
 
-    def test_add_inline_comment_with_html_content(self, comments_mixin_dc):
-        """add_inline_comment skips markdown conversion for HTML content (Server/DC)."""
+    def test_add_inline_comment_with_html_content(self, comments_mixin):
+        """add_inline_comment skips markdown conversion for HTML content."""
         html_content = "<p>Already <strong>HTML</strong></p>"
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
+
+        v2_converted = {
+            "id": "444555666",
+            "type": "comment",
+            "status": "open",
+            "body": {"view": {"value": html_content, "representation": "view"}},
+            "extensions": {"location": "inline"},
+            "version": {"number": 1},
+            "_links": {},
         }
-        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
-        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+        comments_mixin.preprocessor.process_html_content.return_value = (
             html_content,
-            "Already **HTML**",
+            "Already HTML",
         )
 
-        result = comments_mixin_dc.add_inline_comment(
-            "12345", html_content, "some text"
-        )
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.return_value = v2_converted
 
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.assert_not_called()
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=PropertyMock,
+            return_value=mock_adapter,
+        ):
+            result = comments_mixin.add_inline_comment(
+                "12345", html_content, "some text"
+            )
+
+        comments_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
         assert result is not None
 
-    def test_add_inline_comment_empty_response(self, comments_mixin_dc):
-        """add_inline_comment returns None on empty API response (Server/DC)."""
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
-        }
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+    def test_add_inline_comment_propagates_value_error(self, comments_mixin):
+        """add_inline_comment propagates ValueError (e.g. text not found)."""
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
             "<p>Test</p>"
         )
-        comments_mixin_dc.confluence.post.return_value = None
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.side_effect = ValueError(
+            "text not found on page"
+        )
 
-        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=PropertyMock,
+            return_value=mock_adapter,
+        ):
+            with pytest.raises(ValueError, match="text not found on page"):
+                comments_mixin.add_inline_comment("12345", "Test", "missing text")
 
-        assert result is None
-
-    def test_add_inline_comment_network_error(self, comments_mixin_dc):
-        """add_inline_comment returns None on network error (Server/DC)."""
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
-        }
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+    def test_add_inline_comment_network_error(self, comments_mixin):
+        """add_inline_comment returns None on network error."""
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
             "<p>Test</p>"
         )
-        comments_mixin_dc.confluence.post.side_effect = requests.RequestException(
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.side_effect = requests.RequestException(
             "Network error"
         )
 
-        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=PropertyMock,
+            return_value=mock_adapter,
+        ):
+            result = comments_mixin.add_inline_comment("12345", "Test", "anchor text")
 
         assert result is None
 

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -6,10 +6,13 @@ import pytest
 import requests
 
 from mcp_atlassian.confluence.comments import CommentsMixin
+from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.models.confluence import ConfluenceComment
 from tests.fixtures.confluence_mocks import (
     MOCK_COMMENT_REPLY_V1_RESPONSE,
     MOCK_COMMENT_REPLY_V2_RESPONSE,
+    MOCK_INLINE_COMMENT_V1_RESPONSE,
+    MOCK_INLINE_COMMENT_V2_RESPONSE,
 )
 
 
@@ -24,6 +27,37 @@ def comments_mixin(confluence_client):
         mixin.confluence = confluence_client.confluence
         mixin.config = confluence_client.config
         mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+@pytest.fixture
+def comments_mixin_dc():
+    """Create a CommentsMixin instance for Server/DC testing (is_cloud=False).
+
+    Inline comments on Server/DC use the v1 API path.
+    """
+    with patch(
+        "mcp_atlassian.confluence.comments.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = CommentsMixin()
+        mixin.config = ConfluenceConfig(
+            url="https://confluence.example.com",
+            auth_type="basic",
+            username="test_user",
+            api_token="test_token",
+        )
+        mixin.confluence = MagicMock()
+        mixin.confluence._session = MagicMock()
+        mock_preprocessor = MagicMock()
+        mock_preprocessor.process_html_content.return_value = (
+            "<p>Processed HTML</p>",
+            "Processed Markdown",
+        )
+        mock_preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Processed</p>"
+        )
+        mixin.preprocessor = mock_preprocessor
         return mixin
 
 
@@ -513,3 +547,295 @@ class TestConfluenceCommentModel:
         comment = ConfluenceComment.from_api_response(data)
         result = comment.to_simplified_dict()
         assert "location" not in result
+
+
+class TestGetInlineComments:
+    """Tests for get_inline_comments method."""
+
+    def test_get_inline_comments_v1_success(self, comments_mixin_dc):
+        """get_inline_comments v1 (Server/DC) filters by location=inline."""
+        page_id = "12345"
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.get_page_comments.return_value = {
+            "results": [
+                MOCK_INLINE_COMMENT_V1_RESPONSE,
+                # footer comment that should be filtered out
+                {
+                    "id": "999",
+                    "body": {"view": {"value": "<p>footer</p>"}},
+                    "extensions": {"location": "footer"},
+                },
+            ]
+        }
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            "<p>This is an inline comment</p>",
+            "This is an inline comment",
+        )
+
+        result = comments_mixin_dc.get_inline_comments(page_id)
+
+        assert len(result) == 1
+        assert result[0].location == "inline"
+        assert result[0].id == "333444555"
+        # Verify expanded fields were requested
+        comments_mixin_dc.confluence.get_page_comments.assert_called_once_with(
+            content_id=page_id,
+            expand="body.view.value,version,extensions.inlineProperties",
+            depth="all",
+        )
+
+    def test_get_inline_comments_v2_cloud_success(self, comments_mixin):
+        """get_inline_comments uses v2 API on Cloud (any auth type)."""
+        mock_adapter = MagicMock()
+        mock_adapter.get_inline_comments.return_value = [
+            {
+                "id": "444555666",
+                "type": "comment",
+                "status": "open",
+                "body": {
+                    "view": {"value": "<p>v2 inline</p>", "representation": "view"}
+                },
+                "extensions": {"location": "inline"},
+                "version": {"number": 1},
+                "_links": {},
+            }
+        ]
+        comments_mixin.preprocessor.process_html_content.return_value = (
+            "<p>v2 inline</p>",
+            "v2 inline",
+        )
+
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=lambda: property(lambda self: mock_adapter),
+        ):
+            result = comments_mixin.get_inline_comments("12345")
+
+        assert len(result) == 1
+        mock_adapter.get_inline_comments.assert_called_once_with("12345")
+        # v1 API should not be called
+        comments_mixin.confluence.get_page_comments.assert_not_called()
+
+    def test_get_inline_comments_empty(self, comments_mixin_dc):
+        """get_inline_comments returns empty list if no inline comments (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.get_page_comments.return_value = {
+            "results": [
+                {
+                    "id": "999",
+                    "body": {"view": {"value": "<p>footer</p>"}},
+                    "extensions": {"location": "footer"},
+                }
+            ]
+        }
+
+        result = comments_mixin_dc.get_inline_comments("12345")
+
+        assert result == []
+
+    def test_get_inline_comments_network_error(self, comments_mixin_dc):
+        """get_inline_comments returns empty list on network error (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_comments.side_effect = (
+            requests.RequestException("Network error")
+        )
+
+        result = comments_mixin_dc.get_inline_comments("12345")
+
+        assert result == []
+
+    def test_get_inline_comments_html_format(self, comments_mixin_dc):
+        """get_inline_comments returns HTML body when return_markdown=False (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.get_page_comments.return_value = {
+            "results": [MOCK_INLINE_COMMENT_V1_RESPONSE]
+        }
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            "<p>HTML body</p>",
+            "Markdown body",
+        )
+
+        result = comments_mixin_dc.get_inline_comments("12345", return_markdown=False)
+
+        assert result[0].body == "<p>HTML body</p>"
+
+
+class TestAddInlineComment:
+    """Tests for add_inline_comment method."""
+
+    def test_add_inline_comment_v1_success(self, comments_mixin_dc):
+        """add_inline_comment v1 (Server/DC) posts with inline location."""
+        page_id = "12345"
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Inline comment</p>"
+        )
+        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            "<p>Inline comment</p>",
+            "Inline comment",
+        )
+
+        result = comments_mixin_dc.add_inline_comment(
+            page_id, "Inline comment", "some text to anchor"
+        )
+
+        assert result is not None
+        assert result.location == "inline"
+        call_args = comments_mixin_dc.confluence.post.call_args
+        assert call_args[0][0] == "rest/api/content/"
+        data = call_args[1]["data"]
+        assert data["extensions"]["location"] == "inline"
+        assert data["extensions"]["inlineProperties"]["originalSelection"] == (
+            "some text to anchor"
+        )
+
+    def test_add_inline_comment_v2_cloud_success(self, comments_mixin):
+        """add_inline_comment uses v2 API on Cloud (any auth type)."""
+
+        v2_converted = {
+            "id": "444555666",
+            "type": "comment",
+            "status": "open",
+            "body": {"view": {"value": "<p>v2 inline</p>", "representation": "view"}},
+            "extensions": {"location": "inline"},
+            "version": {"number": 1},
+            "_links": {},
+            "inlineCommentProperties": {
+                "textSelection": "some text to anchor",
+                "textSelectionMatchCount": 1,
+                "textSelectionMatchIndex": 0,
+            },
+        }
+
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.return_value = v2_converted
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>v2 inline</p>"
+        )
+        comments_mixin.preprocessor.process_html_content.return_value = (
+            "<p>v2 inline</p>",
+            "v2 inline",
+        )
+
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=lambda: property(lambda self: mock_adapter),
+        ):
+            result = comments_mixin.add_inline_comment(
+                "12345",
+                "v2 inline",
+                "some text to anchor",
+                text_selection_match_count=2,
+                text_selection_match_index=1,
+            )
+
+        assert result is not None
+        mock_adapter.create_inline_comment.assert_called_once_with(
+            page_id="12345",
+            body="<p>v2 inline</p>",
+            text_selection="some text to anchor",
+            text_selection_match_count=2,
+            text_selection_match_index=1,
+        )
+        # v1 API should not be called
+        comments_mixin.confluence.post.assert_not_called()
+
+    def test_add_inline_comment_with_html_content(self, comments_mixin_dc):
+        """add_inline_comment skips markdown conversion for HTML content (Server/DC)."""
+        html_content = "<p>Already <strong>HTML</strong></p>"
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
+        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+            html_content,
+            "Already **HTML**",
+        )
+
+        result = comments_mixin_dc.add_inline_comment(
+            "12345", html_content, "some text"
+        )
+
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.assert_not_called()
+        assert result is not None
+
+    def test_add_inline_comment_empty_response(self, comments_mixin_dc):
+        """add_inline_comment returns None on empty API response (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Test</p>"
+        )
+        comments_mixin_dc.confluence.post.return_value = None
+
+        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+
+        assert result is None
+
+    def test_add_inline_comment_network_error(self, comments_mixin_dc):
+        """add_inline_comment returns None on network error (Server/DC)."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Test</p>"
+        )
+        comments_mixin_dc.confluence.post.side_effect = requests.RequestException(
+            "Network error"
+        )
+
+        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+
+        assert result is None
+
+
+class TestInlineCommentModel:
+    """Tests for ConfluenceComment model with inline comment data."""
+
+    def test_inline_comment_from_v1_response(self):
+        """ConfluenceComment correctly parses v1 inline comment response."""
+        comment = ConfluenceComment.from_api_response(MOCK_INLINE_COMMENT_V1_RESPONSE)
+        assert comment.id == "333444555"
+        assert comment.location == "inline"
+        assert comment.body == "<p>This is an inline comment</p>"
+
+    def test_inline_comment_from_v2_response_converted(self):
+        """ConfluenceComment parses v2 inline comment after v1 conversion."""
+        # Simulate what _convert_v2_inline_comment_to_v1_format outputs
+        v1_converted = {
+            "id": "444555666",
+            "type": "comment",
+            "status": "open",
+            "body": {
+                "view": {
+                    "value": "<p>This is a v2 inline comment</p>",
+                    "representation": "view",
+                }
+            },
+            "version": MOCK_INLINE_COMMENT_V2_RESPONSE["version"],
+            "author": MOCK_INLINE_COMMENT_V2_RESPONSE["author"],
+            "_links": MOCK_INLINE_COMMENT_V2_RESPONSE["_links"],
+            "extensions": {"location": "inline"},
+            "inlineCommentProperties": {
+                "textSelection": "some text to anchor",
+                "textSelectionMatchCount": 1,
+                "textSelectionMatchIndex": 0,
+            },
+        }
+        comment = ConfluenceComment.from_api_response(v1_converted)
+        assert comment.id == "444555666"
+        assert comment.location == "inline"
+        assert comment.body == "<p>This is a v2 inline comment</p>"
+        assert comment.author is not None
+        assert comment.author.display_name == "Test User"

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -358,3 +358,71 @@ def test_from_env_without_cookie():
     ):
         config = ConfluenceConfig.from_env()
         assert config.cookie is None
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_service_account_with_cloud_id():
+    """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "test-cloud-uuid",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.auth_type == "basic"
+        assert config.is_cloud is True
+        assert config.username == "svc@company.atlassian.net"
+
+
+def test_from_env_service_account_with_confluence_cloud_id():
+    """Test service-specific CONFLUENCE_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "global-cloud-id",
+            "CONFLUENCE_CLOUD_ID": "confluence-specific-cloud-id",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "confluence-specific-cloud-id"
+
+
+def test_from_env_service_account_no_url_required():
+    """Test that CONFLUENCE_URL is not required when cloud_id is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_CLOUD_ID": "test-cloud-uuid",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        # Should not raise ValueError about missing URL
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == ""
+
+
+def test_is_cloud_with_cloud_id_basic_auth():
+    """Test is_cloud returns True when cloud_id is set, regardless of URL."""
+    config = ConfluenceConfig(
+        url="",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -329,3 +329,32 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://confluence.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+def test_from_env_with_cookie():
+    """Test that from_env reads CONFLUENCE_COOKIE and stores it in config."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+            "CONFLUENCE_COOKIE": "JSESSIONID=abc123; other=xyz",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cookie == "JSESSIONID=abc123; other=xyz"
+
+
+def test_from_env_without_cookie():
+    """Test that cookie defaults to None when CONFLUENCE_COOKIE is not set."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cookie is None

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -38,7 +38,8 @@ class TestPagesMixin:
 
         # Assert
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,history,ancestors",
         )
 
         # Verify result structure
@@ -66,6 +67,42 @@ class TestPagesMixin:
         assert len(result.attachments) == 2
         assert result.attachments[0].id is not None
         assert result.attachments[1].id is not None
+
+    def test_get_page_content_includes_ancestors_in_response(self, pages_mixin):
+        """Ancestors in API response flow through to ConfluencePage model.
+
+        Regression for https://github.com/sooperset/mcp-atlassian/issues/1131
+        Verifies the full path: API response → model → to_simplified_dict().
+        """
+        # Arrange — build a page response with ancestors included
+        import copy
+
+        from tests.fixtures.confluence_mocks import MOCK_PAGE_RESPONSE
+
+        page_with_ancestors = copy.deepcopy(MOCK_PAGE_RESPONSE)
+        page_with_ancestors["ancestors"] = [
+            {"id": "111", "title": "Grandparent Page", "type": "page"},
+            {"id": "222", "title": "Parent Page", "type": "page"},
+        ]
+        pages_mixin.confluence.get_page_by_id.return_value = page_with_ancestors
+        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+
+        # Act
+        result = pages_mixin.get_page_content("987654321", convert_to_markdown=True)
+
+        # Assert — ancestors populated on model
+        assert len(result.ancestors) == 2
+        assert result.ancestors[0]["id"] == "111"
+        assert result.ancestors[0]["title"] == "Grandparent Page"
+        assert result.ancestors[1]["id"] == "222"
+        assert result.ancestors[1]["title"] == "Parent Page"
+
+        # Assert — ancestors included in simplified dict (MCP tool output)
+        simplified = result.to_simplified_dict()
+        assert "ancestors" in simplified
+        assert len(simplified["ancestors"]) == 2
+        assert simplified["ancestors"][0] == {"id": "111", "title": "Grandparent Page"}
+        assert simplified["ancestors"][1] == {"id": "222", "title": "Parent Page"}
 
     def test_get_page_ancestors(self, pages_mixin):
         """Test getting page ancestors (parent pages)."""
@@ -698,7 +735,8 @@ class TestPagesMixin:
 
         # Verify the API call
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,history,ancestors",
         )
 
         # Verify the result
@@ -1029,7 +1067,7 @@ class TestPagesMixin:
             page_id=page_id,
             status="historical",
             version=version,
-            expand="body.storage,version,space,children.attachment",
+            expand="body.storage,version,space,children.attachment,history,ancestors",
         )
 
         # Verify result is a ConfluencePage
@@ -1453,7 +1491,8 @@ class TestPagesOAuthMixin:
 
             # Assert that v2 API was used instead of v1
             mock_v2_adapter.get_page.assert_called_once_with(
-                page_id=page_id, expand="body.storage,version,space,children.attachment"
+                page_id=page_id,
+                expand="body.storage,version,space,children.attachment,history,ancestors",
             )
 
             # Verify v1 API was NOT called
@@ -1544,7 +1583,7 @@ class TestPagesOAuthMixin:
             mock_v2_adapter.get_page_by_version.assert_called_once_with(
                 page_id=page_id,
                 version=version,
-                expand="body.storage,version,space,children.attachment",
+                expand="body.storage,version,space,children.attachment,history,ancestors",
             )
 
             # Verify v1 API was NOT called
@@ -2944,3 +2983,161 @@ class TestPageHierarchy:
 
         assert result["total_pages"] == 1
         assert result["has_more"] is False
+
+
+class TestUpdatePageSection:
+    """Tests for PagesMixin.update_page_section."""
+
+    @pytest.fixture
+    def pages_mixin(self, confluence_client):
+        """Create a PagesMixin instance for testing."""
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceClient.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            mixin = PagesMixin()
+            mixin.confluence = confluence_client.confluence
+            mixin.config = confluence_client.config
+            mixin.preprocessor = confluence_client.preprocessor
+            return mixin
+
+    def _make_page(self, page_id: str, title: str, storage_html: str) -> ConfluencePage:
+        return ConfluencePage(
+            id=page_id,
+            title=title,
+            content=storage_html,
+            space={"key": "PROJ", "name": "Project"},
+            version={"number": 1},
+        )
+
+    def test_replaces_section_content(self, pages_mixin):
+        """Section body is replaced; heading and surrounding content are kept."""
+        storage = (
+            "<h1>Intro</h1><p>intro text</p>"
+            "<h2>Target Section</h2><p>old content</p>"
+            "<h2>Another Section</h2><p>other content</p>"
+        )
+        raw_page = self._make_page("123", "My Page", storage)
+        updated_page = self._make_page("123", "My Page", "updated")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new content</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
+        ):
+            result = pages_mixin.update_page_section(
+                page_id="123",
+                heading_text="Target Section",
+                new_content="new content",
+            )
+
+        assert result is updated_page
+        call_body: str = mock_update.call_args.kwargs["body"]
+        # Heading preserved
+        assert "<h2>Target Section</h2>" in call_body
+        # New content inserted
+        assert "<p>new content</p>" in call_body
+        # Old content removed
+        assert "old content" not in call_body
+        # Sibling section untouched
+        assert "<h2>Another Section</h2>" in call_body
+        assert "<p>other content</p>" in call_body
+        # Written back as storage format
+        assert mock_update.call_args.kwargs["is_markdown"] is False
+        assert mock_update.call_args.kwargs["content_representation"] == "storage"
+
+    def test_stops_at_same_level_heading(self, pages_mixin):
+        """Content replacement stops at the next heading of the same level."""
+        storage = (
+            "<h2>Section A</h2><p>a content</p>"
+            "<h2>Section B</h2><p>b content</p><h3>Sub</h3><p>sub</p>"
+            "<h2>Section C</h2><p>c content</p>"
+        )
+        raw_page = self._make_page("1", "P", storage)
+        updated_page = self._make_page("1", "P", "")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new b</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
+        ):
+            pages_mixin.update_page_section("1", "Section B", "new b")
+
+        body: str = mock_update.call_args.kwargs["body"]
+        assert "b content" not in body
+        assert "<p>new b</p>" in body
+        # Section C must be intact
+        assert "<h2>Section C</h2>" in body
+        assert "<p>c content</p>" in body
+        # Section A must be intact
+        assert "<h2>Section A</h2>" in body
+        assert "<p>a content</p>" in body
+
+    def test_heading_not_found_raises(self, pages_mixin):
+        """ValueError is raised when heading text does not exist on the page."""
+        raw_page = self._make_page("1", "P", "<h2>Existing</h2><p>content</p>")
+
+        with patch.object(pages_mixin, "get_page_content", return_value=raw_page):
+            with pytest.raises(ValueError, match="not found in page"):
+                pages_mixin.update_page_section("1", "Nonexistent Heading", "data")
+
+    def test_invalid_content_format_raises(self, pages_mixin):
+        """ValueError is raised for unsupported content_format values."""
+        with pytest.raises(ValueError, match="Invalid content_format"):
+            pages_mixin.update_page_section(
+                "1", "Heading", "content", content_format="wiki"
+            )
+
+    def test_macros_outside_section_preserved(self, pages_mixin):
+        """Confluence macros outside the target section survive the update."""
+        macro = (
+            '<ac:structured-macro ac:name="toc">'
+            '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        storage = f"{macro}<h2>Section</h2><p>old</p><h2>Other</h2><p>other</p>"
+        raw_page = self._make_page("1", "P", storage)
+        updated_page = self._make_page("1", "P", "")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
+        ):
+            pages_mixin.update_page_section("1", "Section", "new")
+
+        body: str = mock_update.call_args.kwargs["body"]
+        assert 'ac:name="toc"' in body
+
+    def test_storage_format_content_not_converted(self, pages_mixin):
+        """When content_format='storage', markdown_to_confluence_storage is not called."""
+        raw_page = self._make_page("1", "P", "<h2>Section</h2><p>old</p>")
+        updated_page = self._make_page("1", "P", "")
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(pages_mixin, "update_page", return_value=updated_page),
+        ):
+            pages_mixin.update_page_section(
+                "1",
+                "Section",
+                "<p>raw storage</p>",
+                content_format="storage",
+            )
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -788,7 +788,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify create_page was called with the converted content
@@ -875,7 +875,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify update_page was called with the converted content
@@ -3141,3 +3141,159 @@ class TestUpdatePageSection:
             )
 
         pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+
+
+class TestContentProperties:
+    """Tests for arbitrary content property get/set."""
+
+    @pytest.fixture
+    def pages_mixin(self, confluence_client):
+        """Create a PagesMixin instance for testing."""
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceClient.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            mixin = PagesMixin()
+            mixin.confluence = confluence_client.confluence
+            mixin.config = confluence_client.config
+            mixin.preprocessor = confluence_client.preprocessor
+            return mixin
+
+    def test_get_content_properties_all(self, pages_mixin):
+        """Get all properties returns {key: value} dict."""
+        pages_mixin.confluence.get_page_properties.return_value = {
+            "results": [
+                {"key": "content-appearance-published", "value": "full-width"},
+                {"key": "content-appearance-draft", "value": "fixed-width"},
+            ]
+        }
+
+        result = pages_mixin.get_content_properties("123456789")
+
+        pages_mixin.confluence.get_page_properties.assert_called_once_with("123456789")
+        assert result == {
+            "content-appearance-published": "full-width",
+            "content-appearance-draft": "fixed-width",
+        }
+
+    def test_get_content_properties_empty(self, pages_mixin):
+        """Empty results return empty dict."""
+        pages_mixin.confluence.get_page_properties.return_value = {"results": []}
+
+        result = pages_mixin.get_content_properties("123456789")
+
+        assert result == {}
+
+    def test_get_content_properties_single_key(self, pages_mixin):
+        """Single key returns only that property."""
+        pages_mixin.confluence.get_page_property.return_value = {
+            "key": "content-appearance-published",
+            "value": "full-width",
+            "version": {"number": 2},
+        }
+
+        result = pages_mixin.get_content_properties(
+            "123456789", key="content-appearance-published"
+        )
+
+        pages_mixin.confluence.get_page_property.assert_called_once_with(
+            "123456789", "content-appearance-published"
+        )
+        assert result == {"content-appearance-published": "full-width"}
+
+    def test_get_content_properties_api_error(self, pages_mixin):
+        """API errors propagate without wrapping."""
+        pages_mixin.confluence.get_page_properties.side_effect = Exception("API error")
+
+        with pytest.raises(Exception, match="API error"):
+            pages_mixin.get_content_properties("123456789")
+
+    def test_set_content_property_creates_when_not_exists(self, pages_mixin):
+        """Property that doesn't exist is created via set_page_property."""
+        pages_mixin.confluence.get_page_property.side_effect = Exception("Not found")
+        pages_mixin.confluence.set_page_property.return_value = {
+            "key": "custom-key",
+            "value": "custom-value",
+        }
+
+        result = pages_mixin.set_content_property(
+            "123456789", "custom-key", "custom-value"
+        )
+
+        pages_mixin.confluence.set_page_property.assert_called_once_with(
+            "123456789", {"key": "custom-key", "value": "custom-value"}
+        )
+        assert result == {"custom-key": "custom-value"}
+
+    def test_set_content_property_updates_existing(self, pages_mixin):
+        """Existing property is updated with version increment."""
+        pages_mixin.confluence.get_page_property.return_value = {
+            "key": "content-appearance-published",
+            "value": "fixed-width",
+            "version": {"number": 2},
+        }
+        pages_mixin.confluence.update_page_property.return_value = None
+
+        result = pages_mixin.set_content_property(
+            "123456789", "content-appearance-published", "full-width"
+        )
+
+        pages_mixin.confluence.update_page_property.assert_called_once_with(
+            "123456789",
+            {
+                "key": "content-appearance-published",
+                "value": "full-width",
+                "version": {"number": 3},
+            },
+        )
+        assert result == {"content-appearance-published": "full-width"}
+
+    def test_set_content_property_version_defaults_to_1(self, pages_mixin):
+        """Missing version info defaults to version 1."""
+        pages_mixin.confluence.get_page_property.return_value = {
+            "key": "custom-key",
+            "value": "old",
+        }
+        pages_mixin.confluence.update_page_property.return_value = None
+
+        result = pages_mixin.set_content_property("123456789", "custom-key", "new")
+
+        call_data = pages_mixin.confluence.update_page_property.call_args[0][1]
+        assert call_data["version"]["number"] == 1
+
+    def test_set_content_property_dict_value(self, pages_mixin):
+        """Dict values (JSON objects) are supported."""
+        pages_mixin.confluence.get_page_property.side_effect = Exception("Not found")
+        pages_mixin.confluence.set_page_property.return_value = {
+            "key": "editor",
+            "value": {"version": 2},
+        }
+
+        result = pages_mixin.set_content_property("123456789", "editor", {"version": 2})
+
+        pages_mixin.confluence.set_page_property.assert_called_once_with(
+            "123456789", {"key": "editor", "value": {"version": 2}}
+        )
+        assert result == {"editor": {"version": 2}}
+
+    def test_set_content_property_api_error_on_update(self, pages_mixin):
+        """API error during update propagates."""
+        pages_mixin.confluence.get_page_property.return_value = {
+            "key": "k",
+            "value": "v",
+            "version": {"number": 1},
+        }
+        pages_mixin.confluence.update_page_property.side_effect = Exception(
+            "Version conflict"
+        )
+
+        with pytest.raises(Exception, match="Version conflict"):
+            pages_mixin.set_content_property("123456789", "k", "new")
+
+    def test_set_content_property_api_error_on_create(self, pages_mixin):
+        """API error during create propagates."""
+        pages_mixin.confluence.get_page_property.side_effect = Exception("Not found")
+        pages_mixin.confluence.set_page_property.side_effect = Exception("Bad request")
+
+        with pytest.raises(Exception, match="Bad request"):
+            pages_mixin.set_content_property("123456789", "k", "v")

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -177,20 +177,23 @@ class TestPagesMixin:
         assert len(result) == 0
 
     def test_get_page_content_html(self, pages_mixin):
-        """Test getting page content in HTML format."""
+        """Test getting page content in raw storage format."""
         pages_mixin.config.url = "https://example.atlassian.net/wiki"
-
-        # Mock the preprocessor to return HTML
-        pages_mixin.preprocessor.process_html_content.return_value = (
-            "<p>Processed HTML</p>",
-            "Processed Markdown",
+        original_storage = (
+            '<p><ac:structured-macro ac:name="status">'
+            '<ac:parameter ac:name="title">INCOMPLETE</ac:parameter>'
+            "</ac:structured-macro></p>"
         )
+        pages_mixin.confluence.get_page_by_id.return_value["body"]["storage"][
+            "value"
+        ] = original_storage
 
         # Act
         result = pages_mixin.get_page_content("987654321", convert_to_markdown=False)
 
-        # Assert HTML processing was used
-        assert result.content == "<p>Processed HTML</p>"
+        # Assert original storage was returned without preprocessing
+        assert result.content == original_storage
+        pages_mixin.preprocessor.process_html_content.assert_not_called()
 
     def test_get_page_by_title_success(self, pages_mixin):
         """Test getting a page by title when it exists."""
@@ -225,6 +228,31 @@ class TestPagesMixin:
         assert result.id == "987654321"
         assert result.title == title
         assert result.content == "Processed Markdown"
+
+    def test_get_page_by_title_storage_preserves_macros(self, pages_mixin):
+        """Storage mode should preserve macro-heavy content exactly."""
+        space_key = "DEMO"
+        title = "Macro Page"
+        original_storage = (
+            "<ac:task-list><ac:task><ac:task-id>1</ac:task-id>"
+            "<ac:task-status>incomplete</ac:task-status>"
+            "<ac:task-body>Test task</ac:task-body></ac:task></ac:task-list>"
+        )
+        pages_mixin.confluence.get_page_by_title.return_value = {
+            "id": "987654321",
+            "title": title,
+            "space": {"key": space_key},
+            "body": {"storage": {"value": original_storage}},
+            "version": {"number": 1},
+        }
+
+        result = pages_mixin.get_page_by_title(
+            space_key, title, convert_to_markdown=False
+        )
+
+        assert result is not None
+        assert result.content == original_storage
+        pages_mixin.preprocessor.process_html_content.assert_not_called()
 
     def test_get_page_by_title_space_not_found(self, pages_mixin):
         """Test getting a page when the space doesn't exist."""
@@ -441,6 +469,74 @@ class TestPagesMixin:
         with pytest.raises(Exception, match="Failed to update page"):
             pages_mixin.update_page("987654321", "Test Page", "<p>Content</p>")
 
+    def test_update_page_preserves_existing_width_by_default(self, pages_mixin):
+        """Test updating a page preserves the current width when none is provided."""
+        page_id = "987654321"
+        title = "Updated Page"
+        body = "<p>Updated content</p>"
+
+        mock_document = ConfluencePage(
+            id=page_id,
+            title=title,
+            content="Updated content",
+            space={"key": "PROJ", "name": "Project"},
+            version={"number": 1},
+        )
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=mock_document),
+            patch.object(pages_mixin, "_get_page_width", return_value="full-width"),
+            patch.object(pages_mixin, "_set_page_width") as mock_set_width,
+        ):
+            result = pages_mixin.update_page(
+                page_id,
+                title,
+                body,
+                is_markdown=False,
+            )
+
+            pages_mixin.confluence.update_page.assert_called_once_with(
+                page_id=page_id,
+                title=title,
+                body=body,
+                type="page",
+                representation="storage",
+                minor_edit=False,
+                version_comment="",
+                always_update=True,
+            )
+            mock_set_width.assert_called_once_with(page_id, "full-width")
+            assert result.id == page_id
+
+    def test_update_page_explicit_width_overrides_existing_width(self, pages_mixin):
+        """Test updating a page honors an explicitly provided width."""
+        page_id = "987654321"
+        title = "Updated Page"
+        body = "<p>Updated content</p>"
+
+        mock_document = ConfluencePage(
+            id=page_id,
+            title=title,
+            content="Updated content",
+            space={"key": "PROJ", "name": "Project"},
+            version={"number": 1},
+        )
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=mock_document),
+            patch.object(pages_mixin, "_get_page_width") as mock_get_width,
+            patch.object(pages_mixin, "_set_page_width") as mock_set_width,
+        ):
+            result = pages_mixin.update_page(
+                page_id,
+                title,
+                body,
+                is_markdown=False,
+                page_width="default",
+            )
+
+            mock_get_width.assert_not_called()
+            mock_set_width.assert_called_once_with(page_id, "default")
+            assert result.id == page_id
+
     def test_update_page_with_wiki_format(self, pages_mixin):
         """Test updating a page with wiki markup format."""
         # Arrange
@@ -650,7 +746,43 @@ class TestPagesMixin:
             space_key="DEMO",
             confluence_client=pages_mixin.confluence,
             content_id="789012",
+            attachments=None,
         )
+
+    def test_get_page_children_storage_preserves_macros(self, pages_mixin):
+        """Storage mode should preserve child page content exactly."""
+        parent_id = "123456"
+        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+        original_storage = (
+            '<p><ac:structured-macro ac:name="status">'
+            '<ac:parameter ac:name="title">READY</ac:parameter>'
+            "</ac:structured-macro></p>"
+        )
+        child_pages_data = {
+            "results": [
+                {
+                    "id": "789012",
+                    "title": "Child Page With Macro",
+                    "space": {"key": "DEMO"},
+                    "version": {"number": 1},
+                    "body": {"storage": {"value": original_storage}},
+                }
+            ]
+        }
+        child_folders_data = {"results": []}
+
+        pages_mixin.confluence.get_page_child_by_type.side_effect = [
+            child_pages_data,
+            child_folders_data,
+        ]
+
+        results = pages_mixin.get_page_children(
+            page_id=parent_id, expand="body.storage", convert_to_markdown=False
+        )
+
+        assert len(results) == 1
+        assert results[0].content == original_storage
+        pages_mixin.preprocessor.process_html_content.assert_not_called()
 
     def test_get_page_children_empty(self, pages_mixin):
         """Test getting child pages when there are none."""
@@ -1079,7 +1211,7 @@ class TestPagesMixin:
         assert result.space.key == "PROJ"
 
     def test_get_page_history_html_v1(self, pages_mixin):
-        """Test retrieving historical version with HTML format (convert_to_markdown=False)."""
+        """Test retrieving historical version in raw storage format."""
         # Arrange
         page_id = "987654321"
         version = 3
@@ -1090,15 +1222,14 @@ class TestPagesMixin:
             "title": "HTML Historical Page",
             "space": {"key": "PROJ"},
             "version": {"number": version},
-            "body": {"storage": {"value": "<p>HTML content</p>"}},
+            "body": {
+                "storage": {
+                    "value": '<p><ac:structured-macro ac:name="details"><ac:rich-text-body><p>HTML content</p></ac:rich-text-body></ac:structured-macro></p>'
+                }
+            },
             "children": {"attachment": {"results": []}},
         }
         pages_mixin.confluence.get_page_by_id.return_value = historical_page_data
-
-        pages_mixin.preprocessor.process_html_content.return_value = (
-            "<p>Processed HTML content</p>",
-            "Processed markdown",
-        )
         pages_mixin.confluence.get_page_properties.return_value = {"results": []}
 
         # Act
@@ -1106,10 +1237,11 @@ class TestPagesMixin:
             page_id, version, convert_to_markdown=False
         )
 
-        # Assert - HTML should be used instead of markdown
+        # Assert - exact storage should be returned instead of processed HTML
         assert isinstance(result, ConfluencePage)
-        assert result.content == "<p>Processed HTML content</p>"
+        assert result.content == historical_page_data["body"]["storage"]["value"]
         assert result.version.number == version
+        pages_mixin.preprocessor.process_html_content.assert_not_called()
 
     def test_get_page_history_with_attachments_v1(self, pages_mixin):
         """Test that attachments are included in historical version."""
@@ -1635,7 +1767,7 @@ class TestPagesOAuthMixin:
             assert result.space.key == "PROJ"
 
     def test_get_page_history_oauth_html(self, oauth_pages_mixin):
-        """Test retrieving historical version with HTML format using OAuth."""
+        """Test retrieving historical version in raw storage format using OAuth."""
         # Arrange
         page_id = "oauth_html_789"
         version = 1
@@ -1656,20 +1788,16 @@ class TestPagesOAuthMixin:
             }
 
             mock_v2_adapter.get_page_emoji.return_value = None
-            oauth_pages_mixin.preprocessor.process_html_content.return_value = (
-                "<h1>Processed HTML</h1>",
-                "Processed markdown",
-            )
-
-            # Act - get HTML instead of markdown
+            # Act - get raw storage instead of markdown
             result = oauth_pages_mixin.get_page_history(
                 page_id, version, convert_to_markdown=False
             )
 
-            # Assert - should return HTML
+            # Assert - should return exact storage without preprocessing
             assert isinstance(result, ConfluencePage)
-            assert result.content == "<h1>Processed HTML</h1>"
+            assert result.content == "<h1>HTML</h1>"
             assert result.version.number == version
+            oauth_pages_mixin.preprocessor.process_html_content.assert_not_called()
 
     def test_get_page_history_oauth_missing_body(self, oauth_pages_mixin):
         """Test handling missing body with v2 API."""

--- a/tests/unit/confluence/test_restrictions.py
+++ b/tests/unit/confluence/test_restrictions.py
@@ -1,0 +1,169 @@
+"""Unit tests for Confluence page restriction operations."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.confluence.restrictions import RestrictionsMixin
+
+
+@pytest.fixture
+def restrictions_mixin(confluence_client):
+    """Return a RestrictionsMixin with a mocked Confluence client."""
+    with patch(
+        "mcp_atlassian.confluence.restrictions.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = RestrictionsMixin()
+        mixin.confluence = confluence_client.confluence
+        mixin.config = confluence_client.config
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+@pytest.fixture
+def restrictions_mixin_server_dc(confluence_client):
+    """Return a RestrictionsMixin configured as Server/DC."""
+    with patch(
+        "mcp_atlassian.confluence.restrictions.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = RestrictionsMixin()
+        mixin.confluence = confluence_client.confluence
+        # Use a MagicMock config so is_cloud can be set freely
+        mixin.config = MagicMock()
+        mixin.config.is_cloud = False
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+class TestGetPageRestrictions:
+    def test_get_restrictions_parses_users_and_groups(self, restrictions_mixin):
+        """get_page_restrictions extracts user account IDs and group names."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {
+            "read": {
+                "restrictions": {
+                    "user": {
+                        "results": [
+                            {"accountId": "user-111"},
+                            {"accountId": "user-222"},
+                        ]
+                    },
+                    "group": {
+                        "results": [
+                            {"name": "developers"},
+                        ]
+                    },
+                }
+            },
+            "update": {
+                "restrictions": {
+                    "user": {"results": [{"accountId": "user-111"}]},
+                    "group": {"results": []},
+                }
+            },
+        }
+
+        result = restrictions_mixin.get_page_restrictions("123")
+
+        assert result["read"]["users"] == ["user-111", "user-222"]
+        assert result["read"]["groups"] == ["developers"]
+        assert result["update"]["users"] == ["user-111"]
+        assert result["update"]["groups"] == []
+
+    def test_get_restrictions_empty_response(self, restrictions_mixin):
+        """get_page_restrictions handles an empty / unrestricted page gracefully."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {}
+
+        result = restrictions_mixin.get_page_restrictions("456")
+
+        assert result == {
+            "read": {"users": [], "groups": []},
+            "update": {"users": [], "groups": []},
+        }
+
+    def test_get_restrictions_api_error(self, restrictions_mixin):
+        """get_page_restrictions raises on API failure."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.side_effect = (
+            Exception("API error")
+        )
+
+        with pytest.raises(Exception, match="Failed to get restrictions for page 789"):
+            restrictions_mixin.get_page_restrictions("789")
+
+
+class TestSetPageRestrictions:
+    def test_set_restrictions_calls_put_with_correct_payload(self, restrictions_mixin):
+        """set_page_restrictions sends a correctly structured PUT payload."""
+        restrictions_mixin.confluence.put = MagicMock()
+
+        result = restrictions_mixin.set_page_restrictions(
+            "123",
+            read_users=["user-aaa"],
+            read_groups=["viewers"],
+            edit_users=["user-bbb"],
+            edit_groups=["editors"],
+        )
+
+        call_args = restrictions_mixin.confluence.put.call_args
+        assert call_args[0][0] == "rest/api/content/123/restriction"
+        # data is serialised as a JSON string
+        import json as _json
+
+        payload = _json.loads(call_args[1]["data"])
+
+        read_op = next(o for o in payload if o["operation"] == "read")
+        update_op = next(o for o in payload if o["operation"] == "update")
+
+        assert read_op["restrictions"]["user"][0]["accountId"] == "user-aaa"
+        assert read_op["restrictions"]["group"][0]["name"] == "viewers"
+        assert update_op["restrictions"]["user"][0]["accountId"] == "user-bbb"
+        assert update_op["restrictions"]["group"][0]["name"] == "editors"
+
+        assert result["read"]["users"] == ["user-aaa"]
+        assert result["update"]["groups"] == ["editors"]
+
+    def test_set_restrictions_empty_clears_all(self, restrictions_mixin):
+        """set_page_restrictions with no args sends empty restriction lists."""
+        import json as _json
+
+        restrictions_mixin.confluence.put = MagicMock()
+
+        result = restrictions_mixin.set_page_restrictions("123")
+
+        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        for op in payload:
+            assert op["restrictions"]["user"] == []
+            assert op["restrictions"]["group"] == []
+
+        assert result == {
+            "read": {"users": [], "groups": []},
+            "update": {"users": [], "groups": []},
+        }
+
+    def test_set_restrictions_server_dc_uses_username(
+        self, restrictions_mixin_server_dc
+    ):
+        """set_page_restrictions uses 'username' key for Server/DC instances."""
+        import json as _json
+
+        restrictions_mixin = restrictions_mixin_server_dc
+        restrictions_mixin.confluence.put = MagicMock()
+
+        restrictions_mixin.set_page_restrictions("123", edit_users=["jdoe"])
+
+        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        update_op = next(o for o in payload if o["operation"] == "update")
+        user_entry = update_op["restrictions"]["user"][0]
+        assert "username" in user_entry
+        assert "accountId" not in user_entry
+        assert user_entry["username"] == "jdoe"
+
+    def test_set_restrictions_api_error(self, restrictions_mixin):
+        """set_page_restrictions raises on PUT failure."""
+        restrictions_mixin.confluence.put = MagicMock(
+            side_effect=Exception("network error")
+        )
+
+        with pytest.raises(Exception, match="Failed to set restrictions for page 999"):
+            restrictions_mixin.set_page_restrictions("999", read_users=["u1"])

--- a/tests/unit/confluence/test_templates.py
+++ b/tests/unit/confluence/test_templates.py
@@ -1,0 +1,223 @@
+"""Unit tests for Confluence template operations."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.confluence.templates import TemplatesMixin
+
+
+@pytest.fixture
+def templates_mixin(confluence_client):
+    """Return a TemplatesMixin with a mocked Confluence client."""
+    with patch(
+        "mcp_atlassian.confluence.templates.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = TemplatesMixin()
+        mixin.confluence = confluence_client.confluence
+        mixin.config = confluence_client.config
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_SUMMARY = {
+    "templateId": "tpl-001",
+    "name": "Meeting Notes",
+    "templateType": "page",
+    "description": {"value": "Standard meeting notes template"},
+    "body": {"storage": {"value": "<h1>Meeting Notes</h1>"}},
+}
+
+_TEMPLATE_SUMMARY_2 = {
+    "templateId": "tpl-002",
+    "name": "Project Charter",
+    "templateType": "page",
+    "description": {"value": ""},
+    "body": {"storage": {"value": "<h1>Project Charter</h1>"}},
+}
+
+
+# ---------------------------------------------------------------------------
+# list_page_templates
+# ---------------------------------------------------------------------------
+
+
+class TestListPageTemplates:
+    def test_returns_list_from_api(self, templates_mixin):
+        """list_page_templates returns the raw list from the API."""
+        templates_mixin.confluence.get_content_templates.return_value = [
+            _TEMPLATE_SUMMARY,
+            _TEMPLATE_SUMMARY_2,
+        ]
+
+        result = templates_mixin.list_page_templates()
+
+        templates_mixin.confluence.get_content_templates.assert_called_once_with(
+            space=None,
+            limit=25,
+        )
+        assert len(result) == 2
+        assert result[0]["templateId"] == "tpl-001"
+        assert result[1]["name"] == "Project Charter"
+
+    def test_passes_space_key_and_limit(self, templates_mixin):
+        """list_page_templates forwards space_key and limit to the API."""
+        templates_mixin.confluence.get_content_templates.return_value = []
+
+        templates_mixin.list_page_templates(space_key="ENG", limit=50)
+
+        templates_mixin.confluence.get_content_templates.assert_called_once_with(
+            space="ENG",
+            limit=50,
+        )
+
+    def test_empty_result(self, templates_mixin):
+        """list_page_templates handles an empty result gracefully."""
+        templates_mixin.confluence.get_content_templates.return_value = []
+
+        result = templates_mixin.list_page_templates()
+
+        assert result == []
+
+    def test_api_error_raises(self, templates_mixin):
+        """list_page_templates wraps API errors with a descriptive message."""
+        templates_mixin.confluence.get_content_templates.side_effect = Exception(
+            "network error"
+        )
+
+        with pytest.raises(Exception, match="Failed to list page templates"):
+            templates_mixin.list_page_templates()
+
+
+# ---------------------------------------------------------------------------
+# get_page_template
+# ---------------------------------------------------------------------------
+
+
+class TestGetPageTemplate:
+    def test_returns_template_with_body(self, templates_mixin):
+        """get_page_template returns the full template dict including body."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+
+        result = templates_mixin.get_page_template("tpl-001")
+
+        templates_mixin.confluence.get_content_template.assert_called_once_with(
+            "tpl-001"
+        )
+        assert result["templateId"] == "tpl-001"
+        assert result["body"]["storage"]["value"] == "<h1>Meeting Notes</h1>"
+
+    def test_api_error_raises(self, templates_mixin):
+        """get_page_template wraps API errors with a descriptive message."""
+        templates_mixin.confluence.get_content_template.side_effect = Exception(
+            "not found"
+        )
+
+        with pytest.raises(Exception, match="Failed to get template tpl-999"):
+            templates_mixin.get_page_template("tpl-999")
+
+
+# ---------------------------------------------------------------------------
+# create_page_from_template
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePageFromTemplate:
+    def test_creates_page_with_template_body(self, templates_mixin):
+        """create_page_from_template fetches template then calls create_page."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "999", "title": "My Meeting Notes"}
+        )
+
+        result = templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="My Meeting Notes",
+            template_id="tpl-001",
+        )
+
+        templates_mixin.confluence.get_content_template.assert_called_once_with(
+            "tpl-001"
+        )
+        templates_mixin.confluence.create_page.assert_called_once_with(
+            space="ENG",
+            title="My Meeting Notes",
+            body="<h1>Meeting Notes</h1>",
+            parent_id=None,
+            representation="storage",
+        )
+        assert result["id"] == "999"
+        assert result["space_key"] == "ENG"
+
+    def test_passes_parent_id(self, templates_mixin):
+        """create_page_from_template forwards parent_id to create_page."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "888", "title": "Child Page"}
+        )
+
+        templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="Child Page",
+            template_id="tpl-001",
+            parent_id="777",
+        )
+
+        call_kwargs = templates_mixin.confluence.create_page.call_args[1]
+        assert call_kwargs["parent_id"] == "777"
+
+    def test_url_built_from_config(self, templates_mixin):
+        """create_page_from_template constructs the page URL from config.url."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "123", "title": "Test"}
+        )
+
+        result = templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="Test",
+            template_id="tpl-001",
+        )
+
+        assert "123" in result["url"]
+        assert "ENG" in result["url"]
+
+    def test_empty_template_body(self, templates_mixin):
+        """create_page_from_template handles a template with no body gracefully."""
+        templates_mixin.confluence.get_content_template.return_value = {
+            "templateId": "tpl-empty",
+            "name": "Empty",
+            "body": {},
+        }
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "500", "title": "Empty Page"}
+        )
+
+        templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="Empty Page",
+            template_id="tpl-empty",
+        )
+
+        call_kwargs = templates_mixin.confluence.create_page.call_args[1]
+        assert call_kwargs["body"] == ""
+
+    def test_api_error_raises(self, templates_mixin):
+        """create_page_from_template raises when template fetch fails."""
+        templates_mixin.confluence.get_content_template.side_effect = Exception(
+            "not found"
+        )
+
+        with pytest.raises(
+            Exception, match="Failed to create page from template tpl-bad"
+        ):
+            templates_mixin.create_page_from_template(
+                space_key="ENG",
+                title="Whatever",
+                template_id="tpl-bad",
+            )

--- a/tests/unit/jira/test_api_version.py
+++ b/tests/unit/jira/test_api_version.py
@@ -1,0 +1,63 @@
+"""Tests confirming Jira REST API v3 support is implemented.
+
+Regression tests for https://github.com/sooperset/mcp-atlassian/issues/338
+Feature was requested: support Jira REST API v3 for Cloud.
+Already implemented — _post_api3 and _put_api3 helpers in client.py,
+and Cloud search uses rest/api/3/search/jql endpoint.
+"""
+
+import inspect
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.search import SearchMixin
+
+
+class TestJiraRestApiV3:
+    """Jira REST API v3 is used on Cloud for ADF payloads.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/338
+    Feature was requested: support Jira REST API v3.
+    Already implemented — _post_api3 and _put_api3 helpers in client.py,
+    and Cloud search uses rest/api/3/search/jql endpoint.
+    """
+
+    def test_client_has_v3_post_method(self, jira_fetcher: JiraFetcher) -> None:
+        """JiraClient exposes a v3 POST helper for ADF payloads."""
+        assert hasattr(jira_fetcher, "_post_api3"), (
+            "_post_api3 method missing from JiraClient"
+        )
+
+    def test_client_has_v3_put_method(self, jira_fetcher: JiraFetcher) -> None:
+        """JiraClient exposes a v3 PUT helper for ADF payloads."""
+        assert hasattr(jira_fetcher, "_put_api3"), (
+            "_put_api3 method missing from JiraClient"
+        )
+
+    def test_v3_post_method_is_callable(self, jira_fetcher: JiraFetcher) -> None:
+        """_post_api3 is a callable method, not a plain attribute."""
+        assert callable(jira_fetcher._post_api3), "_post_api3 is not callable"
+
+    def test_v3_put_method_is_callable(self, jira_fetcher: JiraFetcher) -> None:
+        """_put_api3 is a callable method, not a plain attribute."""
+        assert callable(jira_fetcher._put_api3), "_put_api3 is not callable"
+
+    def test_cloud_uses_v3_search_endpoint(self) -> None:
+        """Cloud JQL search is routed through the v3 API endpoint."""
+        source = inspect.getsource(SearchMixin.search_issues)
+        assert "rest/api/3/search" in source, (
+            "Cloud v3 search endpoint not found in search_issues source"
+        )
+
+    def test_v3_post_uses_api_version_3(self, jira_fetcher: JiraFetcher) -> None:
+        """_post_api3 implementation explicitly requests api_version='3'."""
+        source = inspect.getsource(jira_fetcher._post_api3)
+        assert 'api_version="3"' in source or "api_version='3'" in source, (
+            "_post_api3 does not request API version 3 from resource_url"
+        )
+
+    def test_v3_put_uses_api_version_3(self, jira_fetcher: JiraFetcher) -> None:
+        """_put_api3 implementation explicitly requests api_version='3'."""
+        source = inspect.getsource(jira_fetcher._put_api3)
+        assert 'api_version="3"' in source or "api_version='3'" in source, (
+            "_put_api3 does not request API version 3 from resource_url"
+        )

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -396,3 +396,83 @@ def test_jira_client_basic_auth_preserves_trust_env():
         JiraClient(config=config)
 
         assert mock_session.trust_env is True
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_basic_auth_with_cloud_id():
+    """Test that basic auth with cloud_id routes through api.atlassian.com."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="basic",
+            username="svc@company.atlassian.net",
+            api_token="svc_token",
+            cloud_id="test-cloud-uuid",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://api.atlassian.com/ex/jira/test-cloud-uuid",
+            username="svc@company.atlassian.net",
+            password="svc_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_pat_auth_with_cloud_id():
+    """Test that PAT auth with cloud_id routes through api.atlassian.com."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="pat",
+            personal_token="test_pat",
+            cloud_id="test-cloud-uuid",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://api.atlassian.com/ex/jira/test-cloud-uuid",
+            token="test_pat",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_basic_auth_without_cloud_id_uses_direct_url():
+    """Test that basic auth without cloud_id uses the direct URL as before."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="basic",
+            username="user@example.com",
+            api_token="token",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://company.atlassian.net",
+            username="user@example.com",
+            password="token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )

--- a/tests/unit/jira/test_comment_visibility.py
+++ b/tests/unit/jira/test_comment_visibility.py
@@ -1,0 +1,96 @@
+"""Regression tests for comment visibility levels (upstream #725).
+
+Verifies that add_comment correctly passes visibility restrictions to
+the Jira API and rejects invalid combinations (visibility + public).
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_atlassian.jira.comments import CommentsMixin
+
+
+class TestCommentVisibility:
+    """Visibility level regression tests for upstream #725."""
+
+    @pytest.fixture
+    def comments_mixin(self, jira_client):
+        """Create a CommentsMixin instance with mocked dependencies."""
+        mixin = CommentsMixin(config=jira_client.config)
+        mixin.jira = jira_client.jira
+
+        # Set up a mock preprocessor with markdown_to_jira method
+        mixin.preprocessor = Mock()
+        mixin.preprocessor.markdown_to_jira = Mock(
+            return_value="*This* is _Jira_ formatted"
+        )
+
+        # Mock the clean_text method
+        mixin._clean_text = Mock(side_effect=lambda x: x)
+
+        return mixin
+
+    def test_add_comment_visibility_group_jira_developers(self, comments_mixin):
+        """add_comment accepts group visibility restricting to jira-developers.
+
+        Regression for https://github.com/sooperset/mcp-atlassian/issues/725
+        """
+        mock_response = {
+            "id": "10001",
+            "body": "Restricted comment",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "John Doe"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+
+        result = comments_mixin.add_comment(
+            "TEST-123",
+            "Restricted comment",
+            visibility={"type": "group", "value": "jira-developers"},
+        )
+
+        call_args = comments_mixin._post_api3.call_args
+        payload = call_args[0][1]
+        assert payload["visibility"] == {"type": "group", "value": "jira-developers"}
+        assert result["id"] == "10001"
+
+    def test_add_comment_visibility_role_administrators(self, comments_mixin):
+        """add_comment accepts role visibility restricting to Administrators.
+
+        Regression for https://github.com/sooperset/mcp-atlassian/issues/725
+        """
+        mock_response = {
+            "id": "10002",
+            "body": "Admin-only comment",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "Jane Smith"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+
+        result = comments_mixin.add_comment(
+            "TEST-456",
+            "Admin-only comment",
+            visibility={"type": "role", "value": "Administrators"},
+        )
+
+        call_args = comments_mixin._post_api3.call_args
+        payload = call_args[0][1]
+        assert payload["visibility"] == {"type": "role", "value": "Administrators"}
+        assert result["id"] == "10002"
+
+    def test_add_comment_visibility_and_public_raises_value_error(self, comments_mixin):
+        """Combining visibility with public=True raises ValueError.
+
+        The ServiceDesk API (used when public is set) does not support Jira
+        visibility restrictions — mixing both is rejected before any API call.
+
+        Regression for https://github.com/sooperset/mcp-atlassian/issues/725
+        """
+        with pytest.raises(ValueError, match="Cannot use both"):
+            comments_mixin.add_comment(
+                "TEST-123",
+                "Conflicting comment",
+                visibility={"type": "group", "value": "jira-developers"},
+                public=True,
+            )

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -551,3 +551,97 @@ class TestCommentsMixin:
         # ServiceDesk post should NOT be called
         comments_mixin.jira.post.assert_not_called()
         assert result["id"] == "10001"
+
+
+class TestInternalCommentPublicParam:
+    """Regression tests for add_comment public parameter (internal comments).
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/716
+    Feature was requested: make comment internal (public: false) via JSM API.
+    Already implemented: add_comment(public=False) routes through
+    _add_servicedesk_comment which posts to rest/servicedeskapi/request/.../comment.
+    """
+
+    SERVICEDESK_COMMENT_RESPONSE = {
+        "id": 10001,
+        "body": "Test comment",
+        "public": True,
+        "created": {
+            "iso8601": "2024-01-01T10:00:00.000+0000",
+            "jira": "2024-01-01T10:00:00.000+0000",
+            "friendly": "Today 10:00 AM",
+            "epochMillis": 1704099600000,
+        },
+        "author": {
+            "accountId": "test-id",
+            "displayName": "Test User",
+        },
+    }
+
+    @pytest.fixture
+    def comments_mixin(self, jira_client):
+        """Create a CommentsMixin instance with mocked dependencies."""
+        mixin = CommentsMixin(config=jira_client.config)
+        mixin.jira = jira_client.jira
+        mixin.preprocessor = Mock()
+        mixin.preprocessor.markdown_to_jira = Mock(
+            return_value="*This* is _Jira_ formatted"
+        )
+        mixin._clean_text = Mock(side_effect=lambda x: x)
+        return mixin
+
+    def test_public_false_calls_servicedesk_comment(self, comments_mixin):
+        """add_comment(public=False) routes through _add_servicedesk_comment."""
+        captured: list[tuple] = []
+        original = comments_mixin._add_servicedesk_comment
+
+        def spy(*args, **kwargs):
+            captured.append((args, kwargs))
+            return original(*args, **kwargs)
+
+        comments_mixin._add_servicedesk_comment = spy
+        response = {**self.SERVICEDESK_COMMENT_RESPONSE, "public": False}
+        comments_mixin.jira.post.return_value = response
+
+        comments_mixin.add_comment("ISSUE-1", "Internal note", public=False)
+
+        assert len(captured) == 1
+        assert captured[0][0] == ("ISSUE-1", "Internal note", False)  # noqa: FBT003
+
+    def test_public_true_calls_servicedesk_comment(self, comments_mixin):
+        """add_comment(public=True) routes through _add_servicedesk_comment."""
+        captured: list[tuple] = []
+        original = comments_mixin._add_servicedesk_comment
+
+        def spy(*args, **kwargs):
+            captured.append((args, kwargs))
+            return original(*args, **kwargs)
+
+        comments_mixin._add_servicedesk_comment = spy
+        response = {**self.SERVICEDESK_COMMENT_RESPONSE, "public": True}
+        comments_mixin.jira.post.return_value = response
+
+        comments_mixin.add_comment("ISSUE-1", "Customer reply", public=True)
+
+        assert len(captured) == 1
+        assert captured[0][0] == ("ISSUE-1", "Customer reply", True)  # noqa: FBT003
+
+    def test_public_none_does_not_call_servicedesk_comment(self, comments_mixin):
+        """add_comment(public=None default) does NOT call _add_servicedesk_comment."""
+        captured: list[tuple] = []
+
+        def spy(*args, **kwargs):
+            captured.append((args, kwargs))
+
+        comments_mixin._add_servicedesk_comment = spy
+        mock_response = {
+            "id": "10001",
+            "body": "Normal comment",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "John Doe"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+
+        comments_mixin.add_comment("ISSUE-1", "text")
+
+        assert len(captured) == 0

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -430,3 +430,99 @@ def test_from_env_without_cookie():
     ):
         config = JiraConfig.from_env()
         assert config.cookie is None
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_service_account_with_cloud_id():
+    """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.auth_type == "basic"
+        assert config.is_cloud is True
+        assert config.username == "svc@company.atlassian.net"
+
+
+def test_from_env_service_account_with_jira_cloud_id():
+    """Test service-specific JIRA_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "global-cloud-id",
+            "JIRA_CLOUD_ID": "jira-specific-cloud-id",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "jira-specific-cloud-id"
+
+
+def test_from_env_service_account_no_url_required():
+    """Test that JIRA_URL is not required when cloud_id is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        # Should not raise ValueError about missing URL
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == ""
+
+
+def test_from_env_service_account_with_url():
+    """Test service account config with both cloud_id and URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://company.atlassian.net",
+            "JIRA_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == "https://company.atlassian.net"
+        assert config.is_cloud is True
+
+
+def test_is_cloud_with_cloud_id_basic_auth():
+    """Test is_cloud returns True when cloud_id is set, regardless of URL."""
+    config = JiraConfig(
+        url="",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True
+
+    # Even with a server-like URL, cloud_id means Cloud
+    config = JiraConfig(
+        url="https://jira.example.com",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -401,3 +401,32 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://jira.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+def test_from_env_with_cookie():
+    """Test that from_env reads JIRA_COOKIE and stores it in config."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+            "JIRA_COOKIE": "JSESSIONID=abc123; other=xyz",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cookie == "JSESSIONID=abc123; other=xyz"
+
+
+def test_from_env_without_cookie():
+    """Test that cookie defaults to None when JIRA_COOKIE is not set."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cookie is None

--- a/tests/unit/jira/test_epics.py
+++ b/tests/unit/jira/test_epics.py
@@ -1,5 +1,6 @@
 """Tests for the Jira Epics mixin."""
 
+import inspect
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -48,7 +49,8 @@ class TestEpicsMixin:
             "fields": {
                 "issuetype": {"name": "Epic"},
                 "summary": "Test Epic",
-                "customfield_10011": "Epic Name Value",  # This should be discovered as epic_name
+                # Should be discovered as epic_name
+                "customfield_10011": "Epic Name Value",
             },
         }
 
@@ -81,8 +83,11 @@ class TestEpicsMixin:
     def test_try_discover_fields_from_existing_epic_with_both_fields(
         self, epics_mixin: EpicsMixin
     ):
-        """Test _try_discover_fields_from_existing_epic when both fields already exist."""
-        field_ids = {"epic_link": "customfield_10014", "epic_name": "customfield_10011"}
+        """_try_discover_fields_from_existing_epic is skipped when both fields exist."""
+        field_ids = {
+            "epic_link": "customfield_10014",
+            "epic_name": "customfield_10011",
+        }
 
         # Call the method - no JQL should be executed
         epics_mixin._try_discover_fields_from_existing_epic(field_ids)
@@ -441,8 +446,10 @@ class TestEpicsMixin:
             return_value={
                 "random_field": "customfield_12345",
                 "some_other_field": "customfield_67890",
-                "Epic-FieldName": "customfield_11111",  # Should be found by pattern matching
-                "epic_colour_field": "customfield_22222",  # Should be found by pattern matching
+                # Should be found by pattern matching
+                "Epic-FieldName": "customfield_11111",
+                # Should be found by pattern matching
+                "epic_colour_field": "customfield_22222",
             }
         )
 
@@ -450,8 +457,8 @@ class TestEpicsMixin:
         fields = {}
         kwargs = {}
 
-        # The _get_epic_name_field_id and _get_epic_color_field_id methods should discover
-        # the fields by pattern matching, even though they're not in the standard format
+        # _get_epic_name_field_id and _get_epic_color_field_id should discover
+        # fields by pattern matching even when not in standard format
 
         # We need to patch these methods to return the expected values
         original_get_name = epics_mixin._get_epic_name_field_id
@@ -722,7 +729,7 @@ class TestEpicsMixin:
             def __len__(self):
                 return len(self.issues)
 
-        # Mock search_issues to return empty results for issueFunction but results for epic_link
+        # Mock: empty for issueFunction, results for epic_link
         def search_side_effect(jql, **kwargs):
             if "issueFunction" in jql:
                 return MockSearchResult([])  # No results for issueFunction
@@ -765,3 +772,71 @@ class TestEpicsMixin:
             match="Error getting epic issues: API error",
         ):
             epics_mixin.get_epic_issues("EPIC-123")
+
+
+class TestEpicFieldDynamicDetection:
+    """Epic link field IDs are detected dynamically, not hardcoded as a fixed value.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/454
+    """
+
+    @pytest.fixture
+    def epics_mixin(self, jira_fetcher: JiraFetcher) -> EpicsMixin:
+        """Create an EpicsMixin instance with mocked dependencies."""
+        return jira_fetcher
+
+    def test_get_field_ids_to_epic_method_exists(self, epics_mixin: EpicsMixin):
+        """get_field_ids_to_epic exists for dynamic field ID detection.
+
+        The method queries the Jira API to discover custom field IDs at runtime,
+        rather than assuming a fixed ID such as customfield_10008.
+        """
+        assert hasattr(epics_mixin, "get_field_ids_to_epic")
+        assert callable(epics_mixin.get_field_ids_to_epic)
+
+    def test_customfield_10008_not_the_only_strategy_in_epics_mixin(self):
+        """EpicsMixin uses dynamic discovery as its primary strategy.
+
+        customfield_10008 may appear in fallback lists but is not the sole
+        strategy. The primary path calls get_field_ids_to_epic() which
+        queries the live Jira field definitions.
+        """
+        source = inspect.getsource(EpicsMixin)
+        # Dynamic discovery method must be present
+        assert "get_field_ids_to_epic" in source, (
+            "EpicsMixin must call get_field_ids_to_epic() for dynamic field detection"
+        )
+
+    def test_get_field_ids_to_epic_returns_dict(self, epics_mixin: EpicsMixin):
+        """get_field_ids_to_epic returns a dict mapping names to field IDs."""
+        epics_mixin.jira.jql.return_value = {"issues": []}
+        result = epics_mixin.get_field_ids_to_epic()
+        assert isinstance(result, dict)
+
+    def test_get_field_ids_to_epic_discovers_epic_link_dynamically(
+        self, epics_mixin: EpicsMixin
+    ):
+        """get_field_ids_to_epic discovers epic_link using live field definitions.
+
+        When the API returns a field named 'Epic Link', the method maps it to
+        the correct custom field ID for that Jira instance rather than assuming
+        a hardcoded value.
+        """
+        epics_mixin.jira.get_all_fields.return_value = [
+            {
+                "id": "customfield_99999",
+                "name": "Epic Link",
+                "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-link"},
+            }
+        ]
+        epics_mixin._field_ids_cache = None
+        epics_mixin._field_map_cache = None
+
+        result = epics_mixin.get_field_ids_to_epic()
+
+        assert isinstance(result, dict)
+        # The dynamically discovered field ID must appear in the result
+        found_ids = list(result.values())
+        assert "customfield_99999" in found_ids, (
+            f"Expected dynamically discovered 'customfield_99999' in {found_ids}"
+        )

--- a/tests/unit/jira/test_field_options.py
+++ b/tests/unit/jira/test_field_options.py
@@ -155,6 +155,45 @@ class TestFieldOptionModel:
         assert opt.child_options[0].value == "United States"
         assert opt.child_options[1].value == "Canada"
 
+    def test_children_key_server_dc(self):
+        """Server/DC createmeta uses 'children' instead of 'cascadingOptions'."""
+        data = {
+            "id": "10200",
+            "value": "North America",
+            "children": [
+                {"id": "10201", "value": "United States"},
+                {"id": "10202", "value": "Canada"},
+            ],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.value == "North America"
+        assert len(opt.child_options) == 2
+        assert opt.child_options[0].value == "United States"
+        assert opt.child_options[1].value == "Canada"
+
+    def test_cascading_options_empty_list_not_shadowed_by_children(self):
+        """An explicit empty cascadingOptions is not overridden by children."""
+        data = {
+            "id": "10200",
+            "value": "Parent",
+            "cascadingOptions": [],
+            "children": [{"id": "1", "value": "Should not appear"}],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.child_options == []
+
+    def test_cascading_options_key_takes_precedence_over_children(self):
+        """cascadingOptions wins when both keys are present."""
+        data = {
+            "id": "10200",
+            "value": "Parent",
+            "cascadingOptions": [{"id": "1", "value": "Cascade Child"}],
+            "children": [{"id": "2", "value": "Regular Child"}],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert len(opt.child_options) == 1
+        assert opt.child_options[0].value == "Cascade Child"
+
     def test_to_simplified_dict_with_children(self):
         opt = FieldOption(
             id="1",
@@ -339,28 +378,125 @@ class TestFieldOptionsMixin:
 
     def test_options_cloud_cascading(self, mixin):
         mixin.config.is_cloud = True
+        # Cloud main endpoint returns a flat list; children reference
+        # their parent via "optionId" or are available via the
+        # cascade-specific endpoint. Mock the main list followed by
+        # the cascade endpoint response for the parent.
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [
-                    {
-                        "id": "10200",
-                        "value": "Americas",
-                        "cascadingOptions": [
-                            {"id": "10201", "value": "US"},
-                            {"id": "10202", "value": "Canada"},
-                        ],
-                    }
-                ],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 1,
-            }
+            side_effect=[
+                # main options list (parent only)
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade-specific endpoint for parent 10200
+                {
+                    "values": [
+                        {"id": "10201", "value": "US"},
+                        {"id": "10202", "value": "Canada"},
+                    ]
+                },
+            ]
         )
 
         result = mixin.get_field_options("customfield_10020", context_id="10001")
         assert len(result) == 1
         assert result[0].value == "Americas"
         assert len(result[0].child_options) == 2
+
+    def test_options_cloud_cascading_cascade_pagination(self, mixin):
+        """Cascade endpoint paginates across multiple pages."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options list (one parent)
+                {
+                    "values": [{"id": "10200", "value": "Americas"}],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade endpoint page 1
+                {
+                    "values": [
+                        {"id": "10201", "value": "US"},
+                        {"id": "10202", "value": "Canada"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+                # cascade endpoint page 2
+                {
+                    "values": [{"id": "10203", "value": "Mexico"}],
+                    "startAt": 2,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 3
+        assert result[0].child_options[2].value == "Mexico"
+
+    def test_options_cloud_cascading_flat_list_fallback(self, mixin):
+        """When cascade endpoint is unreachable, fall back to optionId grouping."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options: parent + children as flat list with optionId
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                        {"id": "10201", "value": "US", "optionId": "10200"},
+                        {"id": "10202", "value": "Canada", "optionId": "10200"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 3,
+                },
+                # cascade endpoint unavailable
+                Exception("404 Not Found"),
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 2
+        assert {c.value for c in result[0].child_options} == {"US", "Canada"}
+
+    def test_options_cloud_cascading_empty_cascade_no_fallback(self, mixin):
+        """Empty cascade response is trusted; optionId fallback must not trigger."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options: parent + flat-list child (optionId present)
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                        {"id": "10201", "value": "US", "optionId": "10200"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 2,
+                },
+                # cascade endpoint responds but says no children
+                {"values": [], "total": 0},
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert result[0].child_options == []
 
     # -- get_field_options (Server/DC) --------------------------------------
 
@@ -517,6 +653,47 @@ class TestFieldOptionsMixin:
         assert len(result) == 1
         assert result[0].value == "Yes"
 
+    def test_options_server_cascading_children_key(self, mixin):
+        """Server/DC allowedValues with 'children' key for cascading select."""
+        mixin.config.is_cloud = False
+        mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Bug"}]
+        )
+        mixin.jira.issue_createmeta_fieldtypes = MagicMock(
+            return_value={
+                "maxResults": 50,
+                "startAt": 0,
+                "total": 1,
+                "isLast": True,
+                "values": [
+                    {
+                        "fieldId": "customfield_10020",
+                        "required": False,
+                        "name": "Region",
+                        "allowedValues": [
+                            {
+                                "id": "10200",
+                                "value": "Americas",
+                                "children": [
+                                    {"id": "10201", "value": "US"},
+                                    {"id": "10202", "value": "Canada"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        result = mixin.get_field_options(
+            "customfield_10020", project_key="TEST", issue_type="Bug"
+        )
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 2
+        assert result[0].child_options[0].value == "US"
+        assert result[0].child_options[1].value == "Canada"
+
 
 # ============================================================================
 # Regression Tests — upstream #673
@@ -549,16 +726,23 @@ class TestGetFieldOptionsRegression673:
         (strings) for a custom field so callers know what to submit.
         """
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [
-                    {"id": "10100", "value": "Blocker", "disabled": False},
-                    {"id": "10101", "value": "Critical", "disabled": False},
-                    {"id": "10102", "value": "Major", "disabled": False},
-                ],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 3,
-            }
+            side_effect=[
+                # main options list (flat, no children)
+                {
+                    "values": [
+                        {"id": "10100", "value": "Blocker", "disabled": False},
+                        {"id": "10101", "value": "Critical", "disabled": False},
+                        {"id": "10102", "value": "Major", "disabled": False},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 3,
+                },
+                # cascade endpoint for each parent (empty — no children)
+                {"values": []},
+                {"values": []},
+                {"values": []},
+            ]
         )
 
         result = mixin.get_field_options("customfield_10016", context_id="10001")
@@ -573,12 +757,16 @@ class TestGetFieldOptionsRegression673:
     def test_get_field_options_returns_field_option_objects(self, mixin):
         """Each returned item is a FieldOption with id, value, disabled attrs."""
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [{"id": "10200", "value": "Yes", "disabled": False}],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 1,
-            }
+            side_effect=[
+                {
+                    "values": [{"id": "10200", "value": "Yes", "disabled": False}],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade endpoint (empty)
+                {"values": []},
+            ]
         )
 
         result = mixin.get_field_options("customfield_10020", context_id="10001")
@@ -593,15 +781,20 @@ class TestGetFieldOptionsRegression673:
     def test_get_field_options_to_simplified_dict_contract(self, mixin):
         """to_simplified_dict() provides the serialisable form consumers need."""
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [
-                    {"id": "10300", "value": "Done", "disabled": False},
-                    {"id": "10301", "value": "Won't Do", "disabled": True},
-                ],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 2,
-            }
+            side_effect=[
+                {
+                    "values": [
+                        {"id": "10300", "value": "Done", "disabled": False},
+                        {"id": "10301", "value": "Won't Do", "disabled": True},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 2,
+                },
+                # cascade endpoint for each parent (empty)
+                {"values": []},
+                {"values": []},
+            ]
         )
 
         result = mixin.get_field_options("customfield_10030", context_id="10001")

--- a/tests/unit/jira/test_field_options.py
+++ b/tests/unit/jira/test_field_options.py
@@ -516,3 +516,140 @@ class TestFieldOptionsMixin:
         )
         assert len(result) == 1
         assert result[0].value == "Yes"
+
+
+# ============================================================================
+# Regression Tests — upstream #673
+# ============================================================================
+
+
+class TestGetFieldOptionsRegression673:
+    """Regression for https://github.com/sooperset/mcp-atlassian/issues/673.
+
+    Issue: "Get Jira custom field available values"
+    Status: RESOLVED — get_field_options MCP tool already exists and the
+    fetcher method returns option values with id, value, and disabled fields.
+
+    These tests prove the end-to-end data contract: the fetcher returns
+    FieldOption objects with the fields users need to inspect available values.
+    """
+
+    @pytest.fixture
+    def mixin(self, jira_fetcher: JiraFetcher) -> FieldOptionsMixin:
+        """Create a FieldOptionsMixin configured for Cloud."""
+        fetcher = jira_fetcher
+        fetcher.config = MagicMock()
+        fetcher.config.is_cloud = True
+        return fetcher
+
+    def test_get_field_options_returns_option_values(self, mixin):
+        """get_field_options returns a list of FieldOption with value populated.
+
+        Regression: the core ask in #673 was to retrieve the available values
+        (strings) for a custom field so callers know what to submit.
+        """
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [
+                    {"id": "10100", "value": "Blocker", "disabled": False},
+                    {"id": "10101", "value": "Critical", "disabled": False},
+                    {"id": "10102", "value": "Major", "disabled": False},
+                ],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 3,
+            }
+        )
+
+        result = mixin.get_field_options("customfield_10016", context_id="10001")
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+        values = [opt.value for opt in result]
+        assert "Blocker" in values
+        assert "Critical" in values
+        assert "Major" in values
+
+    def test_get_field_options_returns_field_option_objects(self, mixin):
+        """Each returned item is a FieldOption with id, value, disabled attrs."""
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [{"id": "10200", "value": "Yes", "disabled": False}],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 1,
+            }
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+
+        assert len(result) == 1
+        opt = result[0]
+        assert isinstance(opt, FieldOption)
+        assert opt.id == "10200"
+        assert opt.value == "Yes"
+        assert opt.disabled is False
+
+    def test_get_field_options_to_simplified_dict_contract(self, mixin):
+        """to_simplified_dict() provides the serialisable form consumers need."""
+        mixin.jira.get = MagicMock(
+            return_value={
+                "values": [
+                    {"id": "10300", "value": "Done", "disabled": False},
+                    {"id": "10301", "value": "Won't Do", "disabled": True},
+                ],
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 2,
+            }
+        )
+
+        result = mixin.get_field_options("customfield_10030", context_id="10001")
+
+        active = next(o for o in result if o.value == "Done")
+        deprecated = next(o for o in result if o.value == "Won't Do")
+
+        active_dict = active.to_simplified_dict()
+        assert active_dict["id"] == "10300"
+        assert active_dict["value"] == "Done"
+        assert "disabled" not in active_dict  # omitted when False
+
+        deprecated_dict = deprecated.to_simplified_dict()
+        assert deprecated_dict["disabled"] is True
+
+    def test_get_field_options_server_returns_allowed_values(self, mixin):
+        """Server/DC path: allowedValues from createmeta are returned as options.
+
+        Confirms the feature works on Jira Server/DC as well as Cloud.
+        """
+        mixin.config.is_cloud = False
+        mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Story"}]
+        )
+        mixin.jira.issue_createmeta_fieldtypes = MagicMock(
+            return_value={
+                "maxResults": 50,
+                "startAt": 0,
+                "total": 1,
+                "isLast": True,
+                "values": [
+                    {
+                        "fieldId": "customfield_10016",
+                        "required": False,
+                        "name": "Sprint",
+                        "allowedValues": [
+                            {"id": "1", "value": "Sprint 1"},
+                            {"id": "2", "value": "Sprint 2"},
+                        ],
+                    },
+                ],
+            }
+        )
+
+        result = mixin.get_field_options(
+            "customfield_10016", project_key="PROJ", issue_type="Story"
+        )
+
+        assert len(result) == 2
+        assert result[0].value == "Sprint 1"
+        assert result[1].value == "Sprint 2"

--- a/tests/unit/jira/test_issue_creation_logic.py
+++ b/tests/unit/jira/test_issue_creation_logic.py
@@ -68,6 +68,8 @@ def issues_mixin():
     with patch("mcp_atlassian.jira.config.JiraConfig.from_env") as mock_from_env:
         mock_config = MagicMock()
         mock_config.is_cloud = True
+        mock_config.url = "https://test.atlassian.net"
+        mock_config.ssl_verify = True
         mock_from_env.return_value = mock_config
 
         mixin = ConcreteIssuesMixin()

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1854,3 +1854,46 @@ class TestIssuesMixin:
         assert isinstance(result, JiraIssue)
         assert result.key == "DEV-123"
         assert result.summary == "Development issue"
+
+    def test_find_issue_type_id_exact_match(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id resolves type name to ID."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[
+                {"id": "10000", "name": "Bug"},
+                {"id": "10001", "name": "Story"},
+            ]
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "Bug") == "10000"
+        assert issues_mixin._find_issue_type_id("PROJ", "Story") == "10001"
+
+    def test_find_issue_type_id_case_insensitive(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id matches case-insensitively."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Story"}]
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "story") == "10001"
+        assert issues_mixin._find_issue_type_id("PROJ", "STORY") == "10001"
+
+    def test_find_issue_type_id_untranslated_fallback(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id falls back to untranslatedName for localized instances."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[
+                {"id": "10001", "name": "스토리", "untranslatedName": "Story"},
+            ]
+        )
+        # Korean name doesn't match "Story", but untranslatedName does
+        assert issues_mixin._find_issue_type_id("PROJ", "Story") == "10001"
+
+    def test_find_issue_type_id_not_found(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id returns None when type not found."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10000", "name": "Bug"}]
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "Nonexistent") is None
+
+    def test_find_issue_type_id_exception(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id returns None on exception."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            side_effect=Exception("API error")
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "Bug") is None

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -684,6 +684,62 @@ class TestIssuesMixin:
         assert not issues_mixin._get_account_id.called
         assert document.key == "TEST-123"
 
+    def test_assign_issue(self, issues_mixin: IssuesMixin, make_issue_data):
+        """Test assigning an issue to a user via dedicated endpoint."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock(return_value="account-123")
+
+        document = issues_mixin.assign_issue(
+            issue_key="TEST-123", assignee="user@example.com"
+        )
+
+        issues_mixin._get_account_id.assert_called_once_with("user@example.com")
+        issues_mixin.jira.assign_issue.assert_called_once_with(
+            "TEST-123", "account-123"
+        )
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_unassign(self, issues_mixin: IssuesMixin, make_issue_data):
+        """Test unassigning an issue (passing None)."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(issue_key="TEST-123", assignee=None)
+
+        issues_mixin.jira.assign_issue.assert_called_once_with("TEST-123", None)
+        assert not issues_mixin._get_account_id.called
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_empty_string(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Test unassigning an issue (passing empty string)."""
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description="This is a test"
+        )
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+        issues_mixin._get_account_id = MagicMock()
+
+        document = issues_mixin.assign_issue(issue_key="TEST-123", assignee="")
+
+        issues_mixin.jira.assign_issue.assert_called_once_with("TEST-123", None)
+        assert not issues_mixin._get_account_id.called
+        assert document.key == "TEST-123"
+
+    def test_assign_issue_error(self, issues_mixin: IssuesMixin):
+        """Test error handling when assignment fails."""
+        issues_mixin.jira.assign_issue.side_effect = Exception("Permission denied")
+        issues_mixin._get_account_id = MagicMock(return_value="account-123")
+
+        with pytest.raises(ValueError, match="Failed to assign issue TEST-123"):
+            issues_mixin.assign_issue(issue_key="TEST-123", assignee="user@example.com")
+
     def test_update_issue_components(self, issues_mixin: IssuesMixin):
         """Test updating an issue's components field."""
         issue_data = {
@@ -779,6 +835,29 @@ class TestIssuesMixin:
         )
         assert document.key == "TEST-123"
 
+    def test_update_issue_clears_field_with_none(self, issues_mixin: IssuesMixin):
+        """Test update_issue passes None through kwargs to clear a field."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        issues_mixin.update_issue(issue_key="TEST-123", priority=None)
+
+        issues_mixin.jira.update_issue.assert_called_once()
+        call_kwargs = issues_mixin.jira.update_issue.call_args
+        fields = call_kwargs[1]["update"]["fields"]
+        assert "priority" in fields
+        assert fields["priority"] is None
+
     def test_delete_issue(self, issues_mixin: IssuesMixin):
         """Test deleting an issue."""
         # Call the method
@@ -813,6 +892,44 @@ class TestIssuesMixin:
         # Verify fixVersions was added correctly to fields
         assert "fixVersions" in fields
         assert fields["fixVersions"] == [{"name": "TestRelease"}]
+
+    def test_process_additional_fields_none_clears_field(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test _process_additional_fields passes None through to clear fields."""
+        fields = {}
+        kwargs = {"customfield_10013": None}  # Sprint field, set to null
+
+        issues_mixin._process_additional_fields(fields, kwargs)
+
+        # None must be preserved — it tells Jira API to clear the field
+        assert "customfield_10013" in fields
+        assert fields["customfield_10013"] is None
+
+    def test_process_additional_fields_none_clears_named_field(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test _process_additional_fields passes None through for named fields."""
+        fields = {}
+        kwargs = {"priority": None}
+
+        issues_mixin._process_additional_fields(fields, kwargs)
+
+        # priority=None should clear the priority field
+        assert "priority" in fields
+        assert fields["priority"] is None
+
+    def test_process_additional_fields_invalid_value_still_skipped(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test _process_additional_fields still skips fields with invalid format."""
+        fields = {}
+        kwargs = {"priority": 12345}  # Invalid: priority expects string or dict
+
+        issues_mixin._process_additional_fields(fields, kwargs)
+
+        # Invalid value should NOT be added to fields
+        assert "priority" not in fields
 
     def test_create_issue_with_parent_for_task(
         self, issues_mixin: IssuesMixin, make_issue_data

--- a/tests/unit/jira/test_jsm_internal_comments.py
+++ b/tests/unit/jira/test_jsm_internal_comments.py
@@ -1,0 +1,50 @@
+"""Tests for JSM internal comments (upstream #847)."""
+
+from __future__ import annotations
+
+import inspect
+
+from mcp_atlassian.jira import JiraFetcher
+
+
+class TestJsmInternalComments:
+    """JSM internal (agent-only) comments via public=False.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/847
+    Feature: same as #716 — add_comment(public=False) via ServiceDesk API.
+    Already implemented. See also PR #1111 (closes #716, same feature).
+    """
+
+    def test_add_comment_has_public_param(self, jira_fetcher: JiraFetcher) -> None:
+        """add_comment accepts a public parameter for JSM."""
+        sig = inspect.signature(jira_fetcher.add_comment)
+        assert "public" in sig.parameters, (
+            "add_comment has no public param — JSM internal comments not supported"
+        )
+
+    def test_servicedesk_comment_method_exists(self, jira_fetcher: JiraFetcher) -> None:
+        """_add_servicedesk_comment method exists for routing internal comments."""
+        assert hasattr(jira_fetcher, "_add_servicedesk_comment"), (
+            "_add_servicedesk_comment not found — ServiceDesk routing not implemented"
+        )
+
+    def test_public_false_routes_to_servicedesk(
+        self, jira_fetcher: JiraFetcher
+    ) -> None:
+        """add_comment(public=False) routes through ServiceDesk API."""
+        calls: list[tuple] = []
+        original = jira_fetcher._add_servicedesk_comment
+
+        def capture(*args: object, **kwargs: object) -> dict:
+            calls.append(args)
+            return {"id": "123", "body": "test", "public": False}
+
+        jira_fetcher._add_servicedesk_comment = capture  # type: ignore[method-assign]
+        try:
+            jira_fetcher.add_comment("JSMTEST-1", "Internal note", public=False)
+        finally:
+            jira_fetcher._add_servicedesk_comment = original  # type: ignore[method-assign]
+
+        assert len(calls) == 1, "add_comment(public=False) did not call ServiceDesk API"
+        assert calls[0][1] == "Internal note"
+        assert calls[0][2] is False

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -219,37 +219,64 @@ class TestLinksMixin:
         url: str,
         api_version: str,
     ):
-        """Test successful retrieval of remote issue links."""
+        """Test successful retrieval with simplified shape extraction."""
         config = jira_config_factory(url=url)
         mixin = LinksMixin(config=config)
         mixin.jira = mock_atlassian_jira
-        mock_links = [
+        mock_response = [
             {
-                "id": 1,
+                "id": 10000,
+                "self": "https://jira.example.com/rest/api/3/...",
+                "globalId": "system=https://github.com&id=42",
                 "object": {
-                    "url": "https://example.com",
-                    "title": "Link 1",
+                    "url": "https://github.com/org/repo/pull/42",
+                    "title": "PR #42: Fix bug",
+                    "summary": "A pull request",
+                    "icon": {"url16x16": "https://github.com/favicon.ico"},
+                    "status": {"resolved": False},
                 },
+                "relationship": "links to",
+                "application": {"type": "com.github", "name": "GitHub"},
             },
             {
-                "id": 2,
+                "id": 10001,
                 "object": {
-                    "url": "https://example.org",
-                    "title": "Link 2",
+                    "url": "https://example.com/docs",
+                    "title": "Documentation",
                 },
             },
         ]
-        mixin.jira.get.return_value = mock_links
+        mixin.jira.get.return_value = mock_response
 
         result = mixin.get_remote_issue_links("PROJ-123")
 
-        assert result == mock_links
+        assert len(result) == 2
+        # First link: all optional fields present
+        assert result[0]["id"] == 10000
+        assert result[0]["url"] == "https://github.com/org/repo/pull/42"
+        assert result[0]["title"] == "PR #42: Fix bug"
+        assert result[0]["summary"] == "A pull request"
+        assert result[0]["relationship"] == "links to"
+        assert result[0]["application"] == "GitHub"
+        assert result[0]["resolved"] is False
+        # Noise fields excluded
+        assert "self" not in result[0]
+        assert "globalId" not in result[0]
+        assert "icon" not in result[0]
+        # Second link: minimal fields only
+        assert result[1]["id"] == 10001
+        assert result[1]["url"] == "https://example.com/docs"
+        assert result[1]["title"] == "Documentation"
+        assert "summary" not in result[1]
+        assert "relationship" not in result[1]
+        assert "application" not in result[1]
+        assert "resolved" not in result[1]
         mixin.jira.get.assert_called_once_with(
             f"rest/api/{api_version}/issue/PROJ-123/remotelink"
         )
 
     def test_get_remote_issue_links_dict_response(self, links_mixin):
-        """Test dict responses are unwrapped correctly."""
+        """Test dict responses are unwrapped and simplified."""
         inner = [
             {
                 "id": 1,
@@ -263,10 +290,12 @@ class TestLinksMixin:
 
         result = links_mixin.get_remote_issue_links("PROJ-123")
 
-        assert result == inner
+        assert len(result) == 1
+        assert result[0]["url"] == "https://example.com"
+        assert result[0]["title"] == "A"
 
     def test_get_remote_issue_links_dict_without_key(self, links_mixin):
-        """Dict without remoteLinks wraps as single-element list."""
+        """Dict without remoteLinks wraps as single-element list and simplifies."""
         single = {
             "id": 1,
             "object": {
@@ -278,11 +307,25 @@ class TestLinksMixin:
 
         result = links_mixin.get_remote_issue_links("PROJ-123")
 
-        assert result == [single]
+        assert len(result) == 1
+        assert result[0]["url"] == "https://example.com"
 
     def test_get_remote_issue_links_empty(self, links_mixin):
         """Test empty list response."""
         links_mixin.jira.get.return_value = []
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == []
+
+    def test_get_remote_issue_links_missing_issue_key(self, links_mixin):
+        """Test empty issue key raises ValueError."""
+        with pytest.raises(ValueError, match="Issue key is required"):
+            links_mixin.get_remote_issue_links("")
+
+    def test_get_remote_issue_links_unexpected_response(self, links_mixin):
+        """Test non-list/non-dict response returns empty list."""
+        links_mixin.jira.get.return_value = "not a list"
 
         result = links_mixin.get_remote_issue_links("PROJ-123")
 

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -204,3 +204,93 @@ class TestLinksMixin:
 
         with pytest.raises(MCPAtlassianAuthenticationError):
             links_mixin.remove_issue_link(link_id)
+
+    @pytest.mark.parametrize(
+        "url, api_version",
+        [
+            pytest.param("https://test.atlassian.net", "3", id="cloud"),
+            pytest.param("https://jira.example.com", "2", id="server"),
+        ],
+    )
+    def test_get_remote_issue_links_success(
+        self,
+        jira_config_factory,
+        mock_atlassian_jira,
+        url: str,
+        api_version: str,
+    ):
+        """Test successful retrieval of remote issue links."""
+        config = jira_config_factory(url=url)
+        mixin = LinksMixin(config=config)
+        mixin.jira = mock_atlassian_jira
+        mock_links = [
+            {
+                "id": 1,
+                "object": {
+                    "url": "https://example.com",
+                    "title": "Link 1",
+                },
+            },
+            {
+                "id": 2,
+                "object": {
+                    "url": "https://example.org",
+                    "title": "Link 2",
+                },
+            },
+        ]
+        mixin.jira.get.return_value = mock_links
+
+        result = mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == mock_links
+        mixin.jira.get.assert_called_once_with(
+            f"rest/api/{api_version}/issue/PROJ-123/remotelink"
+        )
+
+    def test_get_remote_issue_links_dict_response(self, links_mixin):
+        """Test dict responses are unwrapped correctly."""
+        inner = [
+            {
+                "id": 1,
+                "object": {
+                    "url": "https://example.com",
+                    "title": "A",
+                },
+            }
+        ]
+        links_mixin.jira.get.return_value = {"remoteLinks": inner}
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == inner
+
+    def test_get_remote_issue_links_dict_without_key(self, links_mixin):
+        """Dict without remoteLinks wraps as single-element list."""
+        single = {
+            "id": 1,
+            "object": {
+                "url": "https://example.com",
+                "title": "A",
+            },
+        }
+        links_mixin.jira.get.return_value = single
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == [single]
+
+    def test_get_remote_issue_links_empty(self, links_mixin):
+        """Test empty list response."""
+        links_mixin.jira.get.return_value = []
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == []
+
+    def test_get_remote_issue_links_auth_error(self, links_mixin):
+        """Test authentication error is raised correctly."""
+        links_mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            links_mixin.get_remote_issue_links("PROJ-123")

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -480,6 +480,20 @@ def test_get_project_issue_types_exception(projects_mixin: ProjectsMixin):
     projects_mixin.jira.issue_createmeta_issuetypes.assert_called_once()
 
 
+def test_get_project_issue_types_issue_types_key_fallback(
+    projects_mixin: ProjectsMixin, mock_issue_types: list[dict]
+):
+    """Test get_project_issue_types falls back to issueTypes key.
+
+    atlassian-python-api returns 'issueTypes' instead of 'values' in some cases.
+    """
+    createmeta = {"issueTypes": mock_issue_types}
+    projects_mixin.jira.issue_createmeta_issuetypes.return_value = createmeta
+
+    result = projects_mixin.get_project_issue_types("PROJ1")
+    assert result == mock_issue_types
+
+
 def test_get_project_issues_count(projects_mixin: ProjectsMixin):
     """Test get_project_issues_count method."""
     jql_result = {"total": 42}

--- a/tests/unit/jira/test_queues.py
+++ b/tests/unit/jira/test_queues.py
@@ -175,3 +175,100 @@ def test_queue_methods_reject_cloud(
     """All queue methods should raise NotImplementedError on Cloud."""
     with pytest.raises(NotImplementedError, match="Server/Data Center"):
         getattr(cloud_queues_fetcher, method)(*args)
+
+
+class TestJiraServiceManagementTools:
+    """JSM tools exist and return structured data when mocked.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/447
+    """
+
+    def test_get_service_desk_for_project_exists(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_service_desk_for_project is implemented on JiraFetcher."""
+        assert hasattr(queues_fetcher, "get_service_desk_for_project")
+        assert callable(queues_fetcher.get_service_desk_for_project)
+
+    def test_get_service_desk_queues_exists(self, queues_fetcher: JiraFetcher) -> None:
+        """get_service_desk_queues is implemented on JiraFetcher."""
+        assert hasattr(queues_fetcher, "get_service_desk_queues")
+        assert callable(queues_fetcher.get_service_desk_queues)
+
+    def test_get_queue_issues_exists(self, queues_fetcher: JiraFetcher) -> None:
+        """get_queue_issues is implemented on JiraFetcher."""
+        assert hasattr(queues_fetcher, "get_queue_issues")
+        assert callable(queues_fetcher.get_queue_issues)
+
+    def test_get_service_desk_for_project_returns_model(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_service_desk_for_project returns a JiraServiceDesk model when found."""
+        from mcp_atlassian.models.jira import JiraServiceDesk
+
+        queues_fetcher.jira.get = MagicMock(
+            return_value={
+                "start": 0,
+                "limit": 50,
+                "isLastPage": True,
+                "values": [
+                    {
+                        "id": "1",
+                        "projectKey": "HELP",
+                        "projectId": "10001",
+                        "projectName": "Help Desk",
+                    }
+                ],
+            }
+        )
+        result = queues_fetcher.get_service_desk_for_project("HELP")
+        assert isinstance(result, JiraServiceDesk)
+        assert result.project_key == "HELP"
+
+    def test_get_service_desk_queues_returns_structured_result(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_service_desk_queues returns JiraServiceDeskQueuesResult."""
+        queues_fetcher.jira.get = MagicMock(
+            return_value={
+                "start": 0,
+                "limit": 50,
+                "size": 1,
+                "isLastPage": True,
+                "values": [{"id": "10", "name": "Open Issues", "issueCount": 5}],
+            }
+        )
+        result = queues_fetcher.get_service_desk_queues("1")
+        assert isinstance(result, JiraServiceDeskQueuesResult)
+        assert result.service_desk_id == "1"
+        assert len(result.queues) == 1
+        assert result.queues[0].name == "Open Issues"
+
+    def test_get_queue_issues_returns_structured_result(
+        self, queues_fetcher: JiraFetcher
+    ) -> None:
+        """get_queue_issues returns JiraQueueIssuesResult with issues list."""
+        queues_fetcher.jira.get = MagicMock(
+            side_effect=[
+                {"id": "10", "name": "Open Issues", "issueCount": 1},
+                {
+                    "start": 0,
+                    "limit": 50,
+                    "size": 1,
+                    "isLastPage": True,
+                    "values": [
+                        {
+                            "id": "100",
+                            "key": "HELP-1",
+                            "fields": {"summary": "Need help"},
+                        }
+                    ],
+                },
+            ]
+        )
+        result = queues_fetcher.get_queue_issues("1", "10")
+        assert isinstance(result, JiraQueueIssuesResult)
+        assert result.service_desk_id == "1"
+        assert result.queue_id == "10"
+        assert len(result.issues) == 1
+        assert result.issues[0]["key"] == "HELP-1"

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -903,3 +903,47 @@ class TestUnicodeLookup:
         # Searching with the email should match (case insensitive)
         account_id = users_mixin._lookup_user_directly("TËST@EXAMPLE.COM")
         assert account_id == "email-account-id"
+
+
+class TestUserProfileMeIdentifier:
+    """get_user_profile_by_identifier handles 'me' identifier.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/596
+    Also addresses https://github.com/sooperset/mcp-atlassian/issues/459
+    """
+
+    def test_me_resolves_to_current_user(self, jira_fetcher):
+        """'me' identifier resolves via get_current_user_account_id."""
+        user_response = {
+            "accountId": "5b10ac8d82e05b22cc7d4ef5",
+            "displayName": "Test User",
+            "emailAddress": "test@example.com",
+            "active": True,
+        }
+        with patch.object(
+            jira_fetcher,
+            "get_current_user_account_id",
+            return_value="5b10ac8d82e05b22cc7d4ef5",
+        ) as mock_get_current:
+            jira_fetcher.jira.user = MagicMock(return_value=user_response)
+            result = jira_fetcher.get_user_profile_by_identifier("me")
+            assert result is not None
+            assert result.account_id == "5b10ac8d82e05b22cc7d4ef5"
+            mock_get_current.assert_called_once()
+
+    def test_me_case_insensitive(self, jira_fetcher):
+        """'Me', 'ME', 'mE' all resolve to current user."""
+        user_response = {
+            "accountId": "5b10ac8d82e05b22cc7d4ef5",
+            "displayName": "Test User",
+            "active": True,
+        }
+        with patch.object(
+            jira_fetcher,
+            "get_current_user_account_id",
+            return_value="5b10ac8d82e05b22cc7d4ef5",
+        ):
+            jira_fetcher.jira.user = MagicMock(return_value=user_response)
+            for variant in ["Me", "ME", "mE"]:
+                result = jira_fetcher.get_user_profile_by_identifier(variant)
+                assert result is not None

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -146,15 +146,43 @@ class TestUsersMixin:
         # Verify self.jira.myself was called
         users_mixin.jira.myself.assert_called_once()
 
-    def test_get_account_id_already_account_id(self, users_mixin):
-        """Test that _get_account_id returns the input if it looks like an account ID."""
-        # Call the method with a string that looks like an account ID
-        account_id = users_mixin._get_account_id("5abcdef1234567890")
+    @pytest.mark.parametrize(
+        "account_id",
+        [
+            "5abcdef123456789abcdef12",  # 24-char hex starting with 5
+            "606b8fb83a516300764cb19d",  # 24-char hex starting with 6
+            "712020:96a182bb-ee48-4240-8465-a7236ccfce2a",  # digits:uuid format
+            "557058:32b276cf-1a9f-45e0-8a70-84e38d677be0",  # digits:uuid starting with 5
+            "aabbccdd11223344aabbccdd",  # 24-char hex starting with a
+        ],
+    )
+    def test_get_account_id_already_account_id(self, users_mixin, account_id):
+        """_get_account_id returns the input unchanged for valid account ID formats."""
+        result = users_mixin._get_account_id(account_id)
 
-        # Verify result
-        assert account_id == "5abcdef1234567890"
-        # Verify no lookups were performed
+        assert result == account_id
+        # No lookups should be performed for recognized account IDs
         users_mixin.jira.user_find_by_user_string.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "not_account_id",
+        [
+            "john@example.com",  # email
+            "John Smith",  # display name
+            "jsmith",  # username
+            "abc",  # too short to be an account ID
+        ],
+    )
+    def test_get_account_id_not_account_id_triggers_lookup(
+        self, users_mixin, not_account_id
+    ):
+        """_get_account_id performs lookup for strings that aren't account IDs."""
+        users_mixin._lookup_user_directly = MagicMock(return_value="resolved-id")
+
+        result = users_mixin._get_account_id(not_account_id)
+
+        assert result == "resolved-id"
+        users_mixin._lookup_user_directly.assert_called_once_with(not_account_id)
 
     def test_get_account_id_direct_lookup(self, users_mixin):
         """Test that _get_account_id uses direct lookup."""

--- a/tests/unit/models/conftest.py
+++ b/tests/unit/models/conftest.py
@@ -7,6 +7,7 @@ reusable fixtures for model validation and serialization testing.
 """
 
 import os
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -141,7 +142,7 @@ def confluence_page_data() -> dict[str, Any]:
     Note: This fixture is maintained for backward compatibility.
     Consider using make_confluence_page_data for new tests.
     """
-    return MOCK_PAGE_RESPONSE
+    return deepcopy(MOCK_PAGE_RESPONSE)
 
 
 @pytest.fixture

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -773,3 +773,113 @@ class TestProcessCustomFieldValue:
         field = simplified["customfield_10200"]
         assert field["name"] == "Okapya Checklist"
         assert field["value"] == checklist_items
+
+
+class TestDisplayNameMethods:
+    """Tests for the additive display-name helper methods.
+
+    These methods sit on top of the existing JiraIssue model without
+    modifying any existing behavior.
+    """
+
+    @pytest.fixture()
+    def issue_with_names(self):
+        """Create a JiraIssue whose custom fields carry display names."""
+        api_data = {
+            "id": "100",
+            "key": "DN-1",
+            "fields": {
+                "summary": "Display name test",
+                "customfield_10001": "text value",
+                "customfield_10002": {"value": "Option A"},
+                "customfield_10003": [
+                    {"value": "Multi 1"},
+                    {"value": "Multi 2"},
+                ],
+                "customfield_10099": "orphan without a name",
+            },
+            "names": {
+                "customfield_10001": "Story Points",
+                "customfield_10002": "Severity",
+                "customfield_10003": "Affected Versions",
+            },
+        }
+        return JiraIssue.from_api_response(api_data, requested_fields="*all")
+
+    # -- get_custom_field_by_name -----------------------------------------
+
+    def test_get_custom_field_by_name_exact(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Story Points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_insensitive(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("story points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_sensitive_miss(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name(
+            "story points", case_sensitive=True
+        )
+        assert result is None
+
+    def test_get_custom_field_by_name_select(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Severity")
+        assert result == "Option A"
+
+    def test_get_custom_field_by_name_multiselect(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Affected Versions")
+        assert result == ["Multi 1", "Multi 2"]
+
+    def test_get_custom_field_by_name_not_found(self, issue_with_names):
+        assert issue_with_names.get_custom_field_by_name("Nonexistent") is None
+
+    # -- custom_fields_by_display_name property ---------------------------
+
+    def test_property_rekeys_by_display_name(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "Story Points" in by_name
+        assert "Severity" in by_name
+        assert "Affected Versions" in by_name
+
+    def test_property_includes_field_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert by_name["Story Points"]["field_id"] == "customfield_10001"
+        assert by_name["Severity"]["field_id"] == "customfield_10002"
+
+    def test_property_keeps_orphans_by_raw_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10099" in by_name
+        assert by_name["customfield_10099"]["field_id"] == "customfield_10099"
+
+    def test_property_does_not_mutate_original(self, issue_with_names):
+        _ = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10001" in issue_with_names.custom_fields
+
+    # -- to_display_name_dict ---------------------------------------------
+
+    def test_display_name_dict_rekeys_customs(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "Story Points" in d
+        assert "Severity" in d
+        assert "Affected Versions" in d
+        assert "customfield_10001" not in d
+        assert "customfield_10002" not in d
+
+    def test_display_name_dict_preserves_standard_fields(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["key"] == "DN-1"
+        assert d["summary"] == "Display name test"
+
+    def test_display_name_dict_includes_field_id(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["Story Points"]["field_id"] == "customfield_10001"
+
+    def test_display_name_dict_orphan_kept(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "customfield_10099" in d
+
+    def test_original_simplified_dict_unchanged(self, issue_with_names):
+        """to_simplified_dict must still use customfield_XXXXX keys."""
+        s = issue_with_names.to_simplified_dict()
+        assert "customfield_10001" in s
+        assert "Story Points" not in s

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -765,6 +765,73 @@ def function_{i}():
         assert "😀" in processed_markdown  # Emoji from numeric entity
 
 
+class TestTableLayout:
+    """Tests for table_layout post-processing in markdown_to_confluence_storage."""
+
+    MARKDOWN_WITH_TABLE = "| A | B |\n|---|---|\n| 1 | 2 |"
+
+    def test_table_layout_full_width(self, confluence_preprocessor):
+        """table_layout='full-width' sets data-table-width=1800 and data-layout=full-width."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="full-width"
+        )
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+
+    def test_table_layout_wide(self, confluence_preprocessor):
+        """table_layout='wide' sets data-table-width=960 and data-layout=wide."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="wide"
+        )
+        assert 'data-table-width="960"' in result
+        assert 'data-layout="wide"' in result
+
+    def test_table_layout_default(self, confluence_preprocessor):
+        """table_layout='default' adds 760 px width attribute."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="default"
+        )
+        assert 'data-table-width="760"' in result
+        assert 'data-layout="default"' in result
+
+    def test_table_layout_none_emits_bare_table(self, confluence_preprocessor):
+        """Omitting table_layout leaves the converter's bare <table> tag unchanged."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE
+        )
+        # md2conf produces a bare <table> with no width attributes
+        assert "data-table-width" not in result
+
+    def test_table_layout_unknown_value_is_ignored(self, confluence_preprocessor):
+        """An unrecognised table_layout value does not add width attributes."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="ultra-wide"
+        )
+        # Unrecognised value: no post-processing applied
+        assert "data-table-width" not in result
+
+    def test_apply_table_layout_injects_attrs_on_bare_tables(
+        self, confluence_preprocessor
+    ):
+        """_apply_table_layout adds attributes to bare <table> tags."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = "<table><tr><td>A</td></tr></table><table><tr><td>B</td></tr></table>"
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert result.count('data-table-width="1800"') == 2
+        assert result.count('data-layout="full-width"') == 2
+
+    def test_apply_table_layout_replaces_existing_attrs(self, confluence_preprocessor):
+        """_apply_table_layout replaces existing data-table-width/layout attrs."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = '<table data-table-width="760" data-layout="default"><tr><td>X</td></tr></table>'
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+        assert 'data-table-width="760"' not in result
+
+
 class TestContentProcessingInteroperability:
     """Test interoperability between Jira and Confluence content processing."""
 

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -927,3 +927,62 @@ Emojis: 😀 😎 🚀 💻 ✅ ❌ ⚡ 🔥"""
             confluence_preprocessor.process_html_content(malformed_content)
         )
         assert len(confluence_result) > 0
+
+
+class TestTaskLists:
+    """Tests for GFM task list → ac:task-list conversion."""
+
+    def _convert(self, md: str, apply_task_lists: bool = True) -> str:
+        p = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        return p.markdown_to_confluence_storage(md, apply_task_lists=apply_task_lists)
+
+    def test_unchecked_item_becomes_incomplete_task(self):
+        """- [ ] item converts to ac:task with status incomplete."""
+        result = self._convert("- [ ] Todo item")
+        assert "<ac:task-list>" in result
+        assert "<ac:task-status>incomplete</ac:task-status>" in result
+        assert "<ac:task-body>Todo item</ac:task-body>" in result
+
+    def test_checked_item_becomes_complete_task(self):
+        """- [x] item converts to ac:task with status complete."""
+        result = self._convert("- [x] Done item")
+        assert "<ac:task-status>complete</ac:task-status>" in result
+        assert "<ac:task-body>Done item</ac:task-body>" in result
+
+    def test_uppercase_x_treated_as_complete(self):
+        """- [X] (uppercase) is also treated as complete."""
+        result = self._convert("- [X] Done")
+        assert "<ac:task-status>complete</ac:task-status>" in result
+
+    def test_mixed_list_left_as_ul(self):
+        """A list mixing task and non-task items is left as a plain <ul>."""
+        result = self._convert("- [ ] Task\n- Regular item")
+        assert "<ul>" in result
+        assert "<ac:task-list>" not in result
+
+    def test_multiple_tasks_in_one_list(self):
+        """All tasks in a list are converted, preserving order."""
+        result = self._convert("- [ ] First\n- [x] Second\n- [ ] Third")
+        assert result.count("<ac:task>") == 3
+        assert result.index("First") < result.index("Second") < result.index("Third")
+
+    def test_apply_task_lists_false_leaves_ul(self):
+        """apply_task_lists=False skips conversion entirely."""
+        result = self._convert("- [ ] Skip me", apply_task_lists=False)
+        assert "<ul>" in result
+        assert "<ac:task-list>" not in result
+
+    def test_apply_task_lists_classmethod_directly(self):
+        """_apply_task_lists can be called as a classmethod."""
+        html = "<ul><li>[ ] Todo</li><li>[x] Done</li></ul>"
+        result = ConfluencePreprocessor._apply_task_lists(html)
+        assert "<ac:task-list>" in result
+        assert "<ac:task-status>incomplete</ac:task-status>" in result
+        assert "<ac:task-status>complete</ac:task-status>" in result
+        assert "<ul>" not in result
+
+    def test_non_task_ul_not_modified(self):
+        """A plain <ul> with no checkbox markers is left untouched."""
+        html = "<ul><li>Alpha</li><li>Beta</li></ul>"
+        result = ConfluencePreprocessor._apply_task_lists(html)
+        assert result == html

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -592,6 +592,97 @@ More content.
     assert "<h2>" in result_with_anchors
 
 
+# Regression tests — bare-filename images produce "Preview unavailable"
+
+
+class TestFixAttachmentImages:
+    """Unit tests for ConfluencePreprocessor._fix_attachment_images."""
+
+    def setup_method(self):
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        self.fix = ConfluencePreprocessor._fix_attachment_images
+
+    def test_bare_filename_replaced_with_attachment_macro(self):
+        html = '<img src="chart.png" alt="Revenue chart"/>'
+        result = self.fix(html)
+        assert result == (
+            '<ac:image ac:alt="Revenue chart">'
+            '<ri:attachment ri:filename="chart.png"/>'
+            "</ac:image>"
+        )
+        assert "<img" not in result
+
+    def test_alt_text_preserved(self):
+        html = '<img alt="My diagram" src="diagram.svg"/>'
+        result = self.fix(html)
+        assert 'ac:alt="My diagram"' in result
+        assert 'ri:filename="diagram.svg"' in result
+
+    def test_missing_alt_defaults_to_empty_string(self):
+        html = '<img src="figure.png"/>'
+        result = self.fix(html)
+        assert 'ac:alt=""' in result
+        assert 'ri:filename="figure.png"' in result
+
+    def test_https_url_left_untouched(self):
+        html = '<img src="https://example.com/logo.png" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_http_url_left_untouched(self):
+        html = '<img src="http://example.com/img.jpg" alt="x"/>'
+        assert self.fix(html) == html
+
+    def test_data_uri_left_untouched(self):
+        html = '<img src="data:image/png;base64,abc123" alt="inline"/>'
+        assert self.fix(html) == html
+
+    def test_absolute_path_left_untouched(self):
+        html = '<img src="/images/logo.png" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_mixed_content_only_bare_filenames_rewritten(self):
+        html = (
+            '<img src="local.png" alt="local"/>'
+            '<img src="https://cdn.example.com/remote.png" alt="remote"/>'
+        )
+        result = self.fix(html)
+        assert "ri:filename" in result
+        assert "https://cdn.example.com/remote.png" in result
+        assert '<img src="local.png"' not in result
+
+    def test_no_img_tags_unchanged(self):
+        html = "<p>No images here</p>"
+        assert self.fix(html) == html
+
+
+def test_markdown_to_confluence_storage_attachment_image():
+    """Regression: bare-filename images must produce ac:image attachment macros."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    result = preprocessor.markdown_to_confluence_storage("![Revenue chart](chart.png)")
+    assert "ri:filename" in result, (
+        "Expected Confluence attachment macro, got: " + result
+    )
+    assert 'ri:filename="chart.png"' in result
+    assert "<img" not in result, (
+        "Raw <img> tag found — will show as 'Preview unavailable'"
+    )
+
+
+def test_markdown_to_confluence_storage_external_image_unchanged():
+    """External image URLs must not be rewritten to attachment macros."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    result = preprocessor.markdown_to_confluence_storage(
+        "![Logo](https://example.com/logo.png)"
+    )
+    assert "https://example.com/logo.png" in result
+    assert 'ri:filename="https://example.com/logo.png"' not in result
+
+
 # Issue #786 regression tests - Wiki Markup Corruption
 
 

--- a/tests/unit/scripts/test_oauth_authorize.py
+++ b/tests/unit/scripts/test_oauth_authorize.py
@@ -1,0 +1,122 @@
+"""Tests for the scripts/oauth_authorize.py CLI script."""
+
+import importlib.util
+import os
+import sys
+from unittest.mock import patch
+
+
+def _load_script_module():
+    """Load the oauth_authorize script as a module."""
+    script_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "scripts", "oauth_authorize.py"
+    )
+    script_path = os.path.abspath(script_path)
+    spec = importlib.util.spec_from_file_location("oauth_authorize", script_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestOAuthAuthorizeScript:
+    """Tests for the oauth_authorize CLI script."""
+
+    def test_dc_argument_parsing(self):
+        """DC base_url is passed through to OAuthSetupArgs."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--base-url",
+            "https://jira.corp.example.com",
+            "--client-id",
+            "X",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "WRITE",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch.object(mod, "run_oauth_flow") as mock_flow:
+                mock_flow.return_value = True
+                result = mod.main()
+        assert result == 0
+        mock_flow.assert_called_once()
+        args = mock_flow.call_args[0][0]
+        assert args.base_url == "https://jira.corp.example.com"
+
+    def test_cloud_base_url_clearing(self):
+        """Cloud URL clears base_url so OAuthSetupArgs has base_url=None."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--base-url",
+            "https://company.atlassian.net",
+            "--client-id",
+            "X",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "read:jira-work offline_access",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch.object(mod, "run_oauth_flow") as mock_flow:
+                mock_flow.return_value = True
+                result = mod.main()
+        assert result == 0
+        mock_flow.assert_called_once()
+        args = mock_flow.call_args[0][0]
+        assert args.base_url is None
+
+    def test_env_var_fallback_chain(self):
+        """JIRA_OAUTH_CLIENT_ID takes priority over ATLASSIAN_OAUTH_CLIENT_ID."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "WRITE",
+        ]
+        env = {
+            "JIRA_OAUTH_CLIENT_ID": "jira-id",
+            "ATLASSIAN_OAUTH_CLIENT_ID": "atlassian-id",
+        }
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, env, clear=False):
+                with patch.object(mod, "run_oauth_flow") as mock_flow:
+                    mock_flow.return_value = True
+                    result = mod.main()
+        assert result == 0
+        mock_flow.assert_called_once()
+        args = mock_flow.call_args[0][0]
+        assert args.client_id == "jira-id"
+
+    def test_offline_access_warning_skipped_for_dc(self, caplog):
+        """DC scope without offline_access does not log a warning."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--base-url",
+            "https://jira.corp.example.com",
+            "--client-id",
+            "X",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "WRITE",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch.object(mod, "run_oauth_flow") as mock_flow:
+                mock_flow.return_value = True
+                mod.main()
+        # No warning about offline_access for DC
+        assert "offline_access" not in caplog.text

--- a/tests/unit/servers/test_auto_oauth.py
+++ b/tests/unit/servers/test_auto_oauth.py
@@ -1,0 +1,517 @@
+"""Tests for the auto-OAuth browser flow triggered during server startup."""
+
+import os
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.servers.main import _try_auto_oauth, main_lifespan
+from mcp_atlassian.utils.oauth import BYOAccessTokenOAuthConfig, OAuthConfig
+from tests.utils.mocks import MockEnvironment
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_oauth_config(
+    *,
+    client_id: str = "cid",
+    client_secret: str = "csec",
+    redirect_uri: str = "http://localhost:8080/callback",
+    scope: str = "WRITE",
+    access_token: str | None = None,
+    refresh_token: str | None = None,
+    base_url: str | None = None,
+) -> OAuthConfig:
+    cfg = OAuthConfig(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        access_token=access_token,
+        base_url=base_url,
+    )
+    cfg.refresh_token = refresh_token
+    return cfg
+
+
+@dataclass
+class _StubConfig:
+    """Minimal stand-in for JiraConfig / ConfluenceConfig."""
+
+    auth_type: str
+    oauth_config: OAuthConfig | BYOAccessTokenOAuthConfig | None = None
+
+
+FLOW_PATCH = "mcp_atlassian.utils.oauth_setup.run_oauth_flow"
+
+
+# ---------------------------------------------------------------------------
+# _try_auto_oauth predicate (early-return when auto-OAuth not needed)
+# ---------------------------------------------------------------------------
+
+
+class TestTryAutoOAuthPredicate:
+    """Tests for the predicate logic inside _try_auto_oauth (skips vs triggers)."""
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_triggers_when_oauth_creds_present_no_tokens(self, mock_flow):
+        mock_flow.return_value = True
+        cfg = _StubConfig(
+            auth_type="oauth",
+            oauth_config=_make_oauth_config(),
+        )
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is True
+        mock_flow.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_when_access_token_already_present(self, mock_flow):
+        cfg = _StubConfig(
+            auth_type="oauth",
+            oauth_config=_make_oauth_config(access_token="tok"),
+        )
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_for_basic_auth(self, mock_flow):
+        cfg = _StubConfig(auth_type="basic", oauth_config=None)
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_for_pat_auth(self, mock_flow):
+        cfg = _StubConfig(auth_type="pat", oauth_config=None)
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_when_client_id_missing(self, mock_flow):
+        cfg = _StubConfig(
+            auth_type="oauth",
+            oauth_config=_make_oauth_config(client_id=""),
+        )
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_when_client_secret_missing(self, mock_flow):
+        cfg = _StubConfig(
+            auth_type="oauth",
+            oauth_config=_make_oauth_config(client_secret=""),
+        )
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_for_byo_token_config(self, mock_flow):
+        byo = BYOAccessTokenOAuthConfig(access_token="byo-tok")
+        cfg = _StubConfig(auth_type="oauth", oauth_config=byo)
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_when_oauth_config_is_none(self, mock_flow):
+        cfg = _StubConfig(auth_type="oauth", oauth_config=None)
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_skips_when_refresh_token_present(self, mock_flow):
+        cfg = _StubConfig(
+            auth_type="oauth",
+            oauth_config=_make_oauth_config(refresh_token="rt"),
+        )
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is False
+        mock_flow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_triggers_for_dc_oauth_without_tokens(self, mock_flow):
+        mock_flow.return_value = True
+        cfg = _StubConfig(
+            auth_type="oauth",
+            oauth_config=_make_oauth_config(
+                base_url="https://jira.corp.example.com",
+            ),
+        )
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is True
+        mock_flow.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_triggers_for_cloud_oauth_with_cloud_id_no_tokens(self, mock_flow):
+        """Cloud OAuth with cloud_id set but no tokens should trigger auto-oauth."""
+        mock_flow.return_value = True
+        oauth_cfg = _make_oauth_config(
+            client_id="cloud-cid",
+            client_secret="cloud-csec",
+            scope="read:jira-work offline_access",
+        )
+        oauth_cfg.cloud_id = "test-cloud-id"
+        cfg = _StubConfig(auth_type="oauth", oauth_config=oauth_cfg)
+        result = await _try_auto_oauth(cfg, "Jira")
+        assert result is True
+        mock_flow.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _try_auto_oauth
+# ---------------------------------------------------------------------------
+
+
+class TestTryAutoOAuth:
+    """Tests for the async _try_auto_oauth helper."""
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_returns_true_on_success(self, mock_flow):
+        mock_flow.return_value = True
+        cfg = _StubConfig(auth_type="oauth", oauth_config=_make_oauth_config())
+
+        result = await _try_auto_oauth(cfg, "Jira")
+
+        assert result is True
+        mock_flow.assert_called_once()
+        args = mock_flow.call_args[0][0]
+        assert args.client_id == "cid"
+        assert args.client_secret == "csec"
+        assert args.redirect_uri == "http://localhost:8080/callback"
+        assert args.scope == "WRITE"
+        assert args.base_url is None
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_returns_false_on_failure(self, mock_flow):
+        mock_flow.return_value = False
+        cfg = _StubConfig(auth_type="oauth", oauth_config=_make_oauth_config())
+
+        result = await _try_auto_oauth(cfg, "Confluence")
+
+        assert result is False
+        mock_flow.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_passes_dc_base_url(self, mock_flow):
+        mock_flow.return_value = True
+        dc_url = "https://jira.corp.example.com"
+        cfg = _StubConfig(
+            auth_type="oauth",
+            oauth_config=_make_oauth_config(base_url=dc_url),
+        )
+
+        await _try_auto_oauth(cfg, "Jira")
+
+        args = mock_flow.call_args[0][0]
+        assert args.base_url == dc_url
+
+    @pytest.mark.asyncio
+    @patch(FLOW_PATCH)
+    async def test_flow_exception_returns_false(self, mock_flow):
+        mock_flow.side_effect = RuntimeError("port in use")
+        cfg = _StubConfig(auth_type="oauth", oauth_config=_make_oauth_config())
+
+        result = await _try_auto_oauth(cfg, "Jira")
+
+        assert result is False
+        mock_flow.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# main_lifespan integration (auto-OAuth branches)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestLifespanAutoOAuth:
+    """Integration tests for main_lifespan auto-OAuth branching."""
+
+    async def test_jira_auth_configured_auto_oauth_success(self):
+        """Auth configured, auto-oauth, _try_auto_oauth succeeds; from_env twice."""
+        env = {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_USERNAME": "test@example.com",
+            "JIRA_API_TOKEN": "test-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with (
+                patch(
+                    "mcp_atlassian.jira.config.JiraConfig.from_env"
+                ) as mock_jira_from_env,
+                patch(
+                    "mcp_atlassian.servers.main._try_auto_oauth",
+                    new_callable=AsyncMock,
+                ) as mock_try_auto_oauth,
+            ):
+                initial_config = MagicMock()
+                initial_config.is_auth_configured.return_value = True
+                initial_config.auth_type = "oauth"
+                initial_config.oauth_config = _make_oauth_config()
+
+                reloaded_config = MagicMock()
+                reloaded_config.is_auth_configured.return_value = True
+                reloaded_config.auth_type = "oauth"
+                reloaded_config.oauth_config = _make_oauth_config(
+                    access_token="new-tok"
+                )
+
+                mock_jira_from_env.side_effect = [initial_config, reloaded_config]
+                mock_try_auto_oauth.return_value = True
+
+                app = MagicMock()
+                async with main_lifespan(app) as context:
+                    app_context = context["app_lifespan_context"]
+                    assert app_context.full_jira_config == reloaded_config
+
+                assert mock_jira_from_env.call_count == 2
+                mock_try_auto_oauth.assert_called_once()
+
+    async def test_jira_auth_configured_auto_oauth_failure(self):
+        """Auth configured, auto-oauth, _try_auto_oauth fails; config still set."""
+        env = {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_USERNAME": "test@example.com",
+            "JIRA_API_TOKEN": "test-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with (
+                patch(
+                    "mcp_atlassian.jira.config.JiraConfig.from_env"
+                ) as mock_jira_from_env,
+                patch(
+                    "mcp_atlassian.servers.main._try_auto_oauth",
+                    new_callable=AsyncMock,
+                ) as mock_try_auto_oauth,
+            ):
+                jira_config = MagicMock()
+                jira_config.is_auth_configured.return_value = True
+                jira_config.auth_type = "oauth"
+                jira_config.oauth_config = _make_oauth_config()
+
+                mock_jira_from_env.return_value = jira_config
+                mock_try_auto_oauth.return_value = False
+
+                app = MagicMock()
+                async with main_lifespan(app) as context:
+                    app_context = context["app_lifespan_context"]
+                    assert app_context.full_jira_config == jira_config
+
+                mock_jira_from_env.assert_called_once()
+                mock_try_auto_oauth.assert_called_once()
+
+    async def test_jira_auth_not_configured_auto_oauth_succeeds(self):
+        """Auth not configured, auto-oauth, _try_auto_oauth succeeds; config set."""
+        env = {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_USERNAME": "test@example.com",
+            "JIRA_API_TOKEN": "test-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with (
+                patch(
+                    "mcp_atlassian.jira.config.JiraConfig.from_env"
+                ) as mock_jira_from_env,
+                patch(
+                    "mcp_atlassian.servers.main._try_auto_oauth",
+                    new_callable=AsyncMock,
+                ) as mock_try_auto_oauth,
+            ):
+                initial_config = MagicMock()
+                initial_config.is_auth_configured.return_value = False
+                initial_config.auth_type = "oauth"
+                initial_config.oauth_config = _make_oauth_config()
+
+                reloaded_config = MagicMock()
+                reloaded_config.is_auth_configured.return_value = True
+                reloaded_config.auth_type = "oauth"
+                reloaded_config.oauth_config = _make_oauth_config(
+                    access_token="new-tok"
+                )
+
+                mock_jira_from_env.side_effect = [initial_config, reloaded_config]
+                mock_try_auto_oauth.return_value = True
+
+                app = MagicMock()
+                async with main_lifespan(app) as context:
+                    app_context = context["app_lifespan_context"]
+                    assert app_context.full_jira_config == reloaded_config
+
+                assert mock_jira_from_env.call_count == 2
+                mock_try_auto_oauth.assert_called_once()
+
+    async def test_jira_auth_not_configured_auto_oauth_fails(self):
+        """Auth not configured, needs auto-oauth, _try_auto_oauth fails; config None."""
+        env = {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_USERNAME": "test@example.com",
+            "JIRA_API_TOKEN": "test-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with (
+                patch(
+                    "mcp_atlassian.jira.config.JiraConfig.from_env"
+                ) as mock_jira_from_env,
+                patch(
+                    "mcp_atlassian.servers.main._try_auto_oauth",
+                    new_callable=AsyncMock,
+                ) as mock_try_auto_oauth,
+            ):
+                jira_config = MagicMock()
+                jira_config.is_auth_configured.return_value = False
+                jira_config.auth_type = "oauth"
+                jira_config.oauth_config = _make_oauth_config()
+
+                mock_jira_from_env.return_value = jira_config
+                mock_try_auto_oauth.return_value = False
+
+                app = MagicMock()
+                async with main_lifespan(app) as context:
+                    app_context = context["app_lifespan_context"]
+                    assert app_context.full_jira_config is None
+
+                mock_jira_from_env.assert_called_once()
+                mock_try_auto_oauth.assert_called_once()
+
+    async def test_confluence_auth_configured_auto_oauth_success(self):
+        """Confluence: auth configured, needs auto-oauth, _try_auto_oauth succeeds."""
+        env = {
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+            "CONFLUENCE_USERNAME": "test@example.com",
+            "CONFLUENCE_API_TOKEN": "test-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with (
+                patch(
+                    "mcp_atlassian.confluence.config.ConfluenceConfig.from_env"
+                ) as mock_conf_from_env,
+                patch(
+                    "mcp_atlassian.servers.main._try_auto_oauth",
+                    new_callable=AsyncMock,
+                ) as mock_try_auto_oauth,
+            ):
+                initial_config = MagicMock()
+                initial_config.is_auth_configured.return_value = True
+                initial_config.auth_type = "oauth"
+                initial_config.oauth_config = _make_oauth_config()
+
+                reloaded_config = MagicMock()
+                reloaded_config.is_auth_configured.return_value = True
+                reloaded_config.auth_type = "oauth"
+                reloaded_config.oauth_config = _make_oauth_config(
+                    access_token="new-tok"
+                )
+
+                mock_conf_from_env.side_effect = [initial_config, reloaded_config]
+                mock_try_auto_oauth.return_value = True
+
+                app = MagicMock()
+                async with main_lifespan(app) as context:
+                    app_context = context["app_lifespan_context"]
+                    assert app_context.full_confluence_config == reloaded_config
+
+                assert mock_conf_from_env.call_count == 2
+                mock_try_auto_oauth.assert_called_once()
+
+    async def test_confluence_auth_not_configured_auto_oauth_fails(self):
+        """Confluence: auth not configured, needs auto-oauth, _try_auto_oauth fails."""
+        env = {
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+            "CONFLUENCE_USERNAME": "test@example.com",
+            "CONFLUENCE_API_TOKEN": "test-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with (
+                patch(
+                    "mcp_atlassian.confluence.config.ConfluenceConfig.from_env"
+                ) as mock_conf_from_env,
+                patch(
+                    "mcp_atlassian.servers.main._try_auto_oauth",
+                    new_callable=AsyncMock,
+                ) as mock_try_auto_oauth,
+            ):
+                conf_config = MagicMock()
+                conf_config.is_auth_configured.return_value = False
+                conf_config.auth_type = "oauth"
+                conf_config.oauth_config = _make_oauth_config()
+
+                mock_conf_from_env.return_value = conf_config
+                mock_try_auto_oauth.return_value = False
+
+                app = MagicMock()
+                async with main_lifespan(app) as context:
+                    app_context = context["app_lifespan_context"]
+                    assert app_context.full_confluence_config is None
+
+                mock_conf_from_env.assert_called_once()
+                mock_try_auto_oauth.assert_called_once()
+
+    async def test_both_services_auto_oauth(self):
+        """Both Jira and Confluence need auto-oauth; both succeed; both loaded."""
+        with MockEnvironment.basic_auth_env():
+            with (
+                patch(
+                    "mcp_atlassian.jira.config.JiraConfig.from_env"
+                ) as mock_jira_from_env,
+                patch(
+                    "mcp_atlassian.confluence.config.ConfluenceConfig.from_env"
+                ) as mock_conf_from_env,
+                patch(
+                    "mcp_atlassian.servers.main._try_auto_oauth",
+                    new_callable=AsyncMock,
+                ) as mock_try_auto_oauth,
+            ):
+                jira_initial = MagicMock()
+                jira_initial.is_auth_configured.return_value = True
+                jira_initial.auth_type = "oauth"
+                jira_initial.oauth_config = _make_oauth_config()
+
+                jira_reloaded = MagicMock()
+                jira_reloaded.is_auth_configured.return_value = True
+                jira_reloaded.auth_type = "oauth"
+                jira_reloaded.oauth_config = _make_oauth_config(access_token="jira-tok")
+
+                conf_initial = MagicMock()
+                conf_initial.is_auth_configured.return_value = True
+                conf_initial.auth_type = "oauth"
+                conf_initial.oauth_config = _make_oauth_config()
+
+                conf_reloaded = MagicMock()
+                conf_reloaded.is_auth_configured.return_value = True
+                conf_reloaded.auth_type = "oauth"
+                conf_reloaded.oauth_config = _make_oauth_config(access_token="conf-tok")
+
+                mock_jira_from_env.side_effect = [jira_initial, jira_reloaded]
+                mock_conf_from_env.side_effect = [conf_initial, conf_reloaded]
+                mock_try_auto_oauth.return_value = True
+
+                app = MagicMock()
+                async with main_lifespan(app) as context:
+                    app_context = context["app_lifespan_context"]
+                    assert app_context.full_jira_config == jira_reloaded
+                    assert app_context.full_confluence_config == conf_reloaded
+
+                assert mock_jira_from_env.call_count == 2
+                assert mock_conf_from_env.call_count == 2
+                assert mock_try_auto_oauth.call_count == 2

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -37,6 +37,7 @@ def mock_confluence_fetcher():
             "format": "markdown",
         },
     }
+    mock_page.id = "123456"
     mock_page.content = "This is a test page content in Markdown"
 
     # Set up mock responses for each method
@@ -86,6 +87,23 @@ def mock_confluence_fetcher():
         "body": "This is a test comment added via API",
     }
     mock_fetcher.add_comment.return_value = mock_comment
+
+    # Mock get_user_details methods
+    mock_fetcher.get_current_user_info.return_value = {
+        "accountId": "current-user-id",
+        "displayName": "Current User",
+        "email": "current@example.com",
+    }
+    mock_fetcher.get_user_details_by_accountid.return_value = {
+        "accountId": "a031248587011jasoidf9832jd8j1",
+        "displayName": "First Last",
+        "email": "first.last@foo.com",
+    }
+    mock_fetcher.get_user_details_by_username.return_value = {
+        "username": "firstlast",
+        "displayName": "First Last",
+        "email": "first.last@foo.com",
+    }
 
     # Mock search_user method
     mock_user_search_result = MagicMock()
@@ -201,6 +219,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
         get_page_children,
         get_page_images,
         get_space_page_tree,
+        get_user_details,
         search,
         search_user,
         update_page,
@@ -237,6 +256,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
     confluence_sub_mcp.add_tool(update_page)
     confluence_sub_mcp.add_tool(delete_page)
     confluence_sub_mcp.add_tool(search_user)
+    confluence_sub_mcp.add_tool(get_user_details)
     confluence_sub_mcp.add_tool(upload_attachment)
     confluence_sub_mcp.add_tool(upload_attachments)
     confluence_sub_mcp.add_tool(get_attachments)
@@ -743,6 +763,126 @@ async def test_get_page_with_numeric_id(client, mock_confluence_fetcher):
     assert result_data["metadata"]["id"] == "123456"
 
 
+# --- get_page include enrichment tests (issue #1103) ---
+
+
+@pytest.mark.anyio
+async def test_get_page_include_comments(client, mock_confluence_fetcher):
+    """Test get_page with include='comments' inlines comment data."""
+    response = await client.call_tool(
+        "confluence_get_page", {"page_id": "123456", "include": "comments"}
+    )
+
+    mock_confluence_fetcher.get_page_content.assert_called_once_with(
+        "123456", convert_to_markdown=True
+    )
+    mock_confluence_fetcher.get_page_comments.assert_called_once_with("123456")
+
+    result_data = json.loads(response.content[0].text)
+    assert "metadata" in result_data
+    assert "comments" in result_data
+    assert len(result_data["comments"]) == 1
+    assert result_data["comments"][0]["id"] == "789"
+
+
+@pytest.mark.anyio
+async def test_get_page_include_labels(client, mock_confluence_fetcher):
+    """Test get_page with include='labels' inlines label data."""
+    response = await client.call_tool(
+        "confluence_get_page", {"page_id": "123456", "include": "labels"}
+    )
+
+    mock_confluence_fetcher.get_page_labels.assert_called_once_with("123456")
+
+    result_data = json.loads(response.content[0].text)
+    assert "metadata" in result_data
+    assert "labels" in result_data
+    assert len(result_data["labels"]) == 1
+    assert result_data["labels"][0]["name"] == "test-label"
+
+
+@pytest.mark.anyio
+async def test_get_page_include_views(client, mock_confluence_fetcher):
+    """Test get_page with include='views' inlines view statistics."""
+    from src.mcp_atlassian.models.confluence.analytics import PageViews
+
+    mock_confluence_fetcher.get_page_views.return_value = PageViews(
+        page_id="123456", total_views=42
+    )
+
+    response = await client.call_tool(
+        "confluence_get_page", {"page_id": "123456", "include": "views"}
+    )
+
+    mock_confluence_fetcher.get_page_views.assert_called_once_with(
+        page_id="123456", include_title=False
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert "metadata" in result_data
+    assert "views" in result_data
+    assert result_data["views"]["total_views"] == 42
+
+
+@pytest.mark.anyio
+async def test_get_page_include_multiple(client, mock_confluence_fetcher):
+    """Test get_page with include='comments, labels, views' inlines all three."""
+    from src.mcp_atlassian.models.confluence.analytics import PageViews
+
+    mock_confluence_fetcher.get_page_views.return_value = PageViews(
+        page_id="123456", total_views=10
+    )
+
+    response = await client.call_tool(
+        "confluence_get_page",
+        {"page_id": "123456", "include": "comments, labels, views"},
+    )
+
+    mock_confluence_fetcher.get_page_comments.assert_called_once_with("123456")
+    mock_confluence_fetcher.get_page_labels.assert_called_once_with("123456")
+    mock_confluence_fetcher.get_page_views.assert_called_once_with(
+        page_id="123456", include_title=False
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert "comments" in result_data
+    assert "labels" in result_data
+    assert "views" in result_data
+
+
+@pytest.mark.anyio
+async def test_get_page_include_views_graceful_degradation(
+    client, mock_confluence_fetcher
+):
+    """Test get_page with include='views' degrades gracefully on Server/DC."""
+    mock_confluence_fetcher.get_page_views.side_effect = ValueError(
+        "Page view analytics is only available for Confluence Cloud."
+    )
+
+    response = await client.call_tool(
+        "confluence_get_page", {"page_id": "123456", "include": "views"}
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert "metadata" in result_data
+    assert "views" in result_data
+    assert result_data["views"] == {}
+
+
+@pytest.mark.anyio
+async def test_get_page_include_none_no_enrichments(client, mock_confluence_fetcher):
+    """Test get_page without include param does not call enrichment methods."""
+    response = await client.call_tool("confluence_get_page", {"page_id": "123456"})
+
+    mock_confluence_fetcher.get_page_comments.assert_not_called()
+
+    result_data = json.loads(response.content[0].text)
+    assert "metadata" in result_data
+    assert "comments" not in result_data
+    assert "labels" not in result_data
+    assert "views" not in result_data
+
+
 # Phase 5: MCP Attachment Tools Tests (TDD RED Phase)
 @pytest.mark.anyio
 async def test_upload_attachment(client, mock_confluence_fetcher):
@@ -963,3 +1103,62 @@ async def test_get_page_images_fetch_failure(client, mock_confluence_fetcher):
     summary = json.loads(response.content[0].text)
     assert summary["downloaded"] == 0
     assert len(summary["failed"]) == 1
+
+
+@pytest.mark.anyio
+async def test_get_user_details_me(client, mock_confluence_fetcher):
+    """Test get_user_details with 'me' identifier returns current user."""
+    response = await client.call_tool(
+        "confluence_get_user_details", {"identifier": "me"}
+    )
+
+    mock_confluence_fetcher.get_current_user_info.assert_called_once()
+    result_data = json.loads(response.content[0].text)
+    assert result_data["accountId"] == "current-user-id"
+    assert result_data["displayName"] == "Current User"
+
+
+@pytest.mark.anyio
+async def test_get_user_details_me_case_insensitive(client, mock_confluence_fetcher):
+    """Test get_user_details with 'ME' identifier (case-insensitive)."""
+    response = await client.call_tool(
+        "confluence_get_user_details", {"identifier": "ME"}
+    )
+
+    mock_confluence_fetcher.get_current_user_info.assert_called_once()
+    result_data = json.loads(response.content[0].text)
+    assert result_data["accountId"] == "current-user-id"
+
+
+@pytest.mark.anyio
+async def test_get_user_details_cloud_account_id(client, mock_confluence_fetcher):
+    """Test get_user_details on Cloud routes to get_user_details_by_accountid."""
+    mock_confluence_fetcher.config.is_cloud = True
+
+    response = await client.call_tool(
+        "confluence_get_user_details", {"identifier": "a031248587011jasoidf9832jd8j1"}
+    )
+
+    mock_confluence_fetcher.get_user_details_by_accountid.assert_called_once_with(
+        "a031248587011jasoidf9832jd8j1"
+    )
+    result_data = json.loads(response.content[0].text)
+    assert result_data["accountId"] == "a031248587011jasoidf9832jd8j1"
+    assert result_data["displayName"] == "First Last"
+
+
+@pytest.mark.anyio
+async def test_get_user_details_server_username(client, mock_confluence_fetcher):
+    """Test get_user_details on Server/DC routes to get_user_details_by_username."""
+    mock_confluence_fetcher.config.is_cloud = False
+
+    response = await client.call_tool(
+        "confluence_get_user_details", {"identifier": "firstlast"}
+    )
+
+    mock_confluence_fetcher.get_user_details_by_username.assert_called_once_with(
+        "firstlast"
+    )
+    result_data = json.loads(response.content[0].text)
+    assert result_data["username"] == "firstlast"
+    assert result_data["displayName"] == "First Last"

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.client import FastMCPTransport
+from fastmcp.exceptions import ToolError
 from starlette.requests import Request
 
 from src.mcp_atlassian.confluence import ConfluenceFetcher
@@ -222,6 +223,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
         get_user_details,
         search,
         search_user,
+        set_content_property,
         update_page,
         upload_attachment,
         upload_attachments,
@@ -264,6 +266,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
     confluence_sub_mcp.add_tool(download_content_attachments)
     confluence_sub_mcp.add_tool(delete_attachment)
     confluence_sub_mcp.add_tool(get_page_images)
+    confluence_sub_mcp.add_tool(set_content_property)
 
     test_mcp.mount(confluence_sub_mcp, prefix="confluence")
 
@@ -870,6 +873,27 @@ async def test_get_page_include_views_graceful_degradation(
 
 
 @pytest.mark.anyio
+async def test_get_page_include_properties(client, mock_confluence_fetcher):
+    """Test get_page with include='properties' inlines content properties."""
+    mock_confluence_fetcher.get_content_properties.return_value = {
+        "content-appearance-published": "full-width",
+        "editor": {"version": 2},
+    }
+
+    response = await client.call_tool(
+        "confluence_get_page", {"page_id": "123456", "include": "properties"}
+    )
+
+    mock_confluence_fetcher.get_content_properties.assert_called_once_with("123456")
+
+    result_data = json.loads(response.content[0].text)
+    assert "metadata" in result_data
+    assert "properties" in result_data
+    assert result_data["properties"]["content-appearance-published"] == "full-width"
+    assert result_data["properties"]["editor"] == {"version": 2}
+
+
+@pytest.mark.anyio
 async def test_get_page_include_none_no_enrichments(client, mock_confluence_fetcher):
     """Test get_page without include param does not call enrichment methods."""
     response = await client.call_tool("confluence_get_page", {"page_id": "123456"})
@@ -1162,3 +1186,68 @@ async def test_get_user_details_server_username(client, mock_confluence_fetcher)
     result_data = json.loads(response.content[0].text)
     assert result_data["username"] == "firstlast"
     assert result_data["displayName"] == "First Last"
+
+
+@pytest.mark.anyio
+async def test_set_content_property_valid_json(client, mock_confluence_fetcher):
+    """Test set_content_property with valid JSON string value."""
+    mock_confluence_fetcher.set_content_property.return_value = {
+        "content-appearance-published": "full-width"
+    }
+
+    response = await client.call_tool(
+        "confluence_set_content_property",
+        {
+            "page_id": "123456",
+            "key": "content-appearance-published",
+            "value": '"full-width"',
+        },
+    )
+
+    mock_confluence_fetcher.set_content_property.assert_called_once_with(
+        "123456", "content-appearance-published", "full-width"
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["content-appearance-published"] == "full-width"
+
+
+@pytest.mark.anyio
+async def test_set_content_property_json_object(client, mock_confluence_fetcher):
+    """Test set_content_property with JSON object value."""
+    mock_confluence_fetcher.set_content_property.return_value = {
+        "editor": {"version": 2}
+    }
+
+    response = await client.call_tool(
+        "confluence_set_content_property",
+        {
+            "page_id": "123456",
+            "key": "editor",
+            "value": '{"version": 2}',
+        },
+    )
+
+    mock_confluence_fetcher.set_content_property.assert_called_once_with(
+        "123456", "editor", {"version": 2}
+    )
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["editor"] == {"version": 2}
+
+
+@pytest.mark.anyio
+async def test_set_content_property_invalid_json(client, mock_confluence_fetcher):
+    """Test set_content_property rejects invalid JSON value."""
+    with pytest.raises(ToolError) as excinfo:
+        await client.call_tool(
+            "confluence_set_content_property",
+            {
+                "page_id": "123456",
+                "key": "some-key",
+                "value": "not valid json",
+            },
+        )
+
+    assert "valid JSON" in str(excinfo.value)
+    mock_confluence_fetcher.set_content_property.assert_not_called()

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -146,6 +146,23 @@ def mock_jira_fetcher():
 
     mock_fetcher.update_issue.side_effect = mock_update_issue
 
+    # Configure assign_issue
+    def mock_assign_issue(issue_key, assignee=None):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test Issue",
+            "status": {"name": "Open"},
+            "assignee": (
+                {"displayName": "Test User", "accountId": "test-account-id"}
+                if assignee
+                else None
+            ),
+        }
+        return mock_issue
+
+    mock_fetcher.assign_issue.side_effect = mock_assign_issue
+
     # Configure batch_create_issues
     def mock_batch_create_issues(issues, validate_only=False):
         if not isinstance(issues, list):
@@ -383,6 +400,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         add_comment,
         add_issues_to_sprint,
         add_worklog,
+        assign_issue,
         batch_create_issues,
         batch_create_versions,
         batch_get_changelogs,
@@ -445,6 +463,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(batch_create_issues)
     jira_sub_mcp.add_tool(batch_get_changelogs)
     jira_sub_mcp.add_tool(update_issue)
+    jira_sub_mcp.add_tool(assign_issue)
     jira_sub_mcp.add_tool(delete_issue)
     jira_sub_mcp.add_tool(add_comment)
     jira_sub_mcp.add_tool(edit_comment)
@@ -1042,8 +1061,8 @@ async def test_get_all_projects_tool(jira_client, mock_jira_fetcher):
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with default parameters (include_archived=False)
@@ -1091,8 +1110,8 @@ async def test_get_all_projects_tool_with_archived(jira_client, mock_jira_fetche
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with include_archived=True
@@ -1145,8 +1164,8 @@ async def test_get_all_projects_tool_with_projects_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up the projects filter in the config
@@ -1199,8 +1218,8 @@ async def test_get_all_projects_tool_no_projects_filter(jira_client, mock_jira_f
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Ensure no projects filter is set
@@ -1260,8 +1279,8 @@ async def test_get_all_projects_tool_case_insensitive_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up projects filter with mixed case and whitespace
@@ -2430,3 +2449,277 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
     # return_limit=1 caps to first match
     assert len(result) == 1
     assert result[0] == "High"
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_remote_links(jira_client, mock_jira_fetcher):
+    """get_issue with include=remote_links fetches remote links."""
+    mock_jira_fetcher.get_remote_issue_links.return_value = [
+        {
+            "id": 1,
+            "object": {
+                "url": "https://example.com",
+                "title": "Link",
+            },
+        }
+    ]
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "remote_links"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "remote_links" in content
+    assert len(content["remote_links"]) == 1
+    mock_jira_fetcher.get_remote_issue_links.assert_called_once_with("TEST-123")
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_watchers(jira_client, mock_jira_fetcher):
+    """get_issue with include=watchers fetches watchers."""
+    mock_jira_fetcher.get_issue_watchers.return_value = {
+        "watchCount": 1,
+        "watchers": [{"name": "user1"}],
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "watchers"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "watchers" in content
+    assert content["watchers"]["watchCount"] == 1
+    mock_jira_fetcher.get_issue_watchers.assert_called_once_with("TEST-123")
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_transitions_adds_expand(
+    jira_client, mock_jira_fetcher
+):
+    """get_issue with include=transitions adds to expand."""
+    await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "transitions"},
+    )
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "transitions" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_changelog_adds_expand(jira_client, mock_jira_fetcher):
+    """get_issue with include=changelog adds to expand."""
+    await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "changelog"},
+    )
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "changelog" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_multiple(jira_client, mock_jira_fetcher):
+    """get_issue with multiple include sections."""
+    mock_jira_fetcher.get_remote_issue_links.return_value = []
+    mock_jira_fetcher.get_issue_watchers.return_value = {
+        "watchCount": 0,
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {
+            "issue_key": "TEST-123",
+            "include": "remote_links,watchers,transitions,changelog",
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert "remote_links" in content
+    assert "watchers" in content
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "transitions" in expand_val
+    assert "changelog" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_preserves_existing_expand(
+    jira_client, mock_jira_fetcher
+):
+    """include merges with an existing expand parameter."""
+    await jira_client.call_tool(
+        "jira_get_issue",
+        {
+            "issue_key": "TEST-123",
+            "expand": "renderedFields",
+            "include": "transitions",
+        },
+    )
+    call_args = mock_jira_fetcher.get_issue.call_args
+    expand_val = call_args.kwargs.get("expand", "")
+    assert "renderedFields" in expand_val
+    assert "transitions" in expand_val
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_none_no_enrichments(jira_client, mock_jira_fetcher):
+    """Omitting include produces no enrichment keys."""
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "remote_links" not in content
+    assert "watchers" not in content
+
+
+# =============================================================================
+# assign_issue tests
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_assign_issue(jira_client, mock_jira_fetcher):
+    """Test assigning an issue to a user."""
+    response = await jira_client.call_tool(
+        "jira_assign_issue",
+        {
+            "issue_key": "TEST-123",
+            "assignee": "user@example.com",
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue TEST-123 assigned successfully"
+    assert "issue" in content
+    mock_jira_fetcher.assign_issue.assert_called_once_with(
+        issue_key="TEST-123", assignee="user@example.com"
+    )
+
+
+@pytest.mark.anyio
+async def test_assign_issue_unassign(jira_client, mock_jira_fetcher):
+    """Test unassigning an issue (passing None)."""
+    response = await jira_client.call_tool(
+        "jira_assign_issue",
+        {
+            "issue_key": "TEST-123",
+            "assignee": None,
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue TEST-123 assigned successfully"
+    mock_jira_fetcher.assign_issue.assert_called_once_with(
+        issue_key="TEST-123", assignee=None
+    )
+
+
+@pytest.mark.anyio
+async def test_assign_issue_error(jira_client, mock_jira_fetcher):
+    """Test assign_issue error handling."""
+    mock_jira_fetcher.assign_issue.side_effect = ValueError("User not found")
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_assign_issue",
+            {
+                "issue_key": "TEST-123",
+                "assignee": "nonexistent@example.com",
+            },
+        )
+    assert "User not found" in str(excinfo.value)
+
+
+# ============================================================================
+# Display-Name Feature Tests
+# ============================================================================
+
+
+@pytest.mark.anyio
+async def test_get_issue_use_display_names(jira_client, mock_jira_fetcher):
+    """Test get_issue with use_display_names=True returns display-name keys."""
+    display_name_response = {
+        "key": "TEST-123",
+        "summary": "Test Issue Summary",
+        "status": {"name": "Open"},
+        "Story Points": {"value": 5, "field_id": "customfield_10243"},
+    }
+
+    def mock_get_issue_dn(
+        issue_key,
+        fields=None,
+        expand=None,
+        comment_limit=10,
+        properties=None,
+        update_history=True,
+    ):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test Issue Summary",
+            "status": {"name": "Open"},
+            "customfield_10243": 5,
+        }
+        mock_issue.to_display_name_dict.return_value = {
+            **display_name_response,
+            "key": issue_key,
+        }
+        return mock_issue
+
+    mock_jira_fetcher.get_issue.side_effect = mock_get_issue_dn
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "use_display_names": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert "Story Points" in content
+    assert "customfield_10243" not in content
+
+    mock_jira_fetcher.get_issue.assert_called_once()
+    call_kwargs = mock_jira_fetcher.get_issue.call_args
+    assert call_kwargs[1]["issue_key"] == "TEST-123"
+    assert call_kwargs[1]["expand"] == "names"
+
+
+@pytest.mark.anyio
+async def test_search_use_display_names(jira_client, mock_jira_fetcher):
+    """Test search with use_display_names=True returns display-name keys."""
+    display_name_issues = [
+        {
+            "key": "PROJ-123",
+            "summary": "First issue",
+            "Story Points": {"value": 3, "field_id": "customfield_10243"},
+        },
+    ]
+
+    def mock_search_dn(jql, **kwargs):
+        mock_search_result = MagicMock()
+        mock_search_result.to_simplified_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": [
+                {"key": "PROJ-123", "summary": "First issue", "customfield_10243": 3},
+            ],
+        }
+        mock_search_result.to_display_name_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": display_name_issues,
+        }
+        return mock_search_result
+
+    mock_jira_fetcher.search_issues.side_effect = mock_search_dn
+
+    response = await jira_client.call_tool(
+        "jira_search",
+        {"jql": "project = TEST", "use_display_names": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert content["issues"][0].get("Story Points") is not None
+    assert "customfield_10243" not in content["issues"][0]
+
+    mock_jira_fetcher.search_issues.assert_called_once()
+    call_kwargs = mock_jira_fetcher.search_issues.call_args
+    assert call_kwargs[1]["jql"] == "project = TEST"
+    assert call_kwargs[1]["expand"] == "names"

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2723,3 +2723,63 @@ async def test_search_use_display_names(jira_client, mock_jira_fetcher):
     call_kwargs = mock_jira_fetcher.search_issues.call_args
     assert call_kwargs[1]["jql"] == "project = TEST"
     assert call_kwargs[1]["expand"] == "names"
+
+
+# ============================================================================
+# update_issue attachment upload tests
+# ============================================================================
+
+
+@pytest.mark.anyio
+async def test_update_issue_with_attachments_comma_separated(
+    jira_client, mock_jira_fetcher
+):
+    """update_issue with attachments param uploads files via the mixin."""
+    response = await jira_client.call_tool(
+        "jira_update_issue",
+        {
+            "issue_key": "TEST-123",
+            "fields": '{"summary": "Updated"}',
+            "attachments": "/path/to/file1.pdf,/path/to/file2.png",
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue updated successfully"
+    mock_jira_fetcher.update_issue.assert_called_once()
+    call_kwargs = mock_jira_fetcher.update_issue.call_args[1]
+    assert call_kwargs["attachments"] == ["/path/to/file1.pdf", "/path/to/file2.png"]
+
+
+@pytest.mark.anyio
+async def test_update_issue_with_attachments_json_array(jira_client, mock_jira_fetcher):
+    """update_issue with attachments as JSON array string."""
+    response = await jira_client.call_tool(
+        "jira_update_issue",
+        {
+            "issue_key": "TEST-123",
+            "fields": '{"summary": "Updated"}',
+            "attachments": '["/path/to/file1.pdf", "/path/to/file2.png"]',
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue updated successfully"
+    mock_jira_fetcher.update_issue.assert_called_once()
+    call_kwargs = mock_jira_fetcher.update_issue.call_args[1]
+    assert call_kwargs["attachments"] == ["/path/to/file1.pdf", "/path/to/file2.png"]
+
+
+@pytest.mark.anyio
+async def test_update_issue_without_attachments(jira_client, mock_jira_fetcher):
+    """update_issue without attachments param does not pass attachments kwarg."""
+    response = await jira_client.call_tool(
+        "jira_update_issue",
+        {
+            "issue_key": "TEST-123",
+            "fields": '{"summary": "Updated"}',
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue updated successfully"
+    mock_jira_fetcher.update_issue.assert_called_once()
+    call_kwargs = mock_jira_fetcher.update_issue.call_args[1]
+    assert "attachments" not in call_kwargs

--- a/tests/unit/servers/test_transport_lifecycle.py
+++ b/tests/unit/servers/test_transport_lifecycle.py
@@ -78,6 +78,10 @@ class TestTransportLifecycleBehavior:
                             called_coro, "cr_code"
                         ), f"{transport} should use direct run_async execution"
 
+                        # Close unawaited coroutine to avoid RuntimeWarning
+                        if hasattr(called_coro, "close"):
+                            called_coro.close()
+
     @pytest.mark.anyio
     async def test_stdio_no_race_condition(self):
         """Test that stdio transport doesn't create race condition with MCP server.
@@ -177,6 +181,10 @@ class TestTransportLifecycleBehavior:
                             called_coro
                         )
 
+                        # Close unawaited coroutine to avoid RuntimeWarning
+                        if hasattr(called_coro, "close"):
+                            called_coro.close()
+
     @pytest.mark.anyio
     async def test_shutdown_event_handling(self):
         """Test that shutdown events are handled correctly for all transports."""
@@ -236,6 +244,10 @@ class TestTransportLifecycleBehavior:
                         called_coro
                     )
 
+                    # Close unawaited coroutine to avoid RuntimeWarning
+                    if hasattr(called_coro, "close"):
+                        called_coro.close()
+
 
 class TestRegressionPrevention:
     """Tests to prevent regression of specific issues."""
@@ -256,7 +268,7 @@ class TestRegressionPrevention:
     def test_signal_handlers_are_setup(self):
         """Verify signal handlers are properly configured."""
         with patch("mcp_atlassian.setup_signal_handlers") as mock_setup:
-            with patch("asyncio.run"):
+            with patch("asyncio.run") as mock_run:
                 with patch("mcp_atlassian.servers.main.AtlassianMCP"):
                     with patch("sys.argv", ["mcp-atlassian"]):
                         try:
@@ -266,3 +278,9 @@ class TestRegressionPrevention:
 
                     # Signal handlers should always be set up
                     mock_setup.assert_called_once()
+
+                # Close captured coroutines
+                for call in mock_run.call_args_list:
+                    coro = call[0][0] if call[0] else None
+                    if coro and hasattr(coro, "close"):
+                        coro.close()

--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -22,9 +22,19 @@ class TestMainTransportSelection:
     def mock_asyncio_run(self):
         """Mock asyncio.run to capture what coroutine is executed."""
         with patch("asyncio.run") as mock_run:
-            # Store the coroutine for inspection
-            mock_run.side_effect = lambda coro: setattr(mock_run, "_called_with", coro)
+            captured_coros = []
+
+            def _capture(coro):
+                captured_coros.append(coro)
+                mock_run._called_with = coro
+
+            mock_run.side_effect = _capture
             yield mock_run
+
+            # Close all captured coroutines to avoid RuntimeWarning
+            for coro in captured_coros:
+                if hasattr(coro, "close"):
+                    coro.close()
 
     @pytest.mark.parametrize("transport", ["sse", "streamable-http"])
     def test_http_transports_use_direct_execution(
@@ -148,7 +158,7 @@ class TestMainTransportSelection:
     def test_signal_handlers_always_setup(self, mock_server):
         """Test that signal handlers are set up regardless of transport."""
         with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
-            with patch("asyncio.run"):
+            with patch("asyncio.run") as mock_run:
                 # Patch where it's imported in the main module
                 with patch("mcp_atlassian.setup_signal_handlers") as mock_setup:
                     with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
@@ -161,6 +171,12 @@ class TestMainTransportSelection:
                             # Signal handlers should always be set up
                             mock_setup.assert_called_once()
 
+                # Close captured coroutines
+                for call in mock_run.call_args_list:
+                    coro = call[0][0] if call[0] else None
+                    if coro and hasattr(coro, "close"):
+                        coro.close()
+
     def test_error_handling_preserved(self, mock_server):
         """Test that error handling works correctly for all transports."""
         # Make the server's run_async raise an exception when awaited
@@ -171,10 +187,16 @@ class TestMainTransportSelection:
 
         mock_server.run_async = failing_run_async
 
+        leaked_coros = []
+
+        def _raise_and_capture(coro):
+            leaked_coros.append(coro)
+            raise error
+
         with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
             with patch("asyncio.run") as mock_run:
                 # Simulate the exception propagating through asyncio.run
-                mock_run.side_effect = error
+                mock_run.side_effect = _raise_and_capture
 
                 with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
                     with patch("sys.argv", ["mcp-atlassian"]):
@@ -188,3 +210,8 @@ class TestMainTransportSelection:
                             assert (
                                 mock_exit.call_args_list[1][0][0] == 0
                             )  # Finally exit
+
+        # Close leaked coroutines to avoid RuntimeWarning
+        for coro in leaked_coros:
+            if hasattr(coro, "close"):
+                coro.close()

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -436,7 +436,10 @@ class TestGetAvailableServicesWithHeaders:
             assert "Data Center" in caplog.text
 
     def test_oauth_enable_without_urls(self, caplog):
-        """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true without service URLs."""
+        """Test that ATLASSIAN_OAUTH_ENABLE=true without service URLs does NOT mark services as available.
+
+        The OAuth enable check is now scoped inside the URL check, so a URL is required.
+        """
         with MockEnvironment.clean_env():
             import os
 
@@ -444,17 +447,10 @@ class TestGetAvailableServicesWithHeaders:
 
             result = get_available_services()
             _assert_service_availability(
-                result, confluence_expected=True, jira_expected=True
+                result, confluence_expected=False, jira_expected=False
             )
-            assert_log_contains(
-                caplog,
-                "INFO",
-                "Using Confluence minimal OAuth configuration",
-            )
-            assert_log_contains(
-                caplog,
-                "INFO",
-                "Using Jira minimal OAuth configuration",
+            _assert_authentication_logs(
+                caplog, "not_configured", ["confluence", "jira"]
             )
 
     def test_oauth_enable_with_cloud_url_no_creds(self, caplog):
@@ -476,7 +472,25 @@ class TestGetAvailableServicesWithHeaders:
         ["true", "True", "TRUE", "1", "yes", "YES"],
     )
     def test_oauth_enable_value_variations(self, enable_value, caplog):
-        """Test various ATLASSIAN_OAUTH_ENABLE value formats."""
+        """Test various ATLASSIAN_OAUTH_ENABLE value formats with URLs present."""
+        with MockEnvironment.clean_env():
+            import os
+
+            os.environ["ATLASSIAN_OAUTH_ENABLE"] = enable_value
+            os.environ["CONFLUENCE_URL"] = "https://test.atlassian.net/wiki"
+            os.environ["JIRA_URL"] = "https://test.atlassian.net"
+
+            result = get_available_services()
+            _assert_service_availability(
+                result, confluence_expected=True, jira_expected=True
+            )
+
+    @pytest.mark.parametrize(
+        "enable_value",
+        ["true", "True", "TRUE", "1", "yes", "YES"],
+    )
+    def test_oauth_enable_without_urls_value_variations(self, enable_value, caplog):
+        """Test that ATLASSIAN_OAUTH_ENABLE without URLs returns False regardless of value format."""
         with MockEnvironment.clean_env():
             import os
 
@@ -484,7 +498,7 @@ class TestGetAvailableServicesWithHeaders:
 
             result = get_available_services()
             _assert_service_availability(
-                result, confluence_expected=True, jira_expected=True
+                result, confluence_expected=False, jira_expected=False
             )
 
     @pytest.mark.parametrize(

--- a/tests/unit/utils/test_oauth_setup.py
+++ b/tests/unit/utils/test_oauth_setup.py
@@ -1,6 +1,8 @@
 """Tests for the OAuth setup utilities."""
 
 import json
+import logging
+import os
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -8,6 +10,8 @@ import pytest
 
 from mcp_atlassian.utils.oauth_setup import (
     OAuthSetupArgs,
+    _log_cloud_success,
+    _log_dc_success,
     parse_redirect_uri,
     run_oauth_flow,
     run_oauth_setup,
@@ -15,6 +19,8 @@ from mcp_atlassian.utils.oauth_setup import (
 from tests.utils.assertions import assert_config_contains
 from tests.utils.base import BaseAuthTest
 from tests.utils.mocks import MockEnvironment, MockOAuthServer
+
+DC_JIRA_URL = "https://jira.local.example.com"
 
 
 class TestCallbackHandlerLogic:
@@ -111,6 +117,7 @@ class TestOAuthFlow:
                 mock_config.redirect_uri = "http://localhost:8080/callback"
                 mock_config.scope = "read:jira-work"
                 mock_config.cloud_id = "test-cloud-id"
+                mock_config.is_data_center = False
                 mock_config.access_token = "test-access-token"
                 mock_config.refresh_token = "test-refresh-token"
                 mock_oauth_config.return_value = mock_config
@@ -161,6 +168,7 @@ class TestOAuthFlow:
                 mock_config.redirect_uri = "https://example.com/callback"
                 mock_config.scope = "read:jira-work"
                 mock_config.cloud_id = "test-cloud-id"
+                mock_config.is_data_center = False
                 mock_config.access_token = "test-access-token"
                 mock_config.refresh_token = "test-refresh-token"
                 mock_oauth_config.return_value = mock_config
@@ -175,11 +183,120 @@ class TestOAuthFlow:
                 result = run_oauth_flow(args)
 
                 assert result is True
-                mock_start_server.assert_not_called()  # No local server for external redirect
+                # No local server for external redirect
+                mock_start_server.assert_not_called()
                 mocks["browser"].assert_called_once()
                 mock_config.exchange_code_for_tokens.assert_called_once_with(
                     "test-auth-code"
                 )
+
+    def test_run_oauth_flow_success_dc(self):
+        """Test successful OAuth flow with DC base_url."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+            ):
+
+                def setup_callback_state():
+                    import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                    oauth_module.authorization_code = "test-auth-code"
+                    oauth_module.authorization_state = "test-state-token"
+                    return True
+
+                mock_wait.side_effect = setup_callback_state
+                mock_httpd = MagicMock()
+                mock_start_server.return_value = mock_httpd
+
+                mock_config = MagicMock()
+                mock_config.exchange_code_for_tokens.return_value = True
+                mock_config.client_id = "dc-client-id"
+                mock_config.client_secret = "dc-client-secret"
+                mock_config.redirect_uri = "http://localhost:8080/callback"
+                mock_config.scope = "WRITE"
+                mock_config.cloud_id = None
+                mock_config.is_data_center = True
+                mock_config.base_url = DC_JIRA_URL
+                mock_config.access_token = "dc-access-token"
+                mock_config.refresh_token = None
+                mock_oauth_config.return_value = mock_config
+
+                args = OAuthSetupArgs(
+                    client_id="dc-client-id",
+                    client_secret="dc-client-secret",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="WRITE",
+                    base_url=DC_JIRA_URL,
+                )
+
+                result = run_oauth_flow(args)
+
+                assert result is True
+                mock_oauth_config.assert_called_once_with(
+                    client_id="dc-client-id",
+                    client_secret="dc-client-secret",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="WRITE",
+                    base_url=DC_JIRA_URL,
+                )
+                mock_config.exchange_code_for_tokens.assert_called_once_with(
+                    "test-auth-code"
+                )
+                mock_httpd.shutdown.assert_called_once()
+
+    def test_run_oauth_flow_dc_no_cloud_id_error(self):
+        """Test that DC flow does not log 'Failed to obtain cloud ID'."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+                patch("mcp_atlassian.utils.oauth_setup._log_dc_success") as mock_dc_log,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup._log_cloud_success"
+                ) as mock_cloud_log,
+            ):
+
+                def setup_callback_state():
+                    import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                    oauth_module.authorization_code = "test-auth-code"
+                    oauth_module.authorization_state = "test-state-token"
+                    return True
+
+                mock_wait.side_effect = setup_callback_state
+                mock_start_server.return_value = MagicMock()
+
+                mock_config = MagicMock()
+                mock_config.exchange_code_for_tokens.return_value = True
+                mock_config.is_data_center = True
+                mock_config.cloud_id = None
+                mock_config.refresh_token = None
+                mock_oauth_config.return_value = mock_config
+
+                args = OAuthSetupArgs(
+                    client_id="dc-id",
+                    client_secret="dc-secret",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="WRITE",
+                    base_url=DC_JIRA_URL,
+                )
+
+                result = run_oauth_flow(args)
+
+                assert result is True
+                mock_dc_log.assert_called_once_with(mock_config)
+                mock_cloud_log.assert_not_called()
 
     def test_run_oauth_flow_server_start_failure(self):
         """Test OAuth flow when server fails to start."""
@@ -210,7 +327,7 @@ class TestOAuthFlow:
     )
     def test_run_oauth_flow_failures(self, failure_condition, expected_result):
         """Test OAuth flow failure scenarios."""
-        with MockOAuthServer.mock_oauth_flow() as mocks:
+        with MockOAuthServer.mock_oauth_flow():
             with (
                 patch(
                     "mcp_atlassian.utils.oauth_setup.OAuthConfig"
@@ -260,15 +377,192 @@ class TestOAuthFlow:
                 assert result == expected_result
                 mock_httpd.shutdown.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "failure_condition,expected_result",
+        [
+            ("timeout", False),
+            ("state_mismatch", False),
+            ("token_exchange_failure", False),
+        ],
+    )
+    def test_run_oauth_flow_dc_failures(self, failure_condition, expected_result):
+        """Test OAuth flow failure scenarios for DC."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+            ):
+                mock_httpd = MagicMock()
+                mock_start_server.return_value = mock_httpd
+                mock_config = MagicMock()
+                mock_config.is_data_center = True
+                mock_config.cloud_id = None
+                mock_config.base_url = DC_JIRA_URL
+                mock_oauth_config.return_value = mock_config
+
+                if failure_condition == "timeout":
+                    mock_wait.return_value = False
+                elif failure_condition == "state_mismatch":
+
+                    def setup_mismatched_state():
+                        import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                        oauth_module.authorization_code = "test-auth-code"
+                        oauth_module.authorization_state = "wrong-state"
+                        return True
+
+                    mock_wait.side_effect = setup_mismatched_state
+                elif failure_condition == "token_exchange_failure":
+
+                    def setup_callback_state():
+                        import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                        oauth_module.authorization_code = "test-auth-code"
+                        oauth_module.authorization_state = "test-state-token"
+                        return True
+
+                    mock_wait.side_effect = setup_callback_state
+                    mock_config.exchange_code_for_tokens.return_value = False
+
+                args = OAuthSetupArgs(
+                    client_id="dc-client-id",
+                    client_secret="dc-client-secret",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="WRITE",
+                    base_url=DC_JIRA_URL,
+                )
+
+                result = run_oauth_flow(args)
+                assert result == expected_result
+                mock_httpd.shutdown.assert_called_once()
+
+    def test_run_oauth_flow_dc_no_refresh_token_warning(self, caplog):
+        """Test DC flow logs warning when no refresh token received."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+                patch("mcp_atlassian.utils.oauth_setup._log_dc_success"),
+            ):
+
+                def setup_callback_state():
+                    import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                    oauth_module.authorization_code = "test-auth-code"
+                    oauth_module.authorization_state = "test-state-token"
+                    return True
+
+                mock_wait.side_effect = setup_callback_state
+                mock_httpd = MagicMock()
+                mock_start_server.return_value = mock_httpd
+
+                mock_config = MagicMock()
+                mock_config.exchange_code_for_tokens.return_value = True
+                mock_config.is_data_center = True
+                mock_config.refresh_token = None
+                mock_config.cloud_id = None
+                mock_config.base_url = DC_JIRA_URL
+                mock_oauth_config.return_value = mock_config
+
+                args = OAuthSetupArgs(
+                    client_id="dc-client-id",
+                    client_secret="dc-client-secret",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="WRITE",
+                    base_url=DC_JIRA_URL,
+                )
+
+                with caplog.at_level(
+                    logging.WARNING, logger="mcp-atlassian.oauth-setup"
+                ):
+                    result = run_oauth_flow(args)
+
+                assert result is True
+                assert (
+                    "No refresh token received. DC tokens may expire "
+                    "and require re-authentication." in caplog.text
+                )
+
+    def test_run_oauth_flow_dc_with_refresh_token_no_warning(self, caplog):
+        """Test DC flow does not log warning when refresh token is present."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+                patch("mcp_atlassian.utils.oauth_setup._log_dc_success"),
+            ):
+
+                def setup_callback_state():
+                    import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                    oauth_module.authorization_code = "test-auth-code"
+                    oauth_module.authorization_state = "test-state-token"
+                    return True
+
+                mock_wait.side_effect = setup_callback_state
+                mock_httpd = MagicMock()
+                mock_start_server.return_value = mock_httpd
+
+                mock_config = MagicMock()
+                mock_config.exchange_code_for_tokens.return_value = True
+                mock_config.is_data_center = True
+                mock_config.refresh_token = "dc-refresh-tok"
+                mock_config.cloud_id = None
+                mock_config.base_url = DC_JIRA_URL
+                mock_oauth_config.return_value = mock_config
+
+                args = OAuthSetupArgs(
+                    client_id="dc-client-id",
+                    client_secret="dc-client-secret",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="WRITE",
+                    base_url=DC_JIRA_URL,
+                )
+
+                with caplog.at_level(
+                    logging.WARNING, logger="mcp-atlassian.oauth-setup"
+                ):
+                    result = run_oauth_flow(args)
+
+                assert result is True
+                assert (
+                    "No refresh token received. DC tokens may expire "
+                    "and require re-authentication." not in caplog.text
+                )
+
 
 class TestInteractiveSetup(BaseAuthTest):
     """Tests for the interactive OAuth setup wizard."""
 
     def test_run_oauth_setup_with_env_vars(self):
-        """Test interactive setup using environment variables."""
+        """Test interactive setup using Cloud environment variables."""
         with MockEnvironment.oauth_env() as env_vars:
             with (
-                patch("builtins.input", side_effect=["", "", "", ""]),
+                patch(
+                    "builtins.input",
+                    side_effect=[
+                        "",  # instance URL (from env / empty = Cloud)
+                        "",  # client_id
+                        "",  # client_secret
+                        "",  # redirect_uri
+                        "",  # scope
+                    ],
+                ),
                 patch(
                     "mcp_atlassian.utils.oauth_setup.run_oauth_flow", return_value=True
                 ) as mock_flow,
@@ -283,12 +577,14 @@ class TestInteractiveSetup(BaseAuthTest):
                     client_id=env_vars["ATLASSIAN_OAUTH_CLIENT_ID"],
                     client_secret=env_vars["ATLASSIAN_OAUTH_CLIENT_SECRET"],
                 )
+                assert args.base_url is None
 
     @pytest.mark.parametrize(
         "input_values,expected_result",
         [
             (
                 [
+                    "",  # instance URL (empty = Cloud)
                     "user-client-id",
                     "user-secret",
                     "http://localhost:9000/callback",
@@ -296,8 +592,26 @@ class TestInteractiveSetup(BaseAuthTest):
                 ],
                 0,
             ),
-            (["", "client-secret", "", ""], 1),  # Missing client ID
-            (["client-id", "", "", ""], 1),  # Missing client secret
+            (
+                [
+                    "",  # instance URL
+                    "",  # missing client ID
+                    "client-secret",
+                    "",
+                    "",
+                ],
+                1,
+            ),
+            (
+                [
+                    "",  # instance URL
+                    "client-id",
+                    "",  # missing client secret
+                    "",
+                    "",
+                ],
+                1,
+            ),
         ],
     )
     def test_run_oauth_setup_user_input(self, input_values, expected_result):
@@ -322,7 +636,14 @@ class TestInteractiveSetup(BaseAuthTest):
         with MockEnvironment.clean_env():
             with (
                 patch(
-                    "builtins.input", side_effect=["client-id", "client-secret", "", ""]
+                    "builtins.input",
+                    side_effect=[
+                        "",  # instance URL
+                        "client-id",
+                        "client-secret",
+                        "",
+                        "",
+                    ],
                 ),
                 patch(
                     "mcp_atlassian.utils.oauth_setup.run_oauth_flow", return_value=False
@@ -330,6 +651,126 @@ class TestInteractiveSetup(BaseAuthTest):
             ):
                 result = run_oauth_setup()
                 assert result == 1
+
+    def test_run_oauth_setup_dc_instance(self):
+        """Test interactive setup with a DC instance URL."""
+        dc_env = {
+            "JIRA_URL": DC_JIRA_URL,
+            "JIRA_OAUTH_CLIENT_ID": "dc-client-id",
+            "JIRA_OAUTH_CLIENT_SECRET": "dc-client-secret",
+        }
+        with MockEnvironment.clean_env():
+            with (
+                patch.dict(os.environ, dc_env, clear=False),
+                patch(
+                    "builtins.input",
+                    side_effect=[
+                        "",  # instance URL (picks up JIRA_URL)
+                        "",  # client_id (picks up JIRA_OAUTH_CLIENT_ID)
+                        "",  # client_secret
+                        "",  # redirect_uri
+                        "",  # scope
+                    ],
+                ),
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.run_oauth_flow",
+                    return_value=True,
+                ) as mock_flow,
+            ):
+                result = run_oauth_setup()
+
+                assert result == 0
+                mock_flow.assert_called_once()
+                args = mock_flow.call_args[0][0]
+                assert args.base_url == DC_JIRA_URL
+                assert args.client_id == "dc-client-id"
+                assert args.scope == "WRITE"
+
+    def test_run_oauth_setup_dc_manual_input(self):
+        """Test interactive setup with manually typed DC URL."""
+        with MockEnvironment.clean_env():
+            with (
+                patch(
+                    "builtins.input",
+                    side_effect=[
+                        DC_JIRA_URL,  # instance URL
+                        "manual-dc-id",  # client_id
+                        "manual-dc-secret",  # client_secret
+                        "",  # redirect_uri (default)
+                        "",  # scope (default WRITE for DC)
+                    ],
+                ),
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.run_oauth_flow",
+                    return_value=True,
+                ) as mock_flow,
+            ):
+                result = run_oauth_setup()
+
+                assert result == 0
+                args = mock_flow.call_args[0][0]
+                assert args.base_url == DC_JIRA_URL
+                assert args.client_id == "manual-dc-id"
+                assert args.scope == "WRITE"
+
+    def test_run_oauth_setup_cloud_url_no_base_url(self):
+        """Test that Cloud URLs do not set base_url."""
+        with MockEnvironment.clean_env():
+            with (
+                patch(
+                    "builtins.input",
+                    side_effect=[
+                        "https://company.atlassian.net",  # Cloud URL
+                        "cloud-id",
+                        "cloud-secret",
+                        "",
+                        "",
+                    ],
+                ),
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.run_oauth_flow",
+                    return_value=True,
+                ) as mock_flow,
+            ):
+                result = run_oauth_setup()
+
+                assert result == 0
+                args = mock_flow.call_args[0][0]
+                assert args.base_url is None
+
+    def test_run_oauth_setup_dc_fallback_to_atlassian_env_vars(self):
+        """Test DC wizard falls back to ATLASSIAN_OAUTH_* when JIRA_OAUTH_* unset."""
+        dc_env = {
+            "JIRA_URL": DC_JIRA_URL,
+            "ATLASSIAN_OAUTH_CLIENT_ID": "fallback-id",
+            "ATLASSIAN_OAUTH_CLIENT_SECRET": "fallback-secret",
+        }
+        with MockEnvironment.clean_env():
+            with (
+                patch.dict(os.environ, dc_env, clear=False),
+                patch(
+                    "builtins.input",
+                    side_effect=[
+                        "",  # instance URL (picks up JIRA_URL)
+                        "",  # client_id (fallback to ATLASSIAN_OAUTH_CLIENT_ID)
+                        "",  # client_secret
+                        "",  # redirect_uri
+                        "",  # scope
+                    ],
+                ),
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.run_oauth_flow",
+                    return_value=True,
+                ) as mock_flow,
+            ):
+                result = run_oauth_setup()
+
+                assert result == 0
+                mock_flow.assert_called_once()
+                args = mock_flow.call_args[0][0]
+                assert args.client_id == "fallback-id"
+                assert args.client_secret == "fallback-secret"
+                assert args.base_url == DC_JIRA_URL
 
 
 class TestOAuthSetupArgs:
@@ -351,6 +792,24 @@ class TestOAuthSetupArgs:
             "scope": "read:jira-work",
         }
         assert_config_contains(vars(args), **expected_config)
+        assert args.base_url is None
+
+    def test_oauth_setup_args_with_base_url(self):
+        """Test OAuthSetupArgs with DC base_url."""
+        args = OAuthSetupArgs(
+            client_id="dc-id",
+            client_secret="dc-secret",
+            redirect_uri="http://localhost:8080/callback",
+            scope="WRITE",
+            base_url=DC_JIRA_URL,
+        )
+
+        assert_config_contains(
+            vars(args),
+            client_id="dc-id",
+            scope="WRITE",
+            base_url=DC_JIRA_URL,
+        )
 
 
 class TestConfigurationGeneration:
@@ -373,3 +832,81 @@ class TestConfigurationGeneration:
         # Verify it can be parsed back
         parsed = json.loads(json_str)
         assert_config_contains(parsed, **test_config)
+
+    def test_dc_configuration_serialization(self):
+        """Test DC configuration serialization (no cloud_id, includes JIRA_URL)."""
+        test_config = {
+            "JIRA_URL": DC_JIRA_URL,
+            "JIRA_OAUTH_CLIENT_ID": "dc-id",
+            "JIRA_OAUTH_CLIENT_SECRET": "dc-secret",
+            "ATLASSIAN_OAUTH_REDIRECT_URI": "http://localhost:8080/callback",
+            "ATLASSIAN_OAUTH_SCOPE": "WRITE",
+        }
+
+        json_str = json.dumps(test_config, indent=4)
+        assert DC_JIRA_URL in json_str
+        assert "dc-id" in json_str
+        assert "cloud_id" not in json_str
+        assert "ATLASSIAN_OAUTH_CLOUD_ID" not in json_str
+
+        parsed = json.loads(json_str)
+        assert_config_contains(parsed, **test_config)
+
+
+class TestSuccessOutputHelpers:
+    """Tests for _log_cloud_success and _log_dc_success."""
+
+    def test_log_cloud_success(self, caplog):
+        """Test Cloud success output logs correct env vars."""
+        mock_config = MagicMock()
+        mock_config.client_id = "cloud-id"
+        mock_config.client_secret = "cloud-secret"
+        mock_config.redirect_uri = "http://localhost:8080/callback"
+        mock_config.scope = "read:jira-work offline_access"
+        mock_config.cloud_id = "test-cloud-id"
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="mcp-atlassian.oauth-setup"):
+            _log_cloud_success(mock_config)
+
+        log_text = caplog.text
+        assert "ATLASSIAN_OAUTH_CLOUD_ID=test-cloud-id" in log_text
+        assert "ATLASSIAN_OAUTH_CLIENT_ID=cloud-id" in log_text
+
+    def test_log_dc_success(self, caplog):
+        """Test DC success output logs correct env vars."""
+        mock_config = MagicMock()
+        mock_config.client_id = "dc-id"
+        mock_config.client_secret = "dc-secret"
+        mock_config.redirect_uri = "http://localhost:8080/callback"
+        mock_config.scope = "WRITE"
+        mock_config.base_url = DC_JIRA_URL
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="mcp-atlassian.oauth-setup"):
+            _log_dc_success(mock_config)
+
+        log_text = caplog.text
+        assert f"JIRA_URL={DC_JIRA_URL}" in log_text
+        assert "JIRA_OAUTH_CLIENT_ID=dc-id" in log_text
+        assert "ATLASSIAN_OAUTH_CLOUD_ID" not in log_text
+
+    def test_log_dc_success_no_cloud_id_in_vscode_config(self, caplog):
+        """Test DC VS Code config does not contain ATLASSIAN_OAUTH_CLOUD_ID."""
+        mock_config = MagicMock()
+        mock_config.client_id = "dc-id"
+        mock_config.client_secret = "dc-secret"
+        mock_config.redirect_uri = "http://localhost:8080/callback"
+        mock_config.scope = "WRITE"
+        mock_config.base_url = DC_JIRA_URL
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="mcp-atlassian.oauth-setup"):
+            _log_dc_success(mock_config)
+
+        log_text = caplog.text
+        assert "ATLASSIAN_OAUTH_CLOUD_ID" not in log_text
+        assert "VS CODE CONFIGURATION" in log_text

--- a/tests/unit/utils/test_proxy.py
+++ b/tests/unit/utils/test_proxy.py
@@ -6,12 +6,15 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from requests import PreparedRequest
 from requests.exceptions import ProxyError
+from requests.sessions import Session
 
 from mcp_atlassian.confluence.client import ConfluenceClient
 from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.jira.client import JiraClient
 from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.utils.ssl import NoProxyAdapter, configure_proxy_bypass
 from tests.utils.base import BaseAuthTest
 from tests.utils.mocks import MockEnvironment
 
@@ -293,3 +296,77 @@ class TestProxyConfigurationEnhanced(BaseAuthTest):
                 assert os.environ.get("HTTP_PROXY") == "http://proxy.company.com:8080"
                 assert os.environ.get("HTTPS_PROXY") == "https://proxy.company.com:8443"
                 assert os.environ.get("NO_PROXY") == "localhost,127.0.0.1"
+
+
+class TestNoProxyAdapter:
+    """Tests for NoProxyAdapter and configure_proxy_bypass."""
+
+    def _make_request(self, url: str) -> PreparedRequest:
+        req = PreparedRequest()
+        req.url = url
+        return req
+
+    def test_clears_proxies_when_url_matches_no_proxy(self, monkeypatch):
+        """Proxies are cleared when the request URL matches NO_PROXY."""
+        monkeypatch.setenv("NO_PROXY", "internal.example.com")
+        adapter = NoProxyAdapter()
+        proxies = {"https": "https://proxy:8443"}
+
+        with patch.object(adapter.__class__.__bases__[0], "send") as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(
+                self._make_request("https://internal.example.com/api"),
+                proxies=proxies,
+            )
+            _, kwargs = mock_send.call_args
+            assert kwargs["proxies"] is None
+
+    def test_preserves_proxies_when_url_does_not_match_no_proxy(self, monkeypatch):
+        """Proxies are kept when the request URL is not in NO_PROXY."""
+        monkeypatch.setenv("NO_PROXY", "other.example.com")
+        adapter = NoProxyAdapter()
+        proxies = {"https": "https://proxy:8443"}
+
+        with patch.object(adapter.__class__.__bases__[0], "send") as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(
+                self._make_request("https://external.example.com/api"),
+                proxies=proxies,
+            )
+            _, kwargs = mock_send.call_args
+            assert kwargs["proxies"] == proxies
+
+    def test_no_effect_when_no_proxy_not_set(self, monkeypatch):
+        """Proxies are untouched when NO_PROXY is not set."""
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        adapter = NoProxyAdapter()
+        proxies = {"https": "https://proxy:8443"}
+
+        with patch.object(adapter.__class__.__bases__[0], "send") as mock_send:
+            mock_send.return_value = MagicMock()
+            adapter.send(
+                self._make_request("https://internal.example.com/api"),
+                proxies=proxies,
+            )
+            _, kwargs = mock_send.call_args
+            assert kwargs["proxies"] == proxies
+
+    def test_configure_proxy_bypass_mounts_adapter_when_no_proxy_set(self, monkeypatch):
+        """configure_proxy_bypass mounts NoProxyAdapter when NO_PROXY is set."""
+        monkeypatch.setenv("NO_PROXY", "example.com")
+        session = Session()
+        configure_proxy_bypass("TestService", "https://example.com", session)
+        assert isinstance(session.get_adapter("https://example.com"), NoProxyAdapter)
+        assert isinstance(session.get_adapter("http://example.com"), NoProxyAdapter)
+
+    def test_configure_proxy_bypass_does_nothing_when_no_proxy_not_set(
+        self, monkeypatch
+    ):
+        """configure_proxy_bypass does not mount an adapter when NO_PROXY is absent."""
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        session = Session()
+        default_https_adapter = session.get_adapter("https://example.com")
+        configure_proxy_bypass("TestService", "https://example.com", session)
+        assert session.get_adapter("https://example.com") is default_https_adapter

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -7,7 +7,11 @@ import pytest
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
 
-from mcp_atlassian.utils.ssl import SSLIgnoreAdapter, configure_ssl_verification
+from mcp_atlassian.utils.ssl import (
+    NoProxyAdapter,
+    SSLIgnoreAdapter,
+    configure_ssl_verification,
+)
 
 
 def test_ssl_ignore_adapter_cert_verify():
@@ -90,9 +94,11 @@ def test_configure_ssl_verification_disabled():
             session.mount.assert_any_call("http://test.example.com", mock_adapter)
 
 
-def test_configure_ssl_verification_enabled():
-    """Test configure_ssl_verification when SSL verification is enabled."""
-    # Arrange
+def test_configure_ssl_verification_enabled(monkeypatch):
+    """Test configure_ssl_verification when SSL verification is enabled and NO_PROXY is absent."""
+    # Arrange — ensure NO_PROXY is absent so no proxy-bypass adapter is mounted
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
     service_name = "TestService"
     url = "https://test.example.com/path"
     session = MagicMock()  # Use MagicMock instead of actual Session
@@ -107,12 +113,14 @@ def test_configure_ssl_verification_enabled():
         assert session.mount.call_count == 0
 
 
-def test_configure_ssl_verification_enabled_with_real_session():
-    """Test SSL verification configuration when verification is enabled using a real Session."""
+def test_configure_ssl_verification_enabled_with_real_session(monkeypatch):
+    """Test SSL verification configuration when verification is enabled and NO_PROXY is absent."""
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
     session = Session()
     original_adapters_count = len(session.adapters)
 
-    # Configure with SSL verification enabled
+    # Configure with SSL verification enabled and no NO_PROXY
     configure_ssl_verification(
         service_name="Test",
         url="https://example.com",
@@ -120,7 +128,7 @@ def test_configure_ssl_verification_enabled_with_real_session():
         ssl_verify=True,
     )
 
-    # No adapters should be added when SSL verification is enabled
+    # No adapters should be added when SSL verification is enabled and NO_PROXY is absent
     assert len(session.adapters) == original_adapters_count
 
 
@@ -257,3 +265,58 @@ def test_configure_ssl_disabled_with_client_cert():
             assert session.cert == ("/path/to/cert.pem", "/path/to/key.pem")
             mock_adapter_class.assert_called_once()
             assert session.mount.call_count == 2
+
+
+def test_ssl_ignore_adapter_is_subclass_of_no_proxy_adapter():
+    """SSLIgnoreAdapter must inherit from NoProxyAdapter to pick up NO_PROXY logic."""
+    assert issubclass(SSLIgnoreAdapter, NoProxyAdapter)
+
+
+def test_ssl_ignore_adapter_send_forces_verify_false():
+    """SSLIgnoreAdapter.send() always passes verify=False to parent, ignoring the caller's value."""
+    adapter = SSLIgnoreAdapter()
+    request = MagicMock()
+    request.url = "https://external.example.com/api"
+
+    with patch.object(NoProxyAdapter, "send") as mock_super_send:
+        mock_super_send.return_value = MagicMock()
+        adapter.send(request, verify=True, proxies=None)
+        _, kwargs = mock_super_send.call_args
+        assert kwargs["verify"] is False
+
+
+def test_ssl_ignore_adapter_send_respects_no_proxy(monkeypatch):
+    """SSLIgnoreAdapter.send() honors NO_PROXY by clearing proxies for matching URLs."""
+    monkeypatch.setenv("NO_PROXY", "internal.example.com")
+    adapter = SSLIgnoreAdapter()
+    request = MagicMock()
+    request.url = "https://internal.example.com/api"
+    proxies = {"https": "https://proxy:8443"}
+
+    with patch.object(HTTPAdapter, "send") as mock_base_send:
+        mock_base_send.return_value = MagicMock()
+        adapter.send(request, proxies=proxies)
+        _, kwargs = mock_base_send.call_args
+        assert kwargs["proxies"] is None
+
+
+def test_configure_ssl_verification_enabled_with_no_proxy_mounts_adapter(monkeypatch):
+    """configure_ssl_verification mounts NoProxyAdapter when ssl_verify=True and NO_PROXY is set."""
+    monkeypatch.setenv("NO_PROXY", "test.example.com")
+    session = Session()
+    original_adapters_count = len(session.adapters)
+
+    configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com/path",
+        session=session,
+        ssl_verify=True,
+    )
+
+    assert len(session.adapters) == original_adapters_count + 2
+    assert isinstance(session.get_adapter("https://test.example.com"), NoProxyAdapter)
+    assert isinstance(session.get_adapter("http://test.example.com"), NoProxyAdapter)
+    # Must not be the stricter SSLIgnoreAdapter — SSL verification stays enabled
+    assert not isinstance(
+        session.get_adapter("https://test.example.com"), SSLIgnoreAdapter
+    )

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 28, (
-            f"Expected 28 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 32, (
+            f"Expected 32 Confluence tools, got {len(confluence_tools)}"
         )

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,10 +249,10 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 52, f"Expected 52 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 24, (
-            f"Expected 24 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 28, (
+            f"Expected 28 Confluence tools, got {len(confluence_tools)}"
         )

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 22 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,15 +91,15 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 22 entries."""
+        assert len(ALL_TOOLSETS) == 22
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
         assert len(jira_toolsets) == 15
-        assert len(confluence_toolsets) == 6
+        assert len(confluence_toolsets) == 7
 
 
 class TestShouldIncludeToolByToolset:
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 32, (
-            f"Expected 32 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 35, (
+            f"Expected 35 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
## Summary

**Layers on top of batch 2 (#1203).** Please merge batches 1 and 2 first.

Batch 3 integrates 10 additional community PRs that have been reviewed, tested, and (where needed) refactored in the [community fork](https://github.com/Troubladore/mcp-atlassian/tree/community/main).

## PRs Included

| PR | Author | Description | Integration notes |
|----|--------|-------------|-------------------|
| #1174 | @kbichave | Content properties get/set | Refactored per #1104 Phase C: read via `get_page(include="properties")`, single write tool |
| #1176 | @kbichave | Bare-filename img tag rewriting | As-is |
| #1178 | @kbichave | Table layout, page width, restrictions, copy page | As-is |
| #1180 | @kbichave | GFM task list conversion + page templates | As-is, templates in opt-in toolset |
| #1182 | @kbichave | Inline comment improvements | Cherry-picked Cloud-only guard + ValueError propagation into existing #1151 implementation |
| #1183 | @slusset | Storage round-trip + page width preservation | As-is |
| #1187 | @ffsetit | Cascading select field options | As-is |
| #1190 | @qinqon | Remote issue links tool | Cherry-picked shape simplification + validation into existing `include="remote_links"` enrichment |
| #1191 | @abhinavgaba | NO_PROXY env var support | As-is |
| #1193 | @clwluvw | Service account support via Cloud ID | As-is, clarified env var precedence in comments |

## Skipped PRs

| PR | Reason |
|----|--------|
| #1185 | Marketing badge for README — not a code change |

## Refactoring Notes

- **#1174:** Read side uses Phase A `include` pattern instead of standalone getter tool. Write side kept as single tool since property-only writes can't be a param on `update_page`. Net +1 tool (vs +2), 13 tests (vs 9).
- **#1182:** Existing implementation from #1151 was improved with kbichave's better error handling — Cloud-only hard guard and ValueError propagation.
- **#1190:** Existing `get_issue(include="remote_links")` enrichment improved with qinqon's cleaner return shape. Did not add standalone tool per Phase A/C alignment. Added `resolved` status field.

## Test Results

- 2914 tests passed, 0 failures, 0 warnings (`uv run pytest tests/unit/ -x -W error`)
- Pre-commit clean: ruff, ruff-format, mypy all passing
- All third-party PRs received security review before integration

Closes #1181
Closes #1186
Closes #677
Closes #781