### PR TITLE
feat(jira): support ADF mention nodes in Markdown-to-ADF conversion

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -14,7 +14,7 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
     """Parse inline Markdown formatting into ADF inline nodes.
 
     Handles: bold (**), italic (*), inline code (`), links ([text](url)),
-    and strikethrough (~~).
+    strikethrough (~~), and mentions (@[Display Name](account:ACCOUNT_ID)).
 
     Args:
         text: Raw text potentially containing inline Markdown formatting.
@@ -26,11 +26,13 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
         return []
 
     nodes: list[dict[str, Any]] = []
-    # Pattern order matters: bold before italic, code before others
+    # Pattern order matters: mentions before links, bold before italic,
+    # code before others
     inline_re = re.compile(
         r"`(?P<code_inner>[^`]+)`"
         r"|\*\*(?P<bold_inner>.+?)\*\*"
         r"|~~(?P<strike_inner>.+?)~~"
+        r"|@\[(?P<mention_text>[^\]]+)\]\(account:(?P<mention_id>[^)]+)\)"
         r"|\[(?P<link_text>[^\]]+)\]\((?P<link_href>[^)]+)\)"
         r"|(?<!\*)\*(?!\*)(?P<italic_inner>.+?)(?<!\*)\*(?!\*)"
     )
@@ -65,6 +67,16 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
                     "type": "text",
                     "text": m.group("strike_inner"),
                     "marks": [{"type": "strike"}],
+                }
+            )
+        elif m.group("mention_text") is not None:
+            nodes.append(
+                {
+                    "type": "mention",
+                    "attrs": {
+                        "id": m.group("mention_id"),
+                        "text": "@" + m.group("mention_text"),
+                    },
                 }
             )
         elif m.group("link_text") is not None:

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -416,6 +416,48 @@ class TestMarkdownToAdf:
         assert len(strike_nodes) >= 1
         assert strike_nodes[0]["text"] == "strike"
 
+    # -- Mentions -----------------------------------------------------------
+
+    def test_mention(self):
+        """@[Name](account:id) produces an ADF mention node."""
+        result = markdown_to_adf(
+            "@[Paolo Marin](account:712020:4d76585b-d13b-4869-9da2-b8ce71969b9f)"
+        )
+        para = result["content"][0]
+        mention_nodes = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mention_nodes) == 1
+        assert mention_nodes[0]["attrs"]["id"] == "712020:4d76585b-d13b-4869-9da2-b8ce71969b9f"
+        assert mention_nodes[0]["attrs"]["text"] == "@Paolo Marin"
+
+    def test_mention_with_surrounding_text(self):
+        """Mention embedded in a sentence preserves surrounding text."""
+        result = markdown_to_adf(
+            "Hey @[John Doe](account:123:abc) check this"
+        )
+        para = result["content"][0]
+        types = [n["type"] for n in para["content"]]
+        assert "text" in types
+        assert "mention" in types
+        mention = next(n for n in para["content"] if n["type"] == "mention")
+        assert mention["attrs"]["id"] == "123:abc"
+        assert mention["attrs"]["text"] == "@John Doe"
+
+    def test_mention_does_not_match_regular_link(self):
+        """Regular links without @ prefix are not treated as mentions."""
+        result = markdown_to_adf("[click](https://example.com)")
+        para = result["content"][0]
+        mention_nodes = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mention_nodes) == 0
+
+    def test_mention_roundtrip(self):
+        """markdown_to_adf → adf_to_text preserves mention text."""
+        md = "Hello @[Jane](account:456:def) goodbye"
+        adf = markdown_to_adf(md)
+        text_back = adf_to_text(adf) or ""
+        assert "@Jane" in text_back
+        assert "Hello" in text_back
+        assert "goodbye" in text_back
+
     # -- Links --------------------------------------------------------------
 
     def test_link(self):


### PR DESCRIPTION
## Summary

- Adds inline mention syntax `@[Display Name](account:ACCOUNT_ID)` to the Markdown-to-ADF converter
- Produces proper ADF `mention` nodes with `id` and `text` attrs, so Jira Cloud renders clickable mentions with notifications
- Mention pattern is matched before links to avoid ambiguity (`@[...](...)`  vs `[...](...)`)
- 4 new unit tests covering: basic mention, mention with surrounding text, no false match on regular links, and roundtrip via `adf_to_text`
- All 75 existing + new tests pass with no regressions

## Context

Closes #1208. Previously, `@Name` and `[~accountid:xxx]` both rendered as plain text — users were not tagged and received no notifications.

## Syntax

```markdown
@[John Doe](account:123456:abcdef-1234-5678-abcd-1234567890ab)
```

Produces this ADF node:

```json
{
  "type": "mention",
  "attrs": {
    "id": "123456:abcdef-1234-5678-abcd-1234567890ab",
    "text": "@John Doe"
  }
}
```

## Test plan

- [x] Unit tests pass (`pytest tests/unit/models/test_adf.py` — 75 passed)
- [x] Live-tested on Jira Cloud — mentions render as clickable blue badges with proper notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)