### PR TITLE
feat(jira): add jira_move_issue tool for cross-project moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**80 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**81 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -3,7 +3,7 @@ title: "Tools Reference"
 description: "Overview of all 80 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **80 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **81 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -61,7 +61,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
-| `jira_issues` | Yes | `jira_get_issue`, `jira_search`, `jira_get_project_issues`, `jira_create_issue`, `jira_update_issue`, `jira_delete_issue`, `jira_batch_create_issues`, `jira_batch_get_changelogs` |
+| `jira_issues` | Yes | `jira_get_issue`, `jira_search`, `jira_get_project_issues`, `jira_create_issue`, `jira_update_issue`, `jira_delete_issue`, `jira_move_issue`, `jira_batch_create_issues`, `jira_batch_get_changelogs` |
 | `jira_fields` | Yes | `jira_search_fields`, `jira_get_field_options` |
 | `jira_comments` | Yes | `jira_add_comment`, `jira_edit_comment` |
 | `jira_transitions` | Yes | `jira_get_transitions`, `jira_transition_issue` |
@@ -93,7 +93,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (80 tools)
+# Enable all toolsets (81 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jira Issues"
-description: "Create, read, update, delete, and transition Jira issues"
+description: "Create, read, update, move, delete, and transition Jira issues"
 ---
 
 ### Get Issue
@@ -110,6 +110,31 @@ Delete an existing Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
+
+---
+
+### Move Issue
+
+Move a Jira Cloud issue to a different project.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+<Warning>
+This tool is only available for Jira Cloud. The target project must support the issue's current type. Jira may assign a new issue key in the target project.
+</Warning>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | Jira issue key to move (e.g., 'PROJ-123') |
+| `target_project_key` | `string` | Yes | Target project key (e.g., 'OTHERPROJ') |
+
+**Example:**
+
+```json
+{"issue_key": "PROJ-123", "target_project_key": "OTHERPROJ"}
+```
 
 ---
 

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1,6 +1,7 @@
 """Module for Jira issue operations."""
 
 import logging
+import time
 from collections import defaultdict
 from typing import Any
 
@@ -1314,6 +1315,138 @@ class IssuesMixin(
             msg = f"Error deleting issue {issue_key}: {str(e)}"
             logger.error(msg)
             raise Exception(msg) from e
+
+    def move_issue(self, issue_key: str, target_project_key: str) -> JiraIssue:
+        """
+        Move a Jira issue to a different project.
+
+        Uses Jira Cloud's bulk move API. The issue is assigned a new key in
+        the target project (e.g., DND-123 becomes TRAILER-456). The move is
+        processed asynchronously on Jira's side; this method polls until the
+        task completes or times out after 30 seconds.
+
+        Warning:
+            This function is only available on Jira Cloud.
+
+        Args:
+            issue_key: The key of the issue to move (e.g., 'DND-123')
+            target_project_key: The key of the target project (e.g., 'TRAILER')
+
+        Returns:
+            JiraIssue model representing the moved issue with its new key
+
+        Raises:
+            NotImplementedError: If not running on Jira Cloud
+            ValueError: If the move fails or times out
+        """
+        if not self.config.is_cloud:
+            error_msg = "Cross-project issue move is only available on Jira Cloud."
+            logger.error(error_msg)
+            raise NotImplementedError(error_msg)
+
+        if not issue_key:
+            raise ValueError("Issue key is required")
+        if not target_project_key:
+            raise ValueError("Target project key is required")
+
+        try:
+            # Submit the bulk move request
+            data: dict[str, Any] = {
+                "issues": [
+                    {
+                        "issueIdsOrKeys": [issue_key],
+                        "targetProject": {"projectKey": target_project_key},
+                    }
+                ],
+                "sendBulkNotification": False,
+            }
+
+            response = self._post_api3("issue/bulk/move", data)
+
+            if not isinstance(response, dict):
+                raise ValueError(
+                    f"Unexpected response from bulk move API: {response}"
+                )
+
+            task_id = response.get("taskId")
+            if not task_id:
+                raise ValueError(
+                    f"No task ID in bulk move response: {response}"
+                )
+
+            logger.info(
+                f"Bulk move submitted for {issue_key} → {target_project_key}, "
+                f"task ID: {task_id}"
+            )
+
+            # Poll for task completion (max 30 seconds)
+            task_url = self.jira.resource_url(f"task/{task_id}", api_version="3")
+            new_issue_key = issue_key
+
+            for attempt in range(15):
+                time.sleep(2)
+                task_response = self.jira.get(task_url)
+
+                if not isinstance(task_response, dict):
+                    logger.warning(
+                        f"Unexpected task response on attempt {attempt + 1}: "
+                        f"{type(task_response)}"
+                    )
+                    continue
+
+                status = task_response.get("status")
+                logger.info(f"Move task {task_id} status (attempt {attempt + 1}): {status}")
+
+                if status == "COMPLETE":
+                    result = task_response.get("result", {})
+                    if isinstance(result, dict):
+                        # Handle common response structures for the new issue key
+                        for item in result.get("issues", []):
+                            if isinstance(item, dict) and item.get("key"):
+                                new_issue_key = item["key"]
+                                break
+                        if new_issue_key == issue_key:
+                            for item in result.get("entities", []):
+                                if (
+                                    isinstance(item, dict)
+                                    and item.get("oldIssueKey") == issue_key
+                                ):
+                                    new_issue_key = item.get("newIssueKey", issue_key)
+                                    break
+                    logger.info(
+                        f"Issue {issue_key} moved successfully, new key: {new_issue_key}"
+                    )
+                    break
+
+                elif status == "FAILED":
+                    errors = task_response.get("errorMessages", ["Unknown error"])
+                    raise ValueError(f"Bulk move task failed: {errors}")
+
+                elif status in ("CANCELLED", "CANCEL_REQUESTED"):
+                    raise ValueError(f"Bulk move task was cancelled (status: {status})")
+
+            else:
+                raise ValueError(
+                    f"Move task timed out after 30 seconds (task ID: {task_id})"
+                )
+
+            issue_data = self.jira.get_issue(new_issue_key)
+            if not isinstance(issue_data, dict):
+                msg = f"Unexpected return value type from `jira.get_issue`: {type(issue_data)}"
+                logger.error(msg)
+                raise TypeError(msg)
+            return JiraIssue.from_api_response(issue_data)
+
+        except (ValueError, NotImplementedError, TypeError):
+            raise
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(
+                f"Error moving issue {issue_key} to project {target_project_key}: {error_msg}"
+            )
+            raise ValueError(
+                f"Failed to move issue {issue_key} to project {target_project_key}: {error_msg}"
+            ) from e
 
     def _log_available_fields(self, fields: list[dict]) -> None:
         """

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import time
 from collections import defaultdict
 from typing import Any
 
@@ -1444,6 +1445,198 @@ class IssuesMixin(
             msg = f"Error deleting issue {issue_key}: {str(e)}"
             logger.error(msg)
             raise Exception(msg) from e
+
+    def move_issue(self, issue_key: str, target_project_key: str) -> JiraIssue:
+        """
+        Move a Jira issue to a different project.
+
+        Uses Jira Cloud's bulk move API. The issue can be assigned a new key in
+        the target project (e.g., OLDPROJ-123 becomes NEWPROJ-456). The move is
+        processed asynchronously on Jira's side; this method polls until the
+        task completes or times out after 30 seconds.
+
+        Warning:
+            This function is only available on Jira Cloud.
+
+        Args:
+            issue_key: The key of the issue to move (e.g., 'PROJ-123')
+            target_project_key: The key of the target project (e.g., 'OTHERPROJ').
+                The target project must support the source issue's type.
+
+        Returns:
+            JiraIssue model representing the moved issue with its new key
+
+        Raises:
+            NotImplementedError: If not running on Jira Cloud
+            ValueError: If the move fails or times out
+        """
+        issue_key = issue_key.strip()
+        target_project_key = target_project_key.strip()
+        if not issue_key:
+            raise ValueError("Issue key is required")
+        if not target_project_key:
+            raise ValueError("Target project key is required")
+
+        if not self.config.is_cloud:
+            raise NotImplementedError(
+                "Cross-project issue move is only available on Jira Cloud."
+            )
+
+        try:
+            target_issue_type_id = self._get_target_issue_type_id(
+                issue_key, target_project_key
+            )
+
+            data: dict[str, Any] = {
+                "sendBulkNotification": False,
+                "targetToSourcesMapping": {
+                    f"{target_project_key},{target_issue_type_id}": {
+                        "inferClassificationDefaults": True,
+                        "inferFieldDefaults": True,
+                        "inferStatusDefaults": True,
+                        "inferSubtaskTypeDefault": True,
+                        "issueIdsOrKeys": [issue_key],
+                    }
+                },
+            }
+
+            response = self._post_api3("bulk/issues/move", data)
+
+            if not isinstance(response, dict):
+                raise ValueError(f"Unexpected response from bulk move API: {response}")
+
+            task_id = response.get("taskId")
+            if not task_id:
+                raise ValueError(f"No task ID in bulk move response: {response}")
+
+            logger.info(
+                f"Bulk move submitted for {issue_key} -> {target_project_key}, "
+                f"task ID: {task_id}"
+            )
+
+            task_url = self.jira.resource_url(f"bulk/queue/{task_id}", api_version="3")
+            completed_task: dict[str, Any] | None = None
+
+            for attempt in range(15):
+                task_response = self.jira.get(task_url)
+
+                if not isinstance(task_response, dict):
+                    logger.warning(
+                        f"Unexpected task response on attempt {attempt + 1}: "
+                        f"{type(task_response)}"
+                    )
+                    continue
+
+                status = task_response.get("status")
+                logger.info(
+                    f"Move task {task_id} status (attempt {attempt + 1}): {status}"
+                )
+
+                if status == "COMPLETE":
+                    completed_task = task_response
+                    break
+
+                elif status == "FAILED":
+                    errors = task_response.get("errorMessages", ["Unknown error"])
+                    raise ValueError(f"Bulk move task failed: {errors}")
+
+                elif status in ("CANCELLED", "CANCEL_REQUESTED"):
+                    raise ValueError(f"Bulk move task was cancelled (status: {status})")
+
+                if attempt < 14:
+                    time.sleep(2)
+
+            else:
+                raise ValueError(
+                    f"Move task timed out after 30 seconds (task ID: {task_id})"
+                )
+
+            if completed_task is None:
+                raise ValueError(
+                    f"Move task timed out after 30 seconds (task ID: {task_id})"
+                )
+
+            invalid_count = completed_task.get("invalidOrInaccessibleIssueCount") or 0
+            if int(invalid_count) > 0:
+                raise ValueError(
+                    "Bulk move task completed with "
+                    f"{invalid_count} invalid or inaccessible issue(s)"
+                )
+
+            processed_issues = completed_task.get("processedAccessibleIssues")
+            lookup_key = issue_key
+            if isinstance(processed_issues, list) and processed_issues:
+                lookup_key = str(processed_issues[0])
+
+            issue_data = self.jira.get_issue(lookup_key)
+            if not isinstance(issue_data, dict):
+                msg = f"Unexpected return value type from `jira.get_issue`: {type(issue_data)}"
+                logger.error(msg)
+                raise TypeError(msg)
+            return JiraIssue.from_api_response(issue_data)
+
+        except (ValueError, NotImplementedError, TypeError):
+            raise
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(
+                f"Error moving issue {issue_key} to project {target_project_key}: {error_msg}"
+            )
+            raise ValueError(
+                f"Failed to move issue {issue_key} to project {target_project_key}: {error_msg}"
+            ) from e
+
+    def _get_target_issue_type_id(self, issue_key: str, target_project_key: str) -> str:
+        """Resolve the target issue type ID for a bulk issue move.
+
+        Jira's bulk move mapping key is ``projectKey,issueTypeId``. Because the
+        public tool accepts only a target project, preserve the source issue type
+        by resolving the same type in the target project before submitting.
+        """
+        source_issue = self.jira.get_issue(issue_key, fields="issuetype")
+        if not isinstance(source_issue, dict):
+            msg = (
+                f"Unexpected return value type from `jira.get_issue`: "
+                f"{type(source_issue)}"
+            )
+            logger.error(msg)
+            raise TypeError(msg)
+
+        source_issue_type = source_issue.get("fields", {}).get("issuetype")
+        if not isinstance(source_issue_type, dict):
+            raise ValueError(f"Could not determine issue type for {issue_key}")
+
+        source_type_id = source_issue_type.get("id")
+        source_type_name = source_issue_type.get("name")
+        source_is_subtask = source_issue_type.get("subtask")
+        target_issue_types = self.get_project_issue_types(target_project_key)
+        for issue_type in target_issue_types:
+            if source_type_id and str(issue_type.get("id")) == str(source_type_id):
+                return str(issue_type["id"])
+
+        normalized_source_name = (
+            self._normalize_issue_type_name(str(source_type_name))
+            if source_type_name
+            else ""
+        )
+        for issue_type in target_issue_types:
+            type_name = str(issue_type.get("name", ""))
+            if (
+                normalized_source_name
+                and self._normalize_issue_type_name(type_name) == normalized_source_name
+                and (
+                    source_is_subtask is None
+                    or bool(issue_type.get("subtask", False)) == bool(source_is_subtask)
+                )
+            ):
+                issue_type_id = issue_type.get("id")
+                if issue_type_id:
+                    return str(issue_type_id)
+
+        raise ValueError(
+            f"Target project {target_project_key} does not support issue type "
+            f"{source_type_name or source_type_id or 'unknown'}"
+        )
 
     def _log_available_fields(self, fields: list[dict]) -> None:
         """

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -330,6 +330,10 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
             # The new createmeta endpoint returns paginated "values" array
             issue_types = meta.get("values", [])
             if not issue_types:
+                # atlassian-python-api's issue_createmeta_issuetypes endpoint
+                # returns a paginated "issueTypes" array on Jira Cloud.
+                issue_types = meta.get("issueTypes", [])
+            if not issue_types:
                 # Fallback for older response format
                 projects = meta.get("projects", [])
                 if projects and "issuetypes" in projects[0]:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1725,9 +1725,80 @@ async def delete_issue(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_issues"},
+    annotations={"title": "Move Issue to Project", "destructiveHint": True},
+)
+@check_write_access
+async def move_issue(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key to move (e.g., 'PROJ-123', 'DND-456')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    target_project_key: Annotated[
+        str,
+        Field(
+            description=(
+                "Key of the target project (e.g., 'TRAILER', 'PROJ'). "
+                "The issue will receive a new key in the target project."
+            )
+        ),
+    ],
+) -> str:
+    """Move a Jira issue to a different project (Jira Cloud only).
+
+    Uses Jira Cloud's bulk move API to perform a cross-project move.
+    The issue is assigned a new key in the target project
+    (e.g., DND-123 becomes TRAILER-456).
+
+    The move is processed asynchronously on Jira's side; this tool polls
+    until confirmed or times out after 30 seconds.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key of the issue to move.
+        target_project_key: Key of the target project.
+
+    Returns:
+        JSON string representing the moved issue with its new key and project.
+
+    Raises:
+        ValueError: If in read-only mode, Jira client unavailable, or the move fails.
+        NotImplementedError: If not running on Jira Cloud.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    try:
+        result = jira.move_issue(issue_key, target_project_key)
+        return json.dumps(
+            {
+                "message": (
+                    f"Issue moved successfully from {issue_key} "
+                    f"to project {target_project_key}"
+                ),
+                "issue": result.to_simplified_dict(),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    except NotImplementedError as e:
+        raise ValueError(str(e))
+    except Exception as e:
+        logger.error(
+            f"Error moving issue {issue_key} to project {target_project_key}: {str(e)}",
+            exc_info=True,
+        )
+        raise ValueError(f"Failed to move issue {issue_key}: {str(e)}")
+
+
+@jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_comments"},
     annotations={"title": "Add Comment", "destructiveHint": True},
 )
+
 @check_write_access
 async def add_comment(
     ctx: Context,

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1,5 +1,6 @@
 """Jira FastMCP server instance and tool definitions."""
 
+import asyncio
 import base64
 import json
 import logging
@@ -2037,6 +2038,78 @@ async def delete_issue(
     result = {"message": f"Issue {issue_key} has been deleted successfully."}
     # The underlying method raises on failure, so if we reach here, it's success.
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_issues"},
+    annotations={"title": "Move Issue to Project", "destructiveHint": True},
+)
+@check_write_access
+async def move_issue(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key to move (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    target_project_key: Annotated[
+        str,
+        Field(
+            description=(
+                "Key of the target project (e.g., 'OTHERPROJ'). "
+                "The issue will keep its current issue type and may receive "
+                "a new key in the target project."
+            ),
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+) -> str:
+    """Move a Jira issue to a different project (Jira Cloud only).
+
+    Uses Jira Cloud's bulk move API to perform a cross-project move.
+    The issue keeps its current issue type and may be assigned a new key in the
+    target project (e.g., OLDPROJ-123 becomes NEWPROJ-456).
+
+    The move is processed asynchronously on Jira's side; this tool polls
+    until confirmed or times out after 30 seconds.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key of the issue to move.
+        target_project_key: Key of the target project.
+
+    Returns:
+        JSON string representing the moved issue with its new key and project.
+
+    Raises:
+        ValueError: If in read-only mode, Jira client unavailable, or the move fails.
+        NotImplementedError: If not running on Jira Cloud.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    try:
+        result = await asyncio.to_thread(jira.move_issue, issue_key, target_project_key)
+        return json.dumps(
+            {
+                "message": (
+                    f"Issue moved successfully from {issue_key} "
+                    f"to project {target_project_key}"
+                ),
+                "issue": result.to_simplified_dict(),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    except (NotImplementedError, ValueError):
+        raise
+    except Exception as e:
+        logger.error(
+            f"Error moving issue {issue_key} to project {target_project_key}: {str(e)}",
+            exc_info=True,
+        )
+        raise ValueError(f"Failed to move issue {issue_key}: {str(e)}")
 
 
 @jira_mcp.tool(

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 80 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 81 tools into 21 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -92,6 +92,31 @@ class TestJiraCloudEpicOperations:
         assert epic.key.startswith(cloud_instance.project_key)
 
 
+class TestJiraCloudMoveOperations:
+    """Issue move operations on Cloud."""
+
+    def test_move_issue_same_project(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        issue = jira_fetcher.create_issue(
+            project_key=cloud_instance.project_key,
+            summary=f"Cloud E2E Move Test {uid}",
+            issue_type="Task",
+            description="Issue for Cloud move testing.",
+        )
+        resource_tracker.add_jira_issue(issue.key)
+
+        moved = jira_fetcher.move_issue(issue.key, cloud_instance.project_key)
+        if moved.key != issue.key:
+            resource_tracker.add_jira_issue(moved.key)
+
+        assert moved.key.startswith(cloud_instance.project_key)
+
+
 class TestJiraCloudVersionOperations:
     """Version creation and updates on Cloud."""
 

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -64,6 +64,17 @@ class TestJiraDCBehavior:
             for project in projects
         )
 
+    def test_move_issue_not_supported(
+        self,
+        jira_fetcher: JiraFetcher,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="Jira Cloud"):
+            jira_fetcher.move_issue(
+                dc_instance.test_issue_key,
+                dc_instance.project_key,
+            )
+
 
 class TestJiraDCEpicOperations:
     """Epic creation with DC custom fields."""

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -2054,3 +2054,230 @@ class TestIssuesMixin:
         assert isinstance(result, JiraIssue)
         assert result.key == "DEV-123"
         assert result.summary == "Development issue"
+
+
+class TestMoveIssue:
+    """Tests for IssuesMixin.move_issue."""
+
+    @pytest.fixture
+    def cloud_mixin(self, jira_fetcher: JiraFetcher) -> IssuesMixin:
+        """IssuesMixin wired to a Cloud instance."""
+        mixin = jira_fetcher
+        mixin.config.url = "https://test.atlassian.net"
+        return mixin
+
+    @pytest.fixture
+    def server_mixin(self, jira_fetcher: JiraFetcher) -> IssuesMixin:
+        """IssuesMixin wired to a Server/DC instance."""
+        mixin = jira_fetcher
+        mixin.config.url = "https://jira.example.com"
+        return mixin
+
+    def _task_response(
+        self,
+        status: str,
+        processed_issues: list[str] | None = None,
+        invalid_count: int = 0,
+    ) -> dict[str, Any]:
+        return {
+            "status": status,
+            "processedAccessibleIssues": processed_issues or [],
+            "invalidOrInaccessibleIssueCount": invalid_count,
+        }
+
+    def _source_issue_response(
+        self,
+        issue_type_id: str = "10000",
+        issue_type_name: str = "Task",
+        *,
+        subtask: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "fields": {
+                "issuetype": {
+                    "id": issue_type_id,
+                    "name": issue_type_name,
+                    "subtask": subtask,
+                }
+            }
+        }
+
+    def _configure_target_issue_types(
+        self,
+        cloud_mixin: IssuesMixin,
+        issue_types: list[dict[str, Any]] | None = None,
+    ) -> None:
+        cloud_mixin.jira.issue_createmeta_issuetypes = MagicMock(
+            return_value={
+                "values": issue_types
+                or [{"id": "10000", "name": "Task", "subtask": False}]
+            }
+        )
+
+    def test_move_issue_success(self, cloud_mixin: IssuesMixin, make_issue_data):
+        """Successful move returns JiraIssue with new key."""
+        self._configure_target_issue_types(
+            cloud_mixin,
+            [{"id": "10002", "name": "Task", "subtask": False}],
+        )
+        cloud_mixin._post_api3 = MagicMock(return_value={"taskId": "task-1"})
+        cloud_mixin.jira.resource_url = MagicMock(
+            return_value="https://api/bulk/queue/task-1"
+        )
+        cloud_mixin.jira.get = MagicMock(
+            return_value=self._task_response("COMPLETE", ["10050"])
+        )
+        cloud_mixin.jira.get_issue = MagicMock(
+            side_effect=[
+                self._source_issue_response(issue_type_id="10000"),
+                make_issue_data(key="DST-99", summary="Moved"),
+            ]
+        )
+
+        result = cloud_mixin.move_issue("SRC-1", "DST")
+
+        assert result.key == "DST-99"
+        cloud_mixin._post_api3.assert_called_once_with(
+            "bulk/issues/move",
+            {
+                "sendBulkNotification": False,
+                "targetToSourcesMapping": {
+                    "DST,10002": {
+                        "inferClassificationDefaults": True,
+                        "inferFieldDefaults": True,
+                        "inferStatusDefaults": True,
+                        "inferSubtaskTypeDefault": True,
+                        "issueIdsOrKeys": ["SRC-1"],
+                    }
+                },
+            },
+        )
+        cloud_mixin.jira.resource_url.assert_called_once_with(
+            "bulk/queue/task-1", api_version="3"
+        )
+        assert cloud_mixin.jira.get_issue.call_args_list[0].args == ("SRC-1",)
+        assert cloud_mixin.jira.get_issue.call_args_list[0].kwargs == {
+            "fields": "issuetype"
+        }
+        assert cloud_mixin.jira.get_issue.call_args_list[1].args == ("10050",)
+
+    def test_move_issue_not_cloud(self, server_mixin: IssuesMixin):
+        """Raises NotImplementedError on Server/DC."""
+        with pytest.raises(NotImplementedError, match="Jira Cloud"):
+            server_mixin.move_issue("SRC-1", "DST")
+
+    def test_move_issue_empty_key(self, cloud_mixin: IssuesMixin):
+        """Raises ValueError when issue_key is empty."""
+        with pytest.raises(ValueError, match="Issue key is required"):
+            cloud_mixin.move_issue("", "DST")
+
+    def test_move_issue_empty_target(self, cloud_mixin: IssuesMixin):
+        """Raises ValueError when target_project_key is empty."""
+        with pytest.raises(ValueError, match="Target project key is required"):
+            cloud_mixin.move_issue("SRC-1", "")
+
+    def test_move_issue_task_failed(self, cloud_mixin: IssuesMixin):
+        """Raises ValueError when the async task reports FAILED."""
+        self._configure_target_issue_types(cloud_mixin)
+        cloud_mixin.jira.get_issue = MagicMock(
+            return_value=self._source_issue_response()
+        )
+        cloud_mixin._post_api3 = MagicMock(return_value={"taskId": "task-1"})
+        cloud_mixin.jira.resource_url = MagicMock(
+            return_value="https://api/bulk/queue/task-1"
+        )
+        cloud_mixin.jira.get = MagicMock(
+            return_value={"status": "FAILED", "errorMessages": ["No permission"]}
+        )
+
+        with pytest.raises(ValueError, match="Bulk move task failed"):
+            cloud_mixin.move_issue("SRC-1", "DST")
+
+    def test_move_issue_task_cancelled(self, cloud_mixin: IssuesMixin):
+        """Raises ValueError when the async task is cancelled."""
+        self._configure_target_issue_types(cloud_mixin)
+        cloud_mixin.jira.get_issue = MagicMock(
+            return_value=self._source_issue_response()
+        )
+        cloud_mixin._post_api3 = MagicMock(return_value={"taskId": "task-1"})
+        cloud_mixin.jira.resource_url = MagicMock(
+            return_value="https://api/bulk/queue/task-1"
+        )
+        cloud_mixin.jira.get = MagicMock(
+            return_value={"status": "CANCELLED", "result": {}}
+        )
+
+        with pytest.raises(ValueError, match="cancelled"):
+            cloud_mixin.move_issue("SRC-1", "DST")
+
+    def test_move_issue_timeout(self, cloud_mixin: IssuesMixin):
+        """Raises ValueError after exhausting all polling attempts."""
+        self._configure_target_issue_types(cloud_mixin)
+        cloud_mixin.jira.get_issue = MagicMock(
+            return_value=self._source_issue_response()
+        )
+        cloud_mixin._post_api3 = MagicMock(return_value={"taskId": "task-1"})
+        cloud_mixin.jira.resource_url = MagicMock(
+            return_value="https://api/bulk/queue/task-1"
+        )
+        cloud_mixin.jira.get = MagicMock(return_value={"status": "IN_PROGRESS"})
+
+        with patch("mcp_atlassian.jira.issues.time.sleep"):
+            with pytest.raises(ValueError, match="timed out"):
+                cloud_mixin.move_issue("SRC-1", "DST")
+
+    def test_move_issue_target_project_without_matching_issue_type(
+        self, cloud_mixin: IssuesMixin
+    ):
+        """Raises ValueError when the target project lacks the source issue type."""
+        self._configure_target_issue_types(
+            cloud_mixin,
+            [{"id": "10002", "name": "Story", "subtask": False}],
+        )
+        cloud_mixin.jira.get_issue = MagicMock(
+            return_value=self._source_issue_response(
+                issue_type_id="10000", issue_type_name="Task"
+            )
+        )
+
+        with pytest.raises(ValueError, match="does not support issue type Task"):
+            cloud_mixin.move_issue("SRC-1", "DST")
+
+    def test_move_issue_invalid_issue_count(self, cloud_mixin: IssuesMixin):
+        """Raises ValueError when the completed task reports invalid issues."""
+        self._configure_target_issue_types(cloud_mixin)
+        cloud_mixin.jira.get_issue = MagicMock(
+            return_value=self._source_issue_response()
+        )
+        cloud_mixin._post_api3 = MagicMock(return_value={"taskId": "task-1"})
+        cloud_mixin.jira.resource_url = MagicMock(
+            return_value="https://api/bulk/queue/task-1"
+        )
+        cloud_mixin.jira.get = MagicMock(
+            return_value=self._task_response("COMPLETE", invalid_count=1)
+        )
+
+        with pytest.raises(ValueError, match="invalid or inaccessible"):
+            cloud_mixin.move_issue("SRC-1", "DST")
+
+    def test_move_issue_falls_back_to_original_key(
+        self, cloud_mixin: IssuesMixin, make_issue_data
+    ):
+        """Falls back to the original key when progress omits processed IDs."""
+        self._configure_target_issue_types(cloud_mixin)
+        cloud_mixin._post_api3 = MagicMock(return_value={"taskId": "task-1"})
+        cloud_mixin.jira.resource_url = MagicMock(
+            return_value="https://api/bulk/queue/task-1"
+        )
+        cloud_mixin.jira.get = MagicMock(return_value=self._task_response("COMPLETE"))
+        cloud_mixin.jira.get_issue = MagicMock(
+            side_effect=[
+                self._source_issue_response(),
+                make_issue_data(key="DST-99"),
+            ]
+        )
+
+        result = cloud_mixin.move_issue("SRC-1", "DST")
+
+        assert result.key == "DST-99"
+        assert cloud_mixin.jira.get_issue.call_args_list[1].args == ("SRC-1",)

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -466,6 +466,25 @@ def test_get_project_issue_types(
     )
 
 
+def test_get_project_issue_types_issue_types_format(
+    projects_mixin: ProjectsMixin, mock_issue_types: list[dict]
+):
+    """Test get_project_issue_types with Cloud issueTypes format."""
+    createmeta = {
+        "maxResults": 50,
+        "startAt": 0,
+        "total": len(mock_issue_types),
+        "issueTypes": mock_issue_types,
+    }
+    projects_mixin.jira.issue_createmeta_issuetypes.return_value = createmeta
+
+    result = projects_mixin.get_project_issue_types("PROJ1")
+    assert result == mock_issue_types
+    projects_mixin.jira.issue_createmeta_issuetypes.assert_called_once_with(
+        project="PROJ1"
+    )
+
+
 def test_get_project_issue_types_old_format(
     projects_mixin: ProjectsMixin, mock_issue_types: list[dict]
 ):

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2453,15 +2453,15 @@ async def test_jira_move_issue_success(jira_client, mock_jira_fetcher):
     """Test successful cross-project issue move."""
     response = await jira_client.call_tool(
         "jira_move_issue",
-        {"issue_key": "DND-123", "target_project_key": "TRAILER"},
+        {"issue_key": "PROJ-123", "target_project_key": "OTHER"},
     )
     content = json.loads(response.content[0].text)
     assert "moved successfully" in content["message"]
-    assert "DND-123" in content["message"]
-    assert "TRAILER" in content["message"]
-    assert content["issue"]["key"] == "TRAILER-999"
-    assert content["issue"]["project"]["key"] == "TRAILER"
-    mock_jira_fetcher.move_issue.assert_called_once_with("DND-123", "TRAILER")
+    assert "PROJ-123" in content["message"]
+    assert "OTHER" in content["message"]
+    assert content["issue"]["key"] == "OTHER-999"
+    assert content["issue"]["project"]["key"] == "OTHER"
+    mock_jira_fetcher.move_issue.assert_called_once_with("PROJ-123", "OTHER")
 
 
 @pytest.mark.anyio
@@ -2472,7 +2472,7 @@ async def test_jira_move_issue_failure(jira_client, mock_jira_fetcher):
     with pytest.raises(ToolError) as excinfo:
         await jira_client.call_tool(
             "jira_move_issue",
-            {"issue_key": "DND-123", "target_project_key": "NONEXISTENT"},
+            {"issue_key": "PROJ-123", "target_project_key": "NONEXISTENT"},
         )
     assert "Target project not found" in str(excinfo.value)
 
@@ -2487,6 +2487,6 @@ async def test_jira_move_issue_not_cloud(jira_client, mock_jira_fetcher):
     with pytest.raises(ToolError) as excinfo:
         await jira_client.call_tool(
             "jira_move_issue",
-            {"issue_key": "DND-123", "target_project_key": "TRAILER"},
+            {"issue_key": "PROJ-123", "target_project_key": "OTHER"},
         )
     assert "Jira Cloud" in str(excinfo.value)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -146,6 +146,20 @@ def mock_jira_fetcher():
 
     mock_fetcher.update_issue.side_effect = mock_update_issue
 
+    # Configure move_issue
+    def mock_move_issue(issue_key, target_project_key):
+        mock_issue = MagicMock()
+        new_key = f"{target_project_key}-999"
+        mock_issue.to_simplified_dict.return_value = {
+            "key": new_key,
+            "summary": "Moved Issue",
+            "status": {"name": "In Progress"},
+            "project": {"key": target_project_key},
+        }
+        return mock_issue
+
+    mock_fetcher.move_issue.side_effect = mock_move_issue
+
     # Configure batch_create_issues
     def mock_batch_create_issues(issues, validate_only=False):
         if not isinstance(issues, list):
@@ -411,6 +425,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         get_user_profile,
         get_worklog,
         link_to_epic,
+        move_issue,
         remove_issue_link,
         search,
         search_fields,
@@ -446,6 +461,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(batch_get_changelogs)
     jira_sub_mcp.add_tool(update_issue)
     jira_sub_mcp.add_tool(delete_issue)
+    jira_sub_mcp.add_tool(move_issue)
     jira_sub_mcp.add_tool(add_comment)
     jira_sub_mcp.add_tool(edit_comment)
     jira_sub_mcp.add_tool(add_worklog)
@@ -2430,3 +2446,47 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
     # return_limit=1 caps to first match
     assert len(result) == 1
     assert result[0] == "High"
+
+
+@pytest.mark.anyio
+async def test_jira_move_issue_success(jira_client, mock_jira_fetcher):
+    """Test successful cross-project issue move."""
+    response = await jira_client.call_tool(
+        "jira_move_issue",
+        {"issue_key": "DND-123", "target_project_key": "TRAILER"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "moved successfully" in content["message"]
+    assert "DND-123" in content["message"]
+    assert "TRAILER" in content["message"]
+    assert content["issue"]["key"] == "TRAILER-999"
+    assert content["issue"]["project"]["key"] == "TRAILER"
+    mock_jira_fetcher.move_issue.assert_called_once_with("DND-123", "TRAILER")
+
+
+@pytest.mark.anyio
+async def test_jira_move_issue_failure(jira_client, mock_jira_fetcher):
+    """Test that a move failure propagates as ToolError."""
+    mock_jira_fetcher.move_issue.side_effect = ValueError("Target project not found")
+
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_move_issue",
+            {"issue_key": "DND-123", "target_project_key": "NONEXISTENT"},
+        )
+    assert "Target project not found" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+async def test_jira_move_issue_not_cloud(jira_client, mock_jira_fetcher):
+    """Test that calling move on a Server/DC instance raises ToolError."""
+    mock_jira_fetcher.move_issue.side_effect = NotImplementedError(
+        "Cross-project issue move is only available on Jira Cloud."
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_move_issue",
+            {"issue_key": "DND-123", "target_project_key": "TRAILER"},
+        )
+    assert "Jira Cloud" in str(excinfo.value)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -170,6 +170,20 @@ def mock_jira_fetcher():
 
     mock_fetcher.assign_issue.side_effect = mock_assign_issue
 
+    # Configure move_issue
+    def mock_move_issue(issue_key: str, target_project_key: str) -> MagicMock:
+        mock_issue = MagicMock()
+        new_key = f"{target_project_key}-999"
+        mock_issue.to_simplified_dict.return_value = {
+            "key": new_key,
+            "summary": "Moved Issue",
+            "status": {"name": "In Progress"},
+            "project": {"key": target_project_key},
+        }
+        return mock_issue
+
+    mock_fetcher.move_issue.side_effect = mock_move_issue
+
     # Configure batch_create_issues
     def mock_batch_create_issues(issues, validate_only=False):
         if not isinstance(issues, list):
@@ -464,6 +478,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         get_user_profile,
         get_worklog,
         link_to_epic,
+        move_issue,
         remove_issue_link,
         search,
         search_assignable_users,
@@ -506,6 +521,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(update_issue)
     jira_sub_mcp.add_tool(assign_issue)
     jira_sub_mcp.add_tool(delete_issue)
+    jira_sub_mcp.add_tool(move_issue)
     jira_sub_mcp.add_tool(add_comment)
     jira_sub_mcp.add_tool(edit_comment)
     jira_sub_mcp.add_tool(add_worklog)
@@ -3136,3 +3152,52 @@ async def test_assign_issue_error(jira_client, mock_jira_fetcher):
             },
         )
     assert "User not found" in str(excinfo.value)
+
+
+# =============================================================================
+# move_issue tests
+# =============================================================================
+
+
+@pytest.mark.anyio
+async def test_jira_move_issue_success(jira_client, mock_jira_fetcher):
+    """Test successful cross-project issue move."""
+    response = await jira_client.call_tool(
+        "jira_move_issue",
+        {"issue_key": "PROJ-123", "target_project_key": "OTHER"},
+    )
+    content = json.loads(response.content[0].text)
+    assert "moved successfully" in content["message"]
+    assert "PROJ-123" in content["message"]
+    assert "OTHER" in content["message"]
+    assert content["issue"]["key"] == "OTHER-999"
+    assert content["issue"]["project"]["key"] == "OTHER"
+    mock_jira_fetcher.move_issue.assert_called_once_with("PROJ-123", "OTHER")
+
+
+@pytest.mark.anyio
+async def test_jira_move_issue_failure(jira_client, mock_jira_fetcher):
+    """Test that a move failure propagates as ToolError."""
+    mock_jira_fetcher.move_issue.side_effect = ValueError("Target project not found")
+
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_move_issue",
+            {"issue_key": "PROJ-123", "target_project_key": "NONEXISTENT"},
+        )
+    assert "Target project not found" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+async def test_jira_move_issue_not_cloud(jira_client, mock_jira_fetcher):
+    """Test that calling move on a Server/DC instance raises ToolError."""
+    mock_jira_fetcher.move_issue.side_effect = NotImplementedError(
+        "Cross-project issue move is only available on Jira Cloud."
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_move_issue",
+            {"issue_key": "PROJ-123", "target_project_key": "OTHER"},
+        )
+    assert "Jira Cloud" in str(excinfo.value)

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 55, f"Expected 55 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 56, f"Expected 56 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

Adds a `jira_move_issue` MCP tool that moves a Jira Cloud issue to a different project using the Jira Cloud bulk move API.

The implementation preserves the source issue type by resolving the destination issue type ID in the target project, submits Jira's documented `targetToSourcesMapping` payload to the bulk move endpoint, polls the Cloud bulk queue until completion, and then returns the moved issue. Jira may assign a new key in the target project.

The tool is Cloud-only; calling it against a Server/DC instance raises a clear `NotImplementedError`. Write access is gated via `@check_write_access` so `READ_ONLY_MODE=true` blocks it at the server level. The tool is annotated with `destructiveHint=True` to signal its irreversible nature.

## Changes

- `src/mcp_atlassian/jira/issues.py` - new `move_issue(issue_key, target_project_key)` method on `IssuesMixin`
- `src/mcp_atlassian/servers/jira.py` - new `jira_move_issue` MCP tool
- `docs/` and toolset metadata - document the new tool and update the public tool count
- Unit and e2e coverage for the Jira mixin, MCP server tool, Cloud move path, DC unsupported guard, and tool count

## Testing

- `uv run pytest tests/unit/jira/test_issues.py::TestMoveIssue tests/unit/jira/test_projects.py tests/unit/servers/test_jira_server.py::test_jira_move_issue_success tests/unit/servers/test_jira_server.py::test_jira_move_issue_failure tests/unit/servers/test_jira_server.py::test_jira_move_issue_not_cloud tests/unit/utils/test_toolsets.py::TestToolsetTagCompleteness::test_jira_tool_count -xvs` - 77 passed
- `uv run pytest tests/integration/test_real_api.py::TestRealJiraAPI -xvs` - 7 skipped; integration suite credentials were not configured
- `uv run pytest tests/e2e/cloud/test_confluence_cloud_operations.py::TestConfluenceCloudComments::test_add_and_get_inline_comments --cloud-e2e -xvs` - 1 passed after a transient Confluence 404 in the first full Cloud run
- `uv run pytest tests/e2e/cloud --cloud-e2e -xvs` - 70 passed, 15 skipped
- `uv run pytest tests/e2e/test_jira_dc_operations.py tests/e2e/test_jira_auth_matrix.py tests/e2e/test_mcp_tools_dc.py --dc-e2e -xvs` - 44 passed, 1 skipped
- `uv run pre-commit run --all-files` - passed

## Checklist

- [x] Code follows project style guidelines (linting passes)
- [x] Tests added/updated for changes
- [x] Unit, Cloud e2e, and DC e2e verification completed
