### PR TITLE
feat(confluence): add content_file to create/update page tools

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -51,13 +51,9 @@ def _resolve_page_content(content: str | None, content_file: str | None) -> str:
     has_content = content is not None and content != ""
     has_file = content_file is not None and content_file != ""
     if has_content and has_file:
-        raise ValueError(
-            "Provide either 'content' or 'content_file', not both."
-        )
+        raise ValueError("Provide either 'content' or 'content_file', not both.")
     if not has_content and not has_file:
-        raise ValueError(
-            "One of 'content' or 'content_file' must be provided."
-        )
+        raise ValueError("One of 'content' or 'content_file' must be provided.")
     if has_content:
         return content  # type: ignore[return-value]
     path = Path(content_file).expanduser()  # type: ignore[arg-type]

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import mimetypes
+from pathlib import Path
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
@@ -24,6 +25,47 @@ from mcp_atlassian.utils.media import (
 from mcp_atlassian.utils.urls import resolve_relative_url
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_page_content(content: str | None, content_file: str | None) -> str:
+    """Resolve page body from either an inline string or a file path.
+
+    Exactly one of ``content`` / ``content_file`` must be supplied. ``content_file``
+    exists so callers (especially MCP clients transporting large bodies over stdio
+    JSON) can hand off content via the filesystem instead of marshalling it as a
+    tool-call argument.
+
+    Args:
+        content: Inline page body (any supported content_format).
+        content_file: Absolute or relative filesystem path to read the body from.
+            Read as UTF-8.
+
+    Returns:
+        The resolved page body as a string.
+
+    Raises:
+        ValueError: If neither or both arguments are supplied, or if the file does
+            not exist / is not a regular file.
+        OSError: If the file exists but cannot be read.
+    """
+    has_content = content is not None and content != ""
+    has_file = content_file is not None and content_file != ""
+    if has_content and has_file:
+        raise ValueError(
+            "Provide either 'content' or 'content_file', not both."
+        )
+    if not has_content and not has_file:
+        raise ValueError(
+            "One of 'content' or 'content_file' must be provided."
+        )
+    if has_content:
+        return content  # type: ignore[return-value]
+    path = Path(content_file).expanduser()  # type: ignore[arg-type]
+    if not path.is_file():
+        raise ValueError(
+            f"content_file does not exist or is not a regular file: {path}"
+        )
+    return path.read_text(encoding="utf-8")
 
 
 confluence_mcp = FastMCP(
@@ -530,11 +572,29 @@ async def create_page(
     ],
     title: Annotated[str, Field(description="The title of the page")],
     content: Annotated[
-        str,
+        str | None,
         Field(
-            description="The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, or storage format"
+            description=(
+                "The content of the page. Format depends on content_format"
+                " parameter. Can be Markdown (default), wiki markup, or"
+                " storage format. Either 'content' or 'content_file' must be"
+                " provided, but not both."
+            ),
+            default=None,
         ),
-    ],
+    ] = None,
+    content_file: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Absolute or relative filesystem path to read the"
+                " page body from (UTF-8). Use this instead of 'content' when"
+                " the body is too large to pass comfortably as a tool"
+                " argument. Mutually exclusive with 'content'."
+            ),
+            default=None,
+        ),
+    ] = None,
     parent_id: Annotated[
         str | None,
         Field(
@@ -579,6 +639,10 @@ async def create_page(
         space_key: The key of the space.
         title: The title of the page.
         content: The content of the page (format depends on content_format).
+            Mutually exclusive with content_file; exactly one must be
+            supplied.
+        content_file: Filesystem path to read the page body from (UTF-8).
+            Useful for bodies too large to pass as an inline tool argument.
         parent_id: Optional parent page ID.
         content_format: The format of the content ('markdown', 'wiki', or 'storage').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
@@ -599,6 +663,8 @@ async def create_page(
             f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', or 'storage'"
         )
 
+    resolved_content = _resolve_page_content(content, content_file)
+
     # Determine parameters based on content format
     if content_format == "markdown":
         is_markdown = True
@@ -610,7 +676,7 @@ async def create_page(
     page = confluence_fetcher.create_page(
         space_key=space_key,
         title=title,
-        body=content,
+        body=resolved_content,
         parent_id=parent_id,
         is_markdown=is_markdown,
         enable_heading_anchors=enable_heading_anchors
@@ -639,11 +705,28 @@ async def update_page(
     page_id: Annotated[str, Field(description="The ID of the page to update")],
     title: Annotated[str, Field(description="The new title of the page")],
     content: Annotated[
-        str,
+        str | None,
         Field(
-            description="The new content of the page. Format depends on content_format parameter"
+            description=(
+                "The new content of the page. Format depends on"
+                " content_format parameter. Either 'content' or"
+                " 'content_file' must be provided, but not both."
+            ),
+            default=None,
         ),
-    ],
+    ] = None,
+    content_file: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Absolute or relative filesystem path to read the"
+                " new page body from (UTF-8). Use this instead of 'content'"
+                " when the body is too large to pass comfortably as a tool"
+                " argument. Mutually exclusive with 'content'."
+            ),
+            default=None,
+        ),
+    ] = None,
     is_minor_edit: Annotated[
         bool, Field(description="Whether this is a minor edit", default=False)
     ] = False,
@@ -690,7 +773,12 @@ async def update_page(
         ctx: The FastMCP context.
         page_id: The ID of the page to update.
         title: The new title of the page.
-        content: The new content of the page (format depends on content_format).
+        content: The new content of the page (format depends on
+            content_format). Mutually exclusive with content_file; exactly
+            one must be supplied.
+        content_file: Filesystem path to read the new page body from
+            (UTF-8). Useful for bodies too large to pass as an inline tool
+            argument.
         is_minor_edit: Whether this is a minor edit.
         version_comment: Optional comment for this version.
         parent_id: Optional new parent page ID.
@@ -713,6 +801,8 @@ async def update_page(
             f"Invalid content_format: {content_format}. Must be 'markdown', 'wiki', or 'storage'"
         )
 
+    resolved_content = _resolve_page_content(content, content_file)
+
     # Determine parameters based on content format
     if content_format == "markdown":
         is_markdown = True
@@ -724,7 +814,7 @@ async def update_page(
     updated_page = confluence_fetcher.update_page(
         page_id=page_id,
         title=title,
-        body=content,
+        body=resolved_content,
         is_minor_edit=is_minor_edit,
         version_comment=version_comment,
         is_markdown=is_markdown,

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import mimetypes
+from pathlib import Path
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
@@ -23,6 +24,45 @@ from mcp_atlassian.utils.media import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_page_content(content: str | None, content_file: str | None) -> str:
+    """Resolve page body from either an inline string or a file path.
+
+    Exactly one of ``content`` / ``content_file`` must be supplied. ``content_file``
+    exists so callers (especially MCP clients transporting large bodies over stdio
+    JSON) can hand off content via the filesystem instead of marshalling it as a
+    tool-call argument.
+
+    Args:
+        content: Inline page body (any supported content_format).
+        content_file: Absolute or relative filesystem path to read the body from.
+            Read as UTF-8.
+
+    Returns:
+        The resolved page body as a string.
+
+    Raises:
+        ValueError: If neither or both arguments are supplied, or if the file does
+            not exist / is not a regular file.
+        OSError: If the file exists but cannot be read.
+    """
+    has_content = content is not None
+    has_file = content_file is not None and content_file != ""
+    if has_content and has_file:
+        raise ValueError("Provide either 'content' or 'content_file', not both.")
+    if not has_content and not has_file:
+        raise ValueError("One of 'content' or 'content_file' must be provided.")
+    if has_content:
+        return content
+    if content_file is None or content_file == "":
+        raise ValueError("One of 'content' or 'content_file' must be provided.")
+
+    path = Path(content_file).expanduser()
+    if not path.is_file():
+        msg = f"content_file does not exist or is not a regular file: {path}"
+        raise ValueError(msg)
+    return path.read_text(encoding="utf-8")
 
 
 confluence_mcp = FastMCP(
@@ -529,15 +569,17 @@ async def create_page(
     ],
     title: Annotated[str, Field(description="The title of the page")],
     content: Annotated[
-        str,
+        str | None,
         Field(
             description=(
                 "The content of the page. Format depends on content_format "
                 "parameter. Can be Markdown (default), wiki markup, storage "
-                "format, or XHTML storage format"
-            )
+                "format, or XHTML storage format. Either 'content' or "
+                "'content_file' must be provided, but not both."
+            ),
+            default=None,
         ),
-    ],
+    ] = None,
     parent_id: Annotated[
         str | None,
         Field(
@@ -580,6 +622,18 @@ async def create_page(
             default=None,
         ),
     ] = None,
+    content_file: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Absolute or relative filesystem path to read the "
+                "page body from (UTF-8). Use this instead of 'content' when "
+                "the body is too large to pass comfortably as a tool "
+                "argument. Mutually exclusive with 'content'."
+            ),
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Create a new Confluence page.
 
@@ -588,6 +642,10 @@ async def create_page(
         space_key: The key of the space.
         title: The title of the page.
         content: The content of the page (format depends on content_format).
+            Mutually exclusive with content_file; exactly one must be
+            supplied.
+        content_file: Filesystem path to read the page body from (UTF-8).
+            Useful for bodies too large to pass as an inline tool argument.
         parent_id: Optional parent page ID.
         content_format: The format of the content ('markdown', 'wiki',
             'storage', or 'xhtml').
@@ -610,6 +668,8 @@ async def create_page(
             "'markdown', 'wiki', 'storage', or 'xhtml'"
         )
 
+    resolved_content = _resolve_page_content(content, content_file)
+
     # Determine parameters based on content format
     if content_format == "markdown":
         is_markdown = True
@@ -624,7 +684,7 @@ async def create_page(
     page = confluence_fetcher.create_page(
         space_key=space_key,
         title=title,
-        body=content,
+        body=resolved_content,
         parent_id=parent_id,
         is_markdown=is_markdown,
         enable_heading_anchors=enable_heading_anchors
@@ -653,11 +713,17 @@ async def update_page(
     page_id: Annotated[str, Field(description="The ID of the page to update")],
     title: Annotated[str, Field(description="The new title of the page")],
     content: Annotated[
-        str,
+        str | None,
         Field(
-            description="The new content of the page. Format depends on content_format parameter"
+            description=(
+                "The new content of the page. Format depends on "
+                "content_format parameter and may be Markdown (default), wiki "
+                "markup, storage format, or XHTML storage format. Either "
+                "'content' or 'content_file' must be provided, but not both."
+            ),
+            default=None,
         ),
-    ],
+    ] = None,
     is_minor_edit: Annotated[
         bool, Field(description="Whether this is a minor edit", default=False)
     ] = False,
@@ -703,6 +769,18 @@ async def update_page(
             default=None,
         ),
     ] = None,
+    content_file: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Absolute or relative filesystem path to read the "
+                "new page body from (UTF-8). Use this instead of 'content' "
+                "when the body is too large to pass comfortably as a tool "
+                "argument. Mutually exclusive with 'content'."
+            ),
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Update an existing Confluence page.
 
@@ -710,7 +788,12 @@ async def update_page(
         ctx: The FastMCP context.
         page_id: The ID of the page to update.
         title: The new title of the page.
-        content: The new content of the page (format depends on content_format).
+        content: The new content of the page (format depends on
+            content_format). Mutually exclusive with content_file; exactly
+            one must be supplied.
+        content_file: Filesystem path to read the new page body from
+            (UTF-8). Useful for bodies too large to pass as an inline tool
+            argument.
         is_minor_edit: Whether this is a minor edit.
         version_comment: Optional comment for this version.
         parent_id: Optional new parent page ID.
@@ -735,6 +818,8 @@ async def update_page(
             "'markdown', 'wiki', 'storage', or 'xhtml'"
         )
 
+    resolved_content = _resolve_page_content(content, content_file)
+
     # Determine parameters based on content format
     if content_format == "markdown":
         is_markdown = True
@@ -749,7 +834,7 @@ async def update_page(
     updated_page = confluence_fetcher.update_page(
         page_id=page_id,
         title=title,
-        body=content,
+        body=resolved_content,
         is_minor_edit=is_minor_edit,
         version_comment=version_comment,
         is_markdown=is_markdown,

--- a/tests/e2e/cloud/test_mcp_tools_cloud.py
+++ b/tests/e2e/cloud/test_mcp_tools_cloud.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -260,6 +261,55 @@ class TestMCPConfluenceTools:
                     "title": f"Cloud MCP XHTML Tool Test {uid}",
                     "content": "<p>Updated via MCP XHTML tool test.</p>",
                     "content_format": "xhtml",
+                },
+            )
+            assert not update_result.is_error
+        finally:
+            if page_id:
+                await call_tool(
+                    mcp_client,
+                    "confluence_delete_page",
+                    {"page_id": page_id},
+                )
+
+    @pytest.mark.anyio
+    async def test_confluence_create_update_page_with_content_file(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+        tmp_path: Path,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page_id = None
+        create_file = tmp_path / "cloud-create.md"
+        update_file = tmp_path / "cloud-update.md"
+        create_file.write_text("# Created from file\n\nCloud body.", encoding="utf-8")
+        update_file.write_text("# Updated from file\n\nCloud body.", encoding="utf-8")
+
+        create_result = await call_tool(
+            mcp_client,
+            "confluence_create_page",
+            {
+                "space_key": cloud_instance.space_key,
+                "title": f"Cloud MCP File Tool Test {uid}",
+                "content_file": str(create_file),
+            },
+        )
+        assert not create_result.is_error
+        assert create_result.content and isinstance(
+            create_result.content[0], TextContent
+        )
+        page_id = json.loads(create_result.content[0].text)["page"]["id"]
+        assert page_id is not None
+
+        try:
+            update_result = await call_tool(
+                mcp_client,
+                "confluence_update_page",
+                {
+                    "page_id": page_id,
+                    "title": f"Cloud MCP File Tool Test {uid}",
+                    "content_file": str(update_file),
                 },
             )
             assert not update_result.is_error

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -259,6 +260,55 @@ class TestMCPConfluenceTools:
                     "title": f"MCP XHTML Tool Test {uid}",
                     "content": "<p>Updated via MCP XHTML tool test.</p>",
                     "content_format": "xhtml",
+                },
+            )
+            assert not update_result.is_error
+        finally:
+            if page_id:
+                await call_tool(
+                    mcp_client,
+                    "confluence_delete_page",
+                    {"page_id": page_id},
+                )
+
+    @pytest.mark.anyio
+    async def test_confluence_create_update_page_with_content_file(
+        self,
+        mcp_client: Client,
+        dc_instance: DCInstanceInfo,
+        tmp_path: Path,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page_id = None
+        create_file = tmp_path / "dc-create.md"
+        update_file = tmp_path / "dc-update.md"
+        create_file.write_text("# Created from file\n\nDC body.", encoding="utf-8")
+        update_file.write_text("# Updated from file\n\nDC body.", encoding="utf-8")
+
+        create_result = await call_tool(
+            mcp_client,
+            "confluence_create_page",
+            {
+                "space_key": dc_instance.space_key,
+                "title": f"MCP File Tool Test {uid}",
+                "content_file": str(create_file),
+            },
+        )
+        assert not create_result.is_error
+        assert create_result.content and isinstance(
+            create_result.content[0], TextContent
+        )
+        page_id = json.loads(create_result.content[0].text)["page"]["id"]
+        assert page_id is not None
+
+        try:
+            update_result = await call_tool(
+                mcp_client,
+                "confluence_update_page",
+                {
+                    "page_id": page_id,
+                    "title": f"MCP File Tool Test {uid}",
+                    "content_file": str(update_file),
                 },
             )
             assert not update_result.is_error

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -729,6 +729,97 @@ async def test_update_page_include_content(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
+async def test_create_page_with_content_file(client, mock_confluence_fetcher, tmp_path):
+    """content_file should load the body from disk and be passed to the fetcher."""
+    body = "# Heading\n\nFrom a file."
+    fp = tmp_path / "page.md"
+    fp.write_text(body, encoding="utf-8")
+
+    await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "From File",
+            "content_file": str(fp),
+        },
+    )
+
+    mock_confluence_fetcher.create_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.create_page.call_args.kwargs
+    assert call_kwargs["body"] == body
+
+
+@pytest.mark.anyio
+async def test_update_page_with_content_file(client, mock_confluence_fetcher, tmp_path):
+    """content_file should be accepted by update_page as an alternative to content."""
+    body = "Updated body from disk."
+    fp = tmp_path / "update.md"
+    fp.write_text(body, encoding="utf-8")
+
+    await client.call_tool(
+        "confluence_update_page",
+        {
+            "page_id": "999999",
+            "title": "Updated Page",
+            "content_file": str(fp),
+        },
+    )
+
+    mock_confluence_fetcher.update_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.update_page.call_args.kwargs
+    assert call_kwargs["body"] == body
+
+
+@pytest.mark.anyio
+async def test_create_page_rejects_both_content_and_file(
+    client, mock_confluence_fetcher, tmp_path
+):
+    """Supplying both content and content_file should error cleanly."""
+    fp = tmp_path / "page.md"
+    fp.write_text("x", encoding="utf-8")
+
+    with pytest.raises(Exception, match="not both"):
+        await client.call_tool(
+            "confluence_create_page",
+            {
+                "space_key": "TEST",
+                "title": "Conflict",
+                "content": "inline",
+                "content_file": str(fp),
+            },
+        )
+    mock_confluence_fetcher.create_page.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_create_page_rejects_neither_content_nor_file(
+    client, mock_confluence_fetcher
+):
+    """Supplying neither content nor content_file should error cleanly."""
+    with pytest.raises(Exception, match="must be provided"):
+        await client.call_tool(
+            "confluence_create_page",
+            {"space_key": "TEST", "title": "Missing body"},
+        )
+    mock_confluence_fetcher.create_page.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_update_page_rejects_missing_file(client, mock_confluence_fetcher):
+    """A content_file path that does not exist should error before calling fetcher."""
+    with pytest.raises(Exception, match="does not exist"):
+        await client.call_tool(
+            "confluence_update_page",
+            {
+                "page_id": "999999",
+                "title": "Bad Path",
+                "content_file": "/tmp/definitely-not-here-6f3a2d.md",
+            },
+        )
+    mock_confluence_fetcher.update_page.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_get_page_with_numeric_id(client, mock_confluence_fetcher):
     """Test get_page with numeric page_id (integer) - should convert to string."""
     response = await client.call_tool("confluence_get_page", {"page_id": 123456})

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -1,5 +1,6 @@
 """Unit tests for the Confluence FastMCP server."""
 
+import inspect
 import json
 import logging
 from collections.abc import AsyncGenerator
@@ -14,6 +15,7 @@ from starlette.requests import Request
 from src.mcp_atlassian.confluence import ConfluenceFetcher
 from src.mcp_atlassian.confluence.config import ConfluenceConfig
 from src.mcp_atlassian.models.confluence.page import ConfluencePage
+from src.mcp_atlassian.servers import confluence as confluence_server
 from src.mcp_atlassian.servers.context import MainAppContext
 from src.mcp_atlassian.servers.main import AtlassianMCP
 from src.mcp_atlassian.utils.oauth import OAuthConfig
@@ -801,6 +803,164 @@ async def test_update_page_with_xhtml_format(client, mock_confluence_fetcher):
 
     result_data = json.loads(response.content[0].text)
     assert result_data["message"] == "Page updated successfully"
+
+
+@pytest.mark.anyio
+async def test_create_page_with_content_file(client, mock_confluence_fetcher, tmp_path):
+    """content_file should load the body from disk and be passed to the fetcher."""
+    body = "# Heading\n\nFrom a file."
+    fp = tmp_path / "page.md"
+    fp.write_text(body, encoding="utf-8")
+
+    await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "From File",
+            "content_file": str(fp),
+        },
+    )
+
+    mock_confluence_fetcher.create_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.create_page.call_args.kwargs
+    assert call_kwargs["body"] == body
+
+
+@pytest.mark.anyio
+async def test_update_page_with_content_file(client, mock_confluence_fetcher, tmp_path):
+    """content_file should be accepted by update_page as an alternative to content."""
+    body = "Updated body from disk."
+    fp = tmp_path / "update.md"
+    fp.write_text(body, encoding="utf-8")
+
+    await client.call_tool(
+        "confluence_update_page",
+        {
+            "page_id": "999999",
+            "title": "Updated Page",
+            "content_file": str(fp),
+        },
+    )
+
+    mock_confluence_fetcher.update_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.update_page.call_args.kwargs
+    assert call_kwargs["body"] == body
+
+
+@pytest.mark.anyio
+async def test_create_page_accepts_empty_content(client, mock_confluence_fetcher):
+    """An empty inline content string should still count as provided."""
+    await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "Empty Page",
+            "content": "",
+        },
+    )
+
+    mock_confluence_fetcher.create_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.create_page.call_args.kwargs
+    assert call_kwargs["body"] == ""
+
+
+@pytest.mark.anyio
+async def test_update_page_accepts_empty_content(client, mock_confluence_fetcher):
+    """An empty inline content string should still count as provided."""
+    await client.call_tool(
+        "confluence_update_page",
+        {
+            "page_id": "999999",
+            "title": "Empty Page",
+            "content": "",
+        },
+    )
+
+    mock_confluence_fetcher.update_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.update_page.call_args.kwargs
+    assert call_kwargs["body"] == ""
+
+
+def test_page_content_file_parameters_preserve_positional_order():
+    """content_file should not shift existing positional parameters."""
+    create_params = list(inspect.signature(confluence_server.create_page.fn).parameters)
+    assert create_params == [
+        "ctx",
+        "space_key",
+        "title",
+        "content",
+        "parent_id",
+        "content_format",
+        "enable_heading_anchors",
+        "include_content",
+        "emoji",
+        "content_file",
+    ]
+
+    update_params = list(inspect.signature(confluence_server.update_page.fn).parameters)
+    assert update_params == [
+        "ctx",
+        "page_id",
+        "title",
+        "content",
+        "is_minor_edit",
+        "version_comment",
+        "parent_id",
+        "content_format",
+        "enable_heading_anchors",
+        "include_content",
+        "emoji",
+        "content_file",
+    ]
+
+
+@pytest.mark.anyio
+async def test_create_page_rejects_both_content_and_file(
+    client, mock_confluence_fetcher, tmp_path
+):
+    """Supplying both content and content_file should error cleanly."""
+    fp = tmp_path / "page.md"
+    fp.write_text("x", encoding="utf-8")
+
+    with pytest.raises(Exception, match="not both"):
+        await client.call_tool(
+            "confluence_create_page",
+            {
+                "space_key": "TEST",
+                "title": "Conflict",
+                "content": "inline",
+                "content_file": str(fp),
+            },
+        )
+    mock_confluence_fetcher.create_page.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_create_page_rejects_neither_content_nor_file(
+    client, mock_confluence_fetcher
+):
+    """Supplying neither content nor content_file should error cleanly."""
+    with pytest.raises(Exception, match="must be provided"):
+        await client.call_tool(
+            "confluence_create_page",
+            {"space_key": "TEST", "title": "Missing body"},
+        )
+    mock_confluence_fetcher.create_page.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_update_page_rejects_missing_file(client, mock_confluence_fetcher):
+    """A content_file path that does not exist should error before calling fetcher."""
+    with pytest.raises(Exception, match="does not exist"):
+        await client.call_tool(
+            "confluence_update_page",
+            {
+                "page_id": "999999",
+                "title": "Bad Path",
+                "content_file": "/tmp/definitely-not-here-6f3a2d.md",
+            },
+        )
+    mock_confluence_fetcher.update_page.assert_not_called()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

Large Confluence page bodies sent through the MCP stdio transport as a
single JSON argument can stall an MCP client or exceed buffer limits. This
PR adds a `content_file` parameter to `confluence_create_page` and
`confluence_update_page` so callers can hand off the body via the
filesystem instead. This mirrors the `file_path` pattern already used by
`upload_attachment`.

## Changes

- `confluence_create_page` and `confluence_update_page` each gain a new
  `content_file: str | None` parameter. The existing `content` parameter
  becomes optional (`str | None`, defaults to `None`).
- New `_resolve_page_content()` helper validates that exactly one of
  `content` / `content_file` is supplied and reads UTF-8 from disk.
  Violations raise `ValueError` with a clear message.
- Tool descriptions are updated so agents know when to reach for
  `content_file`.
- Existing call sites that pass `content` (positionally or by keyword)
  are unchanged.

## Testing

- [x] Unit tests added (5 new):
  - `test_create_page_with_content_file` — file body flows to the fetcher
  - `test_update_page_with_content_file` — same, for update
  - `test_create_page_rejects_both_content_and_file`
  - `test_create_page_rejects_neither_content_nor_file`
  - `test_update_page_rejects_missing_file`
- [x] Full suite: `PYTHONPATH=. pytest tests/unit/servers/test_confluence_server.py`
  → 31 passed (26 existing + 5 new), no regressions.
- [x] Manual smoke test against a live Confluence Cloud instance:
  create from file → v1, update from file → v2, round-trip read confirmed
  the body on the server matched the file. Error paths (both args, neither
  arg) also surfaced cleanly through the MCP boundary.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed). *— The tool descriptions are
  updated in-code, which is where the MCP clients read them. No separate
  docs file appears to exist for these tools; happy to add one if a
  maintainer points me at the right place.*
