### PR TITLE
feat(jira): add saved filter tools (my filters, favourites, filter by ID)

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -17,6 +17,7 @@ from .development import DevelopmentMixin
 from .epics import EpicsMixin
 from .field_options import FieldOptionsMixin
 from .fields import FieldsMixin
+from .filters import FiltersMixin
 from .forms_api import FormsApiMixin  # Forms REST API
 from .formatting import FormattingMixin
 from .issues import IssuesMixin
@@ -37,6 +38,7 @@ class JiraFetcher(
     ProjectsMixin,
     FieldsMixin,
     FieldOptionsMixin,
+    FiltersMixin,
     FormsApiMixin,  # Use new Forms REST API instead of FormsMixin
     FormattingMixin,
     TransitionsMixin,
@@ -74,6 +76,7 @@ class JiraFetcher(
     - BoardsMixin: Board operations
     - SprintsMixin: Sprint operations
     - AttachmentsMixin: Attachment download operations
+    - FiltersMixin: Saved filter operations
     - LinksMixin: Issue link operations
     - MetricsMixin: Issue metrics and date operations
     - QueuesMixin: Service Desk queue read operations (Server/DC)

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -18,6 +18,7 @@ from .development import DevelopmentMixin
 from .epics import EpicsMixin
 from .field_options import FieldOptionsMixin
 from .fields import FieldsMixin
+from .filters import FiltersMixin
 from .forms_api import FormsApiMixin  # Forms REST API
 from .formatting import FormattingMixin
 from .issues import IssuesMixin
@@ -39,6 +40,7 @@ class JiraFetcher(
     ProjectsMixin,
     FieldsMixin,
     FieldOptionsMixin,
+    FiltersMixin,
     FormsApiMixin,  # Use new Forms REST API instead of FormsMixin
     FormattingMixin,
     TransitionsMixin,
@@ -78,6 +80,7 @@ class JiraFetcher(
     - BoardsMixin: Board operations
     - SprintsMixin: Sprint operations
     - AttachmentsMixin: Attachment download operations
+    - FiltersMixin: Saved filter operations
     - LinksMixin: Issue link operations
     - MetricsMixin: Issue metrics and date operations
     - QueuesMixin: Service Desk queue read operations (Server/DC)

--- a/src/mcp_atlassian/jira/filters.py
+++ b/src/mcp_atlassian/jira/filters.py
@@ -1,7 +1,6 @@
 """Module for Jira filter operations."""
 
 import logging
-from typing import Any
 
 from requests.exceptions import HTTPError
 
@@ -42,8 +41,9 @@ class FiltersMixin(JiraClient):
         except TypeError:
             raise
         except Exception as e:
-            logger.error(f"Error getting my filters: {str(e)}")
-            raise Exception(f"Error getting my filters: {str(e)}") from e
+            error_msg = f"Error getting my filters: {e!s}"
+            logger.error(error_msg)
+            raise Exception(error_msg) from e
 
     @handle_auth_errors("Jira API")
     def get_favourite_filters(self) -> list[JiraFilter]:
@@ -61,7 +61,9 @@ class FiltersMixin(JiraClient):
             response = self.jira.get("rest/api/2/filter/favourite")
 
             if not isinstance(response, list):
-                msg = f"Unexpected response type from filter/favourite: {type(response)}"
+                msg = (
+                    f"Unexpected response type from filter/favourite: {type(response)}"
+                )
                 logger.error(msg)
                 raise TypeError(msg)
 
@@ -72,8 +74,9 @@ class FiltersMixin(JiraClient):
         except TypeError:
             raise
         except Exception as e:
-            logger.error(f"Error getting favourite filters: {str(e)}")
-            raise Exception(f"Error getting favourite filters: {str(e)}") from e
+            error_msg = f"Error getting favourite filters: {e!s}"
+            logger.error(error_msg)
+            raise Exception(error_msg) from e
 
     @handle_auth_errors("Jira API")
     def get_filter_by_id(self, filter_id: str) -> JiraFilter:
@@ -95,7 +98,10 @@ class FiltersMixin(JiraClient):
             response = self.jira.get(f"rest/api/2/filter/{filter_id}")
 
             if not isinstance(response, dict):
-                msg = f"Unexpected response type from filter/{filter_id}: {type(response)}"
+                msg = (
+                    "Unexpected response type from"
+                    f" filter/{filter_id}: {type(response)}"
+                )
                 logger.error(msg)
                 raise TypeError(msg)
 
@@ -103,10 +109,12 @@ class FiltersMixin(JiraClient):
 
         except HTTPError as e:
             if e.response is not None and e.response.status_code == 404:
-                raise ValueError(f"Filter with ID '{filter_id}' not found.") from e
+                error_msg = f"Filter with ID '{filter_id}' not found."
+                raise ValueError(error_msg) from e
             raise  # let decorator handle auth errors
         except TypeError:
             raise
         except Exception as e:
-            logger.error(f"Error getting filter {filter_id}: {str(e)}")
-            raise Exception(f"Error getting filter {filter_id}: {str(e)}") from e
+            error_msg = f"Error getting filter {filter_id}: {e!s}"
+            logger.error(error_msg)
+            raise Exception(error_msg) from e

--- a/src/mcp_atlassian/jira/filters.py
+++ b/src/mcp_atlassian/jira/filters.py
@@ -1,0 +1,112 @@
+"""Module for Jira filter operations."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..models.jira.filter import JiraFilter
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class FiltersMixin(JiraClient):
+    """Mixin for Jira saved filter operations."""
+
+    @handle_auth_errors("Jira API")
+    def get_my_filters(self) -> list[JiraFilter]:
+        """
+        Get all filters owned by the current user.
+
+        Returns:
+            List of JiraFilter model instances.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If there is an error retrieving filters.
+        """
+        try:
+            response = self.jira.get("rest/api/2/filter/my")
+
+            if not isinstance(response, list):
+                msg = f"Unexpected response type from filter/my: {type(response)}"
+                logger.error(msg)
+                raise TypeError(msg)
+
+            return [JiraFilter.from_api_response(f) for f in response]
+
+        except HTTPError:
+            raise  # let decorator handle auth errors
+        except TypeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting my filters: {str(e)}")
+            raise Exception(f"Error getting my filters: {str(e)}") from e
+
+    @handle_auth_errors("Jira API")
+    def get_favourite_filters(self) -> list[JiraFilter]:
+        """
+        Get all favourite/starred filters for the current user.
+
+        Returns:
+            List of JiraFilter model instances.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If there is an error retrieving filters.
+        """
+        try:
+            response = self.jira.get("rest/api/2/filter/favourite")
+
+            if not isinstance(response, list):
+                msg = f"Unexpected response type from filter/favourite: {type(response)}"
+                logger.error(msg)
+                raise TypeError(msg)
+
+            return [JiraFilter.from_api_response(f) for f in response]
+
+        except HTTPError:
+            raise  # let decorator handle auth errors
+        except TypeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting favourite filters: {str(e)}")
+            raise Exception(f"Error getting favourite filters: {str(e)}") from e
+
+    @handle_auth_errors("Jira API")
+    def get_filter_by_id(self, filter_id: str) -> JiraFilter:
+        """
+        Get a specific filter by its ID.
+
+        Args:
+            filter_id: The ID of the filter.
+
+        Returns:
+            JiraFilter model instance.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            ValueError: If the filter is not found.
+            Exception: If there is an error retrieving the filter.
+        """
+        try:
+            response = self.jira.get(f"rest/api/2/filter/{filter_id}")
+
+            if not isinstance(response, dict):
+                msg = f"Unexpected response type from filter/{filter_id}: {type(response)}"
+                logger.error(msg)
+                raise TypeError(msg)
+
+            return JiraFilter.from_api_response(response)
+
+        except HTTPError as e:
+            if e.response is not None and e.response.status_code == 404:
+                raise ValueError(f"Filter with ID '{filter_id}' not found.") from e
+            raise  # let decorator handle auth errors
+        except TypeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting filter {filter_id}: {str(e)}")
+            raise Exception(f"Error getting filter {filter_id}: {str(e)}") from e

--- a/src/mcp_atlassian/jira/filters.py
+++ b/src/mcp_atlassian/jira/filters.py
@@ -1,6 +1,7 @@
 """Module for Jira filter operations."""
 
 import logging
+from typing import Any
 
 from requests.exceptions import HTTPError
 
@@ -27,7 +28,7 @@ class FiltersMixin(JiraClient):
             Exception: If there is an error retrieving filters.
         """
         try:
-            response = self.jira.get("rest/api/2/filter/my")
+            response: Any = self.jira.get("rest/api/2/filter/my")
 
             if not isinstance(response, list):
                 msg = f"Unexpected response type from filter/my: {type(response)}"
@@ -58,7 +59,7 @@ class FiltersMixin(JiraClient):
             Exception: If there is an error retrieving filters.
         """
         try:
-            response = self.jira.get("rest/api/2/filter/favourite")
+            response: Any = self.jira.get("rest/api/2/filter/favourite")
 
             if not isinstance(response, list):
                 msg = (
@@ -95,7 +96,7 @@ class FiltersMixin(JiraClient):
             Exception: If there is an error retrieving the filter.
         """
         try:
-            response = self.jira.get(f"rest/api/2/filter/{filter_id}")
+            response: Any = self.jira.get(f"rest/api/2/filter/{filter_id}")
 
             if not isinstance(response, dict):
                 msg = (

--- a/src/mcp_atlassian/jira/filters.py
+++ b/src/mcp_atlassian/jira/filters.py
@@ -25,8 +25,16 @@ class FiltersMixin(JiraClient):
 
         Raises:
             MCPAtlassianAuthenticationError: If authentication fails.
+            ValueError: If running on Jira Server/Data Center.
             Exception: If there is an error retrieving filters.
         """
+        if not self.config.is_cloud:
+            raise ValueError(
+                "Listing filters owned by the current user is only supported on "
+                "Jira Cloud. On Jira Server/Data Center, use get_favourite_filters "
+                "or get_filter_by_id instead."
+            )
+
         try:
             response: Any = self.jira.get("rest/api/2/filter/my")
 

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -18,6 +18,7 @@ from .common import (
     JiraUser,
 )
 from .field_option import FieldContext, FieldOption
+from .filter import JiraFilter
 from .forms import ProFormaForm, ProFormaFormField, ProFormaFormState
 from .issue import JiraIssue
 from .link import (
@@ -69,6 +70,8 @@ __all__ = [
     "JiraAttachment",
     "JiraResolution",
     "JiraTimetracking",
+    # Filter models
+    "JiraFilter",
     # Entity-specific models
     "JiraComment",
     "JiraWorklog",

--- a/src/mcp_atlassian/models/jira/__init__.py
+++ b/src/mcp_atlassian/models/jira/__init__.py
@@ -18,6 +18,7 @@ from .common import (
     JiraUser,
 )
 from .field_option import FieldContext, FieldOption
+from .filter import JiraFilter
 from .forms import ProFormaForm, ProFormaFormField, ProFormaFormState
 from .issue import JiraIssue
 from .link import (
@@ -76,6 +77,8 @@ __all__ = [
     "JiraAttachment",
     "JiraResolution",
     "JiraTimetracking",
+    # Filter models
+    "JiraFilter",
     # Entity-specific models
     "JiraComment",
     "JiraWorklog",

--- a/src/mcp_atlassian/models/jira/filter.py
+++ b/src/mcp_atlassian/models/jira/filter.py
@@ -1,0 +1,82 @@
+"""
+Jira filter models.
+
+This module provides Pydantic models for Jira saved filters.
+"""
+
+import logging
+from typing import Any
+
+from ..base import ApiModel
+from ..constants import EMPTY_STRING
+from .common import JiraUser
+
+logger = logging.getLogger(__name__)
+
+
+class JiraFilter(ApiModel):
+    """
+    Model representing a Jira saved filter.
+    """
+
+    id: str = EMPTY_STRING
+    name: str = EMPTY_STRING
+    description: str | None = None
+    jql: str = EMPTY_STRING
+    owner: JiraUser | None = None
+    url: str | None = None
+    favourite: bool = False
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraFilter":
+        """
+        Create a JiraFilter from a Jira API response.
+
+        Args:
+            data: The filter data from the Jira API
+
+        Returns:
+            A JiraFilter instance
+        """
+        if not data:
+            return cls()
+
+        if not isinstance(data, dict):
+            logger.debug("Received non-dictionary data, returning default instance")
+            return cls()
+
+        owner = None
+        owner_data = data.get("owner")
+        if owner_data:
+            owner = JiraUser.from_api_response(owner_data)
+
+        filter_id = data.get("id", EMPTY_STRING)
+        if filter_id is not None:
+            filter_id = str(filter_id)
+
+        return cls(
+            id=filter_id,
+            name=str(data.get("name", EMPTY_STRING)),
+            description=data.get("description"),
+            jql=str(data.get("jql", EMPTY_STRING)),
+            owner=owner,
+            url=data.get("self"),
+            favourite=bool(data.get("favourite", False)),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to simplified dictionary for API response."""
+        result: dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+            "jql": self.jql,
+            "favourite": self.favourite,
+        }
+
+        if self.description:
+            result["description"] = self.description
+
+        if self.owner:
+            result["owner"] = self.owner.to_simplified_dict()
+
+        return result

--- a/src/mcp_atlassian/models/jira/filter.py
+++ b/src/mcp_atlassian/models/jira/filter.py
@@ -28,7 +28,7 @@ class JiraFilter(ApiModel):
     favourite: bool = False
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraFilter":
+    def from_api_response(cls, data: Any, **kwargs: Any) -> "JiraFilter":
         """
         Create a JiraFilter from a Jira API response.
 
@@ -50,15 +50,11 @@ class JiraFilter(ApiModel):
         if owner_data:
             owner = JiraUser.from_api_response(owner_data)
 
-        filter_id = data.get("id", EMPTY_STRING)
-        if filter_id is not None:
-            filter_id = str(filter_id)
-
         return cls(
-            id=filter_id,
-            name=str(data.get("name", EMPTY_STRING)),
+            id=str(data.get("id") or EMPTY_STRING),
+            name=str(data.get("name") or EMPTY_STRING),
             description=data.get("description"),
-            jql=str(data.get("jql", EMPTY_STRING)),
+            jql=str(data.get("jql") or EMPTY_STRING),
             owner=owner,
             url=data.get("self"),
             favourite=bool(data.get("favourite", False)),

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2629,7 +2629,9 @@ async def get_filter_by_id(
             "error": error_message,
             "filter_id": filter_id,
         }
-        logger.log(log_level, f"get_filter_by_id failed for '{filter_id}': {error_message}")
+        logger.log(
+            log_level, f"get_filter_by_id failed for '{filter_id}': {error_message}"
+        )
         return json.dumps(error_result, indent=2, ensure_ascii=False)
 
     result = jira_filter.to_simplified_dict()

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2482,6 +2482,161 @@ async def get_all_projects(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get My Filters", "readOnlyHint": True},
+)
+async def get_my_filters(
+    ctx: Context,
+    name_filter: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Filter results by name substring (case-insensitive)",
+        ),
+    ] = None,
+) -> str:
+    """Get all Jira filters owned by the current user.
+
+    Args:
+        ctx: The FastMCP context.
+        name_filter: Optional substring to filter results by name.
+
+    Returns:
+        JSON string representing a list of saved filter objects.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    try:
+        jira = await get_jira_fetcher(ctx)
+        filters = jira.get_my_filters()
+    except (MCPAtlassianAuthenticationError, HTTPError, OSError, ValueError) as e:
+        error_message = ""
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+        }
+        logger.log(log_level, f"get_my_filters failed: {error_message}")
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    result = [f.to_simplified_dict() for f in filters]
+    if name_filter:
+        name_lower = name_filter.lower()
+        result = [f for f in result if name_lower in f.get("name", "").lower()]
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get Favourite Filters", "readOnlyHint": True},
+)
+async def get_favourite_filters(
+    ctx: Context,
+    name_filter: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Filter results by name substring (case-insensitive)",
+        ),
+    ] = None,
+) -> str:
+    """Get all favourite/starred Jira filters for the current user.
+
+    Args:
+        ctx: The FastMCP context.
+        name_filter: Optional substring to filter results by name.
+
+    Returns:
+        JSON string representing a list of favourite filter objects.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    try:
+        jira = await get_jira_fetcher(ctx)
+        filters = jira.get_favourite_filters()
+    except (MCPAtlassianAuthenticationError, HTTPError, OSError, ValueError) as e:
+        error_message = ""
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+        }
+        logger.log(log_level, f"get_favourite_filters failed: {error_message}")
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    result = [f.to_simplified_dict() for f in filters]
+    if name_filter:
+        name_lower = name_filter.lower()
+        result = [f for f in result if name_lower in f.get("name", "").lower()]
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get Filter By ID", "readOnlyHint": True},
+)
+async def get_filter_by_id(
+    ctx: Context,
+    filter_id: Annotated[
+        str,
+        Field(
+            description="The ID of the Jira filter to retrieve (e.g., '10001')",
+        ),
+    ],
+) -> str:
+    """Get a specific Jira saved filter by its ID.
+
+    Args:
+        ctx: The FastMCP context.
+        filter_id: The ID of the filter.
+
+    Returns:
+        JSON string representing the filter object.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    try:
+        jira = await get_jira_fetcher(ctx)
+        jira_filter = jira.get_filter_by_id(filter_id)
+    except (MCPAtlassianAuthenticationError, HTTPError, OSError, ValueError) as e:
+        error_message = ""
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            log_level = logging.WARNING
+            error_message = str(e)
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+            "filter_id": filter_id,
+        }
+        logger.log(log_level, f"get_filter_by_id failed for '{filter_id}': {error_message}")
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    result = jira_filter.to_simplified_dict()
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_service_desk"},
     annotations={
         "title": "Get Service Desk For Project",

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3136,7 +3136,9 @@ async def get_my_filters(
     name_filter: Annotated[
         str | None,
         Field(
-            description="(Optional) Filter results by name substring (case-insensitive)",
+            description=(
+                "(Optional) Filter results by name substring (case-insensitive)"
+            ),
         ),
     ] = None,
 ) -> str:
@@ -3188,7 +3190,9 @@ async def get_favourite_filters(
     name_filter: Annotated[
         str | None,
         Field(
-            description="(Optional) Filter results by name substring (case-insensitive)",
+            description=(
+                "(Optional) Filter results by name substring (case-insensitive)"
+            ),
         ),
     ] = None,
 ) -> str:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3128,6 +3128,164 @@ async def get_all_projects(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get My Filters", "readOnlyHint": True},
+)
+async def get_my_filters(
+    ctx: Context,
+    name_filter: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Filter results by name substring (case-insensitive)",
+        ),
+    ] = None,
+) -> str:
+    """Get all Jira filters owned by the current user.
+
+    Args:
+        ctx: The FastMCP context.
+        name_filter: Optional substring to filter results by name.
+
+    Returns:
+        JSON string representing a list of saved filter objects.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    try:
+        jira = await get_jira_fetcher(ctx)
+        filters = jira.get_my_filters()
+    except (MCPAtlassianAuthenticationError, HTTPError, OSError, ValueError) as e:
+        error_message = ""
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+        }
+        logger.log(log_level, f"get_my_filters failed: {error_message}")
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    result = [jira_filter.to_simplified_dict() for jira_filter in filters]
+    if name_filter:
+        name_lower = name_filter.lower()
+        result = [f for f in result if name_lower in f.get("name", "").lower()]
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get Favourite Filters", "readOnlyHint": True},
+)
+async def get_favourite_filters(
+    ctx: Context,
+    name_filter: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Filter results by name substring (case-insensitive)",
+        ),
+    ] = None,
+) -> str:
+    """Get all favourite/starred Jira filters for the current user.
+
+    Args:
+        ctx: The FastMCP context.
+        name_filter: Optional substring to filter results by name.
+
+    Returns:
+        JSON string representing a list of favourite filter objects.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    try:
+        jira = await get_jira_fetcher(ctx)
+        filters = jira.get_favourite_filters()
+    except (MCPAtlassianAuthenticationError, HTTPError, OSError, ValueError) as e:
+        error_message = ""
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            error_message = f"Configuration Error: {str(e)}"
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+        }
+        logger.log(log_level, f"get_favourite_filters failed: {error_message}")
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    result = [jira_filter.to_simplified_dict() for jira_filter in filters]
+    if name_filter:
+        name_lower = name_filter.lower()
+        result = [f for f in result if name_lower in f.get("name", "").lower()]
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get Filter By ID", "readOnlyHint": True},
+)
+async def get_filter_by_id(
+    ctx: Context,
+    filter_id: Annotated[
+        str,
+        Field(
+            description="The ID of the Jira filter to retrieve (e.g., '10001')",
+        ),
+    ],
+) -> str:
+    """Get a specific Jira saved filter by its ID.
+
+    Args:
+        ctx: The FastMCP context.
+        filter_id: The ID of the filter.
+
+    Returns:
+        JSON string representing the filter object.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    try:
+        jira = await get_jira_fetcher(ctx)
+        jira_filter = jira.get_filter_by_id(filter_id)
+    except (MCPAtlassianAuthenticationError, HTTPError, OSError, ValueError) as e:
+        error_message = ""
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        elif isinstance(e, ValueError):
+            log_level = logging.WARNING
+            error_message = str(e)
+
+        error_result = {
+            "success": False,
+            "error": error_message,
+            "filter_id": filter_id,
+        }
+        logger.log(
+            log_level,
+            f"get_filter_by_id failed for '{filter_id}': {error_message}",
+        )
+        return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+    result = jira_filter.to_simplified_dict()
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_projects"},
     annotations={"title": "Search Projects", "readOnlyHint": True},
 )

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -100,6 +100,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_filters": ToolsetDefinition(
+        name="jira_filters",
+        description="Saved filter operations (my filters, favourites, filter by ID)",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (6) ---

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -105,6 +105,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Project epic hierarchy and cross-project dependencies",
         default=False,
     ),
+    "jira_filters": ToolsetDefinition(
+        name="jira_filters",
+        description="Saved filter operations (my filters, favourites, filter by ID)",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (8) ---

--- a/tests/unit/jira/test_filters.py
+++ b/tests/unit/jira/test_filters.py
@@ -9,7 +9,6 @@ from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.jira.filters import FiltersMixin
 from mcp_atlassian.models.jira.filter import JiraFilter
 
-
 MOCK_FILTER_RESPONSE = {
     "id": "10001",
     "name": "My Open Bugs",
@@ -81,7 +80,10 @@ class TestFiltersMixin:
         assert f.id == "10001"
         assert f.name == "My Open Bugs"
         assert f.description == "All open bugs assigned to me"
-        assert f.jql == "assignee = currentUser() AND type = Bug AND statusCategory != Done"
+        assert (
+            f.jql
+            == "assignee = currentUser() AND type = Bug AND statusCategory != Done"
+        )
         assert f.favourite is True
         assert f.owner is not None
         assert f.owner.display_name == "Test User"
@@ -131,9 +133,7 @@ class TestFiltersMixin:
         assert result.id == "10001"
         assert result.name == "My Open Bugs"
 
-    def test_get_filter_by_id_calls_correct_endpoint(
-        self, filters_mixin: FiltersMixin
-    ):
+    def test_get_filter_by_id_calls_correct_endpoint(self, filters_mixin: FiltersMixin):
         """Test that get_filter_by_id calls the correct REST API endpoint."""
         filters_mixin.jira.get = MagicMock(return_value=MOCK_FILTER_RESPONSE)
 
@@ -212,7 +212,10 @@ class TestJiraFilterModel:
 
         assert d["id"] == "10001"
         assert d["name"] == "My Open Bugs"
-        assert d["jql"] == "assignee = currentUser() AND type = Bug AND statusCategory != Done"
+        assert (
+            d["jql"]
+            == "assignee = currentUser() AND type = Bug AND statusCategory != Done"
+        )
         assert d["favourite"] is True
         assert "description" in d
         assert "owner" in d

--- a/tests/unit/jira/test_filters.py
+++ b/tests/unit/jira/test_filters.py
@@ -1,0 +1,227 @@
+"""Tests for the Jira Filters mixin."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.filters import FiltersMixin
+from mcp_atlassian.models.jira.filter import JiraFilter
+
+
+MOCK_FILTER_RESPONSE = {
+    "id": "10001",
+    "name": "My Open Bugs",
+    "description": "All open bugs assigned to me",
+    "jql": "assignee = currentUser() AND type = Bug AND statusCategory != Done",
+    "owner": {
+        "accountId": "test-account-id",
+        "displayName": "Test User",
+        "emailAddress": "test@example.com",
+        "active": True,
+    },
+    "self": "https://example.atlassian.net/rest/api/2/filter/10001",
+    "favourite": True,
+}
+
+MOCK_FILTER_RESPONSE_2 = {
+    "id": "10002",
+    "name": "Sprint Backlog",
+    "description": None,
+    "jql": "project = TEST AND sprint in openSprints()",
+    "owner": {
+        "accountId": "test-account-id",
+        "displayName": "Test User",
+    },
+    "self": "https://example.atlassian.net/rest/api/2/filter/10002",
+    "favourite": False,
+}
+
+
+class TestFiltersMixin:
+    """Tests for the FiltersMixin class."""
+
+    @pytest.fixture
+    def filters_mixin(self, jira_fetcher: JiraFetcher) -> FiltersMixin:
+        """Create a FiltersMixin instance with mocked dependencies."""
+        mixin = jira_fetcher
+        mixin.config = MagicMock()
+        mixin.config.is_cloud = True
+        mixin.config.url = "https://example.atlassian.net"
+        return mixin
+
+    def test_get_my_filters_returns_list(self, filters_mixin: FiltersMixin):
+        """Test that get_my_filters returns a list of JiraFilter objects."""
+        filters_mixin.jira.get = MagicMock(
+            return_value=[MOCK_FILTER_RESPONSE, MOCK_FILTER_RESPONSE_2]
+        )
+
+        result = filters_mixin.get_my_filters()
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(f, JiraFilter) for f in result)
+
+    def test_get_my_filters_calls_correct_endpoint(self, filters_mixin: FiltersMixin):
+        """Test that get_my_filters calls the correct REST API endpoint."""
+        filters_mixin.jira.get = MagicMock(return_value=[])
+
+        filters_mixin.get_my_filters()
+
+        filters_mixin.jira.get.assert_called_once_with("rest/api/2/filter/my")
+
+    def test_get_my_filters_parses_fields_correctly(self, filters_mixin: FiltersMixin):
+        """Test that filter fields are correctly parsed."""
+        filters_mixin.jira.get = MagicMock(return_value=[MOCK_FILTER_RESPONSE])
+
+        result = filters_mixin.get_my_filters()
+
+        f = result[0]
+        assert f.id == "10001"
+        assert f.name == "My Open Bugs"
+        assert f.description == "All open bugs assigned to me"
+        assert f.jql == "assignee = currentUser() AND type = Bug AND statusCategory != Done"
+        assert f.favourite is True
+        assert f.owner is not None
+        assert f.owner.display_name == "Test User"
+
+    def test_get_my_filters_empty_response(self, filters_mixin: FiltersMixin):
+        """Test that get_my_filters handles empty response."""
+        filters_mixin.jira.get = MagicMock(return_value=[])
+
+        result = filters_mixin.get_my_filters()
+
+        assert result == []
+
+    def test_get_my_filters_unexpected_response_type(self, filters_mixin: FiltersMixin):
+        """Test that get_my_filters raises TypeError for non-list response."""
+        filters_mixin.jira.get = MagicMock(return_value="unexpected")
+
+        with pytest.raises(TypeError):
+            filters_mixin.get_my_filters()
+
+    def test_get_favourite_filters_returns_list(self, filters_mixin: FiltersMixin):
+        """Test that get_favourite_filters returns a list of JiraFilter objects."""
+        filters_mixin.jira.get = MagicMock(return_value=[MOCK_FILTER_RESPONSE])
+
+        result = filters_mixin.get_favourite_filters()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].favourite is True
+
+    def test_get_favourite_filters_calls_correct_endpoint(
+        self, filters_mixin: FiltersMixin
+    ):
+        """Test that get_favourite_filters calls the correct REST API endpoint."""
+        filters_mixin.jira.get = MagicMock(return_value=[])
+
+        filters_mixin.get_favourite_filters()
+
+        filters_mixin.jira.get.assert_called_once_with("rest/api/2/filter/favourite")
+
+    def test_get_filter_by_id_returns_filter(self, filters_mixin: FiltersMixin):
+        """Test that get_filter_by_id returns a JiraFilter object."""
+        filters_mixin.jira.get = MagicMock(return_value=MOCK_FILTER_RESPONSE)
+
+        result = filters_mixin.get_filter_by_id("10001")
+
+        assert isinstance(result, JiraFilter)
+        assert result.id == "10001"
+        assert result.name == "My Open Bugs"
+
+    def test_get_filter_by_id_calls_correct_endpoint(
+        self, filters_mixin: FiltersMixin
+    ):
+        """Test that get_filter_by_id calls the correct REST API endpoint."""
+        filters_mixin.jira.get = MagicMock(return_value=MOCK_FILTER_RESPONSE)
+
+        filters_mixin.get_filter_by_id("10001")
+
+        filters_mixin.jira.get.assert_called_once_with("rest/api/2/filter/10001")
+
+    def test_get_filter_by_id_not_found(self, filters_mixin: FiltersMixin):
+        """Test that get_filter_by_id raises ValueError for 404 response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        http_error = requests.exceptions.HTTPError(response=mock_response)
+        filters_mixin.jira.get = MagicMock(side_effect=http_error)
+
+        with pytest.raises(ValueError, match="not found"):
+            filters_mixin.get_filter_by_id("99999")
+
+    def test_get_filter_by_id_unexpected_response_type(
+        self, filters_mixin: FiltersMixin
+    ):
+        """Test that get_filter_by_id raises TypeError for non-dict response."""
+        filters_mixin.jira.get = MagicMock(return_value="unexpected")
+
+        with pytest.raises(TypeError):
+            filters_mixin.get_filter_by_id("10001")
+
+
+class TestJiraFilterModel:
+    """Tests for the JiraFilter model."""
+
+    def test_from_api_response_full(self):
+        """Test creating a JiraFilter from a full API response."""
+        f = JiraFilter.from_api_response(MOCK_FILTER_RESPONSE)
+
+        assert f.id == "10001"
+        assert f.name == "My Open Bugs"
+        assert f.description == "All open bugs assigned to me"
+        assert f.favourite is True
+        assert f.owner is not None
+        assert f.owner.display_name == "Test User"
+
+    def test_from_api_response_minimal(self):
+        """Test creating a JiraFilter from a minimal API response."""
+        data = {"id": "10003", "name": "Simple Filter", "jql": "project = TEST"}
+        f = JiraFilter.from_api_response(data)
+
+        assert f.id == "10003"
+        assert f.name == "Simple Filter"
+        assert f.jql == "project = TEST"
+        assert f.description is None
+        assert f.owner is None
+        assert f.favourite is False
+
+    def test_from_api_response_empty(self):
+        """Test creating a JiraFilter from an empty dict."""
+        f = JiraFilter.from_api_response({})
+        assert f.id == ""
+        assert f.name == ""
+
+    def test_from_api_response_none(self):
+        """Test creating a JiraFilter from None."""
+        f = JiraFilter.from_api_response(None)
+        assert f.id == ""
+        assert f.name == ""
+
+    def test_from_api_response_non_dict(self):
+        """Test creating a JiraFilter from non-dict data."""
+        f = JiraFilter.from_api_response("not a dict")
+        assert f.id == ""
+        assert f.name == ""
+
+    def test_to_simplified_dict(self):
+        """Test converting a JiraFilter to a simplified dict."""
+        f = JiraFilter.from_api_response(MOCK_FILTER_RESPONSE)
+        d = f.to_simplified_dict()
+
+        assert d["id"] == "10001"
+        assert d["name"] == "My Open Bugs"
+        assert d["jql"] == "assignee = currentUser() AND type = Bug AND statusCategory != Done"
+        assert d["favourite"] is True
+        assert "description" in d
+        assert "owner" in d
+
+    def test_to_simplified_dict_no_optional_fields(self):
+        """Test that optional fields are excluded when not present."""
+        data = {"id": "10003", "name": "Simple", "jql": "project = TEST"}
+        f = JiraFilter.from_api_response(data)
+        d = f.to_simplified_dict()
+
+        assert "description" not in d
+        assert "owner" not in d

--- a/tests/unit/jira/test_filters.py
+++ b/tests/unit/jira/test_filters.py
@@ -70,6 +70,16 @@ class TestFiltersMixin:
 
         filters_mixin.jira.get.assert_called_once_with("rest/api/2/filter/my")
 
+    def test_get_my_filters_rejects_server_dc(self, filters_mixin: FiltersMixin):
+        """Test that the Cloud-only endpoint is not called on Server/DC."""
+        filters_mixin.config.is_cloud = False
+        filters_mixin.jira.get = MagicMock()
+
+        with pytest.raises(ValueError, match="only supported on Jira Cloud"):
+            filters_mixin.get_my_filters()
+
+        filters_mixin.jira.get.assert_not_called()
+
     def test_get_my_filters_parses_fields_correctly(self, filters_mixin: FiltersMixin):
         """Test that filter fields are correctly parsed."""
         filters_mixin.jira.get = MagicMock(return_value=[MOCK_FILTER_RESPONSE])

--- a/tests/unit/jira/test_filters.py
+++ b/tests/unit/jira/test_filters.py
@@ -205,6 +205,14 @@ class TestJiraFilterModel:
         assert f.id == ""
         assert f.name == ""
 
+    def test_from_api_response_null_required_fields(self):
+        """Test null required fields fall back to empty strings."""
+        f = JiraFilter.from_api_response({"id": None, "name": None, "jql": None})
+
+        assert f.id == ""
+        assert f.name == ""
+        assert f.jql == ""
+
     def test_to_simplified_dict(self):
         """Test converting a JiraFilter to a simplified dict."""
         f = JiraFilter.from_api_response(MOCK_FILTER_RESPONSE)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -470,10 +470,13 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         get_all_projects,
         get_board_issues,
         get_create_fields,
+        get_favourite_filters,
         get_field_options,
+        get_filter_by_id,
         get_issue,
         get_issue_images,
         get_link_types,
+        get_my_filters,
         get_project_components,
         get_project_fields,
         get_project_issue_types,
@@ -513,6 +516,9 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(get_project_issue_types)
     jira_sub_mcp.add_tool(get_create_fields)
     jira_sub_mcp.add_tool(get_all_projects)
+    jira_sub_mcp.add_tool(get_my_filters)
+    jira_sub_mcp.add_tool(get_favourite_filters)
+    jira_sub_mcp.add_tool(get_filter_by_id)
     jira_sub_mcp.add_tool(search_projects)
     jira_sub_mcp.add_tool(get_service_desk_for_project)
     jira_sub_mcp.add_tool(get_service_desk_queues)
@@ -1318,6 +1324,74 @@ async def test_get_project_components_tool(jira_client, mock_jira_fetcher):
     assert len(data) == 2
     assert data[0]["id"] == "10000"
     assert data[0]["name"] == "Backend"
+
+
+@pytest.mark.anyio
+async def test_get_my_filters_tool_filters_by_name(jira_client, mock_jira_fetcher):
+    """Test the saved-filter tool returns simplified, name-filtered results."""
+    first_filter = MagicMock()
+    first_filter.to_simplified_dict.return_value = {
+        "id": "10001",
+        "name": "My Open Bugs",
+        "jql": "assignee = currentUser()",
+        "favourite": True,
+    }
+    second_filter = MagicMock()
+    second_filter.to_simplified_dict.return_value = {
+        "id": "10002",
+        "name": "Sprint Backlog",
+        "jql": "sprint in openSprints()",
+        "favourite": False,
+    }
+    mock_jira_fetcher.get_my_filters.return_value = [first_filter, second_filter]
+
+    response = await jira_client.call_tool(
+        "jira_get_my_filters",
+        {"name_filter": "open bugs"},
+    )
+
+    data = json.loads(response.content[0].text)
+    assert data == [first_filter.to_simplified_dict.return_value]
+    mock_jira_fetcher.get_my_filters.assert_called_once_with()
+
+
+@pytest.mark.anyio
+async def test_get_favourite_filters_tool(jira_client, mock_jira_fetcher):
+    """Test the favourite-filter tool returns simplified filters."""
+    favourite_filter = MagicMock()
+    favourite_filter.to_simplified_dict.return_value = {
+        "id": "10001",
+        "name": "My Open Bugs",
+        "jql": "assignee = currentUser()",
+        "favourite": True,
+    }
+    mock_jira_fetcher.get_favourite_filters.return_value = [favourite_filter]
+
+    response = await jira_client.call_tool("jira_get_favourite_filters", {})
+
+    data = json.loads(response.content[0].text)
+    assert data == [favourite_filter.to_simplified_dict.return_value]
+    mock_jira_fetcher.get_favourite_filters.assert_called_once_with()
+
+
+@pytest.mark.anyio
+async def test_get_filter_by_id_tool_handles_not_found(jira_client, mock_jira_fetcher):
+    """Test the filter-by-ID tool converts a missing filter into an error result."""
+    mock_jira_fetcher.get_filter_by_id.side_effect = ValueError(
+        "Filter with ID '99999' not found."
+    )
+
+    response = await jira_client.call_tool(
+        "jira_get_filter_by_id",
+        {"filter_id": "99999"},
+    )
+
+    data = json.loads(response.content[0].text)
+    assert data == {
+        "success": False,
+        "error": "Filter with ID '99999' not found.",
+        "filter_id": "99999",
+    }
 
 
 @pytest.mark.anyio

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -39,7 +39,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -92,13 +92,13 @@ class TestGetEnabledToolsets:
 
     def test_all_toolsets_count(self):
         """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        assert len(ALL_TOOLSETS) == 22
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 16
         assert len(confluence_toolsets) == 6
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 52, f"Expected 52 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -39,7 +39,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 24
+        assert len(result) == 25
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 24
+        assert len(result) == 25
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 24 entries."""
-        assert len(ALL_TOOLSETS) == 24
+        """Verify ALL_TOOLSETS has exactly 25 entries."""
+        assert len(ALL_TOOLSETS) == 25
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 16
+        assert len(jira_toolsets) == 17
         assert len(confluence_toolsets) == 8
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 63, f"Expected 63 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 66, f"Expected 66 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Description

Add support for retrieving Jira saved filters via new MCP tools. Users currently have no way to list or inspect their saved Jira filters through the MCP interface — this fills that gap.

## Changes

- Add `JiraFilter` Pydantic model with API parsing and simplified serialization
- Add `FiltersMixin` with methods for owned filters, favourite filters, and filter lookup by ID
- Register three read-only MCP tools: `get_my_filters`, `get_favourite_filters`, and `get_filter_by_id`
- Add the `jira_filters` toolset and wire the mixin into `JiraFetcher`
- Handle null required fields safely and cover MCP tool behavior with regression tests

## Testing

- [x] Unit tests: 3,297 passed, 5 skipped
- [x] Focused saved-filter/server/toolset tests: 185 passed
- [x] Integration suite collected: 23 environment-gated tests skipped
- [x] Jira Cloud e2e: 89 passed, 15 skipped
- [x] Jira Data Center e2e: 99 passed, 105 skipped
- [x] Pre-commit hooks: passed

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added/updated for changes
- [x] Unit and live compatibility verification passed
- [x] Contributor credit preserved