### PR TITLE
feat(jira): add JSM customer request tools

### DIFF
--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 93 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 96 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **93 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **96 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -27,7 +27,7 @@ MCP Atlassian provides **93 tools** for interacting with Jira and Confluence. To
     Download attachments and render images
   </Card>
   <Card title="Service Desk" icon="headset" href="/docs/tools/jira-service-desk">
-    Service desk queues and queue issues
+    Customer requests, service desks, and queues
   </Card>
   <Card title="Forms & Metrics" icon="chart-line" href="/docs/tools/jira-forms-metrics">
     ProForma forms, SLA, dates, development info
@@ -78,7 +78,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images` |
 | `jira_users` | No | `jira_get_user_profile` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
-| `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues` |
+| `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues`, `jira_get_request_types`, `jira_get_request_type_fields`, `jira_create_customer_request` |
 | `jira_forms` | No | `jira_get_issue_proforma_forms`, `jira_get_proforma_form_details`, `jira_update_proforma_form_answers` |
 | `jira_metrics` | No | `jira_get_issue_dates`, `jira_get_issue_sla` |
 | `jira_development` | No | `jira_get_issue_development_info`, `jira_get_issues_development_info` |
@@ -101,7 +101,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (93 tools)
+# Enable all toolsets (96 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/jira-service-desk.mdx
+++ b/docs/tools/jira-service-desk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jira Service Desk"
-description: "Service desk queues and queue issues"
+description: "Customer requests, service desks, and queues"
 ---
 
 ### Get Service Desk For Project
@@ -41,5 +41,52 @@ Get issues from a Jira Service Desk queue.
 | `queue_id` | `string` | Yes | Queue ID (e.g., '47') |
 | `start_at` | `integer` | No | Starting index for pagination (0-based) |
 | `limit` | `integer` | No | Maximum number of results (1-50) |
+
+---
+
+### Get Request Types
+
+Get request types for a Jira Service Management service desk.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `service_desk_id` | `string` | Yes | Service desk ID (e.g., '4') |
+| `start_at` | `integer` | No | Starting index for pagination (0-based) |
+| `limit` | `integer` | No | Maximum number of results (1-50) |
+
+---
+
+### Get Request Type Fields
+
+Get field definitions for a Jira Service Management request type.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `service_desk_id` | `string` | Yes | Service desk ID (e.g., '4') |
+| `request_type_id` | `string` | Yes | Request type ID (e.g., '23') |
+
+---
+
+### Create Customer Request
+
+Create a Jira Service Management customer request.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `service_desk_id` | `string` | Yes | Service desk ID (e.g., '4') |
+| `request_type_id` | `string` | Yes | Request type ID (e.g., '23') |
+| `request_field_values` | `string` | Yes | JSON string of request field values keyed by field ID. Examples: - Summary and description: `{"summary": "Access issue", "description": "Cannot log in"}` - Multi-value field: `{"customfield_10001": ["alice", "bob"]}` |
+| `raise_on_behalf_of` | `string` | No | (Optional) Jira user identifier for raiseOnBehalfOf. For Server/DC this is typically username or key; for Cloud use the identifier expected by your JSM instance. |
+| `request_participants` | `string` | No | (Optional) JSON array string or comma-separated list of request participants. Examples: ["user1","user2"] or "user1,user2" |
+| `attachments` | `string` | No | (Optional) JSON array string of files to attach to the created request. Each object must contain 'filename', 'mime_type', and base64-encoded 'base64' content. Example: `[{"filename": "log.txt", "mime_type": "text/plain", "base64": "aGVsbG8="}]` |
+| `strict_on_behalf` | `boolean` | No | If true, fail immediately when raiseOnBehalfOf cannot be applied. If false, retry without raiseOnBehalfOf and return a fallback warning. |
 
 ---

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -93,6 +93,9 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
         "jira_get_service_desk_for_project",
         "jira_get_service_desk_queues",
         "jira_get_queue_issues",
+        "jira_get_request_types",
+        "jira_get_request_type_fields",
+        "jira_create_customer_request",
     ],
     "jira-forms-metrics": [
         "jira_get_issue_proforma_forms",
@@ -181,7 +184,7 @@ CATEGORY_META: dict[str, dict[str, str]] = {
     },
     "jira-service-desk": {
         "title": "Jira Service Desk",
-        "description": "Service desk queues and queue issues",
+        "description": "Customer requests, service desks, and queues",
     },
     "jira-forms-metrics": {
         "title": "Jira Forms & Metrics",

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -13,6 +13,7 @@ from .boards import BoardsMixin
 from .client import JiraClient
 from .comments import CommentsMixin
 from .config import JiraConfig
+from .customer_requests import CustomerRequestsMixin
 from .development import DevelopmentMixin
 from .epics import EpicsMixin
 from .field_options import FieldOptionsMixin
@@ -43,6 +44,7 @@ class JiraFetcher(
     WorklogMixin,
     EpicsMixin,
     CommentsMixin,
+    CustomerRequestsMixin,
     SearchMixin,
     IssuesMixin,
     UsersMixin,

--- a/src/mcp_atlassian/jira/customer_requests.py
+++ b/src/mcp_atlassian/jira/customer_requests.py
@@ -3,8 +3,11 @@
 import logging
 from typing import Any
 
+from requests.exceptions import HTTPError
+
 from ..models.jira import (
     JiraCustomerRequest,
+    JiraRequestTypeField,
     JiraRequestTypeFieldsResult,
     JiraRequestTypesResult,
 )
@@ -17,6 +20,18 @@ class CustomerRequestsMixin(JiraClient):
     """Mixin for Jira Service Management customer request operations."""
 
     @staticmethod
+    def _trace_prefix(
+        service_desk_id: str,
+        request_type_id: str,
+        marker: str,
+    ) -> str:
+        """Build a stable prefix for tracing JSM customer request failures."""
+        return (
+            f"JSM_CUSTOMER_REQUEST_{marker} "
+            f"service_desk_id={service_desk_id} request_type_id={request_type_id}"
+        )
+
+    @staticmethod
     def _get_servicedesk_headers(default_headers: dict[str, Any]) -> dict[str, Any]:
         """Return headers required for ServiceDesk API calls."""
         return {
@@ -25,22 +40,296 @@ class CustomerRequestsMixin(JiraClient):
         }
 
     @staticmethod
-    def _format_request_field_value(
-        value: Any, jira_schema: dict[str, Any] | None
+    def _is_missing_field_value(value: Any) -> bool:
+        """Check whether a request field value should be treated as missing."""
+        if value is None:
+            return True
+        if isinstance(value, str):
+            return not value.strip()
+        if isinstance(value, (list, dict)):
+            return len(value) == 0
+        return False
+
+    @staticmethod
+    def _describe_value_shape(value: Any) -> str:
+        """Return a trace-friendly summary of a field value without logging content."""
+        if isinstance(value, str):
+            return f"str[len={len(value)}]"
+        if isinstance(value, list):
+            return f"list[len={len(value)}]"
+        if isinstance(value, dict):
+            keys = ",".join(sorted(str(key) for key in value.keys()))
+            return f"dict[keys={keys}]"
+        if value is None:
+            return "none"
+        return type(value).__name__
+
+    @staticmethod
+    def _shorten_error_text(error_text: str, max_length: int = 400) -> str:
+        """Shorten a raw Jira error text for logs and tool responses."""
+        normalized = " ".join(error_text.split())
+        if len(normalized) <= max_length:
+            return normalized
+        return f"{normalized[: max_length - 3]}..."
+
+    @staticmethod
+    def _field_display_name(
+        field_id: str,
+        field_definition: JiraRequestTypeField | None,
+    ) -> str:
+        """Return a readable field name for trace messages."""
+        if field_definition and field_definition.name:
+            return field_definition.name
+        return field_id
+
+    @staticmethod
+    def _is_select_like_field(field_definition: JiraRequestTypeField | None) -> bool:
+        """Determine whether a field behaves like a select/dropdown."""
+        if not field_definition or not field_definition.jira_schema:
+            return False
+
+        jira_schema = field_definition.jira_schema
+        field_type = str(jira_schema.get("type", "")).lower()
+        custom_type = str(jira_schema.get("custom", "")).lower()
+        return field_type == "option" or "select" in custom_type
+
+    @staticmethod
+    def _normalize_array_value(value: Any) -> list[Any]:
+        """Normalize a request field value to a list."""
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            parts = [part.strip() for part in value.split(",") if part.strip()]
+            return parts or [value]
+        return [value]
+
+    @staticmethod
+    def _extract_option_candidates(value: Any) -> list[str]:
+        """Extract candidate strings from raw option input."""
+        if isinstance(value, dict):
+            candidates: list[str] = []
+            for key in ("id", "value", "label", "name"):
+                candidate = value.get(key)
+                if candidate is None:
+                    continue
+                candidate_text = str(candidate).strip()
+                if candidate_text:
+                    candidates.append(candidate_text)
+            return candidates
+
+        if isinstance(value, (str, int, float)):
+            candidate_text = str(value).strip()
+            return [candidate_text] if candidate_text else []
+
+        return []
+
+    @staticmethod
+    def _build_select_payload(option: dict[str, Any]) -> dict[str, str] | None:
+        """Build a canonical JSM payload for a matched select option."""
+        option_id = option.get("id") or option.get("value")
+        option_label = option.get("label") or option.get("name")
+
+        if option_id is not None and str(option_id).strip():
+            return {"id": str(option_id).strip()}
+        if option_label is not None and str(option_label).strip():
+            return {"value": str(option_label).strip()}
+        return None
+
+    def _match_select_option(
+        self,
+        field_definition: JiraRequestTypeField,
+        value: Any,
+    ) -> dict[str, str] | None:
+        """Match a raw select value against request type metadata."""
+        candidates = self._extract_option_candidates(value)
+        if not candidates:
+            return None
+
+        for candidate in candidates:
+            candidate_lower = candidate.lower()
+            for option in field_definition.valid_values:
+                if not isinstance(option, dict):
+                    continue
+
+                option_id = option.get("id") or option.get("value")
+                option_value = option.get("value")
+                option_label = option.get("label") or option.get("name")
+                payload = self._build_select_payload(option)
+                if payload is None:
+                    continue
+
+                if option_id is not None and candidate == str(option_id).strip():
+                    return payload
+                if (
+                    option_id is not None
+                    and candidate_lower == str(option_id).strip().lower()
+                ):
+                    return payload
+                if option_value is not None and candidate == str(option_value).strip():
+                    return payload
+                if (
+                    option_value is not None
+                    and candidate_lower == str(option_value).strip().lower()
+                ):
+                    return payload
+                if option_label is not None and candidate == str(option_label).strip():
+                    return payload
+                if (
+                    option_label is not None
+                    and candidate_lower == str(option_label).strip().lower()
+                ):
+                    return payload
+
+        return None
+
+    @staticmethod
+    def _summarize_allowed_values(
+        field_definition: JiraRequestTypeField,
+        limit: int = 6,
+    ) -> str:
+        """Summarize the first few allowed values for trace messages."""
+        values: list[str] = []
+        for option in field_definition.valid_values[:limit]:
+            if isinstance(option, dict):
+                label = option.get("label") or option.get("name") or option.get("value")
+                if label is not None:
+                    values.append(str(label))
+            elif option is not None:
+                values.append(str(option))
+
+        summary = ", ".join(values)
+        if len(field_definition.valid_values) > limit:
+            return f"{summary}, ..."
+        return summary or "n/a"
+
+    def _normalize_select_field_value(
+        self,
+        field_id: str,
+        value: Any,
+        field_definition: JiraRequestTypeField,
     ) -> Any:
-        """Format request field values for the JSM customer request API."""
-        if not jira_schema:
+        """Normalize a select-like field to a canonical JSM payload shape."""
+        jira_schema = field_definition.jira_schema or {}
+        if jira_schema.get("type") == "array":
+            if not field_definition.valid_values:
+                return self._normalize_array_value(value)
+
+            normalized_values: list[dict[str, str]] = []
+            for item in self._normalize_array_value(value):
+                matched_payload = self._match_select_option(field_definition, item)
+                if matched_payload is None:
+                    field_name = self._field_display_name(field_id, field_definition)
+                    message = (
+                        "invalid select value for "
+                        f"field '{field_name}' ({field_id}); "
+                        f"provided_shape={self._describe_value_shape(item)}; "
+                        f"allowed_values={self._summarize_allowed_values(field_definition)}"
+                    )
+                    raise ValueError(message)
+                normalized_values.append(matched_payload)
+            return normalized_values
+
+        matched_payload = self._match_select_option(field_definition, value)
+        if matched_payload is not None:
+            return matched_payload
+
+        if not field_definition.valid_values:
             return value
 
+        field_name = self._field_display_name(field_id, field_definition)
+        message = (
+            "invalid select value for "
+            f"field '{field_name}' ({field_id}); "
+            f"provided_shape={self._describe_value_shape(value)}; "
+            f"allowed_values={self._summarize_allowed_values(field_definition)}"
+        )
+        raise ValueError(message)
+
+    def _format_request_field_value(
+        self,
+        field_id: str,
+        value: Any,
+        field_definition: JiraRequestTypeField | None,
+    ) -> Any:
+        """Format request field values for the JSM customer request API."""
+        jira_schema = field_definition.jira_schema if field_definition else None
+        if not jira_schema or field_definition is None:
+            return value
+
+        if self._is_select_like_field(field_definition):
+            return self._normalize_select_field_value(
+                field_id,
+                value,
+                field_definition,
+            )
+
         if jira_schema.get("type") == "array":
-            if isinstance(value, list):
-                return value
-            if isinstance(value, str):
-                parts = [part.strip() for part in value.split(",") if part.strip()]
-                return parts or [value]
-            return [value]
+            return self._normalize_array_value(value)
 
         return value
+
+    @staticmethod
+    def _extract_error_details(exception: Exception) -> tuple[int | None, str]:
+        """Extract status code and readable error text from an exception."""
+        response = exception.response if isinstance(exception, HTTPError) else None
+        if response is None:
+            return None, str(exception).strip() or type(exception).__name__
+
+        raw_text = response.text.strip()
+        try:
+            data = response.json()
+        except ValueError:
+            return response.status_code, raw_text or str(exception).strip()
+
+        if isinstance(data, dict):
+            error_text = data.get("errorMessage")
+            if not error_text and isinstance(data.get("errorMessages"), list):
+                error_text = "; ".join(str(item) for item in data["errorMessages"])
+            if not error_text and isinstance(data.get("errors"), dict):
+                error_text = "; ".join(
+                    f"{field}: {message}" for field, message in data["errors"].items()
+                )
+            if error_text:
+                return response.status_code, str(error_text)
+
+        return response.status_code, raw_text or str(exception).strip()
+
+    def _log_request_error(
+        self,
+        service_desk_id: str,
+        request_type_id: str,
+        request_field_values: dict[str, Any],
+        exception: Exception,
+    ) -> str:
+        """Log a trace-friendly JSM request error and return a compact message."""
+        status_code, error_text = self._extract_error_details(exception)
+        shortened_error = self._shorten_error_text(error_text)
+        prefix = self._trace_prefix(
+            service_desk_id,
+            request_type_id,
+            "HTTP_ERROR",
+        )
+        field_shapes = {
+            field_id: self._describe_value_shape(value)
+            for field_id, value in request_field_values.items()
+        }
+        if status_code is None:
+            logger.error(
+                "%s field_shapes=%s error=%s",
+                prefix,
+                field_shapes,
+                shortened_error,
+            )
+            return f"{prefix}: {shortened_error}"
+
+        logger.error(
+            "%s status=%s field_shapes=%s error=%s",
+            prefix,
+            status_code,
+            field_shapes,
+            shortened_error,
+        )
+        return f"{prefix} status={status_code}: {shortened_error}"
 
     def _build_portal_url(
         self,
@@ -71,14 +360,14 @@ class CustomerRequestsMixin(JiraClient):
         normalized = error_message.lower()
         retry_markers = [
             "raiseonbehalfof",
+            "raise_on_behalf_of",
             "on behalf",
             "unknown user",
-            "permission",
-            "forbidden",
-            "customer",
-            "400",
-            "403",
-            "404",
+            "user does not exist",
+            "invalid customer",
+            "customer account",
+            "permission to raise",
+            "raise requests on behalf",
         ]
         return any(marker in normalized for marker in retry_markers)
 
@@ -112,7 +401,7 @@ class CustomerRequestsMixin(JiraClient):
                 response,
                 service_desk_id=service_desk_id,
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.error(
                 "Error getting request types for service desk %s: %s",
                 service_desk_id,
@@ -151,9 +440,12 @@ class CustomerRequestsMixin(JiraClient):
                 service_desk_id=service_desk_id,
                 request_type_id=request_type_id,
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.error(
-                "Error getting request type fields for service desk %s request type %s: %s",
+                (
+                    "Error getting request type fields for service desk %s "
+                    "request type %s: %s"
+                ),
                 service_desk_id,
                 request_type_id,
                 str(e),
@@ -170,6 +462,7 @@ class CustomerRequestsMixin(JiraClient):
         request_field_values: dict[str, Any],
         raise_on_behalf_of: str | None = None,
         request_participants: list[str] | None = None,
+        *,
         strict_on_behalf: bool = False,
     ) -> JiraCustomerRequest:
         """Create a Jira Service Management customer request."""
@@ -188,15 +481,44 @@ class CustomerRequestsMixin(JiraClient):
             field.field_id: field for field in fields_result.fields if field.field_id
         }
 
-        formatted_field_values = {
-            field_id: self._format_request_field_value(
-                value,
-                field_definitions.get(field_id).jira_schema
-                if field_id in field_definitions
-                else None,
+        missing_required_fields = [
+            f"{self._field_display_name(field.field_id, field)} ({field.field_id})"
+            for field in fields_result.fields
+            if field.field_id
+            and field.required
+            and field.visible is not False
+            and self._is_missing_field_value(request_field_values.get(field.field_id))
+        ]
+        if missing_required_fields:
+            missing_fields = ", ".join(missing_required_fields)
+            prefix = self._trace_prefix(
+                service_desk_id,
+                request_type_id,
+                "MISSING_REQUIRED_FIELDS",
             )
-            for field_id, value in request_field_values.items()
-        }
+            message = f"{prefix}: {missing_fields}"
+            raise ValueError(message)
+
+        formatted_field_values: dict[str, Any] = {}
+        for field_id, value in request_field_values.items():
+            field_definition = field_definitions.get(field_id)
+            if self._is_missing_field_value(value):
+                continue
+
+            try:
+                formatted_field_values[field_id] = self._format_request_field_value(
+                    field_id,
+                    value,
+                    field_definition,
+                )
+            except ValueError as exc:
+                prefix = self._trace_prefix(
+                    service_desk_id,
+                    request_type_id,
+                    "FIELD_ERROR",
+                )
+                message = f"{prefix} field_id={field_id}: {exc}"
+                raise ValueError(message) from exc
 
         payload: dict[str, Any] = {
             "serviceDeskId": str(service_desk_id),
@@ -233,7 +555,12 @@ class CustomerRequestsMixin(JiraClient):
                 warnings=warnings,
             )
         except Exception as e:
-            error_message = str(e)
+            error_message = self._log_request_error(
+                service_desk_id,
+                request_type_id,
+                formatted_field_values,
+                e,
+            )
             if (
                 raise_on_behalf_of
                 and not strict_on_behalf
@@ -244,22 +571,38 @@ class CustomerRequestsMixin(JiraClient):
                     for key, value in payload.items()
                     if key != "raiseOnBehalfOf"
                 }
-                warnings.append(
-                    "Could not apply raise_on_behalf_of "
-                    f"'{raise_on_behalf_of}': {error_message}"
+                prefix = self._trace_prefix(
+                    service_desk_id,
+                    request_type_id,
+                    "ON_BEHALF_FALLBACK",
                 )
-                response = self.jira.post(
-                    endpoint,
-                    data=fallback_payload,
-                    headers=headers,
+                warning_message = (
+                    f"{prefix} "
+                    f"raise_on_behalf_of='{raise_on_behalf_of}': {error_message}"
                 )
-                if not isinstance(response, dict):
-                    msg = (
-                        "Unexpected return value type from "
-                        f"ServiceDesk request create API: {type(response)}"
+                warnings.append(warning_message)
+                try:
+                    response = self.jira.post(
+                        endpoint,
+                        data=fallback_payload,
+                        headers=headers,
                     )
-                    logger.error(msg)
-                    raise TypeError(msg)
+                    if not isinstance(response, dict):
+                        msg = (
+                            "Unexpected return value type from "
+                            f"ServiceDesk request create API: {type(response)}"
+                        )
+                        logger.error(msg)
+                        raise TypeError(msg)
+                except Exception as fallback_error:
+                    fallback_message = self._log_request_error(
+                        service_desk_id,
+                        request_type_id,
+                        formatted_field_values,
+                        fallback_error,
+                    )
+                    message = f"{error_message}; fallback_failed: {fallback_message}"
+                    raise ValueError(message) from fallback_error
 
                 return JiraCustomerRequest.from_api_response(
                     response,
@@ -270,4 +613,4 @@ class CustomerRequestsMixin(JiraClient):
                     warnings=warnings,
                 )
 
-            raise
+            raise ValueError(error_message) from e

--- a/src/mcp_atlassian/jira/customer_requests.py
+++ b/src/mcp_atlassian/jira/customer_requests.py
@@ -1,0 +1,273 @@
+"""Module for Jira Service Management customer request operations."""
+
+import logging
+from typing import Any
+
+from ..models.jira import (
+    JiraCustomerRequest,
+    JiraRequestTypeFieldsResult,
+    JiraRequestTypesResult,
+)
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class CustomerRequestsMixin(JiraClient):
+    """Mixin for Jira Service Management customer request operations."""
+
+    @staticmethod
+    def _get_servicedesk_headers(default_headers: dict[str, Any]) -> dict[str, Any]:
+        """Return headers required for ServiceDesk API calls."""
+        return {
+            **default_headers,
+            "X-ExperimentalApi": "opt-in",
+        }
+
+    @staticmethod
+    def _format_request_field_value(
+        value: Any, jira_schema: dict[str, Any] | None
+    ) -> Any:
+        """Format request field values for the JSM customer request API."""
+        if not jira_schema:
+            return value
+
+        if jira_schema.get("type") == "array":
+            if isinstance(value, list):
+                return value
+            if isinstance(value, str):
+                parts = [part.strip() for part in value.split(",") if part.strip()]
+                return parts or [value]
+            return [value]
+
+        return value
+
+    def _build_portal_url(
+        self,
+        response_data: dict[str, Any],
+        service_desk_id: str,
+    ) -> str:
+        """Build an absolute portal URL from the API response."""
+        links = response_data.get("_links")
+        if isinstance(links, dict):
+            web_link = links.get("web") or links.get("self")
+            if isinstance(web_link, str) and web_link:
+                if web_link.startswith("http://") or web_link.startswith("https://"):
+                    return web_link
+                return f"{self.config.url.rstrip('/')}{web_link}"
+
+        issue_key = response_data.get("issueKey") or response_data.get("key")
+        if issue_key:
+            return (
+                f"{self.config.url.rstrip('/')}/servicedesk/customer/portal/"
+                f"{service_desk_id}/{issue_key}"
+            )
+
+        return ""
+
+    @staticmethod
+    def _should_retry_without_on_behalf(error_message: str) -> bool:
+        """Decide whether an on-behalf failure should retry without that field."""
+        normalized = error_message.lower()
+        retry_markers = [
+            "raiseonbehalfof",
+            "on behalf",
+            "unknown user",
+            "permission",
+            "forbidden",
+            "customer",
+            "400",
+            "403",
+            "404",
+        ]
+        return any(marker in normalized for marker in retry_markers)
+
+    def get_request_types(
+        self,
+        service_desk_id: str,
+        start_at: int = 0,
+        limit: int = 50,
+    ) -> JiraRequestTypesResult:
+        """Get request types for a Jira Service Management service desk."""
+        if not service_desk_id or not service_desk_id.strip():
+            raise ValueError("Service desk ID is required")
+        if start_at < 0:
+            raise ValueError("start_at must be >= 0")
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
+
+        try:
+            response = self.jira.get(
+                f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype",
+                params={"start": start_at, "limit": limit},
+            )
+            if not isinstance(response, dict):
+                logger.error(
+                    "Unexpected response type from request type list endpoint: %s",
+                    type(response),
+                )
+                return JiraRequestTypesResult(service_desk_id=service_desk_id)
+
+            return JiraRequestTypesResult.from_api_response(
+                response,
+                service_desk_id=service_desk_id,
+            )
+        except Exception as e:
+            logger.error(
+                "Error getting request types for service desk %s: %s",
+                service_desk_id,
+                str(e),
+            )
+            return JiraRequestTypesResult(service_desk_id=service_desk_id)
+
+    def get_request_type_fields(
+        self,
+        service_desk_id: str,
+        request_type_id: str,
+    ) -> JiraRequestTypeFieldsResult:
+        """Get field definitions for a Jira Service Management request type."""
+        if not service_desk_id or not service_desk_id.strip():
+            raise ValueError("Service desk ID is required")
+        if not request_type_id or not request_type_id.strip():
+            raise ValueError("Request type ID is required")
+
+        try:
+            response = self.jira.get(
+                "rest/servicedeskapi/servicedesk/"
+                f"{service_desk_id}/requesttype/{request_type_id}/field"
+            )
+            if not isinstance(response, dict):
+                logger.error(
+                    "Unexpected response type from request type fields endpoint: %s",
+                    type(response),
+                )
+                return JiraRequestTypeFieldsResult(
+                    service_desk_id=service_desk_id,
+                    request_type_id=request_type_id,
+                )
+
+            return JiraRequestTypeFieldsResult.from_api_response(
+                response,
+                service_desk_id=service_desk_id,
+                request_type_id=request_type_id,
+            )
+        except Exception as e:
+            logger.error(
+                "Error getting request type fields for service desk %s request type %s: %s",
+                service_desk_id,
+                request_type_id,
+                str(e),
+            )
+            return JiraRequestTypeFieldsResult(
+                service_desk_id=service_desk_id,
+                request_type_id=request_type_id,
+            )
+
+    def create_customer_request(
+        self,
+        service_desk_id: str,
+        request_type_id: str,
+        request_field_values: dict[str, Any],
+        raise_on_behalf_of: str | None = None,
+        request_participants: list[str] | None = None,
+        strict_on_behalf: bool = False,
+    ) -> JiraCustomerRequest:
+        """Create a Jira Service Management customer request."""
+        if not service_desk_id or not service_desk_id.strip():
+            raise ValueError("Service desk ID is required")
+        if not request_type_id or not request_type_id.strip():
+            raise ValueError("Request type ID is required")
+        if not isinstance(request_field_values, dict):
+            raise ValueError("request_field_values must be a dictionary")
+
+        fields_result = self.get_request_type_fields(
+            service_desk_id=service_desk_id,
+            request_type_id=request_type_id,
+        )
+        field_definitions = {
+            field.field_id: field for field in fields_result.fields if field.field_id
+        }
+
+        formatted_field_values = {
+            field_id: self._format_request_field_value(
+                value,
+                field_definitions.get(field_id).jira_schema
+                if field_id in field_definitions
+                else None,
+            )
+            for field_id, value in request_field_values.items()
+        }
+
+        payload: dict[str, Any] = {
+            "serviceDeskId": str(service_desk_id),
+            "requestTypeId": str(request_type_id),
+            "requestFieldValues": formatted_field_values,
+        }
+        if raise_on_behalf_of:
+            payload["raiseOnBehalfOf"] = raise_on_behalf_of
+        if request_participants:
+            payload["requestParticipants"] = request_participants
+
+        headers = self._get_servicedesk_headers(self.jira.default_headers)
+        endpoint = "rest/servicedeskapi/request"
+        warnings: list[str] = []
+
+        try:
+            response = self.jira.post(endpoint, data=payload, headers=headers)
+            if not isinstance(response, dict):
+                msg = (
+                    "Unexpected return value type from "
+                    f"ServiceDesk request create API: {type(response)}"
+                )
+                logger.error(msg)
+                raise TypeError(msg)
+
+            return JiraCustomerRequest.from_api_response(
+                response,
+                portal_url=self._build_portal_url(response, service_desk_id),
+                created_mode=(
+                    "created_on_behalf_of" if raise_on_behalf_of else "created_direct"
+                ),
+                on_behalf_user=raise_on_behalf_of,
+                request_participants=request_participants or [],
+                warnings=warnings,
+            )
+        except Exception as e:
+            error_message = str(e)
+            if (
+                raise_on_behalf_of
+                and not strict_on_behalf
+                and self._should_retry_without_on_behalf(error_message)
+            ):
+                fallback_payload = {
+                    key: value
+                    for key, value in payload.items()
+                    if key != "raiseOnBehalfOf"
+                }
+                warnings.append(
+                    "Could not apply raise_on_behalf_of "
+                    f"'{raise_on_behalf_of}': {error_message}"
+                )
+                response = self.jira.post(
+                    endpoint,
+                    data=fallback_payload,
+                    headers=headers,
+                )
+                if not isinstance(response, dict):
+                    msg = (
+                        "Unexpected return value type from "
+                        f"ServiceDesk request create API: {type(response)}"
+                    )
+                    logger.error(msg)
+                    raise TypeError(msg)
+
+                return JiraCustomerRequest.from_api_response(
+                    response,
+                    portal_url=self._build_portal_url(response, service_desk_id),
+                    created_mode="created_as_agent_fallback",
+                    on_behalf_user=raise_on_behalf_of,
+                    request_participants=request_participants or [],
+                    warnings=warnings,
+                )
+
+            raise

--- a/src/mcp_atlassian/jira/customer_requests.py
+++ b/src/mcp_atlassian/jira/customer_requests.py
@@ -46,7 +46,7 @@ class CustomerRequestsMixin(JiraClient):
             return True
         if isinstance(value, str):
             return not value.strip()
-        if isinstance(value, (list, dict)):
+        if isinstance(value, list | dict):
             return len(value) == 0
         return False
 
@@ -117,7 +117,7 @@ class CustomerRequestsMixin(JiraClient):
                     candidates.append(candidate_text)
             return candidates
 
-        if isinstance(value, (str, int, float)):
+        if isinstance(value, str | int | float):
             candidate_text = str(value).strip()
             return [candidate_text] if candidate_text else []
 

--- a/src/mcp_atlassian/jira/customer_requests.py
+++ b/src/mcp_atlassian/jira/customer_requests.py
@@ -1,5 +1,7 @@
 """Module for Jira Service Management customer request operations."""
 
+import base64
+import binascii
 import logging
 from typing import Any
 
@@ -455,6 +457,186 @@ class CustomerRequestsMixin(JiraClient):
                 request_type_id=request_type_id,
             )
 
+    @staticmethod
+    def _decode_attachment_file(file: Any) -> tuple[str, str, bytes]:
+        """Decode a base64 attachment descriptor into upload-ready bytes.
+
+        Args:
+            file: A mapping with ``filename``, optional ``mime_type`` and
+                base64-encoded ``base64`` content.
+
+        Returns:
+            A tuple of ``(filename, mime_type, content_bytes)``.
+
+        Raises:
+            ValueError: If the descriptor is malformed or the content is not
+                valid base64.
+        """
+        if not isinstance(file, dict):
+            raise ValueError("Each attachment must be an object")
+
+        filename = file.get("filename")
+        if not isinstance(filename, str) or not filename.strip():
+            raise ValueError("Attachment filename is required")
+
+        mime_type = file.get("mime_type") or "application/octet-stream"
+        if not isinstance(mime_type, str) or not mime_type.strip():
+            raise ValueError(f"Attachment '{filename}' mime_type must be a string")
+
+        encoded = file.get("base64")
+        if not isinstance(encoded, str) or not encoded.strip():
+            raise ValueError(f"Attachment '{filename}' is missing base64 content")
+
+        try:
+            content = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(
+                f"Attachment '{filename}' has invalid base64 content"
+            ) from exc
+
+        if not content:
+            raise ValueError(f"Attachment '{filename}' is empty")
+
+        return filename.strip(), mime_type.strip(), content
+
+    def attach_temporary_files(
+        self,
+        service_desk_id: str,
+        files: list[dict[str, Any]],
+    ) -> list[str]:
+        """Upload files to the ServiceDesk temporary attachment store.
+
+        Args:
+            service_desk_id: The service desk ID owning the attachments.
+            files: A list of descriptors, each containing ``filename``,
+                optional ``mime_type`` and base64-encoded ``base64`` content.
+
+        Returns:
+            A list of temporary attachment IDs returned by Jira.
+
+        Raises:
+            ValueError: If the service desk ID is missing or a descriptor is
+                malformed.
+        """
+        if not service_desk_id or not service_desk_id.strip():
+            raise ValueError("Service desk ID is required")
+        if not files:
+            return []
+
+        multipart_files = []
+        for file in files:
+            filename, mime_type, content = self._decode_attachment_file(file)
+            multipart_files.append(("file", (filename, content, mime_type)))
+
+        headers = self._get_servicedesk_headers(self.jira.default_headers)
+        headers["X-Atlassian-Token"] = "no-check"
+        # Let requests set the multipart Content-Type (with boundary) itself.
+        headers.pop("Content-Type", None)
+
+        base_url = self.config.url.rstrip("/")
+        url = (
+            f"{base_url}/rest/servicedeskapi/servicedesk/"
+            f"{service_desk_id}/attachTemporaryFile"
+        )
+
+        response = self.jira._session.post(url, headers=headers, files=multipart_files)
+        response.raise_for_status()
+        data = response.json()
+
+        temporary_attachments = (
+            data.get("temporaryAttachments", []) if isinstance(data, dict) else []
+        )
+        return [
+            str(item["temporaryAttachmentId"])
+            for item in temporary_attachments
+            if isinstance(item, dict) and item.get("temporaryAttachmentId")
+        ]
+
+    def _attach_files_to_request(
+        self,
+        issue_key: str,
+        temporary_attachment_ids: list[str],
+        *,
+        public: bool = True,
+    ) -> None:
+        """Attach previously uploaded temporary files to a customer request.
+
+        Args:
+            issue_key: The created request issue key.
+            temporary_attachment_ids: Temporary attachment IDs to attach.
+            public: Whether the attachments are visible to the customer.
+
+        Raises:
+            TypeError: If the ServiceDesk attachment API returns an unexpected
+                response type.
+        """
+        if not issue_key or not temporary_attachment_ids:
+            return
+
+        headers = self._get_servicedesk_headers(self.jira.default_headers)
+        payload: dict[str, Any] = {
+            "temporaryAttachmentIds": temporary_attachment_ids,
+            "public": public,
+        }
+        endpoint = f"rest/servicedeskapi/request/{issue_key}/attachment"
+        response = self.jira.post(endpoint, data=payload, headers=headers)
+        if not isinstance(response, dict):
+            msg = (
+                "Unexpected return value type from "
+                f"ServiceDesk attachment API: {type(response)}"
+            )
+            logger.error(msg)
+            raise TypeError(msg)
+
+    def _process_request_attachments(
+        self,
+        service_desk_id: str,
+        request_type_id: str,
+        issue_key: str,
+        attachments: list[dict[str, Any]],
+        warnings: list[str],
+    ) -> None:
+        """Upload and attach files to a created request, recording warnings.
+
+        Attachment failures never break a successfully created request; they
+        are logged and appended to ``warnings`` instead.
+        """
+        if not attachments:
+            return
+
+        if not issue_key:
+            prefix = self._trace_prefix(
+                service_desk_id,
+                request_type_id,
+                "ATTACH_SKIPPED",
+            )
+            warnings.append(f"{prefix}: missing issue key for attachments")
+            return
+
+        try:
+            temporary_ids = self.attach_temporary_files(service_desk_id, attachments)
+            self._attach_files_to_request(issue_key, temporary_ids)
+        except Exception as exc:  # noqa: BLE001
+            status_code, error_text = self._extract_error_details(exc)
+            shortened_error = self._shorten_error_text(error_text)
+            prefix = self._trace_prefix(
+                service_desk_id,
+                request_type_id,
+                "ATTACH_ERROR",
+            )
+            logger.error(
+                "%s issue_key=%s file_count=%s status=%s error=%s",
+                prefix,
+                issue_key,
+                len(attachments),
+                status_code,
+                shortened_error,
+            )
+            warnings.append(
+                f"{prefix} issue_key={issue_key} "
+                f"status={status_code}: {shortened_error}"
+            )
+
     def create_customer_request(
         self,
         service_desk_id: str,
@@ -462,6 +644,7 @@ class CustomerRequestsMixin(JiraClient):
         request_field_values: dict[str, Any],
         raise_on_behalf_of: str | None = None,
         request_participants: list[str] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
         *,
         strict_on_behalf: bool = False,
     ) -> JiraCustomerRequest:
@@ -544,6 +727,16 @@ class CustomerRequestsMixin(JiraClient):
                 logger.error(msg)
                 raise TypeError(msg)
 
+            if attachments:
+                issue_key = response.get("issueKey") or response.get("key") or ""
+                self._process_request_attachments(
+                    service_desk_id,
+                    request_type_id,
+                    str(issue_key),
+                    attachments,
+                    warnings,
+                )
+
             return JiraCustomerRequest.from_api_response(
                 response,
                 portal_url=self._build_portal_url(response, service_desk_id),
@@ -603,6 +796,16 @@ class CustomerRequestsMixin(JiraClient):
                     )
                     message = f"{error_message}; fallback_failed: {fallback_message}"
                     raise ValueError(message) from fallback_error
+
+                if attachments:
+                    issue_key = response.get("issueKey") or response.get("key") or ""
+                    self._process_request_attachments(
+                        service_desk_id,
+                        request_type_id,
+                        str(issue_key),
+                        attachments,
+                        warnings,
+                    )
 
                 return JiraCustomerRequest.from_api_response(
                     response,

--- a/src/mcp_atlassian/jira/customer_requests.py
+++ b/src/mcp_atlassian/jira/customer_requests.py
@@ -13,6 +13,7 @@ from ..models.jira import (
     JiraRequestTypeFieldsResult,
     JiraRequestTypesResult,
 )
+from ..utils.media import ATTACHMENT_MAX_BYTES
 from .client import JiraClient
 
 logger = logging.getLogger("mcp-jira")
@@ -93,7 +94,10 @@ class CustomerRequestsMixin(JiraClient):
         jira_schema = field_definition.jira_schema
         field_type = str(jira_schema.get("type", "")).lower()
         custom_type = str(jira_schema.get("custom", "")).lower()
-        return field_type == "option" or "select" in custom_type
+        option_markers = ("select", "radiobutton", "checkbox")
+        return field_type == "option" or any(
+            marker in custom_type for marker in option_markers
+        )
 
     @staticmethod
     def _normalize_array_value(value: Any) -> list[Any]:
@@ -387,29 +391,21 @@ class CustomerRequestsMixin(JiraClient):
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
-        try:
-            response = self.jira.get(
-                f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype",
-                params={"start": start_at, "limit": limit},
+        response = self.jira.get(
+            f"rest/servicedeskapi/servicedesk/{service_desk_id}/requesttype",
+            params={"start": start_at, "limit": limit},
+        )
+        if not isinstance(response, dict):
+            msg = (
+                "Unexpected response type from request type list endpoint: "
+                f"{type(response)}"
             )
-            if not isinstance(response, dict):
-                logger.error(
-                    "Unexpected response type from request type list endpoint: %s",
-                    type(response),
-                )
-                return JiraRequestTypesResult(service_desk_id=service_desk_id)
+            raise TypeError(msg)
 
-            return JiraRequestTypesResult.from_api_response(
-                response,
-                service_desk_id=service_desk_id,
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.error(
-                "Error getting request types for service desk %s: %s",
-                service_desk_id,
-                str(e),
-            )
-            return JiraRequestTypesResult(service_desk_id=service_desk_id)
+        return JiraRequestTypesResult.from_api_response(
+            response,
+            service_desk_id=service_desk_id,
+        )
 
     def get_request_type_fields(
         self,
@@ -422,40 +418,22 @@ class CustomerRequestsMixin(JiraClient):
         if not request_type_id or not request_type_id.strip():
             raise ValueError("Request type ID is required")
 
-        try:
-            response = self.jira.get(
-                "rest/servicedeskapi/servicedesk/"
-                f"{service_desk_id}/requesttype/{request_type_id}/field"
+        response = self.jira.get(
+            "rest/servicedeskapi/servicedesk/"
+            f"{service_desk_id}/requesttype/{request_type_id}/field"
+        )
+        if not isinstance(response, dict):
+            msg = (
+                "Unexpected response type from request type fields endpoint: "
+                f"{type(response)}"
             )
-            if not isinstance(response, dict):
-                logger.error(
-                    "Unexpected response type from request type fields endpoint: %s",
-                    type(response),
-                )
-                return JiraRequestTypeFieldsResult(
-                    service_desk_id=service_desk_id,
-                    request_type_id=request_type_id,
-                )
+            raise TypeError(msg)
 
-            return JiraRequestTypeFieldsResult.from_api_response(
-                response,
-                service_desk_id=service_desk_id,
-                request_type_id=request_type_id,
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.error(
-                (
-                    "Error getting request type fields for service desk %s "
-                    "request type %s: %s"
-                ),
-                service_desk_id,
-                request_type_id,
-                str(e),
-            )
-            return JiraRequestTypeFieldsResult(
-                service_desk_id=service_desk_id,
-                request_type_id=request_type_id,
-            )
+        return JiraRequestTypeFieldsResult.from_api_response(
+            response,
+            service_desk_id=service_desk_id,
+            request_type_id=request_type_id,
+        )
 
     @staticmethod
     def _decode_attachment_file(file: Any) -> tuple[str, str, bytes]:
@@ -481,21 +459,29 @@ class CustomerRequestsMixin(JiraClient):
 
         mime_type = file.get("mime_type") or "application/octet-stream"
         if not isinstance(mime_type, str) or not mime_type.strip():
-            raise ValueError(f"Attachment '{filename}' mime_type must be a string")
+            msg = f"Attachment '{filename}' mime_type must be a string"
+            raise ValueError(msg)
 
         encoded = file.get("base64")
         if not isinstance(encoded, str) or not encoded.strip():
-            raise ValueError(f"Attachment '{filename}' is missing base64 content")
+            msg = f"Attachment '{filename}' is missing base64 content"
+            raise ValueError(msg)
 
         try:
             content = base64.b64decode(encoded, validate=True)
         except (binascii.Error, ValueError) as exc:
-            raise ValueError(
-                f"Attachment '{filename}' has invalid base64 content"
-            ) from exc
+            msg = f"Attachment '{filename}' has invalid base64 content"
+            raise ValueError(msg) from exc
 
         if not content:
-            raise ValueError(f"Attachment '{filename}' is empty")
+            msg = f"Attachment '{filename}' is empty"
+            raise ValueError(msg)
+        if len(content) > ATTACHMENT_MAX_BYTES:
+            msg = (
+                f"Attachment '{filename}' exceeds the "
+                f"{ATTACHMENT_MAX_BYTES // (1024 * 1024)} MiB inline limit"
+            )
+            raise ValueError(msg)
 
         return filename.strip(), mime_type.strip(), content
 
@@ -533,7 +519,7 @@ class CustomerRequestsMixin(JiraClient):
         # Let requests set the multipart Content-Type (with boundary) itself.
         headers.pop("Content-Type", None)
 
-        base_url = self.config.url.rstrip("/")
+        base_url = self.jira.url.rstrip("/")
         url = (
             f"{base_url}/rest/servicedeskapi/servicedesk/"
             f"{service_desk_id}/attachTemporaryFile"
@@ -542,15 +528,26 @@ class CustomerRequestsMixin(JiraClient):
         response = self.jira._session.post(url, headers=headers, files=multipart_files)
         response.raise_for_status()
         data = response.json()
+        if not isinstance(data, dict):
+            msg = "Unexpected response type from temporary attachment API"
+            raise TypeError(msg)
 
-        temporary_attachments = (
-            data.get("temporaryAttachments", []) if isinstance(data, dict) else []
-        )
-        return [
+        temporary_attachments = data.get("temporaryAttachments")
+        if not isinstance(temporary_attachments, list):
+            msg = "Temporary attachment API did not return an attachment list"
+            raise TypeError(msg)
+
+        temporary_ids = [
             str(item["temporaryAttachmentId"])
             for item in temporary_attachments
             if isinstance(item, dict) and item.get("temporaryAttachmentId")
         ]
+        if len(temporary_ids) != len(files):
+            msg = (
+                "Temporary attachment API did not return an ID for every uploaded file"
+            )
+            raise ValueError(msg)
+        return temporary_ids
 
     def _attach_files_to_request(
         self,
@@ -655,6 +652,9 @@ class CustomerRequestsMixin(JiraClient):
             raise ValueError("Request type ID is required")
         if not isinstance(request_field_values, dict):
             raise ValueError("request_field_values must be a dictionary")
+        if attachments:
+            for attachment in attachments:
+                self._decode_attachment_file(attachment)
 
         fields_result = self.get_request_type_fields(
             service_desk_id=service_desk_id,
@@ -757,6 +757,9 @@ class CustomerRequestsMixin(JiraClient):
             if (
                 raise_on_behalf_of
                 and not strict_on_behalf
+                and isinstance(e, HTTPError)
+                and e.response is not None
+                and e.response.status_code in {400, 403}
                 and self._should_retry_without_on_behalf(error_message)
             ):
                 fallback_payload = {

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -39,6 +39,13 @@ from .queue import (
     JiraServiceDesk,
     JiraServiceDeskQueuesResult,
 )
+from .request import (
+    JiraCustomerRequest,
+    JiraRequestType,
+    JiraRequestTypeField,
+    JiraRequestTypeFieldsResult,
+    JiraRequestTypesResult,
+)
 from .search import JiraSearchResult
 from .sla import (
     CycleTimeMetric,
@@ -82,6 +89,11 @@ __all__ = [
     "JiraQueue",
     "JiraServiceDeskQueuesResult",
     "JiraQueueIssuesResult",
+    "JiraRequestType",
+    "JiraRequestTypesResult",
+    "JiraRequestTypeField",
+    "JiraRequestTypeFieldsResult",
+    "JiraCustomerRequest",
     "JiraIssueLinkType",
     "JiraIssueLink",
     "JiraLinkedIssue",

--- a/src/mcp_atlassian/models/jira/request.py
+++ b/src/mcp_atlassian/models/jira/request.py
@@ -1,0 +1,330 @@
+"""
+Jira Service Management customer request models.
+
+This module provides Pydantic models for Jira Service Management
+request types, request fields, and created customer requests.
+"""
+
+from typing import Any
+
+from pydantic import Field
+
+from ..base import ApiModel
+from ..constants import EMPTY_STRING
+
+
+class JiraRequestType(ApiModel):
+    """Model representing a Jira Service Management request type."""
+
+    id: str = EMPTY_STRING
+    name: str = EMPTY_STRING
+    description: str | None = None
+    help_text: str | None = None
+    issue_type_id: str | None = None
+    group_ids: list[str] = Field(default_factory=list)
+    icon: dict[str, Any] | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraRequestType":
+        """Create a JiraRequestType model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls()
+
+        raw_group_ids = data.get("groupIds")
+        group_ids: list[str] = []
+        if isinstance(raw_group_ids, list):
+            group_ids = [str(value) for value in raw_group_ids if value is not None]
+
+        issue_type_id = data.get("issueTypeId")
+        request_type_id = data.get("id")
+
+        return cls(
+            id=str(request_type_id) if request_type_id is not None else EMPTY_STRING,
+            name=str(data.get("name", EMPTY_STRING)),
+            description=(
+                str(data.get("description")) if data.get("description") else None
+            ),
+            help_text=(str(data.get("helpText")) if data.get("helpText") else None),
+            issue_type_id=(str(issue_type_id) if issue_type_id is not None else None),
+            group_ids=group_ids,
+            icon=data.get("icon") if isinstance(data.get("icon"), dict) else None,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+        }
+        if self.description:
+            result["description"] = self.description
+        if self.help_text:
+            result["help_text"] = self.help_text
+        if self.issue_type_id:
+            result["issue_type_id"] = self.issue_type_id
+        if self.group_ids:
+            result["group_ids"] = self.group_ids
+        if self.icon:
+            result["icon"] = self.icon
+        return result
+
+
+class JiraRequestTypesResult(ApiModel):
+    """Model representing request type listing results for a service desk."""
+
+    service_desk_id: str = EMPTY_STRING
+    start: int = 0
+    limit: int = 50
+    size: int = 0
+    is_last_page: bool = True
+    request_types: list[JiraRequestType] = Field(default_factory=list)
+    links: dict[str, Any] | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraRequestTypesResult":
+        """Create a JiraRequestTypesResult model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls(service_desk_id=str(kwargs.get("service_desk_id", EMPTY_STRING)))
+
+        raw_request_types = data.get("values", [])
+        request_types: list[JiraRequestType] = []
+        if isinstance(raw_request_types, list):
+            request_types = [
+                JiraRequestType.from_api_response(request_type_data)
+                for request_type_data in raw_request_types
+                if isinstance(request_type_data, dict)
+            ]
+
+        def _to_int(value: Any, default: int) -> int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        service_desk_id = kwargs.get("service_desk_id", EMPTY_STRING)
+
+        return cls(
+            service_desk_id=str(service_desk_id),
+            start=_to_int(data.get("start"), 0),
+            limit=_to_int(data.get("limit"), 50),
+            size=_to_int(data.get("size"), len(request_types)),
+            is_last_page=bool(data.get("isLastPage", True)),
+            request_types=request_types,
+            links=data.get("_links") if isinstance(data.get("_links"), dict) else None,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "service_desk_id": self.service_desk_id,
+            "start": self.start,
+            "limit": self.limit,
+            "size": self.size,
+            "is_last_page": self.is_last_page,
+            "request_types": [
+                request_type.to_simplified_dict() for request_type in self.request_types
+            ],
+        }
+        if self.links:
+            result["links"] = self.links
+        return result
+
+
+class JiraRequestTypeField(ApiModel):
+    """Model representing a field in a Jira Service Management request type."""
+
+    field_id: str = EMPTY_STRING
+    name: str = EMPTY_STRING
+    description: str | None = None
+    required: bool = False
+    visible: bool | None = None
+    jira_schema: dict[str, Any] | None = None
+    valid_values: list[Any] = Field(default_factory=list)
+    default_values: list[Any] = Field(default_factory=list)
+    supports_multiple: bool = False
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraRequestTypeField":
+        """Create a JiraRequestTypeField model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls()
+
+        jira_schema = data.get("jiraSchema")
+        if not isinstance(jira_schema, dict):
+            jira_schema = None
+
+        valid_values = data.get("validValues")
+        if not isinstance(valid_values, list):
+            valid_values = []
+
+        default_values = data.get("defaultValues")
+        if not isinstance(default_values, list):
+            default_values = []
+
+        field_id = data.get("fieldId")
+        supports_multiple = bool(jira_schema and jira_schema.get("type") == "array")
+
+        return cls(
+            field_id=str(field_id) if field_id is not None else EMPTY_STRING,
+            name=str(data.get("name", EMPTY_STRING)),
+            description=(
+                str(data.get("description")) if data.get("description") else None
+            ),
+            required=bool(data.get("required", False)),
+            visible=(bool(data.get("visible")) if "visible" in data else None),
+            jira_schema=jira_schema,
+            valid_values=valid_values,
+            default_values=default_values,
+            supports_multiple=supports_multiple,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "field_id": self.field_id,
+            "name": self.name,
+            "required": self.required,
+            "supports_multiple": self.supports_multiple,
+        }
+        if self.description:
+            result["description"] = self.description
+        if self.visible is not None:
+            result["visible"] = self.visible
+        if self.jira_schema:
+            result["jira_schema"] = self.jira_schema
+        if self.valid_values:
+            result["valid_values"] = self.valid_values
+        if self.default_values:
+            result["default_values"] = self.default_values
+        return result
+
+
+class JiraRequestTypeFieldsResult(ApiModel):
+    """Model representing request type field discovery results."""
+
+    service_desk_id: str = EMPTY_STRING
+    request_type_id: str = EMPTY_STRING
+    can_raise_on_behalf_of: bool | None = None
+    can_add_request_participants: bool | None = None
+    fields: list[JiraRequestTypeField] = Field(default_factory=list)
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraRequestTypeFieldsResult":
+        """Create a JiraRequestTypeFieldsResult model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls(
+                service_desk_id=str(kwargs.get("service_desk_id", EMPTY_STRING)),
+                request_type_id=str(kwargs.get("request_type_id", EMPTY_STRING)),
+            )
+
+        raw_fields = data.get("requestTypeFields", [])
+        fields: list[JiraRequestTypeField] = []
+        if isinstance(raw_fields, list):
+            fields = [
+                JiraRequestTypeField.from_api_response(field_data)
+                for field_data in raw_fields
+                if isinstance(field_data, dict)
+            ]
+
+        return cls(
+            service_desk_id=str(kwargs.get("service_desk_id", EMPTY_STRING)),
+            request_type_id=str(kwargs.get("request_type_id", EMPTY_STRING)),
+            can_raise_on_behalf_of=(
+                bool(data.get("canRaiseOnBehalfOf"))
+                if "canRaiseOnBehalfOf" in data
+                else None
+            ),
+            can_add_request_participants=(
+                bool(data.get("canAddRequestParticipants"))
+                if "canAddRequestParticipants" in data
+                else None
+            ),
+            fields=fields,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "service_desk_id": self.service_desk_id,
+            "request_type_id": self.request_type_id,
+            "fields": [field.to_simplified_dict() for field in self.fields],
+        }
+        if self.can_raise_on_behalf_of is not None:
+            result["can_raise_on_behalf_of"] = self.can_raise_on_behalf_of
+        if self.can_add_request_participants is not None:
+            result["can_add_request_participants"] = self.can_add_request_participants
+        return result
+
+
+class JiraCustomerRequest(ApiModel):
+    """Model representing a created Jira Service Management customer request."""
+
+    request_id: str = EMPTY_STRING
+    request_key: str = EMPTY_STRING
+    portal_url: str = EMPTY_STRING
+    created_mode: str = EMPTY_STRING
+    on_behalf_user: str | None = None
+    request_participants: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    links: dict[str, Any] | None = None
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "JiraCustomerRequest":
+        """Create a JiraCustomerRequest model from API response data."""
+        if not data or not isinstance(data, dict):
+            return cls(
+                created_mode=str(kwargs.get("created_mode", EMPTY_STRING)),
+                on_behalf_user=kwargs.get("on_behalf_user"),
+                request_participants=kwargs.get("request_participants", []),
+                warnings=list(kwargs.get("warnings", [])),
+            )
+
+        issue_id = data.get("issueId")
+        request_id = data.get("id", issue_id)
+        request_key = data.get("issueKey") or data.get("key")
+        links = data.get("_links") if isinstance(data.get("_links"), dict) else None
+
+        portal_url = kwargs.get("portal_url", EMPTY_STRING)
+        if not portal_url and links:
+            web_link = links.get("web") or links.get("self")
+            if isinstance(web_link, str):
+                portal_url = web_link
+
+        return cls(
+            request_id=str(request_id) if request_id is not None else EMPTY_STRING,
+            request_key=str(request_key) if request_key is not None else EMPTY_STRING,
+            portal_url=str(portal_url or EMPTY_STRING),
+            created_mode=str(kwargs.get("created_mode", EMPTY_STRING)),
+            on_behalf_user=kwargs.get("on_behalf_user"),
+            request_participants=list(kwargs.get("request_participants", [])),
+            warnings=list(kwargs.get("warnings", [])),
+            links=links,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "request_id": self.request_id,
+            "request_key": self.request_key,
+            "portal_url": self.portal_url,
+            "created_mode": self.created_mode,
+        }
+        if self.on_behalf_user:
+            result["on_behalf_user"] = self.on_behalf_user
+        if self.request_participants:
+            result["request_participants"] = self.request_participants
+        if self.warnings:
+            result["warnings"] = self.warnings
+        if self.links:
+            result["links"] = self.links
+        return result

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -103,6 +103,43 @@ def _parse_additional_fields(
     raise ValueError("additional_fields must be a dictionary or JSON string.")
 
 
+def _parse_request_field_values(
+    request_field_values: dict[str, Any] | str,
+) -> dict[str, Any]:
+    """Parse request_field_values from dict or JSON string."""
+    try:
+        return _parse_additional_fields(request_field_values)
+    except ValueError as e:
+        raise ValueError(f"request_field_values is not valid JSON: {e}") from e
+
+
+def _parse_request_participants(
+    request_participants: str | list[str] | None,
+) -> list[str] | None:
+    """Parse request participants from a JSON array string or comma-separated list."""
+    if request_participants is None:
+        return None
+    if isinstance(request_participants, list):
+        return [
+            str(value).strip() for value in request_participants if str(value).strip()
+        ]
+    if isinstance(request_participants, str):
+        stripped = request_participants.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+            if not isinstance(parsed, list):
+                raise ValueError("request_participants JSON string must be an array.")
+            return [str(value).strip() for value in parsed if str(value).strip()]
+        except json.JSONDecodeError:
+            return [value.strip() for value in stripped.split(",") if value.strip()]
+
+    raise ValueError(
+        "request_participants must be a JSON array string, a list of strings, or None."
+    )
+
+
 @jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_users"},
     annotations={"title": "Get User Profile", "readOnlyHint": True},
@@ -2615,6 +2652,163 @@ async def get_queue_issues(
         queue_id=queue_id,
         start_at=start_at,
         limit=limit,
+    )
+    return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_service_desk"},
+    annotations={"title": "Get Request Types", "readOnlyHint": True},
+)
+async def get_request_types(
+    ctx: Context,
+    service_desk_id: Annotated[
+        str,
+        Field(description="Service desk ID (e.g., '4')"),
+    ],
+    start_at: Annotated[
+        int,
+        Field(description="Starting index for pagination (0-based)", default=0, ge=0),
+    ] = 0,
+    limit: Annotated[
+        int,
+        Field(description="Maximum number of results (1-50)", default=50, ge=1, le=50),
+    ] = 50,
+) -> str:
+    """Get request types for a Jira Service Management service desk.
+
+    Args:
+        ctx: The FastMCP context.
+        service_desk_id: Service desk ID.
+        start_at: Starting index for pagination.
+        limit: Maximum number of request types to return.
+
+    Returns:
+        JSON string with request types and pagination metadata.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_request_types(
+        service_desk_id=service_desk_id,
+        start_at=start_at,
+        limit=limit,
+    )
+    return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_service_desk"},
+    annotations={"title": "Get Request Type Fields", "readOnlyHint": True},
+)
+async def get_request_type_fields(
+    ctx: Context,
+    service_desk_id: Annotated[
+        str,
+        Field(description="Service desk ID (e.g., '4')"),
+    ],
+    request_type_id: Annotated[
+        str,
+        Field(description="Request type ID (e.g., '23')"),
+    ],
+) -> str:
+    """Get field definitions for a Jira Service Management request type.
+
+    Args:
+        ctx: The FastMCP context.
+        service_desk_id: Service desk ID.
+        request_type_id: Request type ID.
+
+    Returns:
+        JSON string with request type field definitions.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_request_type_fields(
+        service_desk_id=service_desk_id,
+        request_type_id=request_type_id,
+    )
+    return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_service_desk"},
+    annotations={"title": "Create Customer Request", "destructiveHint": True},
+)
+@check_write_access
+async def create_customer_request(
+    ctx: Context,
+    service_desk_id: Annotated[
+        str,
+        Field(description="Service desk ID (e.g., '4')"),
+    ],
+    request_type_id: Annotated[
+        str,
+        Field(description="Request type ID (e.g., '23')"),
+    ],
+    request_field_values: Annotated[
+        str,
+        Field(
+            description=(
+                "JSON string of request field values keyed by field ID. Examples:\n"
+                '- Summary and description: {"summary": "Access issue", "description": "Cannot log in"}\n'
+                '- Multi-value field: {"customfield_10001": ["alice", "bob"]}'
+            )
+        ),
+    ],
+    raise_on_behalf_of: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Jira user identifier for raiseOnBehalfOf. "
+                "For Server/DC this is typically username or key; for Cloud use the identifier expected by your JSM instance."
+            ),
+            default=None,
+        ),
+    ] = None,
+    request_participants: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) JSON array string or comma-separated list of request participants. "
+                'Examples: ["user1","user2"] or "user1,user2"'
+            ),
+            default=None,
+        ),
+    ] = None,
+    strict_on_behalf: Annotated[
+        bool,
+        Field(
+            description=(
+                "If true, fail immediately when raiseOnBehalfOf cannot be applied. "
+                "If false, retry without raiseOnBehalfOf and return a fallback warning."
+            ),
+            default=False,
+        ),
+    ] = False,
+) -> str:
+    """Create a Jira Service Management customer request.
+
+    Args:
+        ctx: The FastMCP context.
+        service_desk_id: Service desk ID.
+        request_type_id: Request type ID.
+        request_field_values: JSON string of request field values keyed by field ID.
+        raise_on_behalf_of: Optional Jira user identifier for raiseOnBehalfOf.
+        request_participants: Optional JSON array string or comma-separated list.
+        strict_on_behalf: Whether to fail instead of retrying without on-behalf mode.
+
+    Returns:
+        JSON string representing the created customer request.
+    """
+    jira = await get_jira_fetcher(ctx)
+    parsed_field_values = _parse_request_field_values(request_field_values)
+    parsed_request_participants = _parse_request_participants(request_participants)
+
+    result = jira.create_customer_request(
+        service_desk_id=service_desk_id,
+        request_type_id=request_type_id,
+        request_field_values=parsed_field_values,
+        raise_on_behalf_of=raise_on_behalf_of,
+        request_participants=parsed_request_participants,
+        strict_on_behalf=strict_on_behalf,
     )
     return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -183,7 +183,8 @@ def _parse_request_field_values(
     try:
         return _parse_additional_fields(request_field_values)
     except ValueError as e:
-        raise ValueError(f"request_field_values is not valid JSON: {e}") from e
+        msg = f"request_field_values is not valid JSON: {e}"
+        raise ValueError(msg) from e
 
 
 def _parse_request_participants(
@@ -230,7 +231,8 @@ def _parse_attachments(
         try:
             parsed = json.loads(stripped)
         except json.JSONDecodeError as e:
-            raise ValueError(f"attachments is not valid JSON: {e}") from e
+            msg = f"attachments is not valid JSON: {e}"
+            raise ValueError(msg) from e
     else:
         parsed = attachments
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -140,6 +140,34 @@ def _parse_request_participants(
     )
 
 
+def _parse_attachments(
+    attachments: str | list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    """Parse customer request attachments from a JSON array string or list.
+
+    Each attachment must be an object with ``filename``, ``mime_type`` and
+    base64-encoded ``base64`` content.
+    """
+    if attachments is None:
+        return None
+    if isinstance(attachments, str):
+        stripped = attachments.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"attachments is not valid JSON: {e}") from e
+    else:
+        parsed = attachments
+
+    if not isinstance(parsed, list):
+        raise ValueError("attachments must be a JSON array of attachment objects.")
+    if not all(isinstance(item, dict) for item in parsed):
+        raise ValueError("attachments must be a JSON array of attachment objects.")
+    return parsed
+
+
 @jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_users"},
     annotations={"title": "Get User Profile", "readOnlyHint": True},
@@ -2773,6 +2801,17 @@ async def create_customer_request(
             default=None,
         ),
     ] = None,
+    attachments: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) JSON array string of files to attach to the created request. "
+                "Each object must contain 'filename', 'mime_type', and base64-encoded 'base64' content. "
+                'Example: [{"filename": "log.txt", "mime_type": "text/plain", "base64": "aGVsbG8="}]'
+            ),
+            default=None,
+        ),
+    ] = None,
     strict_on_behalf: Annotated[
         bool,
         Field(
@@ -2793,6 +2832,7 @@ async def create_customer_request(
         request_field_values: JSON string of request field values keyed by field ID.
         raise_on_behalf_of: Optional Jira user identifier for raiseOnBehalfOf.
         request_participants: Optional JSON array string or comma-separated list.
+        attachments: Optional JSON array string of base64-encoded files to attach.
         strict_on_behalf: Whether to fail instead of retrying without on-behalf mode.
 
     Returns:
@@ -2801,6 +2841,7 @@ async def create_customer_request(
     jira = await get_jira_fetcher(ctx)
     parsed_field_values = _parse_request_field_values(request_field_values)
     parsed_request_participants = _parse_request_participants(request_participants)
+    parsed_attachments = _parse_attachments(attachments)
 
     result = jira.create_customer_request(
         service_desk_id=service_desk_id,
@@ -2808,6 +2849,7 @@ async def create_customer_request(
         request_field_values=parsed_field_values,
         raise_on_behalf_of=raise_on_behalf_of,
         request_participants=parsed_request_participants,
+        attachments=parsed_attachments,
         strict_on_behalf=strict_on_behalf,
     )
     return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -82,7 +82,7 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     ),
     "jira_service_desk": ToolsetDefinition(
         name="jira_service_desk",
-        description="Jira Service Management queues and service desks",
+        description="Jira Service Management requests, queues, and service desks",
         default=False,
     ),
     "jira_forms": ToolsetDefinition(

--- a/tests/unit/jira/test_customer_requests.py
+++ b/tests/unit/jira/test_customer_requests.py
@@ -1,0 +1,203 @@
+"""Tests for Jira Service Management customer request operations."""
+
+from unittest.mock import MagicMock
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.models.jira import (
+    JiraCustomerRequest,
+    JiraRequestTypeFieldsResult,
+    JiraRequestTypesResult,
+)
+
+
+def _make_customer_requests_fetcher(jira_fetcher: JiraFetcher) -> JiraFetcher:
+    """Create a Jira fetcher configured for JSM customer request tests."""
+    fetcher = jira_fetcher
+    fetcher.config = MagicMock()
+    fetcher.config.is_cloud = False
+    fetcher.config.url = "https://jira.example.com"
+    fetcher.jira.default_headers = {"Accept": "application/json"}
+    return fetcher
+
+
+def test_get_request_types_success(jira_fetcher: JiraFetcher) -> None:
+    """Request type listing should parse values and pagination metadata."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(
+        return_value={
+            "start": 0,
+            "limit": 50,
+            "size": 2,
+            "isLastPage": True,
+            "values": [
+                {
+                    "id": "23",
+                    "name": "Incident",
+                    "description": "Report an incident",
+                    "helpText": "Use this for production incidents",
+                },
+                {
+                    "id": "24",
+                    "name": "Access Request",
+                },
+            ],
+        }
+    )
+
+    result = fetcher.get_request_types("4")
+
+    assert isinstance(result, JiraRequestTypesResult)
+    assert result.service_desk_id == "4"
+    assert result.size == 2
+    assert len(result.request_types) == 2
+    assert result.request_types[0].id == "23"
+    assert result.request_types[0].help_text == "Use this for production incidents"
+
+
+def test_get_request_type_fields_success(jira_fetcher: JiraFetcher) -> None:
+    """Request type field discovery should expose schema and capability flags."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(
+        return_value={
+            "canRaiseOnBehalfOf": True,
+            "canAddRequestParticipants": False,
+            "requestTypeFields": [
+                {
+                    "fieldId": "summary",
+                    "name": "Summary",
+                    "description": "Short summary",
+                    "required": True,
+                    "visible": True,
+                    "jiraSchema": {"type": "string"},
+                },
+                {
+                    "fieldId": "customfield_10001",
+                    "name": "Approvers",
+                    "required": False,
+                    "jiraSchema": {"type": "array"},
+                    "validValues": ["alice", "bob"],
+                },
+            ],
+        }
+    )
+
+    result = fetcher.get_request_type_fields("4", "23")
+
+    assert isinstance(result, JiraRequestTypeFieldsResult)
+    assert result.service_desk_id == "4"
+    assert result.request_type_id == "23"
+    assert result.can_raise_on_behalf_of is True
+    assert result.can_add_request_participants is False
+    assert len(result.fields) == 2
+    assert result.fields[1].supports_multiple is True
+    assert result.fields[1].valid_values == ["alice", "bob"]
+
+
+def test_create_customer_request_success(jira_fetcher: JiraFetcher) -> None:
+    """Customer request creation should format fields and return portal URL."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(
+        return_value={
+            "requestTypeFields": [
+                {
+                    "fieldId": "customfield_10001",
+                    "name": "Approvers",
+                    "required": False,
+                    "jiraSchema": {"type": "array"},
+                }
+            ]
+        }
+    )
+    fetcher.jira.post = MagicMock(
+        return_value={
+            "issueId": "10010",
+            "issueKey": "SUP-101",
+            "_links": {"web": "/servicedesk/customer/portal/4/SUP-101"},
+        }
+    )
+
+    result = fetcher.create_customer_request(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={
+            "summary": "Production incident",
+            "customfield_10001": "alice,bob",
+        },
+        raise_on_behalf_of="d.zagitov",
+        request_participants=["ops-team"],
+    )
+
+    assert isinstance(result, JiraCustomerRequest)
+    assert result.request_id == "10010"
+    assert result.request_key == "SUP-101"
+    assert (
+        result.portal_url
+        == "https://jira.example.com/servicedesk/customer/portal/4/SUP-101"
+    )
+    assert result.created_mode == "created_on_behalf_of"
+    assert result.on_behalf_user == "d.zagitov"
+    assert result.request_participants == ["ops-team"]
+
+    post_payload = fetcher.jira.post.call_args.kwargs["data"]
+    assert post_payload["raiseOnBehalfOf"] == "d.zagitov"
+    assert post_payload["requestFieldValues"]["customfield_10001"] == ["alice", "bob"]
+
+
+def test_create_customer_request_retries_without_on_behalf(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Non-strict on-behalf mode should retry without raiseOnBehalfOf."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
+    fetcher.jira.post = MagicMock(
+        side_effect=[
+            Exception("403 Client Error: Forbidden for raiseOnBehalfOf"),
+            {
+                "issueId": "10011",
+                "issueKey": "SUP-102",
+                "_links": {"web": "/servicedesk/customer/portal/4/SUP-102"},
+            },
+        ]
+    )
+
+    result = fetcher.create_customer_request(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={"summary": "Fallback test"},
+        raise_on_behalf_of="d.zagitov",
+        strict_on_behalf=False,
+    )
+
+    assert result.created_mode == "created_as_agent_fallback"
+    assert result.request_key == "SUP-102"
+    assert result.warnings
+    assert "raise_on_behalf_of" in result.warnings[0]
+
+    first_payload = fetcher.jira.post.call_args_list[0].kwargs["data"]
+    second_payload = fetcher.jira.post.call_args_list[1].kwargs["data"]
+    assert "raiseOnBehalfOf" in first_payload
+    assert "raiseOnBehalfOf" not in second_payload
+
+
+def test_create_customer_request_strict_on_behalf_raises(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Strict on-behalf mode should not retry silently."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
+    fetcher.jira.post = MagicMock(
+        side_effect=Exception("403 Client Error: Forbidden for raiseOnBehalfOf")
+    )
+
+    try:
+        fetcher.create_customer_request(
+            service_desk_id="4",
+            request_type_id="23",
+            request_field_values={"summary": "Strict test"},
+            raise_on_behalf_of="d.zagitov",
+            strict_on_behalf=True,
+        )
+    except Exception as exc:
+        assert "Forbidden" in str(exc)
+    else:
+        raise AssertionError("Expected strict on-behalf mode to raise an exception")

--- a/tests/unit/jira/test_customer_requests.py
+++ b/tests/unit/jira/test_customer_requests.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+from requests.exceptions import HTTPError
+
 from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.models.jira import (
     JiraCustomerRequest,
@@ -18,6 +21,24 @@ def _make_customer_requests_fetcher(jira_fetcher: JiraFetcher) -> JiraFetcher:
     fetcher.config.url = "https://jira.example.com"
     fetcher.jira.default_headers = {"Accept": "application/json"}
     return fetcher
+
+
+def _make_http_error(
+    *,
+    status_code: int = 400,
+    errors: dict[str, str] | None = None,
+    error_messages: list[str] | None = None,
+    text: str = "Bad Request",
+) -> HTTPError:
+    """Create an HTTPError with a mocked JSON response body."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    response.json.return_value = {
+        "errors": errors or {},
+        "errorMessages": error_messages or [],
+    }
+    return HTTPError(response=response)
 
 
 def test_get_request_types_success(jira_fetcher: JiraFetcher) -> None:
@@ -143,6 +164,146 @@ def test_create_customer_request_success(jira_fetcher: JiraFetcher) -> None:
     assert post_payload["requestFieldValues"]["customfield_10001"] == ["alice", "bob"]
 
 
+def test_create_customer_request_normalizes_select_value_to_option_id(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Select-like JSM fields should normalize semantic input to canonical payload."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(
+        return_value={
+            "requestTypeFields": [
+                {
+                    "fieldId": "customfield_17902",
+                    "name": "Витрина",
+                    "required": False,
+                    "visible": True,
+                    "jiraSchema": {
+                        "type": "option",
+                        "custom": (
+                            "com.atlassian.jira.plugin.system.customfieldtypes:select"
+                        ),
+                    },
+                    "validValues": [
+                        {
+                            "value": "21721",
+                            "label": "users",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    fetcher.jira.post = MagicMock(
+        return_value={
+            "issueId": "10010",
+            "issueKey": "SUP-101",
+            "_links": {"web": "/servicedesk/customer/portal/4/SUP-101"},
+        }
+    )
+
+    fetcher.create_customer_request(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={
+            "summary": "Production incident",
+            "customfield_17902": {"value": "21721"},
+        },
+    )
+
+    post_payload = fetcher.jira.post.call_args.kwargs["data"]
+    assert post_payload["requestFieldValues"]["customfield_17902"] == {"id": "21721"}
+
+
+def test_create_customer_request_rejects_unknown_select_value_before_post(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Unknown select values should fail with a traceable field-level error."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(
+        return_value={
+            "requestTypeFields": [
+                {
+                    "fieldId": "customfield_17902",
+                    "name": "Витрина",
+                    "required": False,
+                    "visible": True,
+                    "jiraSchema": {
+                        "type": "option",
+                        "custom": (
+                            "com.atlassian.jira.plugin.system.customfieldtypes:select"
+                        ),
+                    },
+                    "validValues": [
+                        {
+                            "value": "21721",
+                            "label": "users",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    fetcher.jira.post = MagicMock()
+
+    with pytest.raises(ValueError) as exc_info:
+        fetcher.create_customer_request(
+            service_desk_id="4",
+            request_type_id="23",
+            request_field_values={
+                "summary": "Production incident",
+                "customfield_17902": "unknown-datamart",
+            },
+        )
+
+    error_message = str(exc_info.value)
+    assert "JSM_CUSTOMER_REQUEST_FIELD_ERROR" in error_message
+    assert "service_desk_id=4 request_type_id=23" in error_message
+    assert "field_id=customfield_17902" in error_message
+    assert "allowed_values=users" in error_message
+    fetcher.jira.post.assert_not_called()
+
+
+def test_create_customer_request_validates_visible_required_fields(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Missing visible required fields should fail before calling the API."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(
+        return_value={
+            "requestTypeFields": [
+                {
+                    "fieldId": "summary",
+                    "name": "Summary",
+                    "required": True,
+                    "visible": True,
+                    "jiraSchema": {"type": "string"},
+                },
+                {
+                    "fieldId": "hidden_field",
+                    "name": "Hidden Field",
+                    "required": True,
+                    "visible": False,
+                    "jiraSchema": {"type": "string"},
+                },
+            ]
+        }
+    )
+    fetcher.jira.post = MagicMock()
+
+    with pytest.raises(ValueError) as exc_info:
+        fetcher.create_customer_request(
+            service_desk_id="4",
+            request_type_id="23",
+            request_field_values={},
+        )
+
+    error_message = str(exc_info.value)
+    assert "JSM_CUSTOMER_REQUEST_MISSING_REQUIRED_FIELDS" in error_message
+    assert "Summary (summary)" in error_message
+    assert "Hidden Field" not in error_message
+    fetcher.jira.post.assert_not_called()
+
+
 def test_create_customer_request_retries_without_on_behalf(
     jira_fetcher: JiraFetcher,
 ) -> None:
@@ -151,7 +312,10 @@ def test_create_customer_request_retries_without_on_behalf(
     fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
     fetcher.jira.post = MagicMock(
         side_effect=[
-            Exception("403 Client Error: Forbidden for raiseOnBehalfOf"),
+            _make_http_error(
+                errors={"raiseOnBehalfOf": "Unknown user"},
+                text="raiseOnBehalfOf rejected",
+            ),
             {
                 "issueId": "10011",
                 "issueKey": "SUP-102",
@@ -179,6 +343,42 @@ def test_create_customer_request_retries_without_on_behalf(
     assert "raiseOnBehalfOf" not in second_payload
 
 
+def test_create_customer_request_does_not_retry_for_field_http_error(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Field validation API errors must not trigger on-behalf fallback retries."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
+    fetcher.jira.post = MagicMock(
+        side_effect=_make_http_error(
+            errors={
+                "customfield_17902": (
+                    "Could not find valid 'id' or 'value' in the Parent Option object."
+                )
+            },
+            text="customfield_17902 rejected",
+        )
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        fetcher.create_customer_request(
+            service_desk_id="4",
+            request_type_id="23",
+            request_field_values={
+                "summary": "Fallback test",
+                "customfield_17902": "21721",
+            },
+            raise_on_behalf_of="d.zagitov",
+            strict_on_behalf=False,
+        )
+
+    error_message = str(exc_info.value)
+    assert "JSM_CUSTOMER_REQUEST_HTTP_ERROR" in error_message
+    assert "status=400" in error_message
+    assert "customfield_17902" in error_message
+    assert fetcher.jira.post.call_count == 1
+
+
 def test_create_customer_request_strict_on_behalf_raises(
     jira_fetcher: JiraFetcher,
 ) -> None:
@@ -186,10 +386,13 @@ def test_create_customer_request_strict_on_behalf_raises(
     fetcher = _make_customer_requests_fetcher(jira_fetcher)
     fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
     fetcher.jira.post = MagicMock(
-        side_effect=Exception("403 Client Error: Forbidden for raiseOnBehalfOf")
+        side_effect=_make_http_error(
+            errors={"raiseOnBehalfOf": "Unknown user"},
+            text="raiseOnBehalfOf rejected",
+        )
     )
 
-    try:
+    with pytest.raises(ValueError) as exc_info:
         fetcher.create_customer_request(
             service_desk_id="4",
             request_type_id="23",
@@ -197,7 +400,6 @@ def test_create_customer_request_strict_on_behalf_raises(
             raise_on_behalf_of="d.zagitov",
             strict_on_behalf=True,
         )
-    except Exception as exc:
-        assert "Forbidden" in str(exc)
-    else:
-        raise AssertionError("Expected strict on-behalf mode to raise an exception")
+
+    assert "JSM_CUSTOMER_REQUEST_HTTP_ERROR" in str(exc_info.value)
+    assert fetcher.jira.post.call_count == 1

--- a/tests/unit/jira/test_customer_requests.py
+++ b/tests/unit/jira/test_customer_requests.py
@@ -403,3 +403,120 @@ def test_create_customer_request_strict_on_behalf_raises(
 
     assert "JSM_CUSTOMER_REQUEST_HTTP_ERROR" in str(exc_info.value)
     assert fetcher.jira.post.call_count == 1
+
+
+def _make_session_response(payload: dict) -> MagicMock:
+    """Build a mocked requests.Response for multipart uploads."""
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def test_attach_temporary_files_uploads_and_returns_ids(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Temporary upload should send multipart data and return attachment IDs."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira._session = MagicMock()
+    fetcher.jira._session.post = MagicMock(
+        return_value=_make_session_response(
+            {"temporaryAttachments": [{"temporaryAttachmentId": "temp-1"}]}
+        )
+    )
+
+    result = fetcher.attach_temporary_files(
+        "4",
+        [{"filename": "log.txt", "mime_type": "text/plain", "base64": "aGVsbG8="}],
+    )
+
+    assert result == ["temp-1"]
+    call = fetcher.jira._session.post.call_args
+    assert call.args[0].endswith(
+        "/rest/servicedeskapi/servicedesk/4/attachTemporaryFile"
+    )
+    assert call.kwargs["headers"]["X-Atlassian-Token"] == "no-check"
+    assert "Content-Type" not in call.kwargs["headers"]
+    uploaded_files = call.kwargs["files"]
+    assert uploaded_files[0][0] == "file"
+    assert uploaded_files[0][1] == ("log.txt", b"hello", "text/plain")
+
+
+def test_decode_attachment_file_rejects_invalid_base64(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Invalid base64 content should raise a descriptive ValueError."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+
+    with pytest.raises(ValueError, match="invalid base64 content"):
+        fetcher._decode_attachment_file(
+            {"filename": "bad.txt", "mime_type": "text/plain", "base64": "!!!"}
+        )
+
+
+def test_create_customer_request_attaches_files(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Created requests should upload and attach provided base64 files."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
+    fetcher.jira._session = MagicMock()
+    fetcher.jira._session.post = MagicMock(
+        return_value=_make_session_response(
+            {"temporaryAttachments": [{"temporaryAttachmentId": "temp-1"}]}
+        )
+    )
+    fetcher.jira.post = MagicMock(
+        side_effect=[
+            {"issueId": "10010", "issueKey": "SUP-101"},
+            {"id": "20001"},
+        ]
+    )
+
+    result = fetcher.create_customer_request(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={"summary": "With attachment"},
+        attachments=[
+            {"filename": "log.txt", "mime_type": "text/plain", "base64": "aGVsbG8="}
+        ],
+    )
+
+    assert result.request_key == "SUP-101"
+    assert result.warnings == []
+    fetcher.jira._session.post.assert_called_once()
+    assert fetcher.jira.post.call_count == 2
+    attach_call = fetcher.jira.post.call_args_list[1]
+    assert attach_call.args[0] == "rest/servicedeskapi/request/SUP-101/attachment"
+    assert attach_call.kwargs["data"]["temporaryAttachmentIds"] == ["temp-1"]
+    assert attach_call.kwargs["data"]["public"] is True
+
+
+def test_create_customer_request_attachment_failure_adds_warning(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Attachment failures must not break a successfully created request."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
+    fetcher.jira._session = MagicMock()
+    fetcher.jira._session.post = MagicMock(
+        side_effect=_make_http_error(status_code=413, text="Payload Too Large")
+    )
+    fetcher.jira.post = MagicMock(
+        return_value={"issueId": "10010", "issueKey": "SUP-101"}
+    )
+
+    result = fetcher.create_customer_request(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={"summary": "With attachment"},
+        attachments=[
+            {"filename": "log.txt", "mime_type": "text/plain", "base64": "aGVsbG8="}
+        ],
+    )
+
+    assert result.request_key == "SUP-101"
+    assert len(result.warnings) == 1
+    assert "JSM_CUSTOMER_REQUEST_ATTACH_ERROR" in result.warnings[0]
+    assert "issue_key=SUP-101" in result.warnings[0]
+    assert fetcher.jira.post.call_count == 1

--- a/tests/unit/jira/test_customer_requests.py
+++ b/tests/unit/jira/test_customer_requests.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from requests.exceptions import HTTPError
 
+import mcp_atlassian.jira.customer_requests as customer_requests_module
 from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.models.jira import (
     JiraCustomerRequest,
@@ -114,6 +115,17 @@ def test_get_request_type_fields_success(jira_fetcher: JiraFetcher) -> None:
     assert result.fields[1].valid_values == ["alice", "bob"]
 
 
+def test_get_request_type_fields_propagates_api_errors(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Field discovery failures must not look like a valid empty field set."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(side_effect=_make_http_error(status_code=403))
+
+    with pytest.raises(HTTPError):
+        fetcher.get_request_type_fields("4", "23")
+
+
 def test_create_customer_request_success(jira_fetcher: JiraFetcher) -> None:
     """Customer request creation should format fields and return portal URL."""
     fetcher = _make_customer_requests_fetcher(jira_fetcher)
@@ -212,6 +224,45 @@ def test_create_customer_request_normalizes_select_value_to_option_id(
 
     post_payload = fetcher.jira.post.call_args.kwargs["data"]
     assert post_payload["requestFieldValues"]["customfield_17902"] == {"id": "21721"}
+
+
+def test_create_customer_request_normalizes_radio_button_value(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """JSM radio buttons should use the option object expected by Jira."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(
+        return_value={
+            "requestTypeFields": [
+                {
+                    "fieldId": "customfield_10001",
+                    "name": "Gifts",
+                    "required": True,
+                    "visible": True,
+                    "jiraSchema": {
+                        "type": "string",
+                        "custom": (
+                            "com.atlassian.jira.plugin.system."
+                            "customfieldtypes:radiobuttons"
+                        ),
+                    },
+                    "validValues": [{"value": "10000", "label": "Bottle of Wine"}],
+                }
+            ]
+        }
+    )
+    fetcher.jira.post = MagicMock(
+        return_value={"issueId": "10010", "issueKey": "SUP-101"}
+    )
+
+    fetcher.create_customer_request(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={"customfield_10001": "Bottle of Wine"},
+    )
+
+    post_payload = fetcher.jira.post.call_args.kwargs["data"]
+    assert post_payload["requestFieldValues"]["customfield_10001"] == {"id": "10000"}
 
 
 def test_create_customer_request_rejects_unknown_select_value_before_post(
@@ -405,6 +456,25 @@ def test_create_customer_request_strict_on_behalf_raises(
     assert fetcher.jira.post.call_count == 1
 
 
+def test_create_customer_request_does_not_retry_non_http_errors(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Ambiguous client errors must not trigger a second write request."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
+    fetcher.jira.post = MagicMock(side_effect=ValueError("unknown user"))
+
+    with pytest.raises(ValueError, match="unknown user"):
+        fetcher.create_customer_request(
+            service_desk_id="4",
+            request_type_id="23",
+            request_field_values={"summary": "No retry"},
+            raise_on_behalf_of="d.zagitov",
+        )
+
+    fetcher.jira.post.assert_called_once()
+
+
 def _make_session_response(payload: dict) -> MagicMock:
     """Build a mocked requests.Response for multipart uploads."""
     response = MagicMock()
@@ -418,6 +488,7 @@ def test_attach_temporary_files_uploads_and_returns_ids(
 ) -> None:
     """Temporary upload should send multipart data and return attachment IDs."""
     fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.url = "https://api.atlassian.com/ex/jira/cloud-id"
     fetcher.jira._session = MagicMock()
     fetcher.jira._session.post = MagicMock(
         return_value=_make_session_response(
@@ -432,8 +503,9 @@ def test_attach_temporary_files_uploads_and_returns_ids(
 
     assert result == ["temp-1"]
     call = fetcher.jira._session.post.call_args
-    assert call.args[0].endswith(
-        "/rest/servicedeskapi/servicedesk/4/attachTemporaryFile"
+    assert call.args[0] == (
+        "https://api.atlassian.com/ex/jira/cloud-id/"
+        "rest/servicedeskapi/servicedesk/4/attachTemporaryFile"
     )
     assert call.kwargs["headers"]["X-Atlassian-Token"] == "no-check"
     assert "Content-Type" not in call.kwargs["headers"]
@@ -452,6 +524,41 @@ def test_decode_attachment_file_rejects_invalid_base64(
         fetcher._decode_attachment_file(
             {"filename": "bad.txt", "mime_type": "text/plain", "base64": "!!!"}
         )
+
+
+def test_decode_attachment_file_rejects_oversized_content(
+    jira_fetcher: JiraFetcher,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline attachments must respect the shared in-memory size limit."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    monkeypatch.setattr(customer_requests_module, "ATTACHMENT_MAX_BYTES", 4)
+
+    with pytest.raises(ValueError, match="exceeds the 0 MiB inline limit"):
+        fetcher._decode_attachment_file(
+            {"filename": "big.txt", "mime_type": "text/plain", "base64": "aGVsbG8="}
+        )
+
+
+def test_create_customer_request_validates_attachments_before_post(
+    jira_fetcher: JiraFetcher,
+) -> None:
+    """Malformed attachment input must fail before the request is created."""
+    fetcher = _make_customer_requests_fetcher(jira_fetcher)
+    fetcher.jira.get = MagicMock(return_value={"requestTypeFields": []})
+    fetcher.jira.post = MagicMock()
+
+    with pytest.raises(ValueError, match="invalid base64 content"):
+        fetcher.create_customer_request(
+            service_desk_id="4",
+            request_type_id="23",
+            request_field_values={"summary": "Invalid attachment"},
+            attachments=[
+                {"filename": "bad.txt", "mime_type": "text/plain", "base64": "!!!"}
+            ],
+        )
+
+    fetcher.jira.post.assert_not_called()
 
 
 def test_create_customer_request_attaches_files(

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -14,6 +14,13 @@ from starlette.requests import Request
 
 from src.mcp_atlassian.jira import JiraFetcher
 from src.mcp_atlassian.jira.config import JiraConfig
+from src.mcp_atlassian.models.jira import (
+    JiraCustomerRequest,
+    JiraRequestType,
+    JiraRequestTypeField,
+    JiraRequestTypeFieldsResult,
+    JiraRequestTypesResult,
+)
 from src.mcp_atlassian.servers.context import MainAppContext
 from src.mcp_atlassian.servers.main import AtlassianMCP
 from src.mcp_atlassian.utils.oauth import OAuthConfig
@@ -386,6 +393,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         batch_create_issues,
         batch_create_versions,
         batch_get_changelogs,
+        create_customer_request,
         create_issue,
         create_issue_link,
         create_sprint,
@@ -403,6 +411,8 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         get_project_issues,
         get_project_versions,
         get_queue_issues,
+        get_request_type_fields,
+        get_request_types,
         get_service_desk_for_project,
         get_service_desk_queues,
         get_sprint_issues,
@@ -430,6 +440,8 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(get_service_desk_for_project)
     jira_sub_mcp.add_tool(get_service_desk_queues)
     jira_sub_mcp.add_tool(get_queue_issues)
+    jira_sub_mcp.add_tool(get_request_types)
+    jira_sub_mcp.add_tool(get_request_type_fields)
     jira_sub_mcp.add_tool(get_transitions)
     jira_sub_mcp.add_tool(get_worklog)
     jira_sub_mcp.add_tool(download_attachments)
@@ -442,6 +454,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(get_link_types)
     jira_sub_mcp.add_tool(get_user_profile)
     jira_sub_mcp.add_tool(create_issue)
+    jira_sub_mcp.add_tool(create_customer_request)
     jira_sub_mcp.add_tool(batch_create_issues)
     jira_sub_mcp.add_tool(batch_get_changelogs)
     jira_sub_mcp.add_tool(update_issue)
@@ -662,6 +675,106 @@ async def test_get_queue_issues(jira_client, mock_jira_fetcher):
         queue_id="47",
         start_at=0,
         limit=2,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_request_types(jira_client, mock_jira_fetcher):
+    """Test request type listing for a service desk."""
+    mock_jira_fetcher.get_request_types.return_value = JiraRequestTypesResult(
+        service_desk_id="4",
+        size=2,
+        request_types=[
+            JiraRequestType(id="23", name="Incident"),
+            JiraRequestType(id="24", name="Access Request"),
+        ],
+    )
+
+    response = await jira_client.call_tool(
+        "jira_get_request_types",
+        {"service_desk_id": "4", "start_at": 0, "limit": 50},
+    )
+    content = json.loads(response.content[0].text)
+
+    assert content["service_desk_id"] == "4"
+    assert content["size"] == 2
+    assert content["request_types"][0]["id"] == "23"
+    mock_jira_fetcher.get_request_types.assert_called_once_with(
+        service_desk_id="4",
+        start_at=0,
+        limit=50,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_request_type_fields(jira_client, mock_jira_fetcher):
+    """Test request type field discovery."""
+    mock_jira_fetcher.get_request_type_fields.return_value = (
+        JiraRequestTypeFieldsResult(
+            service_desk_id="4",
+            request_type_id="23",
+            can_raise_on_behalf_of=True,
+            fields=[
+                JiraRequestTypeField(
+                    field_id="summary",
+                    name="Summary",
+                    required=True,
+                    supports_multiple=False,
+                )
+            ],
+        )
+    )
+
+    response = await jira_client.call_tool(
+        "jira_get_request_type_fields",
+        {"service_desk_id": "4", "request_type_id": "23"},
+    )
+    content = json.loads(response.content[0].text)
+
+    assert content["service_desk_id"] == "4"
+    assert content["request_type_id"] == "23"
+    assert content["can_raise_on_behalf_of"] is True
+    assert content["fields"][0]["field_id"] == "summary"
+    mock_jira_fetcher.get_request_type_fields.assert_called_once_with(
+        service_desk_id="4",
+        request_type_id="23",
+    )
+
+
+@pytest.mark.anyio
+async def test_create_customer_request(jira_client, mock_jira_fetcher):
+    """Test customer request creation tool."""
+    mock_jira_fetcher.create_customer_request.return_value = JiraCustomerRequest(
+        request_id="10010",
+        request_key="SUP-101",
+        portal_url="https://jira.example.com/servicedesk/customer/portal/4/SUP-101",
+        created_mode="created_on_behalf_of",
+        on_behalf_user="d.zagitov",
+    )
+
+    response = await jira_client.call_tool(
+        "jira_create_customer_request",
+        {
+            "service_desk_id": "4",
+            "request_type_id": "23",
+            "request_field_values": '{"summary": "Production incident"}',
+            "raise_on_behalf_of": "d.zagitov",
+            "strict_on_behalf": False,
+        },
+    )
+    content = json.loads(response.content[0].text)
+
+    assert content["request_id"] == "10010"
+    assert content["request_key"] == "SUP-101"
+    assert content["created_mode"] == "created_on_behalf_of"
+    assert content["on_behalf_user"] == "d.zagitov"
+    mock_jira_fetcher.create_customer_request.assert_called_once_with(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={"summary": "Production incident"},
+        raise_on_behalf_of="d.zagitov",
+        request_participants=None,
+        strict_on_behalf=False,
     )
 
 
@@ -1042,8 +1155,8 @@ async def test_get_all_projects_tool(jira_client, mock_jira_fetcher):
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with default parameters (include_archived=False)
@@ -1091,8 +1204,8 @@ async def test_get_all_projects_tool_with_archived(jira_client, mock_jira_fetche
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with include_archived=True
@@ -1145,8 +1258,8 @@ async def test_get_all_projects_tool_with_projects_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up the projects filter in the config
@@ -1199,8 +1312,8 @@ async def test_get_all_projects_tool_no_projects_filter(jira_client, mock_jira_f
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Ensure no projects filter is set
@@ -1260,8 +1373,8 @@ async def test_get_all_projects_tool_case_insensitive_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up projects filter with mixed case and whitespace

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -774,6 +774,44 @@ async def test_create_customer_request(jira_client, mock_jira_fetcher):
         request_field_values={"summary": "Production incident"},
         raise_on_behalf_of="d.zagitov",
         request_participants=None,
+        attachments=None,
+        strict_on_behalf=False,
+    )
+
+
+@pytest.mark.anyio
+async def test_create_customer_request_with_attachments(jira_client, mock_jira_fetcher):
+    """Customer request tool should forward parsed base64 attachments."""
+    mock_jira_fetcher.create_customer_request.return_value = JiraCustomerRequest(
+        request_id="10010",
+        request_key="SUP-101",
+        created_mode="created_direct",
+    )
+
+    response = await jira_client.call_tool(
+        "jira_create_customer_request",
+        {
+            "service_desk_id": "4",
+            "request_type_id": "23",
+            "request_field_values": '{"summary": "Production incident"}',
+            "attachments": (
+                '[{"filename": "log.txt", "mime_type": "text/plain", '
+                '"base64": "aGVsbG8="}]'
+            ),
+        },
+    )
+    content = json.loads(response.content[0].text)
+
+    assert content["request_key"] == "SUP-101"
+    mock_jira_fetcher.create_customer_request.assert_called_once_with(
+        service_desk_id="4",
+        request_type_id="23",
+        request_field_values={"summary": "Production incident"},
+        raise_on_behalf_of=None,
+        request_participants=None,
+        attachments=[
+            {"filename": "log.txt", "mime_type": "text/plain", "base64": "aGVsbG8="}
+        ],
         strict_on_behalf=False,
     )
 

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 52, f"Expected 52 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Description

This PR adds Jira Service Management customer request tools to the Jira MCP server, allowing clients to list request types, inspect request fields, and create customer requests through MCP.

Customer request creation validates visible required fields, normalizes select-like and multi-value payloads, supports optional request participants and base64 attachments, and can retry without `raiseOnBehalfOf` when Jira explicitly rejects on-behalf creation.

## Changes

- Add `jira_get_request_types`, `jira_get_request_type_fields`, and `jira_create_customer_request`.
- Add JSM request models and a customer request fetcher mixin for Cloud and Server/Data Center.
- Normalize dropdown, multi-select, radio-button, and checkbox option values from request metadata.
- Upload temporary attachments through the authenticated Jira transport, including Cloud OAuth gateway URLs.
- Validate attachment payloads and size limits before creating a request.
- Surface request metadata API failures instead of treating them as empty field sets.
- Restrict on-behalf fallback retries to explicit HTTP 400/403 responses.
- Add generated tool documentation and toolset metadata.
- Add unit and server regression coverage.

## Testing

- `uv run pytest tests/unit/jira/test_customer_requests.py tests/unit/servers/test_jira_server.py tests/unit/utils/test_toolsets.py -q` — 181 passed
- `uv run pytest tests/unit/ -q` — 3197 passed, 5 skipped
- `uv run pytest tests/e2e/cloud --cloud-e2e -q` — 86 passed, 15 skipped
- `uv run pytest tests/e2e --dc-e2e -q -rs` — 71 passed; DC project-specific Epic coverage skipped because the test project has no Epic type
- `pre-commit run --files ...` — passed
- `uv run python scripts/generate_tool_docs.py --check` — all 96 tools mapped

## Checklist

- [x] Code follows project style guidelines.
- [x] Tests added and updated.
- [x] Cloud and Server/Data Center e2e suites re-run.
- [x] Documentation updated.