### PR TITLE
feat(jira): Allow to sort comments (ASC/DESC) before limiting

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -15,6 +15,7 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `fields` | `string` | No | (Optional) Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'). You may also provide a single field as a string (e.g., 'duedate'). Use '*all' for all fields (including custom fields), or omit for essential fields only. |
 | `expand` | `string` | No | (Optional) Fields to expand. Examples: 'renderedFields' (for rendered content), 'transitions' (for available status transitions), 'changelog' (for history) |
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
+| `comment_sort` | `string` | No | Sort order for comments ('asc' - oldest first or 'desc' - newest first). If not specified, comments are returned as provided by Jira. |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
 **Example:**

--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -1,7 +1,7 @@
 """Module for Jira comment operations."""
 
 import logging
-from typing import Any
+from typing import Any, Literal
 
 from ..models.jira.adf import adf_to_text
 from ..utils import parse_date
@@ -14,7 +14,10 @@ class CommentsMixin(JiraClient):
     """Mixin for Jira comment operations."""
 
     def get_issue_comments(
-        self, issue_key: str, limit: int = 50
+        self,
+        issue_key: str,
+        limit: int = 50,
+        sort: None | Literal["asc", "desc"] = None,
     ) -> list[dict[str, Any]]:
         """
         Get comments for a specific issue.
@@ -22,6 +25,7 @@ class CommentsMixin(JiraClient):
         Args:
             issue_key: The issue key (e.g. 'PROJ-123')
             limit: Maximum number of comments to return
+            sort: Sort order for comments ("asc" or "desc"). Default is no sorting.
 
         Returns:
             List of comments with author, creation date, and content
@@ -38,7 +42,7 @@ class CommentsMixin(JiraClient):
                 raise TypeError(msg)
 
             processed_comments = []
-            for comment in comments.get("comments", [])[:limit]:
+            for comment in comments.get("comments", []):
                 processed_comment = {
                     "id": comment.get("id"),
                     "body": self._clean_text(comment.get("body", "")),
@@ -48,7 +52,12 @@ class CommentsMixin(JiraClient):
                 }
                 processed_comments.append(processed_comment)
 
-            return processed_comments
+            if sort == "asc":
+                processed_comments.sort(key=lambda x: x["created"])
+            elif sort == "desc":
+                processed_comments.sort(key=lambda x: x["created"], reverse=True)
+
+            return processed_comments[:limit]
         except Exception as e:
             logger.error(f"Error getting comments for issue {issue_key}: {str(e)}")
             raise Exception(f"Error getting comments: {str(e)}") from e

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import defaultdict
-from typing import Any
+from typing import Any, Literal
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
@@ -46,6 +46,7 @@ class IssuesMixin(
         issue_key: str,
         expand: str | None = None,
         comment_limit: int | str | None = 10,
+        comment_sort: None | Literal["asc", "desc"] = None,
         fields: str | list[str] | tuple[str, ...] | set[str] | None = None,
         properties: str | list[str] | None = None,
         update_history: bool = True,
@@ -57,6 +58,7 @@ class IssuesMixin(
             issue_key: The issue key (e.g., PROJECT-123)
             expand: Fields to expand in the response
             comment_limit: Maximum number of comments to include, or "all"
+            comment_sort: Sort order for comments ("asc" or "desc"). Default is no sorting
             fields: Fields to return (comma-separated string, list, tuple, set, or "*all")
             properties: Issue properties to return (comma-separated string or list)
             update_history: Whether to update the issue view history
@@ -193,7 +195,7 @@ class IssuesMixin(
             if "comment" in fields_data:
                 comment_limit_int = self._normalize_comment_limit(comment_limit)
                 comments = self._get_issue_comments_if_needed(
-                    issue_key, comment_limit_int
+                    issue_key, comment_limit_int, comment_sort=comment_sort
                 )
                 # Add comments to the issue data for processing by the model
                 fields_data["comment"]["comments"] = comments
@@ -315,7 +317,10 @@ class IssuesMixin(
             return 10
 
     def _get_issue_comments_if_needed(
-        self, issue_key: str, comment_limit: int | None
+        self,
+        issue_key: str,
+        comment_limit: int | None,
+        comment_sort: None | Literal["asc", "desc"] = None,
     ) -> list[dict]:
         """
         Get comments for an issue if needed.
@@ -323,6 +328,7 @@ class IssuesMixin(
         Args:
             issue_key: The issue key
             comment_limit: Maximum number of comments to include
+            comment_sort: Sort order for comments ("asc" or "desc"). Default is no sorting.
 
         Returns:
             List of comments
@@ -335,7 +341,13 @@ class IssuesMixin(
                     logger.error(msg)
                     raise TypeError(msg)
 
-                comments = response["comments"]
+                comments = response.get("comments", [])
+
+                # Sort comments if needed
+                if comment_sort == "asc":
+                    comments.sort(key=lambda x: x.get("created", ""))
+                elif comment_sort == "desc":
+                    comments.sort(key=lambda x: x.get("created", ""), reverse=True)
 
                 # Limit comments if needed
                 if comment_limit is not None:

--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -1,7 +1,7 @@
 """Module for Jira protocol definitions."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from ..models.jira import JiraIssue, ProFormaForm
 from ..models.jira.search import JiraSearchResult
@@ -67,6 +67,7 @@ class IssueOperationsProto(Protocol):
         issue_key: str,
         expand: str | None = None,
         comment_limit: int | str | None = 10,
+        comment_sort: None | Literal["asc", "desc"] = None,
         fields: str
         | list[str]
         | tuple[str, ...]

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -328,12 +328,23 @@ async def get_issue(
     comment_limit: Annotated[
         int,
         Field(
-            description="Maximum number of comments to include (0 or null for no comments)",
+            description=(
+                "Maximum number of comments to include (0 or null for no comments). "
+                "If the parameter 'fields' is set to a limited field list, the list must include 'comment' for comments to be fetched."
+            ),
             default=10,
             ge=0,
             le=100,
         ),
     ] = 10,
+    comment_sort: Annotated[
+        str | None,
+        Field(
+            description="Sort order for comments ('asc' - oldest first or 'desc' - newest first). If not specified, comments are returned as provided by Jira.",
+            default=None,
+            pattern="^(asc|desc)$",
+        ),
+    ] = None,
     properties: Annotated[
         str | None,
         Field(
@@ -357,6 +368,7 @@ async def get_issue(
         fields: Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'), a single field as a string (e.g., 'duedate'), '*all' for all fields, or omitted for essentials.
         expand: Optional fields to expand.
         comment_limit: Maximum number of comments.
+        comment_sort: Sort order for comments ("asc" - oldest first or "desc" - newest first). If not specified, comments are returned as provided by Jira.
         properties: Issue properties to return.
         update_history: Whether to update issue view history.
 
@@ -376,6 +388,7 @@ async def get_issue(
         fields=fields_list,
         expand=expand,
         comment_limit=comment_limit,
+        comment_sort=comment_sort if comment_sort in ("asc", "desc") else None,
         properties=properties.split(",") if properties else None,
         update_history=update_history,
     )

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -79,15 +79,21 @@ class TestCommentsMixin:
             ]
         }
 
-        # Call the method with limit=2
-        result = comments_mixin.get_issue_comments("TEST-123", limit=2)
+        for sort in [None, "asc", "desc"]:
+            # Call the method with limit=2
+            comments_mixin.jira.issue_get_comments.reset_mock()
+            result = comments_mixin.get_issue_comments("TEST-123", limit=2, sort=sort)
 
-        # Verify
-        comments_mixin.jira.issue_get_comments.assert_called_once_with("TEST-123")
-        assert len(result) == 2  # Only 2 comments should be returned
-        assert result[0]["id"] == "10001"
-        assert result[1]["id"] == "10002"
-        # Third comment shouldn't be included due to limit
+            # Verify
+            comments_mixin.jira.issue_get_comments.assert_called_once_with("TEST-123")
+            assert len(result) == 2  # Only 2 comments should be returned
+            if sort == "desc":
+                assert result[0]["id"] == "10003"
+                assert result[1]["id"] == "10002"
+            else:
+                assert result[0]["id"] == "10001"
+                assert result[1]["id"] == "10002"
+            # Third comment shouldn't be included due to limit
 
     def test_get_issue_comments_with_missing_fields(self, comments_mixin):
         """Test get_issue_comments with missing fields in the response."""

--- a/tests/unit/jira/test_protocols.py
+++ b/tests/unit/jira/test_protocols.py
@@ -1,7 +1,7 @@
 """Tests for Jira protocol definitions."""
 
 import inspect
-from typing import Any, get_type_hints
+from typing import Any, Literal, get_type_hints
 
 from mcp_atlassian.jira.protocols import (
     AttachmentsOperationsProto,
@@ -36,6 +36,7 @@ class TestProtocolCompliance:
                 issue_key: str,
                 expand: str | None = None,
                 comment_limit: int | str | None = 10,
+                comment_sort: None | Literal["asc", "desc"] = None,
                 fields: str | list[str] | tuple[str, ...] | set[str] | None = (
                     "summary,description,status,assignee,reporter,labels,"
                     "priority,created,updated,issuetype"

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -45,6 +45,7 @@ def mock_jira_fetcher():
         fields=None,
         expand=None,
         comment_limit=10,
+        comment_sort=None,
         properties=None,
         update_history=True,
     ):
@@ -56,6 +57,7 @@ def mock_jira_fetcher():
         response_data["fields_queried"] = fields
         response_data["expand_param"] = expand
         response_data["comment_limit"] = comment_limit
+        response_data["comment_sort"] = comment_sort
         response_data["properties_param"] = properties
         response_data["update_history"] = update_history
         response_data["id"] = MOCK_JIRA_ISSUE_RESPONSE_SIMPLIFIED["id"]
@@ -71,8 +73,11 @@ def mock_jira_fetcher():
     mock_fetcher.get_issue.side_effect = mock_get_issue
 
     # Configure get_issue_comments to return fixture data
-    def mock_get_issue_comments(issue_key, limit=10):
-        return MOCK_JIRA_COMMENTS_SIMPLIFIED["comments"][:limit]
+    def mock_get_issue_comments(issue_key, limit=10, sort=None):
+        c = MOCK_JIRA_COMMENTS_SIMPLIFIED["comments"][:limit]
+        if sort == "desc":
+            c = list(reversed(c))
+        return c
 
     mock_fetcher.get_issue_comments.side_effect = mock_get_issue_comments
 
@@ -547,6 +552,7 @@ async def test_get_issue(jira_client, mock_jira_fetcher):
         fields=["summary", "description", "status"],
         expand=None,
         comment_limit=10,
+        comment_sort=None,
         properties=None,
         update_history=True,
     )
@@ -942,6 +948,7 @@ async def test_get_issue_with_user_specific_fetcher_in_state(
         fields=expected_fields_list,
         expand=None,
         comment_limit=10,
+        comment_sort=None,
         properties=None,
         update_history=True,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

The PR adds the ability to sort JIRA case comments in descending order (on create date) before applying the comment limit. This allows to fetch the newest comments instead of the oldest (current default). 

For backward compatibility, no sorting is applied when the parameter is omitted.

Fixes: #653

## Changes

- Added `comment_sort = ( None | 'asc' | 'desc' )` as input parameter to `get_issue`.
- Also added `sort` or `comment_sort` to all internal implementations to fetch comments.
- Test for `CommentsMixin` (the only location where comment limit is tested) are extended to test the sort order.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated (Note: only where tests for comment limit existed)
- [ ] Integration tests passed
- [x] Manual checks performed: 
      Using the PR with cl..-code. When asking for oldest 3 and newest 3 comments it works as expected (2 calls, asc and desc sorting, limit=3).

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
