### PR TITLE
feat(adf): convert bare Atlassian issue URLs to inlineCard nodes

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -14,7 +14,13 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
     """Parse inline Markdown formatting into ADF inline nodes.
 
     Handles: bold (**), italic (*), inline code (`), links ([text](url)),
-    and strikethrough (~~).
+    strikethrough (~~), and bare Atlassian issue URLs (converted to inlineCard).
+
+    A bare Atlassian issue URL (e.g. ``https://example.atlassian.net/browse/PROJ-1``)
+    is emitted as an ADF ``inlineCard`` node, which renders in JIRA Cloud as a rich
+    card showing the ticket icon, title and status badge.  A Markdown link
+    ``[PROJ-1](url)`` produces an ordinary hyperlink instead — use bare URLs when
+    the inline-card appearance is desired.
 
     Args:
         text: Raw text potentially containing inline Markdown formatting.
@@ -26,13 +32,16 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
         return []
 
     nodes: list[dict[str, Any]] = []
-    # Pattern order matters: bold before italic, code before others
+    # Pattern order matters: bold before italic, code before others.
+    # jira_card must come before the plain-text fallback so bare Atlassian issue
+    # URLs are emitted as inlineCard nodes rather than plain text.
     inline_re = re.compile(
         r"`(?P<code_inner>[^`]+)`"
         r"|\*\*(?P<bold_inner>.+?)\*\*"
         r"|~~(?P<strike_inner>.+?)~~"
         r"|\[(?P<link_text>[^\]]+)\]\((?P<link_href>[^)]+)\)"
         r"|(?<!\*)\*(?!\*)(?P<italic_inner>.+?)(?<!\*)\*(?!\*)"
+        r"|(?P<jira_card>https?://\S+/browse/[A-Z][A-Z0-9_]+-\d+\b)"
     )
 
     pos = 0
@@ -86,6 +95,13 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
                     "type": "text",
                     "text": m.group("italic_inner"),
                     "marks": [{"type": "em"}],
+                }
+            )
+        elif m.group("jira_card") is not None:
+            nodes.append(
+                {
+                    "type": "inlineCard",
+                    "attrs": {"url": m.group("jira_card")},
                 }
             )
 

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -433,6 +433,46 @@ class TestMarkdownToAdf:
         link_mark = next(m for m in link_nodes[0]["marks"] if m["type"] == "link")
         assert link_mark["attrs"]["href"] == "https://example.com"
 
+    # -- Inline cards (bare Atlassian issue URLs) ---------------------------
+
+    def test_bare_jira_url_produces_inline_card(self):
+        """A bare Atlassian browse URL becomes an inlineCard node."""
+        result = markdown_to_adf("https://example.atlassian.net/browse/PROJ-123")
+        para = result["content"][0]
+        card_nodes = [n for n in para["content"] if n["type"] == "inlineCard"]
+        assert len(card_nodes) == 1
+        assert card_nodes[0]["attrs"]["url"] == (
+            "https://example.atlassian.net/browse/PROJ-123"
+        )
+
+    def test_bare_jira_url_in_sentence(self):
+        """A bare URL embedded in prose still produces an inlineCard node."""
+        result = markdown_to_adf(
+            "See https://example.atlassian.net/browse/TIP-42 for context."
+        )
+        para = result["content"][0]
+        card_nodes = [n for n in para["content"] if n["type"] == "inlineCard"]
+        assert len(card_nodes) == 1
+        assert card_nodes[0]["attrs"]["url"] == (
+            "https://example.atlassian.net/browse/TIP-42"
+        )
+
+    def test_markdown_link_does_not_produce_inline_card(self):
+        """[text](url) with a browse URL stays a plain hyperlink, not a card."""
+        result = markdown_to_adf(
+            "[PROJ-1](https://example.atlassian.net/browse/PROJ-1)"
+        )
+        para = result["content"][0]
+        card_nodes = [n for n in para["content"] if n["type"] == "inlineCard"]
+        link_nodes = [
+            n
+            for n in para["content"]
+            if n["type"] == "text"
+            and any(m["type"] == "link" for m in n.get("marks", []))
+        ]
+        assert len(card_nodes) == 0
+        assert len(link_nodes) == 1
+
     # -- Code blocks --------------------------------------------------------
 
     def test_code_block_with_lang(self):


### PR DESCRIPTION
## Summary

When writing JIRA descriptions or comments via this MCP, cross-referencing tickets is a common need. JIRA Cloud supports two ways to render a URL:

- **Plain hyperlink** — produced by a Markdown link `[KEY-N](url)`
- **Inline card** — a rich widget showing the ticket icon, title and status badge; produced by an ADF `inlineCard` node

Before this change, bare URLs (e.g. `https://example.atlassian.net/browse/PROJ-1`) fell through to plain text — neither a hyperlink nor a card. After this change, bare Atlassian browse URLs are emitted as `inlineCard` nodes, which is the idiomatic JIRA way to cross-reference tickets.

## Changes

- `src/mcp_atlassian/models/jira/adf.py` — added `jira_card` named group to `inline_re` in `_parse_inline_formatting`; appended last so it cannot shadow existing patterns (code, bold, strike, link, italic all retain priority)
- `tests/unit/models/test_adf.py` — three new tests:
  - bare URL → `inlineCard` node
  - bare URL embedded in prose → `inlineCard` node
  - Markdown link with a browse URL → plain hyperlink (not a card)

## Behaviour

| Markdown input | ADF output |
|---|---|
| `https://host/browse/PROJ-1` | `{"type":"inlineCard","attrs":{"url":"…"}}` |
| `[PROJ-1](https://host/browse/PROJ-1)` | text node with `link` mark (unchanged) |

Only URLs matching `https?://…/browse/[A-Z][A-Z0-9_]+-\d+` are promoted to cards — generic URLs are unaffected.