### PR TITLE
fix(jira): preserve embedded media on cloud description updates

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -9,6 +9,7 @@ from requests.exceptions import HTTPError
 
 from ..exceptions import MCPAtlassianAuthenticationError
 from ..models.jira import JiraIssue
+from ..models.jira.adf import merge_adf_with_preserved_media
 from ..models.jira.common import JiraChangelog
 from ..utils import parse_date
 from .client import JiraClient
@@ -40,6 +41,36 @@ class IssuesMixin(
     UsersOperationsProto,
 ):
     """Mixin for Jira issue operations."""
+
+    def _preserve_cloud_description_media(
+        self,
+        issue_key: str,
+        description_adf: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Preserve existing Cloud description media during Markdown rewrites."""
+        try:
+            issue_data = self.jira.get(
+                f"rest/api/3/issue/{issue_key}",
+                params={"fields": "description", "updateHistory": "false"},
+            )
+            if not isinstance(issue_data, dict):
+                return description_adf
+
+            current_description = issue_data.get("fields", {}).get("description")
+            if not isinstance(current_description, dict):
+                return description_adf
+
+            return merge_adf_with_preserved_media(
+                target_adf=description_adf,
+                source_adf=current_description,
+            )
+        except (HTTPError, OSError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to preserve existing Jira media nodes for %s: %s",
+                issue_key,
+                exc,
+            )
+            return description_adf
 
     def get_issue(
         self,
@@ -1064,9 +1095,13 @@ class IssuesMixin(
 
             update_fields = fields or {}
             attachments_result = None
+            preserve_description_media = False
 
             # Convert description from Markdown to Jira format if present
-            if "description" in update_fields:
+            if "description" in update_fields and isinstance(
+                update_fields["description"], str
+            ):
+                preserve_description_media = bool(update_fields["description"].strip())
                 update_fields["description"] = self._markdown_to_jira(
                     update_fields["description"]
                 )
@@ -1109,6 +1144,9 @@ class IssuesMixin(
                         )
                 elif key == "description":
                     # Handle description with markdown conversion
+                    preserve_description_media = isinstance(value, str) and bool(
+                        value.strip()
+                    )
                     update_fields["description"] = self._markdown_to_jira(value)
                 else:
                     # Process regular fields using _process_additional_fields
@@ -1120,6 +1158,13 @@ class IssuesMixin(
             if update_fields:
                 has_adf = isinstance(update_fields.get("description"), dict)
                 if has_adf and self.config.is_cloud:
+                    if preserve_description_media:
+                        update_fields["description"] = (
+                            self._preserve_cloud_description_media(
+                                issue_key=issue_key,
+                                description_adf=update_fields["description"],
+                            )
+                        )
                     self._put_api3(
                         f"issue/{issue_key}",
                         {"fields": update_fields},

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -5,9 +5,13 @@ This module provides utilities for converting between ADF and other formats.
 Supports both ADF → plain text (for reading) and Markdown → ADF (for writing).
 """
 
+import copy
+import json
 import re
 from datetime import datetime, timezone
 from typing import Any
+
+_MEDIA_NODE_TYPES = frozenset({"media", "mediaSingle", "mediaGroup"})
 
 
 def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
@@ -272,6 +276,74 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
         doc["content"].append({"type": "paragraph", "content": []})
 
     return doc
+
+
+def _adf_node_contains_media(node: dict[str, Any]) -> bool:
+    """Return True when an ADF node contains media content."""
+    if node.get("type") in _MEDIA_NODE_TYPES:
+        return True
+
+    content = node.get("content")
+    if isinstance(content, list):
+        return any(
+            _adf_node_contains_media(child)
+            for child in content
+            if isinstance(child, dict)
+        )
+
+    return False
+
+
+def extract_top_level_media_nodes(
+    adf_document: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Extract top-level ADF nodes that contain media content."""
+    if not isinstance(adf_document, dict):
+        return []
+
+    content = adf_document.get("content")
+    if not isinstance(content, list):
+        return []
+
+    return [
+        copy.deepcopy(node)
+        for node in content
+        if isinstance(node, dict) and _adf_node_contains_media(node)
+    ]
+
+
+def merge_adf_with_preserved_media(
+    target_adf: dict[str, Any],
+    source_adf: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Append existing media nodes from one ADF document into another.
+
+    This is intentionally narrow: it preserves existing media-bearing blocks
+    when a caller rewrites the surrounding description text, without attempting
+    to merge all prior formatting or layout.
+    """
+    preserved_media = extract_top_level_media_nodes(source_adf)
+    if not preserved_media:
+        return target_adf
+
+    merged = copy.deepcopy(target_adf)
+    content = merged.get("content")
+    if not isinstance(content, list):
+        content = []
+        merged["content"] = content
+
+    existing_signatures = {
+        json.dumps(node, sort_keys=True, separators=(",", ":"))
+        for node in extract_top_level_media_nodes(merged)
+    }
+    for media_node in preserved_media:
+        signature = json.dumps(media_node, sort_keys=True, separators=(",", ":"))
+        if signature in existing_signatures:
+            continue
+        content.append(media_node)
+        existing_signatures.add(signature)
+
+    return merged
 
 
 def adf_to_text(adf_content: dict | list | str | None) -> str | None:

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -626,6 +626,98 @@ class TestIssuesMixin:
         assert document.key == "TEST-123"
         assert document.summary == "Updated Summary"
 
+    def test_update_issue_preserves_existing_cloud_media_nodes(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Cloud markdown updates preserve existing top-level media blocks."""
+        media_single = {
+            "type": "mediaSingle",
+            "attrs": {"layout": "center"},
+            "content": [
+                {
+                    "type": "media",
+                    "attrs": {
+                        "id": "video-123",
+                        "type": "file",
+                        "collection": "",
+                    },
+                }
+            ],
+        }
+        current_description = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Old"}]},
+                media_single,
+            ],
+        }
+        updated_description = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Updated text"}],
+                },
+                media_single,
+            ],
+        }
+        issues_mixin._put_api3 = MagicMock(return_value={})
+        issues_mixin.jira.get.side_effect = [
+            {"key": "TEST-123", "fields": {"description": current_description}},
+        ]
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description=updated_description
+        )
+
+        document = issues_mixin.update_issue(
+            issue_key="TEST-123",
+            fields={"description": "Updated text"},
+        )
+
+        issues_mixin._put_api3.assert_called_once()
+        call_args = issues_mixin._put_api3.call_args
+        assert call_args[0][0] == "issue/TEST-123"
+        sent_description = call_args[0][1]["fields"]["description"]
+        assert sent_description["content"][-1] == media_single
+        issues_mixin.jira.get.assert_called_once_with(
+            "rest/api/3/issue/TEST-123",
+            params={"fields": "description", "updateHistory": "false"},
+        )
+        issues_mixin.jira.get_issue.assert_called_once_with("TEST-123")
+        assert document.key == "TEST-123"
+
+    def test_update_issue_with_explicit_adf_does_not_fetch_current_description(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Explicit ADF updates keep replace semantics and skip media prefetch."""
+        explicit_adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Explicit ADF"}],
+                }
+            ],
+        }
+        issues_mixin._put_api3 = MagicMock(return_value={})
+        issues_mixin.jira.get_issue.return_value = make_issue_data(
+            description=explicit_adf
+        )
+
+        issues_mixin.update_issue(
+            issue_key="TEST-123",
+            fields={"description": explicit_adf},
+        )
+
+        issues_mixin._put_api3.assert_called_once_with(
+            "issue/TEST-123",
+            {"fields": {"description": explicit_adf}},
+        )
+        issues_mixin.jira.get_issue.assert_called_once_with("TEST-123")
+
     def test_update_issue_with_status(self, issues_mixin: IssuesMixin):
         """Test updating an issue with a status change."""
         # Mock get_issue response

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -10,7 +10,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.mcp_atlassian.models.jira.adf import adf_to_text, markdown_to_adf
+from src.mcp_atlassian.models.jira.adf import (
+    adf_to_text,
+    extract_top_level_media_nodes,
+    markdown_to_adf,
+    merge_adf_with_preserved_media,
+)
 
 
 class TestAdfToText:
@@ -603,6 +608,101 @@ class TestMarkdownToAdf:
         text_back = adf_to_text(adf) or ""
         for word in ["Hello", "world", "bold", "italic", "text"]:
             assert word in text_back
+
+
+class TestAdfMediaPreservation:
+    """Tests for preserving existing media nodes during description rewrites."""
+
+    def test_extract_top_level_media_nodes(self):
+        """Media blocks are extracted from the document root."""
+        media_single = {
+            "type": "mediaSingle",
+            "attrs": {"layout": "center"},
+            "content": [
+                {
+                    "type": "media",
+                    "attrs": {
+                        "id": "video-123",
+                        "type": "file",
+                        "collection": "",
+                    },
+                }
+            ],
+        }
+        adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Intro"}]},
+                media_single,
+            ],
+        }
+
+        extracted = extract_top_level_media_nodes(adf)
+
+        assert extracted == [media_single]
+
+    def test_merge_adf_with_preserved_media_appends_media_blocks(self):
+        """Existing media blocks are preserved in the outgoing ADF document."""
+        media_single = {
+            "type": "mediaSingle",
+            "attrs": {"layout": "center"},
+            "content": [
+                {
+                    "type": "media",
+                    "attrs": {
+                        "id": "video-123",
+                        "type": "file",
+                        "collection": "",
+                    },
+                }
+            ],
+        }
+        source_adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Old"}]},
+                media_single,
+            ],
+        }
+        target_adf = markdown_to_adf("Updated text")
+
+        merged = merge_adf_with_preserved_media(target_adf, source_adf)
+
+        assert merged["content"][-1] == media_single
+        assert merged["content"][0]["type"] == "paragraph"
+
+    def test_merge_adf_with_preserved_media_skips_duplicates(self):
+        """Media nodes already present in the target are not duplicated."""
+        media_single = {
+            "type": "mediaSingle",
+            "attrs": {"layout": "center"},
+            "content": [
+                {
+                    "type": "media",
+                    "attrs": {
+                        "id": "video-123",
+                        "type": "file",
+                        "collection": "",
+                    },
+                }
+            ],
+        }
+        target_adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [media_single],
+        }
+        source_adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [media_single],
+        }
+
+        merged = merge_adf_with_preserved_media(target_adf, source_adf)
+
+        assert merged["content"] == [media_single]
 
 
 class TestMarkdownToJiraDispatch:


### PR DESCRIPTION
## Summary

Fixes #1192.

When `jira_update_issue` updates a Jira Cloud description from Markdown/text, it was replacing the entire ADF document and dropping any existing UI-inserted media nodes. On Cloud, that can remove the embedded attachment itself.

This change preserves existing top-level ADF media blocks from the current Jira Cloud description before sending the v3 update payload.

## What changed

- Added a Cloud-only preservation step in `IssuesMixin.update_issue()` for Markdown/text description rewrites
- Fetched the current raw description from Jira Cloud `rest/api/3` before issuing the update
- Merged existing top-level `mediaSingle` / `mediaGroup` / `media` blocks into the outgoing ADF document
- Kept explicit caller-supplied ADF updates as replace semantics
- Added unit regression coverage for both the ADF merge helper and the Cloud update path

## Tests

Ran:

```bash
uv run pytest tests/unit/models/test_adf.py tests/unit/jira/test_issues.py -xvs
```

Result:
- `126 passed`

## Manual Jira Cloud validation

Validated against a real Jira Cloud issue using the local dev server build.

### Repro before fix

1. Create a disposable Jira Cloud issue.
2. Upload a small `.webm` attachment to the issue.
3. In the Jira web UI, embed that uploaded video inline in the description.
4. Confirm the raw v3 issue payload at `rest/api/3/issue/{issueKey}?fields=description,attachment` contains:
   - two attachments
   - a top-level `mediaSingle` node in `fields.description`
5. Call `jira_update_issue` with a Markdown/text description update.
6. Re-fetch the raw v3 issue payload.
7. Observe the bug:
   - the embedded attachment is removed
   - the `mediaSingle` node disappears from `fields.description`

### Verification after fix

1. Create or reset a disposable Jira Cloud issue.
2. Upload a small `.webm` attachment.
3. Embed it inline in the Jira description via the web UI.
4. Confirm the raw v3 payload at `rest/api/3/issue/{issueKey}?fields=description,attachment` shows:
   - both attachments present
   - a top-level `mediaSingle` node in `fields.description`
5. Run `jira_update_issue` with a Markdown/text description update.
6. Re-fetch the same raw v3 payload.
7. Confirm:
   - the updated paragraph text is present
   - the embedded attachment still exists
   - the top-level `mediaSingle` node is still present

### Observed result

After the fix, the raw Jira Cloud payload still contained:
- both attachments
- the preserved `mediaSingle` block
- the new description paragraph text

## Notes

This change intentionally preserves existing embedded media blocks only for Markdown/text description rewrites on Jira Cloud. Explicit ADF updates still behave as full replacement updates.


## Maintainer update

Merged current `origin/main` into this branch and resolved the resulting ADF test conflict.

Verification run by maintainer:

```bash
uv sync --frozen --all-extras --dev
uv run pytest tests/unit/models/test_adf.py tests/unit/jira/test_issues.py -xvs
uv run pytest tests/integration/ -xvs
uv run pytest tests/e2e/cloud --cloud-e2e -xvs
uv run pytest tests/e2e -m dc_e2e --dc-e2e -xvs
uv run pre-commit run --all-files
uv run pytest tests/unit/ -xvs
```

Results:
- Focused unit tests: 174 passed
- Integration suite: 23 skipped because real integration configuration was not present
- Cloud e2e: 71 passed, 15 skipped
- DC e2e: 84 passed, 1 skipped, 86 deselected
- Pre-commit: passed
- Full unit suite: 2873 passed, 5 skipped
