### PR TITLE
Normalize mcp tool annotations

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -464,7 +464,7 @@ async def get_labels(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_labels"},
-    annotations={"title": "Add Label", "destructiveHint": True},
+    annotations={"title": "Add Label", "destructiveHint": False},
 )
 @check_write_access
 async def add_label(
@@ -517,7 +517,7 @@ async def add_label(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_pages"},
-    annotations={"title": "Create Page", "destructiveHint": True},
+    annotations={"title": "Create Page", "destructiveHint": False},
 )
 @check_write_access
 async def create_page(
@@ -871,7 +871,7 @@ async def move_page(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_comments"},
-    annotations={"title": "Add Comment", "destructiveHint": True},
+    annotations={"title": "Add Comment", "destructiveHint": False},
 )
 @check_write_access
 async def add_comment(
@@ -922,7 +922,7 @@ async def add_comment(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_comments"},
-    annotations={"title": "Reply to Comment", "destructiveHint": True},
+    annotations={"title": "Reply to Comment", "destructiveHint": False},
 )
 @check_write_access
 async def reply_to_comment(

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -464,7 +464,7 @@ async def get_labels(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_labels"},
-    annotations={"title": "Add Label", "destructiveHint": False},
+    annotations={"title": "Add Label", "readOnlyHint": False},
 )
 @check_write_access
 async def add_label(
@@ -517,7 +517,7 @@ async def add_label(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_pages"},
-    annotations={"title": "Create Page", "destructiveHint": False},
+    annotations={"title": "Create Page", "readOnlyHint": False},
 )
 @check_write_access
 async def create_page(
@@ -871,7 +871,7 @@ async def move_page(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_comments"},
-    annotations={"title": "Add Comment", "destructiveHint": False},
+    annotations={"title": "Add Comment", "readOnlyHint": False},
 )
 @check_write_access
 async def add_comment(
@@ -922,7 +922,7 @@ async def add_comment(
 
 @confluence_mcp.tool(
     tags={"confluence", "write", "toolset:confluence_comments"},
-    annotations={"title": "Reply to Comment", "destructiveHint": False},
+    annotations={"title": "Reply to Comment", "readOnlyHint": False},
 )
 @check_write_access
 async def reply_to_comment(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -199,7 +199,7 @@ async def get_issue_watchers(
     tags={"jira", "write", "toolset:jira_watchers"},
     annotations={
         "title": "Add Issue Watcher",
-        "readOnlyHint": False,
+        "destructiveHint": False,
     },
 )
 @check_write_access
@@ -244,7 +244,7 @@ async def add_watcher(
     tags={"jira", "write", "toolset:jira_watchers"},
     annotations={
         "title": "Remove Issue Watcher",
-        "readOnlyHint": False,
+        "destructiveHint": True,
     },
 )
 @check_write_access
@@ -1302,7 +1302,7 @@ async def get_link_types(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_issues"},
-    annotations={"title": "Create Issue", "destructiveHint": True},
+    annotations={"title": "Create Issue", "destructiveHint": False},
 )
 @check_write_access
 async def create_issue(
@@ -1410,7 +1410,7 @@ async def create_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_issues"},
-    annotations={"title": "Batch Create Issues", "destructiveHint": True},
+    annotations={"title": "Batch Create Issues", "destructiveHint": False},
 )
 @check_write_access
 async def batch_create_issues(
@@ -1726,7 +1726,7 @@ async def delete_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_comments"},
-    annotations={"title": "Add Comment", "destructiveHint": True},
+    annotations={"title": "Add Comment", "destructiveHint": False},
 )
 @check_write_access
 async def add_comment(
@@ -1830,7 +1830,7 @@ async def edit_comment(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_worklog"},
-    annotations={"title": "Add Worklog", "destructiveHint": True},
+    annotations={"title": "Add Worklog", "destructiveHint": False},
 )
 @check_write_access
 async def add_worklog(
@@ -1950,7 +1950,7 @@ async def link_to_epic(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_links"},
-    annotations={"title": "Create Issue Link", "destructiveHint": True},
+    annotations={"title": "Create Issue Link", "destructiveHint": False},
 )
 @check_write_access
 async def create_issue_link(
@@ -2034,7 +2034,7 @@ async def create_issue_link(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_links"},
-    annotations={"title": "Create Remote Issue Link", "destructiveHint": True},
+    annotations={"title": "Create Remote Issue Link", "destructiveHint": False},
 )
 @check_write_access
 async def create_remote_issue_link(
@@ -2231,7 +2231,7 @@ async def transition_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_agile"},
-    annotations={"title": "Create Sprint", "destructiveHint": True},
+    annotations={"title": "Create Sprint", "destructiveHint": False},
 )
 @check_write_access
 async def create_sprint(
@@ -2338,7 +2338,7 @@ async def update_sprint(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_agile"},
-    annotations={"title": "Add Issues to Sprint", "readOnlyHint": False},
+    annotations={"title": "Add Issues to Sprint", "destructiveHint": True},
 )
 @check_write_access
 async def add_issues_to_sprint(
@@ -2621,7 +2621,7 @@ async def get_queue_issues(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_projects"},
-    annotations={"title": "Create Version", "destructiveHint": True},
+    annotations={"title": "Create Version", "destructiveHint": False},
 )
 @check_write_access
 async def create_version(
@@ -2679,7 +2679,7 @@ async def create_version(
 @jira_mcp.tool(
     name="batch_create_versions",
     tags={"jira", "write", "toolset:jira_projects"},
-    annotations={"title": "Batch Create Versions", "destructiveHint": True},
+    annotations={"title": "Batch Create Versions", "destructiveHint": False},
 )
 @check_write_access
 async def batch_create_versions(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -245,6 +245,7 @@ async def add_watcher(
     annotations={
         "title": "Remove Issue Watcher",
         "destructiveHint": True,
+        "readOnlyHint": False,
     },
 )
 @check_write_access

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -199,7 +199,7 @@ async def get_issue_watchers(
     tags={"jira", "write", "toolset:jira_watchers"},
     annotations={
         "title": "Add Issue Watcher",
-        "destructiveHint": False,
+        "readOnlyHint": False,
     },
 )
 @check_write_access
@@ -1302,7 +1302,7 @@ async def get_link_types(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_issues"},
-    annotations={"title": "Create Issue", "destructiveHint": False},
+    annotations={"title": "Create Issue", "readOnlyHint": False},
 )
 @check_write_access
 async def create_issue(
@@ -1410,7 +1410,7 @@ async def create_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_issues"},
-    annotations={"title": "Batch Create Issues", "destructiveHint": False},
+    annotations={"title": "Batch Create Issues", "readOnlyHint": False},
 )
 @check_write_access
 async def batch_create_issues(
@@ -1726,7 +1726,7 @@ async def delete_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_comments"},
-    annotations={"title": "Add Comment", "destructiveHint": False},
+    annotations={"title": "Add Comment", "readOnlyHint": False},
 )
 @check_write_access
 async def add_comment(
@@ -1830,7 +1830,7 @@ async def edit_comment(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_worklog"},
-    annotations={"title": "Add Worklog", "destructiveHint": False},
+    annotations={"title": "Add Worklog", "readOnlyHint": False},
 )
 @check_write_access
 async def add_worklog(
@@ -1950,7 +1950,7 @@ async def link_to_epic(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_links"},
-    annotations={"title": "Create Issue Link", "destructiveHint": False},
+    annotations={"title": "Create Issue Link", "readOnlyHint": False},
 )
 @check_write_access
 async def create_issue_link(
@@ -2034,7 +2034,7 @@ async def create_issue_link(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_links"},
-    annotations={"title": "Create Remote Issue Link", "destructiveHint": False},
+    annotations={"title": "Create Remote Issue Link", "readOnlyHint": False},
 )
 @check_write_access
 async def create_remote_issue_link(
@@ -2231,7 +2231,7 @@ async def transition_issue(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_agile"},
-    annotations={"title": "Create Sprint", "destructiveHint": False},
+    annotations={"title": "Create Sprint", "readOnlyHint": False},
 )
 @check_write_access
 async def create_sprint(
@@ -2338,7 +2338,7 @@ async def update_sprint(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_agile"},
-    annotations={"title": "Add Issues to Sprint", "destructiveHint": True},
+    annotations={"title": "Add Issues to Sprint", "readOnlyHint": False},
 )
 @check_write_access
 async def add_issues_to_sprint(
@@ -2621,7 +2621,7 @@ async def get_queue_issues(
 
 @jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_projects"},
-    annotations={"title": "Create Version", "destructiveHint": False},
+    annotations={"title": "Create Version", "readOnlyHint": False},
 )
 @check_write_access
 async def create_version(
@@ -2679,7 +2679,7 @@ async def create_version(
 @jira_mcp.tool(
     name="batch_create_versions",
     tags={"jira", "write", "toolset:jira_projects"},
-    annotations={"title": "Batch Create Versions", "destructiveHint": False},
+    annotations={"title": "Batch Create Versions", "readOnlyHint": False},
 )
 @check_write_access
 async def batch_create_versions(


### PR DESCRIPTION
## Description

This PR aligns tool annotations with operation semantics across Atlassian MCP tool definitions: read operations are explicitly marked read-only, and write operations are classified as destructive vs non-destructive based on whether they mutate existing state.

## Changes

- **Hint model consistency**
  - Standardized write-tool annotations to use `destructiveHint` (removed write-tool use of `readOnlyHint: False`).
  - Kept read tools on `readOnlyHint: true`.

- **Non-destructive write reclassification**
  - Set `destructiveHint: false` for additive operations (e.g., create/add/link flows that do not delete or overwrite existing entities).
  - Example updates include Jira `create_issue`, `batch_create_issues`, `add_comment`, `add_worklog`, `create_issue_link`, `create_remote_issue_link`, `create_sprint`, `create_version`, and Confluence `add_label`, `create_page`, `add_comment`, `reply_to_comment`.

- **Destructive write preservation**
  - Retained `destructiveHint: true` for operations that remove or modify existing state (e.g., delete/update/remove transitions), including `remove_watcher` and sprint issue reassignment semantics.

```python
# Before (write tool)
annotations={"title": "Add Comment", "destructiveHint": True}

# After (additive write tool)
annotations={"title": "Add Comment", "destructiveHint": False}
```