### PR TITLE
fix(jira): paginate get_worklogs to return all entries, not just first 20

### DIFF
--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -229,7 +229,9 @@ class WorklogMixin(JiraClient):
                     url, params={"maxResults": page_size, "startAt": start_at}
                 )
                 if not isinstance(result, dict):
-                    msg = f"Unexpected return value type from worklog API: {type(result)}"
+                    msg = (
+                        f"Unexpected return value type from worklog API: {type(result)}"
+                    )
                     logger.error(msg)
                     raise TypeError(msg)
 

--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -215,29 +215,44 @@ class WorklogMixin(JiraClient):
             Exception: If there's an error getting the worklogs
         """
         try:
-            result = self.jira.issue_get_worklog(issue_key)
-            if not isinstance(result, dict):
-                msg = f"Unexpected return value type from `jira.issue_get_worklog`: {type(result)}"
-                logger.error(msg)
-                raise TypeError(msg)
-
-            # Process the worklogs
+            # `jira.issue_get_worklog()` calls GET /issue/{key}/worklog without
+            # pagination parameters, so Jira returns at most 20 entries by default.
+            # We paginate explicitly to retrieve all worklogs regardless of count.
+            base_url = self.jira.resource_url("issue")
+            url = f"{base_url}/{issue_key}/worklog"
+            page_size = 100
+            start_at = 0
             worklogs = []
-            for worklog in result.get("worklogs", []):
-                worklogs.append(
-                    {
-                        "id": worklog.get("id"),
-                        "comment": self._clean_text(worklog.get("comment", "")),
-                        "created": str(parse_date(worklog.get("created", ""))),
-                        "updated": str(parse_date(worklog.get("updated", ""))),
-                        "started": str(parse_date(worklog.get("started", ""))),
-                        "time_spent": worklog.get("timeSpent", ""),
-                        "time_spent_seconds": worklog.get("timeSpentSeconds", 0),
-                        "author": worklog.get("author", {}).get(
-                            "displayName", "Unknown"
-                        ),
-                    }
+
+            while True:
+                result = self.jira.get(
+                    url, params={"maxResults": page_size, "startAt": start_at}
                 )
+                if not isinstance(result, dict):
+                    msg = f"Unexpected return value type from worklog API: {type(result)}"
+                    logger.error(msg)
+                    raise TypeError(msg)
+
+                page = result.get("worklogs", [])
+                for worklog in page:
+                    worklogs.append(
+                        {
+                            "id": worklog.get("id"),
+                            "comment": self._clean_text(worklog.get("comment", "")),
+                            "created": str(parse_date(worklog.get("created", ""))),
+                            "updated": str(parse_date(worklog.get("updated", ""))),
+                            "started": str(parse_date(worklog.get("started", ""))),
+                            "time_spent": worklog.get("timeSpent", ""),
+                            "time_spent_seconds": worklog.get("timeSpentSeconds", 0),
+                            "author": worklog.get("author", {}).get(
+                                "displayName", "Unknown"
+                            ),
+                        }
+                    )
+
+                start_at += len(page)
+                if start_at >= result.get("total", 0) or not page:
+                    break
 
             return worklogs
         except Exception as e:

--- a/tests/unit/jira/test_worklog.py
+++ b/tests/unit/jira/test_worklog.py
@@ -79,7 +79,9 @@ class TestWorklogMixin:
                 }
             ],
         }
-        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
         worklog_mixin.jira.get.return_value = mock_result
 
         result = worklog_mixin.get_worklogs("TEST-123")
@@ -118,7 +120,9 @@ class TestWorklogMixin:
                 },
             ],
         }
-        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
         worklog_mixin.jira.get.return_value = mock_result
 
         result = worklog_mixin.get_worklogs("TEST-123")
@@ -142,7 +146,9 @@ class TestWorklogMixin:
                 }
             ],
         }
-        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
         worklog_mixin.jira.get.return_value = mock_result
 
         result = worklog_mixin.get_worklogs("TEST-123")
@@ -156,7 +162,9 @@ class TestWorklogMixin:
 
     def test_get_worklogs_with_empty_response(self, worklog_mixin):
         """Test get_worklogs with empty response."""
-        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
         worklog_mixin.jira.get.return_value = {"total": 0, "worklogs": []}
 
         result = worklog_mixin.get_worklogs("TEST-123")
@@ -169,17 +177,34 @@ class TestWorklogMixin:
         page1 = {
             "total": 3,
             "worklogs": [
-                {"id": "1", "timeSpent": "1h", "timeSpentSeconds": 3600, "author": {"displayName": "U"}},
-                {"id": "2", "timeSpent": "1h", "timeSpentSeconds": 3600, "author": {"displayName": "U"}},
+                {
+                    "id": "1",
+                    "timeSpent": "1h",
+                    "timeSpentSeconds": 3600,
+                    "author": {"displayName": "U"},
+                },
+                {
+                    "id": "2",
+                    "timeSpent": "1h",
+                    "timeSpentSeconds": 3600,
+                    "author": {"displayName": "U"},
+                },
             ],
         }
         page2 = {
             "total": 3,
             "worklogs": [
-                {"id": "3", "timeSpent": "1h", "timeSpentSeconds": 3600, "author": {"displayName": "U"}},
+                {
+                    "id": "3",
+                    "timeSpent": "1h",
+                    "timeSpentSeconds": 3600,
+                    "author": {"displayName": "U"},
+                },
             ],
         }
-        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
         worklog_mixin.jira.get.side_effect = [page1, page2]
 
         result = worklog_mixin.get_worklogs("TEST-123")
@@ -189,7 +214,9 @@ class TestWorklogMixin:
 
     def test_get_worklogs_with_error(self, worklog_mixin):
         """Test get_worklogs error handling."""
-        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
         worklog_mixin.jira.get.side_effect = Exception("Worklog fetch error")
 
         with pytest.raises(

--- a/tests/unit/jira/test_worklog.py
+++ b/tests/unit/jira/test_worklog.py
@@ -64,8 +64,8 @@ class TestWorklogMixin:
 
     def test_get_worklogs_basic(self, worklog_mixin):
         """Test basic functionality of get_worklogs."""
-        # Setup mock response
         mock_result = {
+            "total": 1,
             "worklogs": [
                 {
                     "id": "10001",
@@ -77,15 +77,17 @@ class TestWorklogMixin:
                     "timeSpentSeconds": 3600,
                     "author": {"displayName": "Test User"},
                 }
-            ]
+            ],
         }
-        worklog_mixin.jira.issue_get_worklog.return_value = mock_result
+        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.get.return_value = mock_result
 
-        # Call the method
         result = worklog_mixin.get_worklogs("TEST-123")
 
-        # Verify
-        worklog_mixin.jira.issue_get_worklog.assert_called_once_with("TEST-123")
+        worklog_mixin.jira.get.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/worklog",
+            params={"maxResults": 100, "startAt": 0},
+        )
         assert len(result) == 1
         assert result[0]["id"] == "10001"
         assert result[0]["comment"] == "Work item 1"
@@ -95,8 +97,8 @@ class TestWorklogMixin:
 
     def test_get_worklogs_with_multiple_entries(self, worklog_mixin):
         """Test get_worklogs with multiple worklog entries."""
-        # Setup mock response with multiple entries
         mock_result = {
+            "total": 2,
             "worklogs": [
                 {
                     "id": "10001",
@@ -114,14 +116,13 @@ class TestWorklogMixin:
                     "timeSpentSeconds": 7200,
                     "author": {"displayName": "User 2"},
                 },
-            ]
+            ],
         }
-        worklog_mixin.jira.issue_get_worklog.return_value = mock_result
+        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.get.return_value = mock_result
 
-        # Call the method
         result = worklog_mixin.get_worklogs("TEST-123")
 
-        # Verify
         assert len(result) == 2
         assert result[0]["id"] == "10001"
         assert result[1]["id"] == "10002"
@@ -130,8 +131,8 @@ class TestWorklogMixin:
 
     def test_get_worklogs_with_missing_fields(self, worklog_mixin):
         """Test get_worklogs with missing fields."""
-        # Setup mock response with missing fields
         mock_result = {
+            "total": 1,
             "worklogs": [
                 {
                     "id": "10001",
@@ -139,14 +140,13 @@ class TestWorklogMixin:
                     "created": "2024-01-01T10:00:00.000+0000",
                     # Missing other fields
                 }
-            ]
+            ],
         }
-        worklog_mixin.jira.issue_get_worklog.return_value = mock_result
+        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.get.return_value = mock_result
 
-        # Call the method
         result = worklog_mixin.get_worklogs("TEST-123")
 
-        # Verify
         assert len(result) == 1
         assert result[0]["id"] == "10001"
         assert result[0]["comment"] == ""
@@ -156,24 +156,42 @@ class TestWorklogMixin:
 
     def test_get_worklogs_with_empty_response(self, worklog_mixin):
         """Test get_worklogs with empty response."""
-        # Setup mock response with no worklogs
-        worklog_mixin.jira.issue_get_worklog.return_value = {}
+        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.get.return_value = {"total": 0, "worklogs": []}
 
-        # Call the method
         result = worklog_mixin.get_worklogs("TEST-123")
 
-        # Verify
         assert isinstance(result, list)
         assert len(result) == 0
 
+    def test_get_worklogs_paginates_multiple_pages(self, worklog_mixin):
+        """Test that get_worklogs fetches all pages when total exceeds page size."""
+        page1 = {
+            "total": 3,
+            "worklogs": [
+                {"id": "1", "timeSpent": "1h", "timeSpentSeconds": 3600, "author": {"displayName": "U"}},
+                {"id": "2", "timeSpent": "1h", "timeSpentSeconds": 3600, "author": {"displayName": "U"}},
+            ],
+        }
+        page2 = {
+            "total": 3,
+            "worklogs": [
+                {"id": "3", "timeSpent": "1h", "timeSpentSeconds": 3600, "author": {"displayName": "U"}},
+            ],
+        }
+        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.get.side_effect = [page1, page2]
+
+        result = worklog_mixin.get_worklogs("TEST-123")
+
+        assert len(result) == 3
+        assert worklog_mixin.jira.get.call_count == 2
+
     def test_get_worklogs_with_error(self, worklog_mixin):
         """Test get_worklogs error handling."""
-        # Setup mock to raise exception
-        worklog_mixin.jira.issue_get_worklog.side_effect = Exception(
-            "Worklog fetch error"
-        )
+        worklog_mixin.jira.resource_url.return_value = "https://jira.example.com/rest/api/2/issue"
+        worklog_mixin.jira.get.side_effect = Exception("Worklog fetch error")
 
-        # Call the method and verify exception
         with pytest.raises(
             Exception, match="Error getting worklogs: Worklog fetch error"
         ):


### PR DESCRIPTION
## Problem

`get_worklogs()` calls `self.jira.issue_get_worklog(issue_key)`, which maps to
`GET /rest/api/2/issue/{key}/worklog` **without any pagination parameters**.
Jira's default `maxResults` is **20**, so issues with more than 20 worklog
entries silently return truncated data with no error or warning.

This means the `jira_get_worklog` MCP tool — despite its description saying it
returns "all" worklogs — was in practice always capped at 20 entries.

## Fix

Replace the single `issue_get_worklog()` call with a pagination loop that uses
explicit `maxResults` and `startAt` parameters (100 entries per page). The loop
continues until `startAt >= total`, guaranteeing all entries are returned.

```python
# Before
result = self.jira.issue_get_worklog(issue_key)  # always ≤20 entries

# After
while True:
    result = self.jira.get(url, params={"maxResults": page_size, "startAt": start_at})
    ...
    start_at += len(page)
    if start_at >= result.get("total", 0) or not page:
        break
```

## Verification

Tested on **Jira Data Center 9.x**:

| True total | Before fix | After fix | Pages fetched |
|-----------|------------|-----------|---------------|
| 68 | 20 | 68 ✅ | 1 |
| 4035 | 20 | 4035 ✅ | 41 |

## Notes

- `page_size = 100` is conservative and works on both Jira Cloud and Server/DC
- The `total` field in the response is used to know when to stop — no over-fetching
- Jira Cloud API v2 and v3 both support `startAt`/`maxResults` on this endpoint