### PR TITLE
fix(confluence): complete DC/Server attachment upload — header, POST method, versioning fallback

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -470,8 +470,10 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             base_url = self.config.url.rstrip("/")
             url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
 
-            # Prepare headers (X-Atlassian-Token required for file uploads)
-            headers = {"X-Atlassian-Token": "nocheck"}
+            # Prepare headers — Confluence Server/DC requires "no-check" (with hyphen)
+            # to bypass XSRF validation on multipart uploads. "nocheck" (no hyphen)
+            # causes a 403 Forbidden on Server/DC instances.
+            headers = {"X-Atlassian-Token": "no-check"}
 
             # Prepare multipart form data
             files = {"file": (filename, open(file_path, "rb"))}
@@ -484,12 +486,43 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             if minor_edit is not None:
                 data["minorEdit"] = str(minor_edit).lower()
 
-            # Use PUT to support creating new versions of existing attachments
-            # PUT will create a new attachment if it doesn't exist, OR create a new
-            # version if an attachment with the same filename already exists
-            response = self.confluence._session.put(
+            # Use POST to create a new attachment on Server/DC.
+            # PUT on the list endpoint is not supported by Confluence Server/DC and
+            # returns 404 or 405. POST is the correct method per the REST API docs.
+            response = self.confluence._session.post(
                 url, headers=headers, files=files, data=data
             )
+
+            # On Server/DC, uploading a file that already exists returns HTTP 400
+            # with "same file name" in the response. In that case we must locate the
+            # existing attachment by filename and POST to its /data endpoint to create
+            # a new version instead.
+            if response.status_code == 400 and "same file name" in response.text:
+                logger.debug(
+                    f"Attachment '{filename}' already exists on content {content_id}, "
+                    "updating existing attachment version"
+                )
+                att_list = self.confluence._session.get(
+                    f"{url}?filename={filename}",
+                    headers={"X-Atlassian-Token": "no-check"},
+                )
+                att_list.raise_for_status()
+                att_results = att_list.json().get("results", [])
+                if att_results:
+                    att_id = att_results[0]["id"]
+                    update_url = (
+                        f"{base_url}/rest/api/content/{content_id}"
+                        f"/child/attachment/{att_id}/data"
+                    )
+                    files2 = {"file": (filename, open(file_path, "rb"))}
+                    if comment:
+                        files2["comment"] = (None, comment, "text/plain; charset=utf-8")
+                    response = self.confluence._session.post(
+                        update_url, headers=headers, files=files2, data=data
+                    )
+                    if "file" in files2 and hasattr(files2["file"][1], "close"):
+                        files2["file"][1].close()
+
             response.raise_for_status()
 
             # Parse response

--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -593,8 +593,9 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
                     f"Attachment '{filename}' already exists on content {content_id}, "
                     "updating existing attachment version"
                 )
+                encoded_filename = urllib.parse.quote(filename, safe="")
                 att_list = self.confluence._session.get(
-                    f"{url}?filename={filename}",
+                    f"{url}?filename={encoded_filename}",
                     headers={"X-Atlassian-Token": "no-check"},
                 )
                 att_list.raise_for_status()

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -62,6 +63,59 @@ class TestConfluenceCloudStorageFormat:
         )
         resource_tracker.add_confluence_page(page.id)
         assert page.id is not None
+
+
+class TestConfluenceCloudAttachments:
+    """Attachment upload/versioning through the fetcher API."""
+
+    def test_upload_attachment_creates_new_version(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+        tmp_path: Path,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Attachment Test {uid}",
+            body="<p>For attachment upload testing.</p>",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        attachment_path = tmp_path / f"cloud upload {uid} & notes #1.txt"
+        attachment_path.write_text(f"first upload {uid}", encoding="utf-8")
+
+        first = confluence_fetcher.upload_attachment(
+            content_id=page.id,
+            file_path=str(attachment_path),
+            comment="first upload",
+        )
+        assert first["success"] is True
+        assert first["filename"] == attachment_path.name
+        assert first["id"]
+
+        attachment_path.write_text(f"second upload {uid}", encoding="utf-8")
+        second = confluence_fetcher.upload_attachment(
+            content_id=page.id,
+            file_path=str(attachment_path),
+            comment="second upload",
+        )
+        assert second["success"] is True
+        assert second["id"] == first["id"]
+
+        attachments = confluence_fetcher.get_content_attachments(
+            content_id=page.id,
+            filename=attachment_path.name,
+        )
+        matching = [
+            attachment
+            for attachment in attachments["attachments"]
+            if attachment["title"] == attachment_path.name
+        ]
+        assert len(matching) == 1
+        if "version" in matching[0]:
+            assert matching[0]["version"]["number"] >= 2
 
 
 class TestConfluenceCloudPageHierarchy:

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -46,6 +47,59 @@ class TestConfluenceDCStorageFormat:
         )
         resource_tracker.add_confluence_page(page.id)
         assert page.id is not None
+
+
+class TestConfluenceDCAttachments:
+    """Attachment upload/versioning through the fetcher API."""
+
+    def test_upload_attachment_creates_new_version(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        dc_instance: DCInstanceInfo,
+        resource_tracker: DCResourceTracker,
+        tmp_path: Path,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=dc_instance.space_key,
+            title=f"E2E Attachment Test {uid}",
+            body="<p>For attachment upload testing.</p>",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        attachment_path = tmp_path / f"dc upload {uid} & notes #1.txt"
+        attachment_path.write_text(f"first upload {uid}", encoding="utf-8")
+
+        first = confluence_fetcher.upload_attachment(
+            content_id=page.id,
+            file_path=str(attachment_path),
+            comment="first upload",
+        )
+        assert first["success"] is True
+        assert first["filename"] == attachment_path.name
+        assert first["id"]
+
+        attachment_path.write_text(f"second upload {uid}", encoding="utf-8")
+        second = confluence_fetcher.upload_attachment(
+            content_id=page.id,
+            file_path=str(attachment_path),
+            comment="second upload",
+        )
+        assert second["success"] is True
+        assert second["id"] == first["id"]
+
+        attachments = confluence_fetcher.get_content_attachments(
+            content_id=page.id,
+            filename=attachment_path.name,
+        )
+        matching = [
+            attachment
+            for attachment in attachments["attachments"]
+            if attachment["title"] == attachment_path.name
+        ]
+        assert len(matching) == 1
+        if "version" in matching[0]:
+            assert matching[0]["version"]["number"] >= 2
 
 
 class TestConfluenceDCPageHierarchy:

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -104,13 +104,12 @@ class TestAttachmentsMixin:
 
         mock_response = Mock()
         if raise_error:
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.side_effect = raise_error
+            attachments_mixin.confluence._session.post.side_effect = raise_error
         else:
+            mock_response.status_code = 200
             mock_response.json.return_value = response_data
             mock_response.raise_for_status.return_value = None
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.return_value = mock_response
+            attachments_mixin.confluence._session.post.return_value = mock_response
 
         return mock_response
 
@@ -152,15 +151,15 @@ class TestAttachmentsMixin:
             assert result["id"] == "att12345"
 
             # Verify the REST API was called with correct parameters
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.assert_called_once()
-            call_args = attachments_mixin.confluence._session.put.call_args
+            attachments_mixin.confluence._session.post.assert_called_once()
+            call_args = attachments_mixin.confluence._session.post.call_args
 
             # Check URL
             assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
 
-            # Check headers include X-Atlassian-Token
-            assert call_args[1]["headers"]["X-Atlassian-Token"] == "nocheck"
+            # Check headers include X-Atlassian-Token with correct value (hyphen required
+            # by Confluence Server/DC to bypass XSRF validation)
+            assert call_args[1]["headers"]["X-Atlassian-Token"] == "no-check"
 
             # Check minorEdit was passed in data
             assert call_args[1]["data"]["minorEdit"] == "false"
@@ -270,6 +269,68 @@ class TestAttachmentsMixin:
             assert result["success"] is False
             # When direct API fails, we get generic failure message
             assert "Failed to upload attachment" in result["error"]
+
+    def test_upload_attachment_versioning_fallback(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test that re-uploading an existing file triggers the versioning fallback.
+
+        On Confluence Server/DC, uploading a file with the same name as an existing
+        attachment returns HTTP 400 with 'same file name' in the body. The code must
+        then GET the existing attachment ID and POST to /child/attachment/{id}/data
+        to create a new version.
+        """
+        updated_attachment = {
+            "id": "att12345",
+            "type": "attachment",
+            "title": "test_file.txt",
+            "extensions": {"mediaType": "text/plain", "fileSize": 200},
+            "_links": {"download": "/download/attachments/123/test_file.txt"},
+            "version": {"number": 2},
+        }
+
+        # First POST returns 400 "same file name"
+        conflict_response = Mock()
+        conflict_response.status_code = 400
+        conflict_response.text = "Attachment with same file name already exists: test_file.txt"
+
+        # GET list returns existing attachment
+        list_response = Mock()
+        list_response.status_code = 200
+        list_response.raise_for_status.return_value = None
+        list_response.json.return_value = {"results": [{"id": "att12345"}]}
+
+        # Second POST (to /data endpoint) returns the updated attachment
+        update_response = Mock()
+        update_response.status_code = 200
+        update_response.raise_for_status.return_value = None
+        update_response.json.return_value = updated_attachment
+
+        attachments_mixin.confluence._session.post.side_effect = [
+            conflict_response,
+            update_response,
+        ]
+        attachments_mixin.confluence._session.get.return_value = list_response
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getsize", return_value=200),
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.abspath", return_value="/absolute/path/test_file.txt"),
+            patch("os.path.basename", return_value="test_file.txt"),
+            patch("builtins.open", mock_open(read_data=b"updated content")),
+        ):
+            result = attachments_mixin.upload_attachment(
+                "123456", "/absolute/path/test_file.txt"
+            )
+
+        assert result["success"] is True
+        assert result["filename"] == "test_file.txt"
+
+        # Verify the versioning POST was made to the /data endpoint
+        assert attachments_mixin.confluence._session.post.call_count == 2
+        second_call_url = attachments_mixin.confluence._session.post.call_args_list[1][0][0]
+        assert "/child/attachment/att12345/data" in second_call_url
 
     # Tests for upload_attachments method
 

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -292,7 +292,9 @@ class TestAttachmentsMixin:
         # First POST returns 400 "same file name"
         conflict_response = Mock()
         conflict_response.status_code = 400
-        conflict_response.text = "Attachment with same file name already exists: test_file.txt"
+        conflict_response.text = (
+            "Attachment with same file name already exists: test_file.txt"
+        )
 
         # GET list returns existing attachment
         list_response = Mock()
@@ -329,7 +331,9 @@ class TestAttachmentsMixin:
 
         # Verify the versioning POST was made to the /data endpoint
         assert attachments_mixin.confluence._session.post.call_count == 2
-        second_call_url = attachments_mixin.confluence._session.post.call_args_list[1][0][0]
+        second_call_url = attachments_mixin.confluence._session.post.call_args_list[1][
+            0
+        ][0]
         assert "/child/attachment/att12345/data" in second_call_url
 
     # Tests for upload_attachments method

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -170,7 +170,7 @@ class TestAttachmentsMixin:
         """Run an upload with the given config URL and return the request URL.
 
         Sets ``config.url`` (which drives ``is_cloud``), performs an upload with
-        all file I/O mocked, and returns the URL passed to ``session.put``.
+        all file I/O mocked, and returns the URL passed to ``session.post``.
         """
         attachments_mixin.config.url = config_url
         self._mock_rest_api_upload(attachments_mixin)
@@ -187,7 +187,7 @@ class TestAttachmentsMixin:
                 "123456", "/absolute/path/test_file.txt"
             )
 
-        return attachments_mixin.confluence._session.put.call_args[0][0]
+        return attachments_mixin.confluence._session.post.call_args[0][0]
 
     def test_upload_attachment_cloud_adds_wiki_prefix(
         self, attachments_mixin: AttachmentsMixin
@@ -343,12 +343,13 @@ class TestAttachmentsMixin:
         then GET the existing attachment ID and POST to /child/attachment/{id}/data
         to create a new version.
         """
+        filename = "test file & notes #1.txt"
         updated_attachment = {
             "id": "att12345",
             "type": "attachment",
-            "title": "test_file.txt",
+            "title": filename,
             "extensions": {"mediaType": "text/plain", "fileSize": 200},
-            "_links": {"download": "/download/attachments/123/test_file.txt"},
+            "_links": {"download": f"/download/attachments/123/{filename}"},
             "version": {"number": 2},
         }
 
@@ -356,7 +357,7 @@ class TestAttachmentsMixin:
         conflict_response = Mock()
         conflict_response.status_code = 400
         conflict_response.text = (
-            "Attachment with same file name already exists: test_file.txt"
+            f"Attachment with same file name already exists: {filename}"
         )
 
         # GET list returns existing attachment
@@ -381,16 +382,20 @@ class TestAttachmentsMixin:
             patch("os.path.exists", return_value=True),
             patch("os.path.getsize", return_value=200),
             patch("os.path.isabs", return_value=True),
-            patch("os.path.abspath", return_value="/absolute/path/test_file.txt"),
-            patch("os.path.basename", return_value="test_file.txt"),
+            patch("os.path.abspath", return_value=f"/absolute/path/{filename}"),
+            patch("os.path.basename", return_value=filename),
             patch("builtins.open", mock_open(read_data=b"updated content")),
         ):
             result = attachments_mixin.upload_attachment(
-                "123456", "/absolute/path/test_file.txt"
+                "123456", f"/absolute/path/{filename}"
             )
 
         assert result["success"] is True
-        assert result["filename"] == "test_file.txt"
+        assert result["filename"] == filename
+
+        # Verify the lookup URL escapes query-special filename characters.
+        list_call_url = attachments_mixin.confluence._session.get.call_args[0][0]
+        assert "filename=test%20file%20%26%20notes%20%231.txt" in list_call_url
 
         # Verify the versioning POST was made to the /data endpoint
         assert attachments_mixin.confluence._session.post.call_count == 2


### PR DESCRIPTION
## Summary

Fixes three independent bugs that together prevent `confluence_upload_attachment` from working on **Confluence Server / Data Center**. All three must be fixed for uploads to succeed end-to-end.

Closes #1207

---

## Bugs Fixed

### Bug 1 — Wrong `X-Atlassian-Token` header value

| | Value |
|---|---|
| Before | `"nocheck"` |
| After | `"no-check"` |

Confluence Server requires the hyphenated form to bypass XSRF validation on multipart uploads. Sending `"nocheck"` (no hyphen) causes the server to return **403 Forbidden** and reject the upload entirely.

Reference: [Atlassian REST API examples — Upload an attachment](https://developer.atlassian.com/server/confluence/confluence-rest-api-examples/#upload-an-attachment)

---

### Bug 2 — Wrong HTTP method (`PUT` → `POST`)

| | Method |
|---|---|
| Before | `PUT /rest/api/content/{id}/child/attachment` |
| After | `POST /rest/api/content/{id}/child/attachment` |

Confluence Server/DC does not support `PUT` on the attachment list endpoint — it returns 404 or 405. `POST` is the correct method for creating a new attachment per the REST API docs.

---

### Bug 3 — No versioning fallback for existing attachments (new fix, not in any open PR)

When a file with the same name already exists, Confluence Server/DC returns **HTTP 400** with `"same file name"` in the body. The previous code had no handling for this case, causing re-uploads to always fail.

**Fix:** Detect the 400 response, look up the existing attachment ID via `GET /child/attachment?filename=<name>`, then `POST` to `/child/attachment/{id}/data` to create a new version.

```python
if response.status_code == 400 and "same file name" in response.text:
    # find existing att_id, then:
    response = session.post(f".../child/attachment/{att_id}/data", ...)
```

This is the fix that makes the tool actually usable day-to-day — without it, you can upload a file once but can never update it.

---

## Relation to Other Open PRs

| PR | Fixes |
|---|---|
| #1202 | Bug 2 only (PUT → POST) |
| #1249, #1217, #1210 | Bug 1 only (header value) |
| **This PR** | **All three bugs, including the versioning fallback** |

This PR supersedes those for Server/DC users. If the maintainers prefer to merge the existing PRs separately, only Bug 3 (versioning fallback) would remain.

---

## Files Changed

| File | Change |
|---|---|
| `src/mcp_atlassian/confluence/attachments.py` | Three-part fix in `_upload_attachment_direct` |
| `tests/unit/confluence/test_attachments.py` | Updated existing assertions (`put` → `post`, header value) + new test for versioning fallback path |

## Test Plan

- [x] Existing unit tests updated to reflect correct method (`post`) and header (`no-check`)
- [x] New unit test `test_upload_attachment_versioning_fallback` verifies the 400 → GET → POST `/data` path
- [x] Manually verified against a Confluence Data Center instance — new files upload correctly, re-uploads create new versions correctly