### PR TITLE
fix: correct X-Atlassian-Token header value from 'nocheck' to 'no-check'

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -471,7 +471,7 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
 
             # Prepare headers (X-Atlassian-Token required for file uploads)
-            headers = {"X-Atlassian-Token": "nocheck"}
+            headers = {"X-Atlassian-Token": "no-check"}
 
             # Prepare multipart form data
             files = {"file": (filename, open(file_path, "rb"))}

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -160,7 +160,7 @@ class TestAttachmentsMixin:
             assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
 
             # Check headers include X-Atlassian-Token
-            assert call_args[1]["headers"]["X-Atlassian-Token"] == "nocheck"
+            assert call_args[1]["headers"]["X-Atlassian-Token"] == "no-check"
 
             # Check minorEdit was passed in data
             assert call_args[1]["data"]["minorEdit"] == "false"


### PR DESCRIPTION
Fixes #1207

## Summary

Confluence Server/Data Center requires `'no-check'` as the `X-Atlassian-Token` header value for attachment uploads via REST API, not `'nocheck'`. The incorrect value causes `confluence_upload_attachment` to always fail on Server/Data Center instances.

## Changes

- `src/mcp_atlassian/confluence/attachments.py`: Corrected header value from `"nocheck"` to `"no-check"`
- `tests/unit/confluence/test_attachments.py`: Updated test assertion to match

## Notes

- The e2e tests already used the correct `'no-check'` value — this aligns the implementation with existing test expectations.
- This is a follow-up to PR #1202 which fixed the HTTP method (PUT → POST) but missed this independent header bug.