### PR TITLE
fix(confluence): correct X-Atlassian-Token header value

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -471,7 +471,7 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
 
             # Prepare headers (X-Atlassian-Token required for file uploads)
-            headers = {"X-Atlassian-Token": "nocheck"}
+            headers = {"X-Atlassian-Token": "no-check"}
 
             # Prepare multipart form data
             files = {"file": (filename, open(file_path, "rb"))}

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -160,7 +160,7 @@ class TestAttachmentsMixin:
             assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
 
             # Check headers include X-Atlassian-Token
-            assert call_args[1]["headers"]["X-Atlassian-Token"] == "nocheck"
+            assert call_args[1]["headers"]["X-Atlassian-Token"] == "no-check"
 
             # Check minorEdit was passed in data
             assert call_args[1]["data"]["minorEdit"] == "false"


### PR DESCRIPTION
## Summary

- Fix `X-Atlassian-Token` header value from `"nocheck"` to `"no-check"` (with hyphen) in `confluence_upload_attachment`
- Confluence Server requires exactly `"no-check"` to bypass XSRF validation on multipart uploads; without the hyphen, the server returns `403 Forbidden`
- Update corresponding unit test assertion to match the corrected value

Fixes #1207

## Context

This is a companion fix to PR #1202 (PUT to POST). Both fixes are required for attachment uploads to work on Confluence Server. The e2e test fixtures in this repo already use the correct `"no-check"` value, confirming this is the intended format.

## Test plan

- [x] Unit test updated to assert `"no-check"` header value
- [ ] Verify attachment upload succeeds on Confluence Server (self-hosted)