### PR TITLE
feat: convert markdown task lists (- [ ] / - [x]) to ADF taskList nodes

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -117,6 +117,15 @@ def _make_list_item(text: str) -> dict[str, Any]:
     return {"type": "listItem", "content": [_make_paragraph(text)]}
 
 
+def _make_task_item(text: str, checked: bool, local_id: str) -> dict[str, Any]:
+    """Create an ADF taskItem node."""
+    return {
+        "type": "taskItem",
+        "attrs": {"localId": local_id, "state": "DONE" if checked else "TODO"},
+        "content": _parse_inline_formatting(text) or [{"type": "text", "text": text}],
+    }
+
+
 def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
     """Convert Markdown text to ADF (Atlassian Document Format) document.
 
@@ -195,6 +204,29 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
                 i += 1
             bq_content = [_make_paragraph(ln) for ln in quote_lines]
             doc["content"].append({"type": "blockquote", "content": bq_content})
+            continue
+
+        # --- Task list (- [ ] / - [x]) ---
+        if re.match(r"^[-*]\s+\[[ xX]\]\s+", line):
+            task_items: list[dict[str, Any]] = []
+            task_counter = 0
+            while i < len(lines) and re.match(r"^[-*]\s+\[[ xX]\]\s+", lines[i]):
+                checked = bool(re.match(r"^[-*]\s+\[[xX]\]\s+", lines[i]))
+                item_text = re.sub(r"^[-*]\s+\[[ xX]\]\s+", "", lines[i])
+                task_counter += 1
+                task_items.append(
+                    _make_task_item(
+                        item_text, checked, f"task-{id(doc)}-{task_counter}"
+                    )
+                )
+                i += 1
+            doc["content"].append(
+                {
+                    "type": "taskList",
+                    "attrs": {"localId": f"tasklist-{id(doc)}-{i}"},
+                    "content": task_items,
+                }
+            )
             continue
 
         # --- Unordered list ---

--- a/tests/e2e/cloud/test_adf_write.py
+++ b/tests/e2e/cloud/test_adf_write.py
@@ -138,6 +138,24 @@ class TestADFCreateIssue:
         finally:
             await _delete_issue(mcp_client, key)
 
+    async def test_create_issue_task_list(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """Task-list markdown is accepted by Jira Cloud and survives readback."""
+        key = await _create_issue_with_description(
+            mcp_client,
+            cloud_instance.project_key,
+            "- [x] completed cloud task\n- [ ] pending cloud task",
+        )
+        try:
+            desc = await _read_issue_description(mcp_client, key)
+            assert "completed cloud task" in desc
+            assert "pending cloud task" in desc
+        finally:
+            await _delete_issue(mcp_client, key)
+
     async def test_create_issue_code_block(
         self,
         mcp_client: Client,

--- a/tests/unit/jira/test_format_conversion.py
+++ b/tests/unit/jira/test_format_conversion.py
@@ -197,6 +197,38 @@ class TestFormatConversionIntegration:
         assert heading["type"] == "heading"
         assert heading["attrs"]["level"] == 2
 
+    def test_create_issue_converts_task_list_to_adf_on_cloud(
+        self, jira_fetcher_with_real_preprocessor
+    ):
+        """Test that task-list Markdown becomes ADF taskList on Cloud."""
+        jira_fetcher_with_real_preprocessor._post_api3 = Mock(
+            return_value={
+                "id": "12345",
+                "key": "TEST-123",
+                "self": "https://test.atlassian.net/rest/api/3/issue/TEST-123",
+            }
+        )
+
+        jira_fetcher_with_real_preprocessor.create_issue(
+            project_key="TEST",
+            summary="Task List Test",
+            issue_type="Task",
+            description="- [x] done\n- [ ] todo",
+        )
+
+        call_args = jira_fetcher_with_real_preprocessor._post_api3.call_args
+        sent_fields = call_args[0][1]["fields"]
+        sent_description = sent_fields["description"]
+        task_list = next(
+            node for node in sent_description["content"] if node["type"] == "taskList"
+        )
+
+        assert task_list["content"][0]["type"] == "taskItem"
+        assert task_list["content"][0]["attrs"]["state"] == "DONE"
+        assert task_list["content"][0]["content"][0]["text"] == "done"
+        assert task_list["content"][1]["attrs"]["state"] == "TODO"
+        assert task_list["content"][1]["content"][0]["text"] == "todo"
+
     def test_numbered_list_not_converted_to_heading(
         self, jira_fetcher_with_real_preprocessor
     ):

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -478,6 +478,42 @@ class TestMarkdownToAdf:
             assert item["type"] == "listItem"
             assert item["content"][0]["type"] == "paragraph"
 
+    def test_task_list_checked(self):
+        """- [x] items produce a taskList with taskItem state=DONE."""
+        md = "- [x] done task"
+        result = markdown_to_adf(md)
+        tl = next(n for n in result["content"] if n["type"] == "taskList")
+        assert len(tl["content"]) == 1
+        item = tl["content"][0]
+        assert item["type"] == "taskItem"
+        assert item["attrs"]["state"] == "DONE"
+        assert item["content"][0]["text"] == "done task"
+
+    def test_task_list_unchecked(self):
+        """- [ ] items produce a taskList with taskItem state=TODO."""
+        md = "- [ ] pending task"
+        result = markdown_to_adf(md)
+        tl = next(n for n in result["content"] if n["type"] == "taskList")
+        item = tl["content"][0]
+        assert item["attrs"]["state"] == "TODO"
+
+    def test_task_list_mixed(self):
+        """Mixed checked/unchecked items in one taskList."""
+        md = "- [x] done\n- [ ] todo\n- [X] also done"
+        result = markdown_to_adf(md)
+        tl = next(n for n in result["content"] if n["type"] == "taskList")
+        assert len(tl["content"]) == 3
+        assert tl["content"][0]["attrs"]["state"] == "DONE"
+        assert tl["content"][1]["attrs"]["state"] == "TODO"
+        assert tl["content"][2]["attrs"]["state"] == "DONE"
+
+    def test_task_list_not_confused_with_bullet_list(self):
+        """Regular - items without [ ] are still bulletList, not taskList."""
+        md = "- regular item"
+        result = markdown_to_adf(md)
+        assert any(n["type"] == "bulletList" for n in result["content"])
+        assert not any(n["type"] == "taskList" for n in result["content"])
+
     # -- Blockquote ---------------------------------------------------------
 
     def test_blockquote(self):


### PR DESCRIPTION
## Summary

Markdown task list syntax (`- [ ] item` and `- [x] item`) is currently converted to a plain `bulletList` with literal `[ ]` / `[x]` text, instead of proper ADF `taskList` nodes. This means checkboxes never appear in Jira Cloud descriptions or comments.

This PR fixes the `markdown_to_adf()` parser to detect task list items and emit the correct ADF structure.

## Changes

- `src/mcp_atlassian/models/jira/adf.py`: Added `_make_task_item()` helper and task list detection block in `markdown_to_adf()`. Task list items are detected **before** the regular unordered list block, so plain `- item` lines continue to produce `bulletList` as before.
- `tests/unit/models/test_adf.py`: Added 4 tests covering checked items, unchecked items, mixed lists, and ensuring regular bullet lists are not affected.

## Behavior

| Markdown input | Before | After |
|---|---|---|
| `- [x] done` | `bulletList` with text `[x] done` | `taskList` > `taskItem` state=`DONE` |
| `- [ ] todo` | `bulletList` with text `[ ] todo` | `taskList` > `taskItem` state=`TODO` |
| `- regular` | `bulletList` | `bulletList` (unchanged) |

Both `[x]` and `[X]` are treated as checked.

## Testing

```
uv run pytest tests/unit/models/test_adf.py -v
# 75 passed
```