### PR TITLE
fix(confluence): use POST instead of PUT for attachment uploads on Server/DC

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -484,12 +484,13 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             if minor_edit is not None:
                 data["minorEdit"] = str(minor_edit).lower()
 
-            # Use PUT to support creating new versions of existing attachments
-            # PUT will create a new attachment if it doesn't exist, OR create a new
-            # version if an attachment with the same filename already exists
-            response = self.confluence._session.put(
-                url, headers=headers, files=files, data=data
-            )
+            # Confluence Cloud accepts PUT on the collection URL for both
+            # create and update.  Confluence Server/DC requires POST for new
+            # attachments — PUT on the collection URL returns an error.
+            # POST works on *both* platforms (creates a new version when the
+            # filename already exists), so we use POST unconditionally.
+            method = self.confluence._session.post
+            response = method(url, headers=headers, files=files, data=data)
             response.raise_for_status()
 
             # Parse response

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -104,13 +104,11 @@ class TestAttachmentsMixin:
 
         mock_response = Mock()
         if raise_error:
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.side_effect = raise_error
+            attachments_mixin.confluence._session.post.side_effect = raise_error
         else:
             mock_response.json.return_value = response_data
             mock_response.raise_for_status.return_value = None
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.return_value = mock_response
+            attachments_mixin.confluence._session.post.return_value = mock_response
 
         return mock_response
 
@@ -152,9 +150,8 @@ class TestAttachmentsMixin:
             assert result["id"] == "att12345"
 
             # Verify the REST API was called with correct parameters
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.assert_called_once()
-            call_args = attachments_mixin.confluence._session.put.call_args
+            attachments_mixin.confluence._session.post.assert_called_once()
+            call_args = attachments_mixin.confluence._session.post.call_args
 
             # Check URL
             assert "/rest/api/content/123456/child/attachment" in call_args[0][0]


### PR DESCRIPTION
## Summary

Fixes attachment uploads failing on all Confluence Server/Data Center instances.

### Root cause

`_upload_attachment_direct()` in `confluence/attachments.py` uses `PUT` on the collection URL `/rest/api/content/{id}/child/attachment`. This works on **Confluence Cloud** (where PUT acts as create-or-update), but **Confluence Server/DC requires `POST`** for new attachments. PUT on the collection URL returns an error on Server/DC, which gets swallowed by the generic exception handler, resulting in `"Failed to upload attachment"` for every upload attempt.

### Fix

Changed `PUT` to `POST` in `_upload_attachment_direct()`. POST works on **both** platforms:
- Creates a new attachment if the filename does not exist
- Creates a new version if the filename already exists

### Changed files

- `src/mcp_atlassian/confluence/attachments.py` — `session.put(...)` → `session.post(...)`
- `tests/unit/confluence/test_attachments.py` — updated mock assertions from `.put` to `.post`

### Tested

- 52/52 unit tests pass
- Manually verified on Confluence Server (Telefónica on-premise instance) with PNG uploads

### Confluence REST API reference

- [Server/DC: Add attachment](https://developer.atlassian.com/server/confluence/content-resource/#post-content-id-child-attachment) — **POST** to `/rest/api/content/{id}/child/attachment`
- [Cloud: Create or update attachment](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content---attachments/#api-wiki-rest-api-content-id-child-attachment-put) — **PUT** to `/wiki/rest/api/content/{id}/child/attachment`