### PR TITLE
feat(jira): add comment_order parameter to control comment sort order

### DIFF
--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -14,7 +14,10 @@ class CommentsMixin(JiraClient):
     """Mixin for Jira comment operations."""
 
     def get_issue_comments(
-        self, issue_key: str, limit: int = 50
+        self,
+        issue_key: str,
+        limit: int = 50,
+        order: str = "asc",
     ) -> list[dict[str, Any]]:
         """
         Get comments for a specific issue.
@@ -22,6 +25,8 @@ class CommentsMixin(JiraClient):
         Args:
             issue_key: The issue key (e.g. 'PROJ-123')
             limit: Maximum number of comments to return
+            order: Sort order by created date -
+                ``"asc"`` (oldest first) or ``"desc"`` (newest first)
 
         Returns:
             List of comments with author, creation date, and content
@@ -37,8 +42,13 @@ class CommentsMixin(JiraClient):
                 logger.error(msg)
                 raise TypeError(msg)
 
+            comment_list = comments.get("comments", [])
+
+            if order == "desc":
+                comment_list = list(reversed(comment_list))
+
             processed_comments = []
-            for comment in comments.get("comments", [])[:limit]:
+            for comment in comment_list[:limit]:
                 processed_comment = {
                     "id": comment.get("id"),
                     "body": self._clean_text(comment.get("body", "")),

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -49,6 +49,7 @@ class IssuesMixin(
         fields: str | list[str] | tuple[str, ...] | set[str] | None = None,
         properties: str | list[str] | None = None,
         update_history: bool = True,
+        comment_order: str = "asc",
     ) -> JiraIssue:
         """
         Get a Jira issue by key.
@@ -60,6 +61,8 @@ class IssuesMixin(
             fields: Fields to return (comma-separated string, list, tuple, set, or "*all")
             properties: Issue properties to return (comma-separated string or list)
             update_history: Whether to update the issue view history
+            comment_order: Sort order for comments by created date -
+                "asc" (oldest first) or "desc" (newest first)
 
         Returns:
             JiraIssue model with issue data and metadata
@@ -193,7 +196,7 @@ class IssuesMixin(
             if "comment" in fields_data:
                 comment_limit_int = self._normalize_comment_limit(comment_limit)
                 comments = self._get_issue_comments_if_needed(
-                    issue_key, comment_limit_int
+                    issue_key, comment_limit_int, comment_order
                 )
                 # Add comments to the issue data for processing by the model
                 fields_data["comment"]["comments"] = comments
@@ -315,7 +318,10 @@ class IssuesMixin(
             return 10
 
     def _get_issue_comments_if_needed(
-        self, issue_key: str, comment_limit: int | None
+        self,
+        issue_key: str,
+        comment_limit: int | None,
+        comment_order: str = "asc",
     ) -> list[dict]:
         """
         Get comments for an issue if needed.
@@ -323,6 +329,7 @@ class IssuesMixin(
         Args:
             issue_key: The issue key
             comment_limit: Maximum number of comments to include
+            comment_order: ``"desc"`` (newest first) or ``"asc"`` (oldest first)
 
         Returns:
             List of comments
@@ -337,7 +344,9 @@ class IssuesMixin(
 
                 comments = response["comments"]
 
-                # Limit comments if needed
+                if comment_order == "desc":
+                    comments = list(reversed(comments))
+
                 if comment_limit is not None:
                     comments = comments[:comment_limit]
 

--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -74,6 +74,7 @@ class IssueOperationsProto(Protocol):
         | None = "summary,description,status,assignee,reporter,labels,priority,created,updated,issuetype",
         properties: str | list[str] | None = None,
         update_history: bool = True,
+        comment_order: str = "asc",
     ) -> JiraIssue:
         """Get a Jira issue by key."""
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -334,6 +334,17 @@ async def get_issue(
             le=100,
         ),
     ] = 10,
+    comment_order: Annotated[
+        str,
+        Field(
+            description=(
+                "Sort order for comments by created date: "
+                "'asc' (oldest first, default) or 'desc' (newest first)"
+            ),
+            default="asc",
+            pattern="^(asc|desc)$",
+        ),
+    ] = "asc",
     properties: Annotated[
         str | None,
         Field(
@@ -357,6 +368,7 @@ async def get_issue(
         fields: Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'), a single field as a string (e.g., 'duedate'), '*all' for all fields, or omitted for essentials.
         expand: Optional fields to expand.
         comment_limit: Maximum number of comments.
+        comment_order: Sort order for comments by created date.
         properties: Issue properties to return.
         update_history: Whether to update issue view history.
 
@@ -378,6 +390,7 @@ async def get_issue(
         comment_limit=comment_limit,
         properties=properties.split(",") if properties else None,
         update_history=update_history,
+        comment_order=comment_order,
     )
     result = issue.to_simplified_dict()
     return json.dumps(result, indent=2, ensure_ascii=False)

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -133,6 +133,60 @@ class TestCommentsMixin:
             result[2]["author"] == "Unknown"
         )  # Should use Unknown when only name is available
 
+    def test_get_issue_comments_desc_returns_newest_first(self, comments_mixin):
+        """Test get_issue_comments with order='desc' returns newest first."""
+        comments_mixin.jira.issue_get_comments.return_value = {
+            "comments": [
+                {
+                    "id": "10001",
+                    "body": "Oldest",
+                    "created": "2024-01-01T10:00:00.000+0000",
+                    "updated": "2024-01-01T10:00:00.000+0000",
+                    "author": {"displayName": "Alice"},
+                },
+                {
+                    "id": "10002",
+                    "body": "Newest",
+                    "created": "2024-06-01T10:00:00.000+0000",
+                    "updated": "2024-06-01T10:00:00.000+0000",
+                    "author": {"displayName": "Bob"},
+                },
+            ]
+        }
+
+        result = comments_mixin.get_issue_comments("TEST-123", limit=1, order="desc")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "10002"
+        assert result[0]["body"] == "Newest"
+
+    def test_get_issue_comments_asc_returns_oldest_first(self, comments_mixin):
+        """Test get_issue_comments with order='asc' preserves oldest first."""
+        comments_mixin.jira.issue_get_comments.return_value = {
+            "comments": [
+                {
+                    "id": "10001",
+                    "body": "Oldest",
+                    "created": "2024-01-01T10:00:00.000+0000",
+                    "updated": "2024-01-01T10:00:00.000+0000",
+                    "author": {"displayName": "Alice"},
+                },
+                {
+                    "id": "10002",
+                    "body": "Newest",
+                    "created": "2024-06-01T10:00:00.000+0000",
+                    "updated": "2024-06-01T10:00:00.000+0000",
+                    "author": {"displayName": "Bob"},
+                },
+            ]
+        }
+
+        result = comments_mixin.get_issue_comments("TEST-123", limit=1, order="asc")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "10001"
+        assert result[0]["body"] == "Oldest"
+
     def test_get_issue_comments_with_empty_response(self, comments_mixin):
         """Test get_issue_comments with an empty response."""
         # Setup mock response with no comments

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -171,6 +171,115 @@ class TestIssuesMixin:
 
         issues_mixin.jira.issue_get_comments.assert_not_called()
 
+    def test_get_issue_comments_desc_returns_newest_first(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test that comment_order='desc' returns newest comments first."""
+        comments_data = {
+            "comments": [
+                {
+                    "id": "1",
+                    "body": "Oldest",
+                    "author": {"displayName": "A"},
+                    "created": "2023-01-01T00:00:00.000+0000",
+                    "updated": "2023-01-01T00:00:00.000+0000",
+                },
+                {
+                    "id": "2",
+                    "body": "Middle",
+                    "author": {"displayName": "B"},
+                    "created": "2023-06-01T00:00:00.000+0000",
+                    "updated": "2023-06-01T00:00:00.000+0000",
+                },
+                {
+                    "id": "3",
+                    "body": "Newest",
+                    "author": {"displayName": "C"},
+                    "created": "2024-01-01T00:00:00.000+0000",
+                    "updated": "2024-01-01T00:00:00.000+0000",
+                },
+            ]
+        }
+
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "comment": comments_data,
+                "summary": "Test Issue",
+                "description": "Test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+                "created": "2023-01-01T00:00:00.000+0000",
+                "updated": "2024-01-02T00:00:00.000+0000",
+            },
+        }
+
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = comments_data
+
+        issue = issues_mixin.get_issue(
+            "TEST-123",
+            fields="summary,description,status,issuetype,comment",
+            comment_limit=2,
+            comment_order="desc",
+        )
+
+        assert len(issue.comments) == 2
+        assert issue.comments[0].body == "Newest"
+        assert issue.comments[1].body == "Middle"
+
+    def test_get_issue_comments_asc_returns_oldest_first(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Test that comment_order='asc' preserves oldest-first order."""
+        comments_data = {
+            "comments": [
+                {
+                    "id": "1",
+                    "body": "Oldest",
+                    "author": {"displayName": "A"},
+                    "created": "2023-01-01T00:00:00.000+0000",
+                    "updated": "2023-01-01T00:00:00.000+0000",
+                },
+                {
+                    "id": "2",
+                    "body": "Newest",
+                    "author": {"displayName": "B"},
+                    "created": "2024-01-01T00:00:00.000+0000",
+                    "updated": "2024-01-01T00:00:00.000+0000",
+                },
+            ]
+        }
+
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "comment": comments_data,
+                "summary": "Test Issue",
+                "description": "Test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Bug"},
+                "created": "2023-01-01T00:00:00.000+0000",
+                "updated": "2024-01-02T00:00:00.000+0000",
+            },
+        }
+
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = comments_data
+
+        issue = issues_mixin.get_issue(
+            "TEST-123",
+            fields="summary,description,status,issuetype,comment",
+            comment_limit=2,
+            comment_order="asc",
+        )
+
+        assert len(issue.comments) == 2
+        assert issue.comments[0].body == "Oldest"
+        assert issue.comments[1].body == "Newest"
+
     def test_get_issue_with_epic_info(self, issues_mixin: IssuesMixin, make_issue_data):
         """Test retrieving issue with epic information."""
         try:

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -47,6 +47,7 @@ def mock_jira_fetcher():
         comment_limit=10,
         properties=None,
         update_history=True,
+        comment_order="asc",
     ):
         if not issue_key:
             raise ValueError("Issue key is required")
@@ -549,6 +550,7 @@ async def test_get_issue(jira_client, mock_jira_fetcher):
         comment_limit=10,
         properties=None,
         update_history=True,
+        comment_order="asc",
     )
 
 
@@ -944,6 +946,7 @@ async def test_get_issue_with_user_specific_fetcher_in_state(
         comment_limit=10,
         properties=None,
         update_history=True,
+        comment_order="asc",
     )
     result_data = json.loads(response.content[0].text)
     assert result_data["key"] == "USRST-1"


### PR DESCRIPTION
## Summary

- Adds a `comment_order` parameter (`"asc"` / `"desc"`) to `jira_get_issue` tool and `get_issue_comments` method
- When `"desc"`, comments are reversed before slicing so the **newest** N comments are returned instead of the oldest
- Default remains `"asc"` for backward compatibility — no behavioral change for existing callers

## Motivation

With the current implementation, `jira_get_issue` with `comment_limit=10` on an issue with 50+ comments always returns the **10 oldest** comments — typically the least relevant ones. This wastes LLM context tokens on stale information while missing the most recent and actionable updates.

This was reported in #1214.

## Changes

| File | What changed |
|---|---|
| `jira/issues.py` | Added `comment_order` param to `get_issue()` and `_get_issue_comments_if_needed()`. When `"desc"`, reverses the comment list before slicing. |
| `jira/comments.py` | Added `order` param to `get_issue_comments()` with same logic. |
| `jira/protocols.py` | Updated `IssueOperationsProto` signature. |
| `servers/jira.py` | Added `comment_order` to the MCP tool schema with validation (`^(asc|desc)$`). |
| `tests/unit/jira/test_issues.py` | Added tests for `comment_order="desc"` and `comment_order="asc"`. |
| `tests/unit/jira/test_comments.py` | Added tests for `order="desc"` and `order="asc"`. |

## Design decisions

- **Client-side ordering** rather than switching to a raw `jira.get()` call with `orderBy` — preserves the semantic `jira.issue_get_comments()` call and keeps the diff minimal.
- **Default `"asc"`** for backward compatibility. Callers who want newest-first pass `comment_order="desc"` explicitly.
- **Naming**: `"asc"` / `"desc"` follows the convention used by GitHub API, Slack API, and most REST APIs for sort direction.

## Test plan

- [x] All 87 existing + new unit tests pass
- [x] `test_get_issue_comments_desc_returns_newest_first` — verifies desc ordering with limit
- [x] `test_get_issue_comments_asc_returns_oldest_first` — verifies asc ordering preserves original behavior
- [x] No linter errors

Closes #1214