### PR TITLE
fix(deps): pin fakeredis<2.35.0 to unblock uvx installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "httpx>=0.28.0",
     "mcp>=1.8.0,<2.0.0",
     "fastmcp>=2.13.0,<2.15.0",
+    "fakeredis>=2.32.1,<2.35.0",
     "python-dotenv>=1.0.1",
     "markdownify>=0.11.6",
     "markdown>=3.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1430,6 +1430,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "cachetools" },
     { name = "click" },
+    { name = "fakeredis" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "keyring" },
@@ -1476,6 +1477,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "click", specifier = ">=8.1.7" },
+    { name = "fakeredis", specifier = ">=2.32.1,<2.35.0" },
     { name = "fastmcp", specifier = ">=2.13.0,<2.15.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "keyring", specifier = ">=25.6.0" },
@@ -2744,9 +2746,9 @@ wheels = [
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fresh `uvx mcp-atlassian` installs crash at FastMCP lifespan startup with `ImportError: cannot import name 'FakeConnection' from 'fakeredis.aioredis'`.

## Root cause chain

1. `fakeredis 2.35.0` (released 2026-04-08) renamed `FakeConnection` → `FakeRedisConnection` / `FakeAsyncRedisConnection` with **no backward-compatible alias** (see [fakeredis-py#468](https://github.com/cunla/fakeredis-py/issues/468)).
2. `pydocket._memory_connection_pool()` does `from fakeredis.aioredis import FakeConnection, FakeServer` at runtime.
3. `pydocket` pins `fakeredis[lua]>=2.32.1` with **no upper bound**, so fresh resolvers pull 2.35.0.
4. `fastmcp` → `pydocket` → crash during `_docket_lifespan` → `mcp-atlassian` fails to start.

Our `uv.lock` already held `fakeredis==2.34.0`, but PyPI-distributed installs (`uvx`, `pip install mcp-atlassian`) re-resolve from scratch and don't honor our dev lock.

## Fix

Add an explicit downstream constraint in `pyproject.toml`:

```toml
"fakeredis>=2.32.1,<2.35.0",
```

Lower bound matches pydocket's constraint; upper bound excludes the broken release.

## Upstream status

- fakeredis maintainer has the fix merged and said a patch release (2.35.1) is coming "in a day or two" (as of 2026-04-09).
- `pydocket` has not yet shipped a release that pins around this.

## Rollback condition

Once fakeredis 2.35.1 is out **and** verified compatible with pydocket, follow up by relaxing the upper bound (or removing the direct dependency entirely if pydocket ships its own pin).

## Verification

- `uv lock` → fakeredis stays at 2.34.0
- `uv sync --reinstall` → fakeredis 2.34.0 installed
- `uv run python -c "from fakeredis.aioredis import FakeConnection, FakeServer"` → OK
- `uv run mcp-atlassian` → lifespan startup clean, server reaches "Starting MCP server 'Atlassian MCP' with transport 'stdio'" (the exact crash point in the reported traceback)
- `pre-commit run --all-files` → clean
- `uv run pytest` → 2578 passed, 161 skipped

Closes #1248