### PR TITLE
feat(jira): add panel node support to markdown_to_adf

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -197,6 +197,30 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
             doc["content"].append({"type": "blockquote", "content": bq_content})
             continue
 
+        # --- Panel block ---
+        panel_match = re.match(r"^:::(\w+)\s*$", line)
+        if panel_match:
+            panel_type = panel_match.group(1).lower()
+            valid_panel_types = {"note", "info", "warning", "success", "error"}
+            if panel_type in valid_panel_types:
+                panel_lines: list[str] = []
+                i += 1
+                while i < len(lines) and lines[i].strip() != ":::":
+                    panel_lines.append(lines[i])
+                    i += 1
+                # Skip closing :::
+                if i < len(lines):
+                    i += 1
+                # Recursively parse panel content
+                inner_doc = markdown_to_adf("\n".join(panel_lines))
+                panel_node: dict[str, Any] = {
+                    "type": "panel",
+                    "attrs": {"panelType": panel_type},
+                    "content": inner_doc["content"],
+                }
+                doc["content"].append(panel_node)
+                continue
+
         # --- Unordered list ---
         if re.match(r"^[-*]\s+", line):
             items: list[dict[str, Any]] = []

--- a/tests/e2e/cloud/test_adf_write.py
+++ b/tests/e2e/cloud/test_adf_write.py
@@ -190,6 +190,24 @@ class TestADFCreateIssue:
         finally:
             await _delete_issue(mcp_client, key)
 
+    async def test_create_issue_panel(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """Panel markdown is accepted by Jira Cloud and survives readback."""
+        key = await _create_issue_with_description(
+            mcp_client,
+            cloud_instance.project_key,
+            ":::warning\nPanel body survives Cloud write.\n- panel bullet\n:::",
+        )
+        try:
+            desc = await _read_issue_description(mcp_client, key)
+            assert "Panel body survives Cloud write." in desc
+            assert "panel bullet" in desc
+        finally:
+            await _delete_issue(mcp_client, key)
+
     async def test_create_issue_mixed(
         self,
         mcp_client: Client,

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -605,6 +605,57 @@ class TestMarkdownToAdf:
             assert word in text_back
 
 
+class TestMarkdownToAdfPanels:
+    """Tests for panel node support in markdown_to_adf."""
+
+    def _assert_valid_adf(self, result: dict) -> None:
+        """Helper: assert the result is a valid ADF document."""
+        assert result["version"] == 1
+        assert result["type"] == "doc"
+        assert isinstance(result["content"], list)
+
+    @pytest.mark.parametrize(
+        "panel_type",
+        ["note", "info", "warning", "success", "error"],
+        ids=["note", "info", "warning", "success", "error"],
+    )
+    def test_all_valid_panel_types(self, panel_type: str):
+        """All five valid panel types produce a panel node."""
+        result = markdown_to_adf(f":::{panel_type}\ntext\n:::")
+        self._assert_valid_adf(result)
+        assert result["content"][0]["type"] == "panel"
+        assert result["content"][0]["attrs"]["panelType"] == panel_type
+
+    def test_panel_content_is_paragraph(self):
+        """Panel body text becomes a paragraph node inside the panel."""
+        result = markdown_to_adf(":::note\nThis is a note.\n:::")
+        panel = result["content"][0]
+        assert panel["type"] == "panel"
+        assert panel["content"][0]["type"] == "paragraph"
+
+    def test_panel_with_nested_heading_and_list(self):
+        """Panel content supports nested headings and bullet lists."""
+        result = markdown_to_adf(":::info\n## Title\n- item 1\n- item 2\n:::")
+        panel = result["content"][0]
+        assert panel["type"] == "panel"
+        assert panel["attrs"]["panelType"] == "info"
+        inner_types = [n["type"] for n in panel["content"]]
+        assert "heading" in inner_types
+        assert "bulletList" in inner_types
+
+    def test_invalid_panel_type_falls_through_as_paragraph(self):
+        """Unknown panel type (:::custom) is not converted to a panel node."""
+        result = markdown_to_adf(":::custom\nsome text\n:::")
+        types = [n["type"] for n in result["content"]]
+        assert "panel" not in types
+
+    def test_panel_mixed_with_other_content(self):
+        """Panel can appear alongside headings and lists in a document."""
+        result = markdown_to_adf("## Heading\n\n:::note\nA note.\n:::\n\n- list item")
+        types = [n["type"] for n in result["content"]]
+        assert types == ["heading", "panel", "bulletList"]
+
+
 class TestMarkdownToJiraDispatch:
     """Tests for _markdown_to_jira Cloud/Server dispatch."""
 

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -6,6 +6,7 @@ including handling of various inline and block node types,
 and the reverse conversion from Markdown to ADF.
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -608,7 +609,7 @@ class TestMarkdownToAdf:
 class TestMarkdownToAdfPanels:
     """Tests for panel node support in markdown_to_adf."""
 
-    def _assert_valid_adf(self, result: dict) -> None:
+    def _assert_valid_adf(self, result: dict[str, Any]) -> None:
         """Helper: assert the result is a valid ADF document."""
         assert result["version"] == 1
         assert result["type"] == "doc"
@@ -619,21 +620,21 @@ class TestMarkdownToAdfPanels:
         ["note", "info", "warning", "success", "error"],
         ids=["note", "info", "warning", "success", "error"],
     )
-    def test_all_valid_panel_types(self, panel_type: str):
+    def test_all_valid_panel_types(self, panel_type: str) -> None:
         """All five valid panel types produce a panel node."""
         result = markdown_to_adf(f":::{panel_type}\ntext\n:::")
         self._assert_valid_adf(result)
         assert result["content"][0]["type"] == "panel"
         assert result["content"][0]["attrs"]["panelType"] == panel_type
 
-    def test_panel_content_is_paragraph(self):
+    def test_panel_content_is_paragraph(self) -> None:
         """Panel body text becomes a paragraph node inside the panel."""
         result = markdown_to_adf(":::note\nThis is a note.\n:::")
         panel = result["content"][0]
         assert panel["type"] == "panel"
         assert panel["content"][0]["type"] == "paragraph"
 
-    def test_panel_with_nested_heading_and_list(self):
+    def test_panel_with_nested_heading_and_list(self) -> None:
         """Panel content supports nested headings and bullet lists."""
         result = markdown_to_adf(":::info\n## Title\n- item 1\n- item 2\n:::")
         panel = result["content"][0]
@@ -643,13 +644,13 @@ class TestMarkdownToAdfPanels:
         assert "heading" in inner_types
         assert "bulletList" in inner_types
 
-    def test_invalid_panel_type_falls_through_as_paragraph(self):
+    def test_invalid_panel_type_falls_through_as_paragraph(self) -> None:
         """Unknown panel type (:::custom) is not converted to a panel node."""
         result = markdown_to_adf(":::custom\nsome text\n:::")
         types = [n["type"] for n in result["content"]]
         assert "panel" not in types
 
-    def test_panel_mixed_with_other_content(self):
+    def test_panel_mixed_with_other_content(self) -> None:
         """Panel can appear alongside headings and lists in a document."""
         result = markdown_to_adf("## Heading\n\n:::note\nA note.\n:::\n\n- list item")
         types = [n["type"] for n in result["content"]]


### PR DESCRIPTION
## Description

Adds `:::panelType` fenced block syntax to `markdown_to_adf()`, enabling ADF `panel` nodes (`note`, `info`, `warning`, `success`, `error`) to be written via `jira_create_issue` and `jira_update_issue`.

Previously, ADF panel blocks could only be created by calling the Jira v3 REST API directly, bypassing the MCP entirely. Panel *reading* was already supported (see #1052, #1057) — this closes the write-side gap.

**Syntax:**
\`\`\`
:::note
Content here. Supports nested **bold**, lists, headings, etc.
:::
\`\`\`

Maps to:
\`\`\`json
{
  "type": "panel",
  "attrs": { "panelType": "note" },
  "content": [...]
}
\`\`\`

Valid panel types: `note`, `info`, `warning`, `success`, `error`

Fixes: N/A (new feature)

## Changes

- Added panel block handler in `markdown_to_adf()` (`adf.py`) after the blockquote handler — detects `:::panelType` fences, recursively parses inner content, emits an ADF `panel` node
- Invalid/unknown panel types fall through to the paragraph handler with no breakage
- Added `TestMarkdownToAdfPanels` test class with 9 test cases covering all valid types, nested content, invalid type fallthrough, and mixed documents

## Testing

- [x] Unit tests added (`TestMarkdownToAdfPanels` in `tests/unit/models/test_adf.py`)
- [x] All existing tests pass — no regressions
- [x] Pre-commit checks pass (Ruff + mypy)

```
uv run pytest tests/unit/models/test_adf.py -xvs
# 80 passed in 4.95s

uv run pytest tests/unit/ -x -q
# 2587 passed, 5 skipped in 8.86s
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for changes
- [x] All tests pass locally
- [x] Documentation updated when applicable (N/A — syntax is self-explanatory and covered in PR description)