### PR TITLE
docs(agents): fix stale Jira/Confluence mixin counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 | Path | Purpose |
 | --- | --- |
 | `src/mcp_atlassian/` | Library source (Python ≥ 3.10) |
-| `  ├─ jira/` | Jira client + 16 mixins (issues, search, SLA, metrics, …) |
-| `  ├─ confluence/` | Confluence client + 7 mixins (pages, search, analytics, …) |
+| `  ├─ jira/` | Jira client + 21 mixins (issues, search, SLA, metrics, …) |
+| `  ├─ confluence/` | Confluence client + 8 mixins (pages, search, analytics, …) |
 | `  ├─ models/` | Pydantic v2 data models (`ApiModel` base) |
 | `  ├─ servers/` | FastMCP server instances (`jira_mcp`, `confluence_mcp`) |
 | `  ├─ preprocessing/` | Content conversion (ADF/Storage → Markdown) |
@@ -22,7 +22,7 @@
 
 ## Architecture
 
-- **Mixin composition**: `JiraFetcher` composes 16 mixins, `ConfluenceFetcher` composes 7. Client inheritance is transitive through mixins.
+- **Mixin composition**: `JiraFetcher` composes 21 mixins, `ConfluenceFetcher` composes 8. Client inheritance is transitive through mixins.
 - **FastMCP servers**: `servers/main.py` → lifespan → dependency injection via `get_jira_fetcher(ctx)` / `get_confluence_fetcher(ctx)`.
 - **Tool naming**: `{service}_{action}_{target}` (e.g., `jira_create_issue`, `confluence_get_page`).
 - **Config**: Environment-based `from_env()` factory on `JiraConfig` / `ConfluenceConfig` dataclasses.


### PR DESCRIPTION
## Summary

`AGENTS.md` mixin counts have drifted from actual class composition. This PR updates two occurrences each for Jira and Confluence to match source truth.

## Verification

Counted directly from source (`src/mcp_atlassian/{jira,confluence}/__init__.py`):

**JiraFetcher** (21 mixins, was documented as 16):
\`ProjectsMixin, FieldsMixin, FieldOptionsMixin, FormsApiMixin, FormattingMixin, TransitionsMixin, WorklogMixin, EpicsMixin, CommentsMixin, SearchMixin, IssuesMixin, UsersMixin, WatchersMixin, BoardsMixin, SprintsMixin, QueuesMixin, AttachmentsMixin, LinksMixin, MetricsMixin, SLAMixin, DevelopmentMixin\`

**ConfluenceFetcher** (8 mixins, was documented as 7):
\`SearchMixin, SpacesMixin, PagesMixin, CommentsMixin, LabelsMixin, UsersMixin, AnalyticsMixin, AttachmentsMixin\`

Changes are in:
- Repository map table (line 12/13)
- Architecture bullet (line 25)

Pure factual fix. No behavior change.