### PR TITLE
fix(confluence): return TextContent for text-based attachments

### DIFF
--- a/docs/tools/confluence-attachments.mdx
+++ b/docs/tools/confluence-attachments.mdx
@@ -86,7 +86,8 @@ Confluence API returns generic MIME types — use the `mediaTypeDescription` fie
 
 ### Download Attachment
 
-Download an attachment from Confluence as an embedded resource.
+Download an attachment from Confluence. Text-based files are returned as readable
+text content; binary files are returned as base64-encoded embedded resources.
 
 <Note>On Confluence Cloud, attachment downloads automatically use the v1 REST endpoint (the legacy `/download/` link was removed and returns 401 for API/scoped tokens). Override with `CONFLUENCE_ATTACHMENT_DOWNLOAD_USE_V1`.</Note>
 
@@ -100,7 +101,9 @@ Download an attachment from Confluence as an embedded resource.
 
 ### Download All Content Attachments
 
-Download all attachments for a Confluence content item as embedded resources.
+Download all attachments for a Confluence content item. Text-based files are
+returned as readable text content; binary files are returned as base64-encoded
+embedded resources.
 
 **Parameters:**
 

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -20,6 +20,7 @@ from mcp_atlassian.utils.media import (
     ATTACHMENT_MAX_BYTES,
     fetch_and_encode_attachment,
     is_image_attachment,
+    is_text_attachment,
 )
 from mcp_atlassian.utils.urls import resolve_relative_url
 
@@ -1689,6 +1690,29 @@ async def download_attachment(
                 ),
             )
 
+        # For text-based formats (BPMN, XML, draw.io, JSON, CSV, etc.) return the
+        # decoded text directly.  Many MCP clients do not forward EmbeddedResource
+        # blob data to the model context, so binary blobs are invisible to the agent.
+        if is_text_attachment(mime_type, filename):
+            try:
+                text_content = data_bytes.decode("utf-8")
+            except UnicodeDecodeError:
+                text_content = data_bytes.decode("latin-1")
+            return TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "success": True,
+                        "attachment_id": attachment_id,
+                        "filename": filename,
+                        "mimeType": mime_type,
+                        "content": text_content,
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                ),
+            )
+
         encoded = base64.b64encode(data_bytes).decode("ascii")
         return EmbeddedResource(
             type="resource",
@@ -1836,16 +1860,46 @@ async def download_content_attachments(
             continue
 
         fetched.append({"filename": filename, "size": fetched_bytes})
-        contents.append(
-            EmbeddedResource(
-                type="resource",
-                resource=BlobResourceContents(
-                    uri=f"attachment:///{content_id}/{filename}",
-                    mimeType=mime_type,
-                    blob=encoded,
-                ),
+
+        # For text-based formats return TextContent so the model can read
+        # the content directly without relying on blob handling by the client.
+        if is_text_attachment(mime_type, filename):
+            try:
+                raw_bytes = base64.b64decode(encoded)
+                text_content = raw_bytes.decode("utf-8")
+            except (UnicodeDecodeError, Exception):
+                try:
+                    raw_bytes = base64.b64decode(encoded)
+                    text_content = raw_bytes.decode("latin-1")
+                except Exception:
+                    text_content = encoded  # fallback: keep base64
+            contents.append(
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "success": True,
+                            "content_id": content_id,
+                            "filename": filename,
+                            "mimeType": mime_type,
+                            "content": text_content,
+                        },
+                        indent=2,
+                        ensure_ascii=False,
+                    ),
+                )
             )
-        )
+        else:
+            contents.append(
+                EmbeddedResource(
+                    type="resource",
+                    resource=BlobResourceContents(
+                        uri=f"attachment:///{content_id}/{filename}",
+                        mimeType=mime_type,
+                        blob=encoded,
+                    ),
+                )
+            )
 
     summary: dict[str, object] = {
         "success": True,

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -2165,20 +2165,18 @@ async def download_attachment(
         ),
     ],
 ) -> TextContent | EmbeddedResource:
-    """Download an attachment from Confluence as an embedded resource.
+    """Download an attachment from Confluence.
 
-    Returns the attachment content as a base64-encoded embedded resource so
-    that it is available over the MCP protocol without requiring filesystem
-    access on the server. Files larger than 50 MB are not downloaded inline;
-    a descriptive error message is returned instead.
+    Text-based files are returned as readable text content. Binary files are
+    returned as base64-encoded embedded resources. Files larger than 50 MB are
+    not downloaded inline; a descriptive error message is returned instead.
 
     Args:
         ctx: The FastMCP context.
         attachment_id: The ID of the attachment.
 
     Returns:
-        An EmbeddedResource with base64-encoded content, or a TextContent
-        with an error or size-exceeded message.
+        TextContent for a text attachment or error, otherwise EmbeddedResource.
     """
 
     confluence_fetcher = await get_confluence_fetcher(ctx)
@@ -2276,9 +2274,7 @@ async def download_attachment(
                 ),
             )
 
-        # For text-based formats (BPMN, XML, draw.io, JSON, CSV, etc.) return the
-        # decoded text directly.  Many MCP clients do not forward EmbeddedResource
-        # blob data to the model context, so binary blobs are invisible to the agent.
+        # Return text directly because some MCP clients omit embedded blob data.
         if is_text_attachment(mime_type, filename):
             try:
                 text_content = data_bytes.decode("utf-8")
@@ -2339,20 +2335,18 @@ async def download_content_attachments(
         ),
     ],
 ) -> list[TextContent | EmbeddedResource]:
-    """Download all attachments for a Confluence content item as embedded resources.
+    """Download all attachments for a Confluence content item.
 
-    Returns attachment contents as base64-encoded embedded resources so that
-    they are available over the MCP protocol without requiring filesystem
-    access on the server. Files larger than 50 MB are skipped with an error
-    entry in the summary.
+    Text-based files are returned as readable text content. Binary files are
+    returned as base64-encoded embedded resources. Files larger than 50 MB are
+    skipped with an error entry in the summary.
 
     Args:
         ctx: The FastMCP context.
         content_id: The ID of the content.
 
     Returns:
-        A list with a text summary followed by one EmbeddedResource per
-        successfully downloaded attachment.
+        A text summary followed by one content item per downloaded attachment.
     """
 
     confluence_fetcher = await get_confluence_fetcher(ctx)
@@ -2449,18 +2443,13 @@ async def download_content_attachments(
 
         fetched.append({"filename": filename, "size": fetched_bytes})
 
-        # For text-based formats return TextContent so the model can read
-        # the content directly without relying on blob handling by the client.
+        # Return text directly because some MCP clients omit embedded blob data.
         if is_text_attachment(mime_type, filename):
+            raw_bytes = base64.b64decode(encoded, validate=True)
             try:
-                raw_bytes = base64.b64decode(encoded)
                 text_content = raw_bytes.decode("utf-8")
-            except (UnicodeDecodeError, Exception):
-                try:
-                    raw_bytes = base64.b64decode(encoded)
-                    text_content = raw_bytes.decode("latin-1")
-                except Exception:
-                    text_content = encoded  # fallback: keep base64
+            except UnicodeDecodeError:
+                text_content = raw_bytes.decode("latin-1")
             contents.append(
                 TextContent(
                     type="text",

--- a/src/mcp_atlassian/utils/media.py
+++ b/src/mcp_atlassian/utils/media.py
@@ -28,6 +28,69 @@ _IMAGE_EXTENSIONS = frozenset(
     {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
 )
 
+_TEXT_MIME_TYPES = frozenset(
+    {
+        "application/xml",
+        "application/json",
+        "application/javascript",
+        "application/xhtml+xml",
+        "application/x-yaml",
+    }
+)
+
+_TEXT_EXTENSIONS = frozenset(
+    {
+        ".bpmn",
+        ".xml",
+        ".drawio",
+        ".json",
+        ".csv",
+        ".txt",
+        ".md",
+        ".yaml",
+        ".yml",
+        ".html",
+        ".htm",
+        ".js",
+        ".ts",
+        ".py",
+        ".java",
+        ".sql",
+    }
+)
+
+
+def is_text_attachment(media_type: str | None, filename: str | None) -> bool:
+    """Detect whether an attachment contains text-based content.
+
+    Text-based attachments (BPMN, XML, draw.io, JSON, CSV, etc.) should be
+    returned as ``TextContent`` so that MCP clients can pass the content
+    directly to the model context.  Binary blobs (``EmbeddedResource``) are
+    often not forwarded to the model by many clients.
+
+    Uses two-tier detection: explicit MIME type check, then filename extension
+    fallback for ambiguous or missing MIME types.
+
+    Args:
+        media_type: The MIME type reported by the API.
+        filename: The attachment filename.
+
+    Returns:
+        ``True`` if the attachment is text-based, ``False`` otherwise.
+    """
+    if media_type:
+        if media_type.startswith("text/"):
+            return True
+        if media_type in _TEXT_MIME_TYPES:
+            return True
+
+    if (not media_type or media_type in _AMBIGUOUS_MIME_TYPES) and filename:
+        ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        if ext in _TEXT_EXTENSIONS:
+            return True
+
+    return False
+
 
 def is_image_attachment(
     media_type: str | None, filename: str | None

--- a/src/mcp_atlassian/utils/media.py
+++ b/src/mcp_atlassian/utils/media.py
@@ -78,13 +78,19 @@ def is_text_attachment(media_type: str | None, filename: str | None) -> bool:
     Returns:
         ``True`` if the attachment is text-based, ``False`` otherwise.
     """
+    normalized_media_type = ""
     if media_type:
-        if media_type.startswith("text/"):
+        normalized_media_type = media_type.partition(";")[0].strip().lower()
+        if normalized_media_type.startswith("text/"):
             return True
-        if media_type in _TEXT_MIME_TYPES:
+        if normalized_media_type in _TEXT_MIME_TYPES:
+            return True
+        if normalized_media_type.endswith(("+json", "+xml")):
             return True
 
-    if (not media_type or media_type in _AMBIGUOUS_MIME_TYPES) and filename:
+    if (
+        not normalized_media_type or normalized_media_type in _AMBIGUOUS_MIME_TYPES
+    ) and filename:
         ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
         if ext in _TEXT_EXTENSIONS:
             return True

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -1315,10 +1315,48 @@ class TestDownloadAttachmentServerTool:
 
 
 class TestDownloadContentAttachmentsServerTool:
-    """Tests for the server-level download_content_attachments tool (EmbeddedResource return)."""
+    """Tests for the server-level download_content_attachments tool."""
 
     @pytest.mark.asyncio
     async def test_returns_summary_plus_embedded_resources(self):
+        mock_fetcher = MagicMock()
+        mock_fetcher.config.url = "https://test.atlassian.net/wiki"
+        mock_fetcher.get_content_attachments.return_value = {
+            "success": True,
+            "attachments": [
+                {
+                    "id": "att1",
+                    "title": "photo.png",
+                    "extensions": {"mediaType": "image/png", "fileSize": 4},
+                    "_links": {"download": "/download/photo.png"},
+                }
+            ],
+        }
+
+        mock_fetcher.fetch_attachment_content.return_value = b"\x89PNG"
+
+        with patch(
+            "mcp_atlassian.servers.confluence.get_confluence_fetcher",
+            AsyncMock(return_value=mock_fetcher),
+        ):
+            from mcp_atlassian.servers.confluence import (
+                download_content_attachments as server_download_content,
+            )
+
+            results = await server_download_content.fn(
+                ctx=MagicMock(), content_id="123456"
+            )
+
+        assert len(results) == 2
+        assert isinstance(results[0], TextContent)
+        summary = json.loads(results[0].text)
+        assert summary["success"] is True
+        assert summary["downloaded"] == 1
+        assert isinstance(results[1], EmbeddedResource)
+        assert results[1].resource.mimeType == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_returns_summary_plus_text_content_for_text_attachment(self):
         mock_fetcher = MagicMock()
         mock_fetcher.config.url = "https://test.atlassian.net/wiki"
         mock_fetcher.get_content_attachments.return_value = {
@@ -1352,8 +1390,11 @@ class TestDownloadContentAttachmentsServerTool:
         summary = json.loads(results[0].text)
         assert summary["success"] is True
         assert summary["downloaded"] == 1
-        assert isinstance(results[1], EmbeddedResource)
-        assert results[1].resource.mimeType == "text/plain"
+        assert isinstance(results[1], TextContent)
+        payload = json.loads(results[1].text)
+        assert payload["success"] is True
+        assert payload["filename"] == "file1.txt"
+        assert payload["content"] == "hello world!"
 
     @pytest.mark.asyncio
     async def test_returns_text_when_no_attachments(self):

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -1481,7 +1481,7 @@ class TestAttachmentsMixin:
 
 
 class TestDownloadAttachmentServerTool:
-    """Tests for the server-level download_attachment tool (EmbeddedResource return)."""
+    """Tests for the server-level download_attachment tool."""
 
     @pytest.mark.asyncio
     async def test_returns_embedded_resource_on_success(self):
@@ -1515,6 +1515,42 @@ class TestDownloadAttachmentServerTool:
         assert isinstance(result, EmbeddedResource)
         assert result.resource.mimeType == "application/pdf"
         assert result.resource.blob
+
+    @pytest.mark.asyncio
+    async def test_returns_text_content_for_text_attachment(self):
+        mock_fetcher = MagicMock()
+        mock_fetcher._v2_adapter = MagicMock()
+        mock_fetcher._v2_adapter.get_attachment_by_id.return_value = {
+            "title": "process.bpmn",
+            "_links": {"download": "/download/process.bpmn"},
+            "extensions": {
+                "mediaType": "application/octet-stream",
+                "fileSize": 11,
+            },
+        }
+        mock_fetcher.fetch_attachment_content.return_value = b"<process />"
+
+        with patch(
+            "mcp_atlassian.servers.confluence.get_confluence_fetcher",
+            AsyncMock(return_value=mock_fetcher),
+        ):
+            from mcp_atlassian.servers.confluence import (
+                download_attachment as server_download_attachment,
+            )
+
+            result = await server_download_attachment.fn(
+                ctx=MagicMock(), attachment_id="att123456"
+            )
+
+        assert isinstance(result, TextContent)
+        payload = json.loads(result.text)
+        assert payload == {
+            "success": True,
+            "attachment_id": "att123456",
+            "filename": "process.bpmn",
+            "mimeType": "application/octet-stream",
+            "content": "<process />",
+        }
 
     @pytest.mark.asyncio
     async def test_returns_text_on_missing_download_url(self):

--- a/tests/unit/utils/test_media.py
+++ b/tests/unit/utils/test_media.py
@@ -8,6 +8,7 @@ from mcp_atlassian.utils.media import (
     ATTACHMENT_MAX_BYTES,
     fetch_and_encode_attachment,
     is_image_attachment,
+    is_text_attachment,
 )
 
 
@@ -69,6 +70,42 @@ def test_is_image_attachment(
 ) -> None:
     """Parametrized test for two-tier MIME detection."""
     assert is_image_attachment(media_type, filename) == expected
+
+
+@pytest.mark.parametrize(
+    ("media_type", "filename", "expected"),
+    [
+        ("application/octet-stream", "process.bpmn", True),
+        ("application/octet-stream", "config.xml", True),
+        ("application/octet-stream", "arch.drawio", True),
+        ("application/json", "data.json", True),
+        ("application/xml", "feed.xml", True),
+        ("text/plain", "notes.txt", True),
+        ("application/octet-stream", "photo.png", False),
+        ("application/octet-stream", "report.pdf", False),
+        (None, None, False),
+        ("image/png", "img.png", False),
+    ],
+    ids=[
+        "octet-stream-bpmn",
+        "octet-stream-xml",
+        "octet-stream-drawio",
+        "json",
+        "xml",
+        "text-plain",
+        "octet-stream-png-ext",
+        "octet-stream-pdf",
+        "both-none",
+        "image-png",
+    ],
+)
+def test_is_text_attachment(
+    media_type: str | None,
+    filename: str | None,
+    expected: bool,
+) -> None:
+    """Parametrized test for text-based attachment detection."""
+    assert is_text_attachment(media_type, filename) is expected
 
 
 # -- fetch_and_encode_attachment tests --------------------------------
@@ -191,7 +228,11 @@ class TestFetchAndEncodeAttachment:
             filename=filename,
         )
         assert encoded is not None
-        assert mime == expected_mime
+        # Windows mimetypes may register .zip as application/x-zip-compressed.
+        if filename == "archive.zip":
+            assert mime in ("application/zip", "application/x-zip-compressed")
+        else:
+            assert mime == expected_mime
         assert size == 4
 
     def test_fetched_size_at_limit_passes(self) -> None:

--- a/tests/unit/utils/test_media.py
+++ b/tests/unit/utils/test_media.py
@@ -80,6 +80,8 @@ def test_is_image_attachment(
         ("application/octet-stream", "arch.drawio", True),
         ("application/json", "data.json", True),
         ("application/xml", "feed.xml", True),
+        ("Application/JSON; charset=UTF-8", "data.bin", True),
+        ("application/bpmn+xml", "process.bin", True),
         ("text/plain", "notes.txt", True),
         ("application/octet-stream", "photo.png", False),
         ("application/octet-stream", "report.pdf", False),
@@ -92,6 +94,8 @@ def test_is_image_attachment(
         "octet-stream-drawio",
         "json",
         "xml",
+        "mime-normalization",
+        "structured-xml-suffix",
         "text-plain",
         "octet-stream-png-ext",
         "octet-stream-pdf",
@@ -102,7 +106,7 @@ def test_is_image_attachment(
 def test_is_text_attachment(
     media_type: str | None,
     filename: str | None,
-    expected: bool,
+    expected: bool,  # noqa: FBT001
 ) -> None:
     """Parametrized test for text-based attachment detection."""
     assert is_text_attachment(media_type, filename) is expected


### PR DESCRIPTION
## Description

Many MCP clients do not forward `EmbeddedResource` blob bytes into model context. For text-based Confluence attachments, callers may therefore see only the URI and MIME type. This PR returns `TextContent` with a JSON payload containing the decoded file body so agents can read and parse it. Binary attachments continue to use `EmbeddedResource` with a base64 blob.

## Changes

- Detect text attachments by normalized MIME type and known text extensions, including ambiguous `application/octet-stream` attachments.
- Recognize `text/*`, JSON/XML media types, and structured `+json`/`+xml` suffixes.
- Return readable text from both single and batch Confluence attachment download tools.
- Preserve UTF-8 text and fall back to Latin-1 when needed.
- Document text and binary download behavior.
- Add unit coverage for MIME detection and both server tool return paths.

## Verification

- `uv run pytest tests/unit/ -q` — 3244 passed, 5 skipped.
- `uv run pytest tests/integration/ -q` — 23 skipped because this suite is credential-gated.
- `uv run pytest tests/e2e/cloud/test_confluence_cloud_operations.py --cloud-e2e -q` — 17 passed.
- `uv run pytest tests/e2e/test_confluence_dc_operations.py --dc-e2e -q` — 15 passed.
- `uv run pre-commit run --all-files` — passed, including Ruff and mypy.
