### PR TITLE
fix: Jira Server/DC string response handling + xhtml content format

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1,5 +1,6 @@
 """Module for Jira issue operations."""
 
+import json
 import logging
 from collections import defaultdict
 from typing import Any
@@ -1146,8 +1147,24 @@ class IssuesMixin(
 
             # Get the updated issue data and convert to JiraIssue model
             issue_data = self.jira.get_issue(issue_key)
+            if isinstance(issue_data, str):
+                # atlassian-python-api can return a string on Jira Server/DC
+                # when response.json() fails. Try parsing it as JSON first.
+                try:
+                    issue_data = json.loads(issue_data)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"get_issue returned a string for {issue_key}, "
+                        f"re-fetching via direct GET"
+                    )
+                    issue_data = self.jira.get(
+                        self.jira.resource_url("issue/" + issue_key)
+                    )
             if not isinstance(issue_data, dict):
-                msg = f"Unexpected return value type from `jira.get_issue`: {type(issue_data)}"
+                msg = (
+                    f"Unexpected return value type from `jira.get_issue`: "
+                    f"{type(issue_data)}"
+                )
                 logger.error(msg)
                 raise TypeError(msg)
             issue = JiraIssue.from_api_response(issue_data)

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1,5 +1,6 @@
 """Module for Jira issue operations."""
 
+import json
 import logging
 from collections import defaultdict
 from typing import Any
@@ -1171,8 +1172,24 @@ class IssuesMixin(
 
             # Get the updated issue data and convert to JiraIssue model
             issue_data = self.jira.get_issue(issue_key)
+            if isinstance(issue_data, str):
+                # atlassian-python-api can return a string on Jira Server/DC
+                # when response.json() fails. Try parsing it as JSON first.
+                try:
+                    issue_data = json.loads(issue_data)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"get_issue returned a string for {issue_key}, "
+                        f"re-fetching via direct GET"
+                    )
+                    issue_data = self.jira.get(
+                        self.jira.resource_url("issue/" + issue_key)
+                    )
             if not isinstance(issue_data, dict):
-                msg = f"Unexpected return value type from `jira.get_issue`: {type(issue_data)}"
+                msg = (
+                    f"Unexpected return value type from `jira.get_issue`: "
+                    f"{type(issue_data)}"
+                )
                 logger.error(msg)
                 raise TypeError(msg)
             issue = JiraIssue.from_api_response(issue_data)

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -546,7 +546,7 @@ async def create_page(
     content_format: Annotated[
         str,
         Field(
-            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax",
+            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' when providing Confluence XHTML storage format (same as 'storage'). Wiki format uses Confluence wiki markup syntax",
             default="markdown",
         ),
     ] = "markdown",
@@ -580,7 +580,7 @@ async def create_page(
         title: The title of the page.
         content: The content of the page (format depends on content_format).
         parent_id: Optional parent page ID.
-        content_format: The format of the content ('markdown', 'wiki', or 'storage').
+        content_format: The format of the content ('markdown', 'wiki', 'storage', or 'xhtml').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
@@ -594,9 +594,9 @@ async def create_page(
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
     # Validate content_format
-    if content_format not in ["markdown", "wiki", "storage"]:
+    if content_format not in ["markdown", "wiki", "storage", "xhtml"]:
         raise ValueError(
-            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', or 'storage'"
+            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', 'storage', or 'xhtml'"
         )
 
     # Determine parameters based on content format
@@ -605,7 +605,10 @@ async def create_page(
         content_representation = None  # Will be converted to storage
     else:
         is_markdown = False
-        content_representation = content_format  # Pass 'wiki' or 'storage' directly
+        # Map 'xhtml' to 'storage' (both use storage format)
+        content_representation = (
+            "storage" if content_format == "xhtml" else content_format
+        )
 
     page = confluence_fetcher.create_page(
         space_key=space_key,
@@ -658,7 +661,7 @@ async def update_page(
     content_format: Annotated[
         str,
         Field(
-            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax",
+            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' when providing Confluence XHTML storage format (same as 'storage'). Wiki format uses Confluence wiki markup syntax",
             default="markdown",
         ),
     ] = "markdown",
@@ -694,7 +697,7 @@ async def update_page(
         is_minor_edit: Whether this is a minor edit.
         version_comment: Optional comment for this version.
         parent_id: Optional new parent page ID.
-        content_format: The format of the content ('markdown', 'wiki', or 'storage').
+        content_format: The format of the content ('markdown', 'wiki', 'storage', or 'xhtml').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
@@ -708,9 +711,9 @@ async def update_page(
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
     # Validate content_format
-    if content_format not in ["markdown", "wiki", "storage"]:
+    if content_format not in ["markdown", "wiki", "storage", "xhtml"]:
         raise ValueError(
-            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', or 'storage'"
+            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', 'storage', or 'xhtml'"
         )
 
     # Determine parameters based on content format
@@ -719,7 +722,10 @@ async def update_page(
         content_representation = None  # Will be converted to storage
     else:
         is_markdown = False
-        content_representation = content_format  # Pass 'wiki' or 'storage' directly
+        # Map 'xhtml' to 'storage' (both use storage format)
+        content_representation = (
+            "storage" if content_format == "xhtml" else content_format
+        )
 
     updated_page = confluence_fetcher.update_page(
         page_id=page_id,

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -545,7 +545,7 @@ async def create_page(
     content_format: Annotated[
         str,
         Field(
-            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax",
+            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' when providing Confluence XHTML storage format (same as 'storage'). Wiki format uses Confluence wiki markup syntax",
             default="markdown",
         ),
     ] = "markdown",
@@ -579,7 +579,7 @@ async def create_page(
         title: The title of the page.
         content: The content of the page (format depends on content_format).
         parent_id: Optional parent page ID.
-        content_format: The format of the content ('markdown', 'wiki', or 'storage').
+        content_format: The format of the content ('markdown', 'wiki', 'storage', or 'xhtml').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
@@ -593,9 +593,9 @@ async def create_page(
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
     # Validate content_format
-    if content_format not in ["markdown", "wiki", "storage"]:
+    if content_format not in ["markdown", "wiki", "storage", "xhtml"]:
         raise ValueError(
-            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', or 'storage'"
+            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', 'storage', or 'xhtml'"
         )
 
     # Determine parameters based on content format
@@ -604,7 +604,10 @@ async def create_page(
         content_representation = None  # Will be converted to storage
     else:
         is_markdown = False
-        content_representation = content_format  # Pass 'wiki' or 'storage' directly
+        # Map 'xhtml' to 'storage' (both use storage format)
+        content_representation = (
+            "storage" if content_format == "xhtml" else content_format
+        )
 
     page = confluence_fetcher.create_page(
         space_key=space_key,
@@ -657,7 +660,7 @@ async def update_page(
     content_format: Annotated[
         str,
         Field(
-            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', or 'storage'. Wiki format uses Confluence wiki markup syntax",
+            description="(Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' when providing Confluence XHTML storage format (same as 'storage'). Wiki format uses Confluence wiki markup syntax",
             default="markdown",
         ),
     ] = "markdown",
@@ -693,7 +696,7 @@ async def update_page(
         is_minor_edit: Whether this is a minor edit.
         version_comment: Optional comment for this version.
         parent_id: Optional new parent page ID.
-        content_format: The format of the content ('markdown', 'wiki', or 'storage').
+        content_format: The format of the content ('markdown', 'wiki', 'storage', or 'xhtml').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
@@ -707,9 +710,9 @@ async def update_page(
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
     # Validate content_format
-    if content_format not in ["markdown", "wiki", "storage"]:
+    if content_format not in ["markdown", "wiki", "storage", "xhtml"]:
         raise ValueError(
-            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', or 'storage'"
+            f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', 'storage', or 'xhtml'"
         )
 
     # Determine parameters based on content format
@@ -718,7 +721,10 @@ async def update_page(
         content_representation = None  # Will be converted to storage
     else:
         is_markdown = False
-        content_representation = content_format  # Pass 'wiki' or 'storage' directly
+        # Map 'xhtml' to 'storage' (both use storage format)
+        content_representation = (
+            "storage" if content_format == "xhtml" else content_format
+        )
 
     updated_page = confluence_fetcher.update_page(
         page_id=page_id,

--- a/tests/e2e/cloud/test_mcp_tools_cloud.py
+++ b/tests/e2e/cloud/test_mcp_tools_cloud.py
@@ -181,3 +181,46 @@ class TestMCPConfluenceTools:
             "confluence_delete_page",
             {"page_id": page_id},
         )
+
+    @pytest.mark.anyio
+    async def test_confluence_create_update_xhtml_page(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        create_result = await call_tool(
+            mcp_client,
+            "confluence_create_page",
+            {
+                "space_key": cloud_instance.space_key,
+                "title": f"Cloud MCP XHTML Tool Test {uid}",
+                "content": "<p>Created via MCP XHTML tool test.</p>",
+                "content_format": "xhtml",
+            },
+        )
+        assert not create_result.is_error
+        assert create_result.content and isinstance(
+            create_result.content[0], TextContent
+        )
+        page_id = json.loads(create_result.content[0].text)["page"]["id"]
+        assert page_id is not None
+
+        try:
+            update_result = await call_tool(
+                mcp_client,
+                "confluence_update_page",
+                {
+                    "page_id": page_id,
+                    "title": f"Cloud MCP XHTML Tool Test {uid}",
+                    "content": "<p>Updated via MCP XHTML tool test.</p>",
+                    "content_format": "xhtml",
+                },
+            )
+            assert not update_result.is_error
+        finally:
+            await call_tool(
+                mcp_client,
+                "confluence_delete_page",
+                {"page_id": page_id},
+            )

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -181,3 +181,46 @@ class TestMCPConfluenceTools:
             "confluence_delete_page",
             {"page_id": page_id},
         )
+
+    @pytest.mark.anyio
+    async def test_confluence_create_update_xhtml_page(
+        self,
+        mcp_client: Client,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        create_result = await call_tool(
+            mcp_client,
+            "confluence_create_page",
+            {
+                "space_key": dc_instance.space_key,
+                "title": f"MCP XHTML Tool Test {uid}",
+                "content": "<p>Created via MCP XHTML tool test.</p>",
+                "content_format": "xhtml",
+            },
+        )
+        assert not create_result.is_error
+        assert create_result.content and isinstance(
+            create_result.content[0], TextContent
+        )
+        page_id = json.loads(create_result.content[0].text)["page"]["id"]
+        assert page_id is not None
+
+        try:
+            update_result = await call_tool(
+                mcp_client,
+                "confluence_update_page",
+                {
+                    "page_id": page_id,
+                    "title": f"MCP XHTML Tool Test {uid}",
+                    "content": "<p>Updated via MCP XHTML tool test.</p>",
+                    "content_format": "xhtml",
+                },
+            )
+            assert not update_result.is_error
+        finally:
+            await call_tool(
+                mcp_client,
+                "confluence_delete_page",
+                {"page_id": page_id},
+            )

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -798,6 +798,31 @@ class TestPagesMixin:
                 representation="storage",
             )
 
+    def test_create_page_with_xhtml_format(self, pages_mixin):
+        """Test creating a page with xhtml format maps to storage representation."""
+        space_key = "PROJ"
+        title = "XHTML Page"
+        xhtml_body = "<ac:structured-macro ac:name='code'><ac:plain-text-body>hello</ac:plain-text-body></ac:structured-macro>"
+
+        with patch.object(
+            pages_mixin,
+            "get_page_content",
+            return_value=ConfluencePage(id="123456789", title=title),
+        ):
+            result = pages_mixin.create_page(
+                space_key=space_key, title=title, body=xhtml_body, is_markdown=False
+            )
+
+            # xhtml should be treated the same as storage
+            pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+            pages_mixin.confluence.create_page.assert_called_once_with(
+                space=space_key,
+                title=title,
+                body=xhtml_body,
+                parent_id=None,
+                representation="storage",
+            )
+
     def test_update_page_with_markdown(self, pages_mixin):
         """Test updating a page with markdown content."""
         # Arrange

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -798,31 +798,6 @@ class TestPagesMixin:
                 representation="storage",
             )
 
-    def test_create_page_with_xhtml_format(self, pages_mixin):
-        """Test creating a page with xhtml format maps to storage representation."""
-        space_key = "PROJ"
-        title = "XHTML Page"
-        xhtml_body = "<ac:structured-macro ac:name='code'><ac:plain-text-body>hello</ac:plain-text-body></ac:structured-macro>"
-
-        with patch.object(
-            pages_mixin,
-            "get_page_content",
-            return_value=ConfluencePage(id="123456789", title=title),
-        ):
-            result = pages_mixin.create_page(
-                space_key=space_key, title=title, body=xhtml_body, is_markdown=False
-            )
-
-            # xhtml should be treated the same as storage
-            pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
-            pages_mixin.confluence.create_page.assert_called_once_with(
-                space=space_key,
-                title=title,
-                body=xhtml_body,
-                parent_id=None,
-                representation="storage",
-            )
-
     def test_update_page_with_markdown(self, pages_mixin):
         """Test updating a page with markdown content."""
         # Arrange

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -601,6 +601,42 @@ class TestIssuesMixin:
                 assert issues_mixin.get_issue.called
                 assert result.key == "EPIC-123"
 
+    def test_update_issue_handles_string_response_as_json(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Test that update_issue handles get_issue returning a JSON string on Server/DC."""
+        import json
+
+        issue_dict = make_issue_data(summary="Updated Summary", status="In Progress")
+        # Simulate atlassian-python-api returning a JSON string instead of dict
+        issues_mixin.jira.get_issue.return_value = json.dumps(issue_dict)
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        document = issues_mixin.update_issue(
+            issue_key="TEST-123", fields={"summary": "Updated Summary"}
+        )
+
+        assert document.key == "TEST-123"
+        assert document.summary == "Updated Summary"
+
+    def test_update_issue_handles_string_response_with_refetch(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Test that update_issue re-fetches via direct GET when string is not valid JSON."""
+        issue_dict = make_issue_data(summary="Refetched", status="Open")
+        # First call returns non-JSON string, direct GET returns dict
+        issues_mixin.jira.get_issue.return_value = "<html>WAF login page</html>"
+        issues_mixin.jira.get.return_value = issue_dict
+        issues_mixin.jira.resource_url.return_value = "/rest/api/2/issue/TEST-123"
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        document = issues_mixin.update_issue(
+            issue_key="TEST-123", fields={"summary": "Refetched"}
+        )
+
+        issues_mixin.jira.get.assert_called_once_with("/rest/api/2/issue/TEST-123")
+        assert document.key == "TEST-123"
+
     def test_update_issue_basic(self, issues_mixin: IssuesMixin, make_issue_data):
         """Test updating an issue with basic fields."""
         issues_mixin.jira.get_issue.return_value = make_issue_data(

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -660,6 +660,37 @@ async def test_create_page_include_content(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
+async def test_create_page_with_xhtml_format(client, mock_confluence_fetcher):
+    """Test create_page maps xhtml content format to storage representation."""
+    xhtml_body = (
+        "<ac:structured-macro ac:name='code'>"
+        "<ac:plain-text-body>hello</ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+
+    response = await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "XHTML Page",
+            "content": xhtml_body,
+            "content_format": "xhtml",
+            "enable_heading_anchors": True,
+        },
+    )
+
+    mock_confluence_fetcher.create_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.create_page.call_args.kwargs
+    assert call_kwargs["body"] == xhtml_body
+    assert call_kwargs["is_markdown"] is False
+    assert call_kwargs["content_representation"] == "storage"
+    assert call_kwargs["enable_heading_anchors"] is False
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["message"] == "Page created successfully"
+
+
+@pytest.mark.anyio
 async def test_update_page_with_numeric_parent_id(client, mock_confluence_fetcher):
     """Test updating a page with numeric parent_id (integer) - should convert to string."""
     response = await client.call_tool(
@@ -726,6 +757,37 @@ async def test_update_page_include_content(client, mock_confluence_fetcher):
     assert result_data["message"] == "Page updated successfully"
     assert result_data["page"]["title"] == "Test Page Mock Title"
     assert "content" in result_data["page"]
+
+
+@pytest.mark.anyio
+async def test_update_page_with_xhtml_format(client, mock_confluence_fetcher):
+    """Test update_page maps xhtml content format to storage representation."""
+    xhtml_body = (
+        "<ac:structured-macro ac:name='info'>"
+        "<ac:rich-text-body><p>hello</p></ac:rich-text-body>"
+        "</ac:structured-macro>"
+    )
+
+    response = await client.call_tool(
+        "confluence_update_page",
+        {
+            "page_id": "999999",
+            "title": "Updated XHTML Page",
+            "content": xhtml_body,
+            "content_format": "xhtml",
+            "enable_heading_anchors": True,
+        },
+    )
+
+    mock_confluence_fetcher.update_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.update_page.call_args.kwargs
+    assert call_kwargs["body"] == xhtml_body
+    assert call_kwargs["is_markdown"] is False
+    assert call_kwargs["content_representation"] == "storage"
+    assert call_kwargs["enable_heading_anchors"] is False
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["message"] == "Page updated successfully"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

Two improvements for Server/DC environments:

1. **Jira Server/DC:** `atlassian-python-api` can return a raw string from `get_issue` when `response.json()` fails. This causes a `TypeError` downstream. Added fallback logic that tries JSON parsing the string, then re-fetches via direct GET.

2. **Confluence:** Added `xhtml` as an accepted `content_format` for `create_page` and `update_page`. Maps to the existing `storage` format but provides a clearer alias — AI assistants (Claude, etc.) sometimes convert XHTML to markdown unnecessarily when only `storage` is listed as an option, since they don't realize `storage` means Confluence XHTML.

## Changes

- Handle string return from `jira.get_issue()` with JSON parse + direct GET fallback
- Add `xhtml` content format option to `create_page` and `update_page` tools
- Update tool descriptions and validation to include `xhtml`
- Add unit tests for both changes

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Verified on Jira Server/DC instance where `get_issue` returns string responses

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).