### PR TITLE
fix(confluence): use correct X-Atlassian-Token header value for uploads

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -471,7 +471,7 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
 
             # Prepare headers (X-Atlassian-Token required for file uploads)
-            headers = {"X-Atlassian-Token": "nocheck"}
+            headers = {"X-Atlassian-Token": "no-check"}
 
             # Prepare multipart form data
             files = {"file": (filename, open(file_path, "rb"))}

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -160,7 +160,7 @@ class TestAttachmentsMixin:
             assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
 
             # Check headers include X-Atlassian-Token
-            assert call_args[1]["headers"]["X-Atlassian-Token"] == "nocheck"
+            assert call_args[1]["headers"]["X-Atlassian-Token"] == "no-check"
 
             # Check minorEdit was passed in data
             assert call_args[1]["data"]["minorEdit"] == "false"


### PR DESCRIPTION
## Summary
- Fix `X-Atlassian-Token` header value from `"nocheck"` to `"no-check"` (with hyphen) in `confluence/attachments.py`
- Confluence Server requires the hyphenated form per the [REST API docs](https://developer.atlassian.com/server/confluence/confluence-rest-api-examples/#upload-an-attachment) — without it, uploads fail with `403 Forbidden` (XSRF check failure)
- Updates the unit test assertion to match the corrected value
- Note: the e2e tests already used the correct `"no-check"` value, confirming this was a bug in the implementation

Closes #1207

**This fix should be combined with PR #1202 (PUT → POST) for full Confluence Server attachment upload support** — see the issue for the compatibility matrix.