### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "mcp-atlassian",
+  "version": "0.1.0",
+  "description": "MCP server for Atlassian tools (Confluence, Jira) - access from Codex",
+  "author": {
+    "name": "sooperset",
+    "url": "https://github.com/sooperset"
+  },
+  "homepage": "https://github.com/sooperset/mcp-atlassian",
+  "repository": "https://github.com/sooperset/mcp-atlassian",
+  "keywords": [
+    "mcp",
+    "atlassian",
+    "confluence",
+    "jira",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "MCP Atlassian",
+    "shortDescription": "Access Confluence and Jira from Codex",
+    "longDescription": "MCP server for Atlassian tools. Search and read Confluence pages, manage Jira issues, and integrate Atlassian knowledge into your Codex workflow.",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/sooperset/mcp-atlassian"
+  },
+  "skills": "./skills/"
+}

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,28 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0
+        with:
+          plugin_dir: "."
+          min_score: 60
+          fail_on_severity: high

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "atlassian": {
+      "command": "uvx",
+      "args": [
+        "mcp-atlassian"
+      ]
+    }
+  }
+}

--- a/skills/mcp-atlassian/SKILL.md
+++ b/skills/mcp-atlassian/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: mcp-atlassian
+description: Access Confluence docs and Jira issues from Codex via MCP.
+---
+
+# MCP Atlassian for Codex
+
+Access Confluence pages and Jira issues through the mcp-atlassian MCP server.
+
+## When to use
+- Searching Confluence documentation
+- Reading and creating Jira issues
+- Accessing team knowledge bases
+- Integrating project management into coding workflows
+
+## Prerequisites
+- uvx (from uv package manager)
+- Atlassian API credentials
+- See https://github.com/sooperset/mcp-atlassian for setup


### PR DESCRIPTION
Adds a `.codex-plugin/plugin.json` manifest so mcp-atlassian can be installed as a Codex CLI plugin.

The plugin wraps the existing package via `.mcp.json` using `uvx mcp-atlassian`.

**What this adds:**
- `.codex-plugin/plugin.json` — Plugin manifest with metadata
- `.mcp.json` — MCP server reference
- `skills/mcp-atlassian/SKILL.md` — Usage guide for Codex

**Related resources:**
- [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins) — Curated directory of Codex plugins (open a PR to get listed!)
- [codex-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner) — Security and quality scanner for Codex plugins (scores 0-100, CI action available)