### PR TITLE
feat(jira): add saved filter and Structure board tools

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -17,7 +17,9 @@ from .development import DevelopmentMixin
 from .epics import EpicsMixin
 from .field_options import FieldOptionsMixin
 from .fields import FieldsMixin
+from .filters import FiltersMixin
 from .forms_api import FormsApiMixin  # Forms REST API
+from .structures import StructuresMixin
 from .formatting import FormattingMixin
 from .issues import IssuesMixin
 from .links import LinksMixin
@@ -37,7 +39,9 @@ class JiraFetcher(
     ProjectsMixin,
     FieldsMixin,
     FieldOptionsMixin,
+    FiltersMixin,
     FormsApiMixin,  # Use new Forms REST API instead of FormsMixin
+    StructuresMixin,
     FormattingMixin,
     TransitionsMixin,
     WorklogMixin,

--- a/src/mcp_atlassian/jira/filters.py
+++ b/src/mcp_atlassian/jira/filters.py
@@ -1,0 +1,162 @@
+"""Module for Jira filter operations."""
+
+import logging
+from typing import Any
+
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class FiltersMixin(JiraClient):
+    """Mixin for Jira filter operations."""
+
+    @handle_auth_errors("Jira API")
+    def get_filter(self, filter_id: str | int) -> dict[str, Any]:
+        """Get a Jira saved filter by ID.
+
+        Args:
+            filter_id: The ID of the filter.
+
+        Returns:
+            Dictionary with filter details including JQL.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+        """
+        result = self.jira.get_filter(filter_id)
+
+        if not isinstance(result, dict):
+            logger.error(
+                "Unexpected response type from get_filter: %s",
+                type(result),
+            )
+            return {"filter_id": str(filter_id), "error": "Invalid response"}
+
+        owner = result.get("owner", {})
+        return {
+            "id": result.get("id"),
+            "name": result.get("name"),
+            "description": result.get("description", ""),
+            "jql": result.get("jql"),
+            "owner": owner.get("displayName", owner.get("name")),
+            "view_url": result.get("viewUrl"),
+            "search_url": result.get("searchUrl"),
+            "is_favourite": result.get("favourite", False),
+            "share_permissions": result.get("sharePermissions", []),
+        }
+
+    @handle_auth_errors("Jira API")
+    def search_filters(
+        self,
+        filter_name: str,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """Search for Jira saved filters by name.
+
+        Note: The /rest/api/2/filter/search endpoint is Cloud-only.
+        On Server/DC this falls back to searching favourite filters.
+
+        Args:
+            filter_name: Filter name to search for.
+            limit: Maximum number of results.
+
+        Returns:
+            Dictionary with list of matching filters.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+        """
+        if not self.config.is_cloud:
+            return self._search_filters_server_fallback(filter_name, limit)
+
+        result = self.jira.get(
+            "rest/api/2/filter/search",
+            params={"filterName": filter_name, "maxResults": limit, "expand": "jql"},
+        )
+
+        if not isinstance(result, dict):
+            return {"filters": [], "total": 0}
+
+        filters = []
+        for f in result.get("values", []):
+            owner = f.get("owner", {})
+            filters.append(
+                {
+                    "id": f.get("id"),
+                    "name": f.get("name"),
+                    "description": f.get("description", ""),
+                    "jql": f.get("jql"),
+                    "owner": owner.get("displayName", owner.get("name")),
+                    "is_favourite": f.get("favourite", False),
+                }
+            )
+
+        return {
+            "filters": filters,
+            "total": result.get("total", len(filters)),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_favourite_filters(self, limit: int = 50) -> dict[str, Any]:
+        """Get the current user's favourite/starred filters.
+
+        Args:
+            limit: Maximum number of filters to return.
+
+        Returns:
+            Dictionary with list of favourite filters.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+        """
+        result = self.jira.get("rest/api/2/filter/favourite")
+
+        if not isinstance(result, list):
+            return {"filters": [], "total": 0}
+
+        filters = []
+        for f in result[:limit]:
+            owner = f.get("owner", {})
+            filters.append(
+                {
+                    "id": f.get("id"),
+                    "name": f.get("name"),
+                    "description": f.get("description", ""),
+                    "jql": f.get("jql"),
+                    "owner": owner.get("displayName", owner.get("name")),
+                }
+            )
+
+        return {"filters": filters, "total": len(filters)}
+
+    def _search_filters_server_fallback(
+        self, filter_name: str, limit: int
+    ) -> dict[str, Any]:
+        """Search filters on Server/DC by fetching favourites and filtering by name.
+
+        The filter search API (``/rest/api/2/filter/search``) is
+        Cloud-only.  On Server/DC we fall back to the user's favourite
+        filters and substring-match locally.  The result is explicitly
+        marked ``partial=True`` so callers know this is not an
+        exhaustive search — shared or private filters the user can
+        access but has not starred will not appear.
+        """
+        favourites = self.get_favourite_filters(limit=1000)
+        needle = filter_name.lower()
+        matched = [
+            f
+            for f in favourites.get("filters", [])
+            if needle in f.get("name", "").lower()
+        ][:limit]
+        return {
+            "filters": matched,
+            "total": len(matched),
+            "partial": True,
+            "note": (
+                "Server/DC: searched favourite filters only — "
+                "filter search API is Cloud-only. Non-starred filters "
+                "the user can access are not included."
+            ),
+        }

--- a/src/mcp_atlassian/jira/filters.py
+++ b/src/mcp_atlassian/jira/filters.py
@@ -1,0 +1,126 @@
+"""Module for Jira filter operations."""
+
+import logging
+from typing import Any
+
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class FiltersMixin(JiraClient):
+    """Mixin for Jira filter operations."""
+
+    @handle_auth_errors("Jira API")
+    def get_filter(self, filter_id: str | int) -> dict[str, Any]:
+        """Get a Jira saved filter by ID.
+
+        Args:
+            filter_id: The ID of the filter.
+
+        Returns:
+            Dictionary with filter details including JQL.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+        """
+        result = self.jira.get_filter(filter_id)
+
+        if not isinstance(result, dict):
+            logger.error(
+                "Unexpected response type from get_filter: %s",
+                type(result),
+            )
+            return {"filter_id": str(filter_id), "error": "Invalid response"}
+
+        owner = result.get("owner", {})
+        return {
+            "id": result.get("id"),
+            "name": result.get("name"),
+            "description": result.get("description", ""),
+            "jql": result.get("jql"),
+            "owner": owner.get("displayName", owner.get("name")),
+            "view_url": result.get("viewUrl"),
+            "search_url": result.get("searchUrl"),
+            "is_favourite": result.get("favourite", False),
+            "share_permissions": result.get("sharePermissions", []),
+        }
+
+    @handle_auth_errors("Jira API")
+    def search_filters(
+        self,
+        filter_name: str,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """Search for Jira saved filters by name.
+
+        Args:
+            filter_name: Filter name to search for.
+            limit: Maximum number of results.
+
+        Returns:
+            Dictionary with list of matching filters.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+        """
+        result = self.jira.get(
+            "rest/api/2/filter/search",
+            params={"filterName": filter_name, "maxResults": limit, "expand": "jql"},
+        )
+
+        if not isinstance(result, dict):
+            return {"filters": [], "total": 0}
+
+        filters = []
+        for f in result.get("values", []):
+            owner = f.get("owner", {})
+            filters.append(
+                {
+                    "id": f.get("id"),
+                    "name": f.get("name"),
+                    "description": f.get("description", ""),
+                    "jql": f.get("jql"),
+                    "owner": owner.get("displayName", owner.get("name")),
+                    "is_favourite": f.get("favourite", False),
+                }
+            )
+
+        return {
+            "filters": filters,
+            "total": result.get("total", len(filters)),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_favourite_filters(self, limit: int = 50) -> dict[str, Any]:
+        """Get the current user's favourite/starred filters.
+
+        Args:
+            limit: Maximum number of filters to return.
+
+        Returns:
+            Dictionary with list of favourite filters.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+        """
+        result = self.jira.get("rest/api/2/filter/favourite")
+
+        if not isinstance(result, list):
+            return {"filters": [], "total": 0}
+
+        filters = []
+        for f in result[:limit]:
+            owner = f.get("owner", {})
+            filters.append(
+                {
+                    "id": f.get("id"),
+                    "name": f.get("name"),
+                    "description": f.get("description", ""),
+                    "jql": f.get("jql"),
+                    "owner": owner.get("displayName", owner.get("name")),
+                }
+            )
+
+        return {"filters": filters, "total": len(filters)}

--- a/src/mcp_atlassian/jira/structures.py
+++ b/src/mcp_atlassian/jira/structures.py
@@ -1,0 +1,270 @@
+"""Module for Jira Structure (Almworks) board operations."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+_SERVER_DC_PAGE_SIZE = 50
+
+
+class StructuresMixin(JiraClient):
+    """Mixin for Jira Structure plugin operations.
+
+    Requires the Structure by Almworks plugin on the Jira instance.
+    Uses the Structure REST API (rest/structure/2.0/).
+    """
+
+    @handle_auth_errors("Jira API")
+    def get_structure(self, structure_id: int | str) -> dict[str, Any]:
+        """Get metadata for a Structure board.
+
+        Args:
+            structure_id: The ID of the structure.
+
+        Returns:
+            Dictionary with structure name, description, etc.
+        """
+        result = self.jira.get(f"rest/structure/2.0/structure/{structure_id}")
+
+        if not isinstance(result, dict):
+            return {"structure_id": str(structure_id), "error": "Invalid response"}
+
+        return {
+            "id": result.get("id"),
+            "name": result.get("name"),
+            "description": result.get("description", ""),
+            "editable": result.get("editable", False),
+            "is_archived": result.get("isArchived", False),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_structure_forest(self, structure_id: int | str) -> dict[str, Any]:
+        """Get the raw forest (hierarchy formula) for a Structure board.
+
+        Returns the parsed row list with item IDs and depths, but
+        without resolved issue details. Use get_structure_issues()
+        for the fully resolved hierarchy.
+
+        Args:
+            structure_id: The ID of the structure.
+
+        Returns:
+            Dictionary with rows (row_id, depth, item_id, item_type)
+            and metadata.
+        """
+        result = self.jira.post(
+            "rest/structure/2.0/forest/latest",
+            json={"structureId": int(structure_id)},
+        )
+
+        if not isinstance(result, dict) or "formula" not in result:
+            return {"structure_id": str(structure_id), "error": "Invalid response"}
+
+        rows = self._parse_formula(result["formula"])
+
+        return {
+            "structure_id": int(structure_id),
+            "total_rows": len(rows),
+            "rows": rows,
+            "version": result.get("version"),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_structure_issues(
+        self,
+        structure_id: int | str,
+        max_depth: int | None = None,
+    ) -> dict[str, Any]:
+        """Get the full resolved hierarchy for a Structure board.
+
+        Fetches the forest, resolves all item IDs to Jira issue
+        details (key, summary, status, type, project), and returns
+        a flat list with depth for hierarchy reconstruction.
+
+        Args:
+            structure_id: The ID of the structure.
+            max_depth: Optional maximum depth to include (0 = top level only).
+
+        Returns:
+            Dictionary with resolved issue hierarchy and structure metadata.
+        """
+        # Step 1: Get structure metadata
+        meta = self.get_structure(structure_id)
+
+        # Step 2: Get the forest
+        forest_result = self.jira.post(
+            "rest/structure/2.0/forest/latest",
+            json={"structureId": int(structure_id)},
+        )
+
+        if not isinstance(forest_result, dict) or "formula" not in forest_result:
+            return {
+                "structure_id": int(structure_id),
+                "name": meta.get("name"),
+                "error": "Could not fetch forest",
+            }
+
+        rows = self._parse_formula(forest_result["formula"])
+
+        # Apply depth filter
+        if max_depth is not None:
+            rows = [r for r in rows if r["depth"] <= max_depth]
+
+        # Step 3: Collect issue IDs to resolve (validate numeric)
+        item_ids = [
+            r["item_id"] for r in rows if r.get("item_id") and r["item_id"].isdigit()
+        ]
+        unique_ids = list(dict.fromkeys(item_ids))
+
+        # Step 4: Batch resolve via search_issues (respects projects_filter)
+        resolved: dict[str, dict] = {}
+        unresolved_ids: list[str] = []
+        _fields = ["summary", "issuetype", "status", "project"]
+        for i in range(0, len(unique_ids), _SERVER_DC_PAGE_SIZE):
+            batch = unique_ids[i : i + _SERVER_DC_PAGE_SIZE]
+            jql = f"id in ({','.join(batch)})"
+            try:
+                sr = self.search_issues(  # type: ignore[attr-defined]
+                    jql=jql,
+                    fields=_fields,
+                    limit=len(batch),
+                )
+                for issue in sr.issues:
+                    sd = issue.to_simplified_dict()
+                    status = sd.get("status", {})
+                    itype = sd.get("issue_type", {})
+                    proj = sd.get("project", {})
+                    resolved[str(issue.id)] = {
+                        "key": issue.key,
+                        "summary": sd.get("summary", ""),
+                        "issue_type": (
+                            itype.get("name", "") if isinstance(itype, dict) else ""
+                        ),
+                        "status": (
+                            status.get("name", "") if isinstance(status, dict) else ""
+                        ),
+                        "status_category": (
+                            str(status.get("category", ""))
+                            if isinstance(status, dict)
+                            else ""
+                        ),
+                        "project": (
+                            proj.get("key", "") if isinstance(proj, dict) else ""
+                        ),
+                    }
+            except HTTPError:
+                raise
+            except Exception:
+                logger.warning("Failed to resolve batch starting at index %d", i)
+                unresolved_ids.extend(batch)
+
+        # Step 5: Build resolved hierarchy — keep unresolved rows as
+        # placeholders so callers can see the gap.
+        items = []
+        total_issue_rows = 0
+        for row in rows:
+            item_id = row.get("item_id")
+            if item_id and item_id in resolved:
+                total_issue_rows += 1
+                items.append({"depth": row["depth"], **resolved[item_id]})
+            elif item_id and item_id.isdigit():
+                total_issue_rows += 1
+                items.append(
+                    {
+                        "depth": row["depth"],
+                        "key": None,
+                        "summary": "[unresolved]",
+                        "issue_type": "",
+                        "status": "",
+                        "status_category": "",
+                        "project": "",
+                    }
+                )
+            elif row.get("row_type") == "generator":
+                items.append(
+                    {
+                        "depth": row["depth"],
+                        "key": None,
+                        "summary": f"[generator: {row.get('item_ref', '?')}]",
+                        "issue_type": "generator",
+                        "status": "",
+                        "status_category": "",
+                        "project": "",
+                    }
+                )
+
+        resolved_count = sum(1 for i in items if i.get("key"))
+        result_dict: dict[str, Any] = {
+            "structure_id": int(structure_id),
+            "name": meta.get("name", ""),
+            "description": meta.get("description", ""),
+            "total_items": len(items),
+            "resolved_count": resolved_count,
+            "items": items,
+        }
+        if resolved_count < total_issue_rows:
+            result_dict["partial"] = True
+            result_dict["unresolved_count"] = total_issue_rows - resolved_count
+        return result_dict
+
+    @staticmethod
+    def _parse_formula(formula: str) -> list[dict[str, Any]]:
+        """Parse a Structure forest formula string into row dicts.
+
+        The formula format is comma-separated entries of:
+          rowId:depth:itemId:itemType  (issue rows)
+          rowId:depth:typeId/generatorId  (generator rows)
+
+        Args:
+            formula: The raw formula string from the API.
+
+        Returns:
+            List of row dicts with depth, item_id, etc.  Malformed
+            entries are skipped with a warning log.
+        """
+        rows: list[dict[str, Any]] = []
+        skipped = 0
+        for entry in formula.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            parts = entry.split(":")
+            try:
+                if len(parts) == 4:
+                    row_id, depth, item_id, item_type = parts
+                    rows.append(
+                        {
+                            "row_id": row_id,
+                            "depth": int(depth),
+                            "item_id": item_id,
+                            "item_type": item_type,
+                            "row_type": "issue",
+                        }
+                    )
+                elif len(parts) == 3:
+                    row_id, depth, item_ref = parts
+                    rows.append(
+                        {
+                            "row_id": row_id,
+                            "depth": int(depth),
+                            "item_ref": item_ref,
+                            "row_type": "generator",
+                        }
+                    )
+                else:
+                    skipped += 1
+                    logger.debug("Skipping malformed formula entry: %s", entry)
+            except (ValueError, TypeError):
+                skipped += 1
+                logger.debug("Skipping malformed formula entry: %s", entry)
+        if skipped:
+            logger.warning(
+                "Skipped %d malformed formula entries during parsing", skipped
+            )
+        return rows

--- a/src/mcp_atlassian/jira/structures.py
+++ b/src/mcp_atlassian/jira/structures.py
@@ -1,0 +1,231 @@
+"""Module for Jira Structure (Almworks) board operations."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class StructuresMixin(JiraClient):
+    """Mixin for Jira Structure plugin operations.
+
+    Requires the Structure by Almworks plugin on the Jira instance.
+    Uses the Structure REST API (rest/structure/2.0/).
+    """
+
+    @handle_auth_errors("Jira API")
+    def get_structure(self, structure_id: int | str) -> dict[str, Any]:
+        """Get metadata for a Structure board.
+
+        Args:
+            structure_id: The ID of the structure.
+
+        Returns:
+            Dictionary with structure name, description, etc.
+        """
+        result = self.jira.get(f"rest/structure/2.0/structure/{structure_id}")
+
+        if not isinstance(result, dict):
+            return {"structure_id": str(structure_id), "error": "Invalid response"}
+
+        return {
+            "id": result.get("id"),
+            "name": result.get("name"),
+            "description": result.get("description", ""),
+            "editable": result.get("editable", False),
+            "is_archived": result.get("isArchived", False),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_structure_forest(self, structure_id: int | str) -> dict[str, Any]:
+        """Get the raw forest (hierarchy formula) for a Structure board.
+
+        Returns the parsed row list with item IDs and depths, but
+        without resolved issue details. Use get_structure_issues()
+        for the fully resolved hierarchy.
+
+        Args:
+            structure_id: The ID of the structure.
+
+        Returns:
+            Dictionary with rows (row_id, depth, item_id, item_type)
+            and metadata.
+        """
+        result = self.jira.post(
+            "rest/structure/2.0/forest/latest",
+            json={"structureId": int(structure_id)},
+        )
+
+        if not isinstance(result, dict) or "formula" not in result:
+            return {"structure_id": str(structure_id), "error": "Invalid response"}
+
+        rows = self._parse_formula(result["formula"])
+
+        return {
+            "structure_id": int(structure_id),
+            "total_rows": len(rows),
+            "rows": rows,
+            "version": result.get("version"),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_structure_issues(
+        self,
+        structure_id: int | str,
+        max_depth: int | None = None,
+    ) -> dict[str, Any]:
+        """Get the full resolved hierarchy for a Structure board.
+
+        Fetches the forest, resolves all item IDs to Jira issue
+        details (key, summary, status, type, project), and returns
+        a flat list with depth for hierarchy reconstruction.
+
+        Args:
+            structure_id: The ID of the structure.
+            max_depth: Optional maximum depth to include (0 = top level only).
+
+        Returns:
+            Dictionary with resolved issue hierarchy and structure metadata.
+        """
+        # Step 1: Get structure metadata
+        meta = self.get_structure(structure_id)
+
+        # Step 2: Get the forest
+        forest_result = self.jira.post(
+            "rest/structure/2.0/forest/latest",
+            json={"structureId": int(structure_id)},
+        )
+
+        if not isinstance(forest_result, dict) or "formula" not in forest_result:
+            return {
+                "structure_id": int(structure_id),
+                "name": meta.get("name"),
+                "error": "Could not fetch forest",
+            }
+
+        rows = self._parse_formula(forest_result["formula"])
+
+        # Apply depth filter
+        if max_depth is not None:
+            rows = [r for r in rows if r["depth"] <= max_depth]
+
+        # Step 3: Collect issue IDs to resolve (validate numeric)
+        item_ids = [
+            r["item_id"] for r in rows if r.get("item_id") and r["item_id"].isdigit()
+        ]
+        unique_ids = list(dict.fromkeys(item_ids))
+
+        # Step 4: Batch resolve via JQL (50 at a time)
+        resolved: dict[str, dict] = {}
+        for i in range(0, len(unique_ids), 50):
+            batch = unique_ids[i : i + 50]
+            jql = f"id in ({','.join(batch)})"
+            try:
+                search_result = self.jira.jql(
+                    jql,
+                    fields="summary,issuetype,status,project",
+                    limit=50,
+                )
+                if not isinstance(search_result, dict):
+                    continue
+                for issue in search_result.get("issues", []):
+                    fields = issue.get("fields", {})
+                    resolved[issue["id"]] = {
+                        "key": issue["key"],
+                        "summary": fields.get("summary", ""),
+                        "issue_type": (fields.get("issuetype", {}).get("name", "")),
+                        "status": (fields.get("status", {}).get("name", "")),
+                        "status_category": (
+                            fields.get("status", {})
+                            .get("statusCategory", {})
+                            .get("name", "")
+                        ),
+                        "project": (fields.get("project", {}).get("key", "")),
+                    }
+            except HTTPError:
+                raise
+            except Exception:
+                logger.warning("Failed to resolve batch starting at index %d", i)
+
+        # Step 5: Build resolved hierarchy
+        items = []
+        for row in rows:
+            item_id = row.get("item_id")
+            if item_id and item_id in resolved:
+                entry = {
+                    "depth": row["depth"],
+                    **resolved[item_id],
+                }
+                items.append(entry)
+            elif row.get("row_type") == "generator":
+                items.append(
+                    {
+                        "depth": row["depth"],
+                        "key": None,
+                        "summary": f"[generator: {row.get('item_ref', '?')}]",
+                        "issue_type": "generator",
+                        "status": "",
+                        "status_category": "",
+                        "project": "",
+                    }
+                )
+
+        return {
+            "structure_id": int(structure_id),
+            "name": meta.get("name", ""),
+            "description": meta.get("description", ""),
+            "total_items": len(items),
+            "resolved_count": sum(1 for i in items if i.get("key")),
+            "items": items,
+        }
+
+    @staticmethod
+    def _parse_formula(formula: str) -> list[dict[str, Any]]:
+        """Parse a Structure forest formula string into row dicts.
+
+        The formula format is comma-separated entries of:
+          rowId:depth:itemId:itemType  (issue rows)
+          rowId:depth:typeId/generatorId  (generator rows)
+
+        Args:
+            formula: The raw formula string from the API.
+
+        Returns:
+            List of row dicts with depth, item_id, etc.
+        """
+        rows = []
+        for entry in formula.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            parts = entry.split(":")
+            try:
+                if len(parts) == 4:
+                    row_id, depth, item_id, item_type = parts
+                    rows.append(
+                        {
+                            "row_id": row_id,
+                            "depth": int(depth),
+                            "item_id": item_id,
+                            "item_type": item_type,
+                            "row_type": "issue",
+                        }
+                    )
+                elif len(parts) == 3:
+                    row_id, depth, item_ref = parts
+                    rows.append(
+                        {
+                            "row_id": row_id,
+                            "depth": int(depth),
+                            "item_ref": item_ref,
+                            "row_type": "generator",
+                        }
+                    )
+            except (ValueError, TypeError):
+                logger.debug("Skipping malformed formula entry: %s", entry)
+        return rows

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3273,3 +3273,187 @@ async def get_issues_development_info(
         logger.error(f"Error getting development info for issues: {str(e)}")
         error_result = {"success": False, "error": str(e)}
         return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get Filter", "readOnlyHint": True},
+)
+async def get_filter(
+    ctx: Context,
+    filter_id: Annotated[
+        str,
+        Field(description="The ID of the Jira saved filter (e.g., '209157')"),
+    ],
+) -> str:
+    """Get a Jira saved filter by ID, including its JQL query.
+
+    Args:
+        ctx: The FastMCP context.
+        filter_id: The ID of the filter.
+
+    Returns:
+        JSON string with filter details including name, JQL, owner.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_filter(filter_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Search Filters", "readOnlyHint": True},
+)
+async def search_filters(
+    ctx: Context,
+    filter_name: Annotated[
+        str,
+        Field(description="Filter name to search for"),
+    ],
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of results (1-50)",
+            ge=1,
+            le=50,
+        ),
+    ] = 20,
+) -> str:
+    """Search for Jira saved filters by name.
+
+    Args:
+        ctx: The FastMCP context.
+        filter_name: Filter name to search for.
+        limit: Maximum number of results.
+
+    Returns:
+        JSON string with list of matching filters and their JQL.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.search_filters(filter_name=filter_name, limit=limit)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get Favourite Filters", "readOnlyHint": True},
+)
+async def get_favourite_filters(
+    ctx: Context,
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of favourite filters to return (1-100)",
+            ge=1,
+            le=100,
+        ),
+    ] = 50,
+) -> str:
+    """Get the current user's favourite/starred Jira filters.
+
+    Args:
+        ctx: The FastMCP context.
+        limit: Maximum number of filters to return.
+
+    Returns:
+        JSON string with list of favourite filters and their JQL.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_favourite_filters(limit=limit)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_structures"},
+    annotations={"title": "Get Structure", "readOnlyHint": True},
+)
+async def get_structure(
+    ctx: Context,
+    structure_id: Annotated[
+        str,
+        Field(description="The ID of the Structure board (e.g., '585')"),
+    ],
+) -> str:
+    """Get metadata for a Jira Structure (Almworks) board.
+
+    Args:
+        ctx: The FastMCP context.
+        structure_id: The ID of the structure.
+
+    Returns:
+        JSON string with structure name, description, and metadata.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_structure(structure_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_structures"},
+    annotations={"title": "Get Structure Forest", "readOnlyHint": True},
+)
+async def get_structure_forest(
+    ctx: Context,
+    structure_id: Annotated[
+        str,
+        Field(description="The ID of the Structure board (e.g., '585')"),
+    ],
+) -> str:
+    """Get the raw hierarchy (forest) for a Structure board.
+
+    Returns row IDs and depths without resolving to issue details.
+    Use get_structure_issues for the fully resolved hierarchy.
+
+    Args:
+        ctx: The FastMCP context.
+        structure_id: The ID of the structure.
+
+    Returns:
+        JSON string with rows containing item IDs and hierarchy depths.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_structure_forest(structure_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_structures"},
+    annotations={"title": "Get Structure Issues", "readOnlyHint": True},
+)
+async def get_structure_issues(
+    ctx: Context,
+    structure_id: Annotated[
+        str,
+        Field(description="The ID of the Structure board (e.g., '585')"),
+    ],
+    max_depth: Annotated[
+        int | None,
+        Field(
+            description=(
+                "(Optional) Maximum hierarchy depth to include. "
+                "0 = top level only, 1 = top + first children, etc. "
+                "Omit for the full tree."
+            ),
+        ),
+    ] = None,
+) -> str:
+    """Get the full resolved hierarchy for a Jira Structure board.
+
+    Fetches the structure's forest, resolves all item IDs to Jira
+    issue details (key, summary, status, type, project), and returns
+    a flat list with depth for hierarchy reconstruction. This is the
+    composite call — one tool invocation gives you the complete
+    picture with issue details.
+
+    Args:
+        ctx: The FastMCP context.
+        structure_id: The ID of the structure.
+        max_depth: Optional maximum depth to include.
+
+    Returns:
+        JSON string with resolved issue hierarchy including key,
+        summary, status, issue_type, project, and depth for each item.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_structure_issues(structure_id, max_depth=max_depth)
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -100,6 +100,16 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_filters": ToolsetDefinition(
+        name="jira_filters",
+        description="Saved filter operations: get, search, favourites",
+        default=True,
+    ),
+    "jira_structures": ToolsetDefinition(
+        name="jira_structures",
+        description="Structure (Almworks) board operations: metadata, forest, resolved hierarchy",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (6) ---

--- a/tests/unit/jira/test_filters.py
+++ b/tests/unit/jira/test_filters.py
@@ -1,0 +1,180 @@
+from unittest.mock import Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.filters import FiltersMixin
+
+
+class TestFiltersMixin:
+    @pytest.fixture
+    def mixin(self, mock_config, mock_atlassian_jira):
+        m = FiltersMixin(config=mock_config)
+        m.jira = mock_atlassian_jira
+        return m
+
+    # ---- get_filter ----
+
+    def test_get_filter_success(self, mixin):
+        mixin.jira.get_filter.return_value = {
+            "id": "12345",
+            "name": "My Filter",
+            "description": "A test filter",
+            "jql": "project = PROJ",
+            "owner": {"displayName": "Alice", "name": "alice"},
+            "viewUrl": "https://jira.example.com/filter/12345",
+            "searchUrl": "https://jira.example.com/search",
+            "favourite": True,
+            "sharePermissions": [],
+        }
+
+        result = mixin.get_filter("12345")
+
+        assert result["id"] == "12345"
+        assert result["name"] == "My Filter"
+        assert result["jql"] == "project = PROJ"
+        assert result["owner"] == "Alice"
+        assert result["is_favourite"] is True
+
+    def test_get_filter_invalid_response(self, mixin):
+        mixin.jira.get_filter.return_value = "not a dict"
+
+        result = mixin.get_filter("99999")
+
+        assert result["error"] == "Invalid response"
+
+    def test_get_filter_auth_error(self, mixin):
+        mixin.jira.get_filter.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_filter("12345")
+
+    # ---- search_filters ----
+
+    def test_search_filters_success(self, mixin):
+        mixin.jira.get.return_value = {
+            "values": [
+                {
+                    "id": "1",
+                    "name": "Sprint Filter",
+                    "description": "",
+                    "jql": "sprint in openSprints()",
+                    "owner": {"displayName": "Bob"},
+                    "favourite": False,
+                },
+                {
+                    "id": "2",
+                    "name": "Sprint Backlog",
+                    "description": "Backlog items",
+                    "jql": "sprint is EMPTY",
+                    "owner": {"name": "charlie"},
+                    "favourite": True,
+                },
+            ],
+            "total": 2,
+        }
+
+        result = mixin.search_filters("Sprint")
+
+        assert result["total"] == 2
+        assert len(result["filters"]) == 2
+        assert result["filters"][0]["name"] == "Sprint Filter"
+        assert result["filters"][1]["is_favourite"] is True
+
+    def test_search_filters_invalid_response(self, mixin):
+        mixin.jira.get.return_value = "bad"
+
+        result = mixin.search_filters("anything")
+
+        assert result == {"filters": [], "total": 0}
+
+    def test_search_filters_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=403))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.search_filters("test")
+
+    # ---- search_filters (Server/DC fallback) ----
+
+    def test_search_filters_server_dc_fallback(
+        self, jira_config_factory, mock_atlassian_jira
+    ):
+        dc_config = jira_config_factory(
+            url="https://jira.example.com", auth_type="pat", personal_token="tok"
+        )
+        dc_mixin = FiltersMixin(config=dc_config)
+        dc_mixin.jira = mock_atlassian_jira
+        dc_mixin.jira.get.return_value = [
+            {"id": "10", "name": "Sprint Board", "jql": "x", "owner": {}},
+            {"id": "20", "name": "My Backlog", "jql": "y", "owner": {}},
+        ]
+
+        result = dc_mixin.search_filters("sprint")
+
+        assert result["total"] == 1
+        assert result["filters"][0]["name"] == "Sprint Board"
+        assert result["partial"] is True
+        assert "favourite" in result.get("note", "").lower()
+
+    def test_search_filters_server_dc_no_match(
+        self, jira_config_factory, mock_atlassian_jira
+    ):
+        dc_config = jira_config_factory(
+            url="https://jira.example.com", auth_type="pat", personal_token="tok"
+        )
+        dc_mixin = FiltersMixin(config=dc_config)
+        dc_mixin.jira = mock_atlassian_jira
+        dc_mixin.jira.get.return_value = [
+            {"id": "10", "name": "My Filter", "jql": "x", "owner": {}},
+        ]
+
+        result = dc_mixin.search_filters("nonexistent")
+
+        assert result["total"] == 0
+        assert result["filters"] == []
+
+    # ---- get_favourite_filters ----
+
+    def test_get_favourite_filters_success(self, mixin):
+        mixin.jira.get.return_value = [
+            {
+                "id": "10",
+                "name": "Fav 1",
+                "description": "",
+                "jql": "assignee = currentUser()",
+                "owner": {"displayName": "Alice"},
+            },
+            {
+                "id": "20",
+                "name": "Fav 2",
+                "description": "desc",
+                "jql": "project = PROJ",
+                "owner": {"name": "bob"},
+            },
+        ]
+
+        result = mixin.get_favourite_filters()
+
+        assert result["total"] == 2
+        assert result["filters"][0]["name"] == "Fav 1"
+        assert result["filters"][1]["owner"] == "bob"
+
+    def test_get_favourite_filters_respects_limit(self, mixin):
+        mixin.jira.get.return_value = [
+            {"id": str(i), "name": f"F{i}", "jql": "x", "owner": {}} for i in range(10)
+        ]
+
+        result = mixin.get_favourite_filters(limit=3)
+
+        assert result["total"] == 3
+
+    def test_get_favourite_filters_invalid_response(self, mixin):
+        mixin.jira.get.return_value = {"not": "a list"}
+
+        result = mixin.get_favourite_filters()
+
+        assert result == {"filters": [], "total": 0}
+
+    def test_get_favourite_filters_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_favourite_filters()

--- a/tests/unit/jira/test_filters.py
+++ b/tests/unit/jira/test_filters.py
@@ -1,0 +1,141 @@
+from unittest.mock import Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.filters import FiltersMixin
+
+
+class TestFiltersMixin:
+    @pytest.fixture
+    def mixin(self, mock_config, mock_atlassian_jira):
+        m = FiltersMixin(config=mock_config)
+        m.jira = mock_atlassian_jira
+        return m
+
+    # ---- get_filter ----
+
+    def test_get_filter_success(self, mixin):
+        mixin.jira.get_filter.return_value = {
+            "id": "12345",
+            "name": "My Filter",
+            "description": "A test filter",
+            "jql": "project = PROJ",
+            "owner": {"displayName": "Alice", "name": "alice"},
+            "viewUrl": "https://jira.example.com/filter/12345",
+            "searchUrl": "https://jira.example.com/search",
+            "favourite": True,
+            "sharePermissions": [],
+        }
+
+        result = mixin.get_filter("12345")
+
+        assert result["id"] == "12345"
+        assert result["name"] == "My Filter"
+        assert result["jql"] == "project = PROJ"
+        assert result["owner"] == "Alice"
+        assert result["is_favourite"] is True
+
+    def test_get_filter_invalid_response(self, mixin):
+        mixin.jira.get_filter.return_value = "not a dict"
+
+        result = mixin.get_filter("99999")
+
+        assert result["error"] == "Invalid response"
+
+    def test_get_filter_auth_error(self, mixin):
+        mixin.jira.get_filter.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_filter("12345")
+
+    # ---- search_filters ----
+
+    def test_search_filters_success(self, mixin):
+        mixin.jira.get.return_value = {
+            "values": [
+                {
+                    "id": "1",
+                    "name": "Sprint Filter",
+                    "description": "",
+                    "jql": "sprint in openSprints()",
+                    "owner": {"displayName": "Bob"},
+                    "favourite": False,
+                },
+                {
+                    "id": "2",
+                    "name": "Sprint Backlog",
+                    "description": "Backlog items",
+                    "jql": "sprint is EMPTY",
+                    "owner": {"name": "charlie"},
+                    "favourite": True,
+                },
+            ],
+            "total": 2,
+        }
+
+        result = mixin.search_filters("Sprint")
+
+        assert result["total"] == 2
+        assert len(result["filters"]) == 2
+        assert result["filters"][0]["name"] == "Sprint Filter"
+        assert result["filters"][1]["is_favourite"] is True
+
+    def test_search_filters_invalid_response(self, mixin):
+        mixin.jira.get.return_value = "bad"
+
+        result = mixin.search_filters("anything")
+
+        assert result == {"filters": [], "total": 0}
+
+    def test_search_filters_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=403))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.search_filters("test")
+
+    # ---- get_favourite_filters ----
+
+    def test_get_favourite_filters_success(self, mixin):
+        mixin.jira.get.return_value = [
+            {
+                "id": "10",
+                "name": "Fav 1",
+                "description": "",
+                "jql": "assignee = currentUser()",
+                "owner": {"displayName": "Alice"},
+            },
+            {
+                "id": "20",
+                "name": "Fav 2",
+                "description": "desc",
+                "jql": "project = PROJ",
+                "owner": {"name": "bob"},
+            },
+        ]
+
+        result = mixin.get_favourite_filters()
+
+        assert result["total"] == 2
+        assert result["filters"][0]["name"] == "Fav 1"
+        assert result["filters"][1]["owner"] == "bob"
+
+    def test_get_favourite_filters_respects_limit(self, mixin):
+        mixin.jira.get.return_value = [
+            {"id": str(i), "name": f"F{i}", "jql": "x", "owner": {}} for i in range(10)
+        ]
+
+        result = mixin.get_favourite_filters(limit=3)
+
+        assert result["total"] == 3
+
+    def test_get_favourite_filters_invalid_response(self, mixin):
+        mixin.jira.get.return_value = {"not": "a list"}
+
+        result = mixin.get_favourite_filters()
+
+        assert result == {"filters": [], "total": 0}
+
+    def test_get_favourite_filters_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_favourite_filters()

--- a/tests/unit/jira/test_structures.py
+++ b/tests/unit/jira/test_structures.py
@@ -1,0 +1,257 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.structures import StructuresMixin
+from mcp_atlassian.models.jira.common import (
+    JiraIssueType,
+    JiraStatus,
+    JiraStatusCategory,
+)
+from mcp_atlassian.models.jira.issue import JiraIssue
+from mcp_atlassian.models.jira.project import JiraProject
+from mcp_atlassian.models.jira.search import JiraSearchResult
+
+
+def _resolved_issue(
+    issue_id: str,
+    key: str,
+    summary: str = "S",
+    issue_type: str = "Task",
+    status: str = "Open",
+    status_category: str = "To Do",
+    project: str = "PROJ",
+) -> JiraIssue:
+    """Build a JiraIssue suitable for Structure batch resolution."""
+    return JiraIssue(
+        id=issue_id,
+        key=key,
+        summary=summary,
+        issue_type=JiraIssueType(name=issue_type),
+        status=JiraStatus(
+            name=status,
+            category=JiraStatusCategory(name=status_category),
+        ),
+        project=JiraProject(key=project),
+    )
+
+
+def _search_result(issues: list[JiraIssue]) -> JiraSearchResult:
+    return JiraSearchResult(
+        total=len(issues), start_at=0, max_results=50, issues=issues
+    )
+
+
+class TestStructuresMixin:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    # ---- get_structure ----
+
+    def test_get_structure_success(self, mixin):
+        mixin.jira.get.return_value = {
+            "id": 585,
+            "name": "My Structure",
+            "description": "A board",
+            "editable": True,
+            "isArchived": False,
+        }
+
+        result = mixin.get_structure("585")
+
+        assert result["id"] == 585
+        assert result["name"] == "My Structure"
+        assert result["editable"] is True
+
+    def test_get_structure_invalid_response(self, mixin):
+        mixin.jira.get.return_value = "bad"
+
+        result = mixin.get_structure("585")
+
+        assert result["error"] == "Invalid response"
+
+    def test_get_structure_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_structure("585")
+
+    # ---- get_structure_forest ----
+
+    def test_get_structure_forest_success(self, mixin):
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0,2:1:200:0,3:1:300:0",
+            "version": 42,
+        }
+
+        result = mixin.get_structure_forest("585")
+
+        assert result["total_rows"] == 3
+        assert result["rows"][0]["depth"] == 0
+        assert result["rows"][0]["item_id"] == "100"
+        assert result["rows"][1]["depth"] == 1
+        assert result["version"] == 42
+
+    def test_get_structure_forest_invalid_response(self, mixin):
+        mixin.jira.post.return_value = {"no_formula": True}
+
+        result = mixin.get_structure_forest("585")
+
+        assert result["error"] == "Invalid response"
+
+    def test_get_structure_forest_auth_error(self, mixin):
+        mixin.jira.post.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_structure_forest("585")
+
+    # ---- _parse_formula ----
+
+    def test_parse_formula_issue_rows(self):
+        rows = StructuresMixin._parse_formula("1:0:100:0,2:1:200:0")
+        assert len(rows) == 2
+        assert rows[0] == {
+            "row_id": "1",
+            "depth": 0,
+            "item_id": "100",
+            "item_type": "0",
+            "row_type": "issue",
+        }
+
+    def test_parse_formula_generator_rows(self):
+        rows = StructuresMixin._parse_formula("10:2:gen/abc")
+        assert len(rows) == 1
+        assert rows[0]["row_type"] == "generator"
+        assert rows[0]["item_ref"] == "gen/abc"
+
+    def test_parse_formula_empty(self):
+        assert StructuresMixin._parse_formula("") == []
+
+    def test_parse_formula_mixed(self):
+        rows = StructuresMixin._parse_formula("1:0:100:0,2:1:gen/x,3:0:200:0")
+        assert len(rows) == 3
+        assert rows[0]["row_type"] == "issue"
+        assert rows[1]["row_type"] == "generator"
+        assert rows[2]["row_type"] == "issue"
+
+    # ---- get_structure_issues ----
+
+    def test_get_structure_issues_success(self, mixin):
+        mixin.jira.get.return_value = {
+            "id": 585,
+            "name": "Board",
+            "description": "",
+            "editable": True,
+            "isArchived": False,
+        }
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0,2:1:200:0",
+            "version": 1,
+        }
+        mixin.search_issues = MagicMock(
+            return_value=_search_result(
+                [
+                    _resolved_issue(
+                        "100",
+                        "PROJ-1",
+                        summary="Top level",
+                        issue_type="Epic",
+                    ),
+                    _resolved_issue(
+                        "200",
+                        "PROJ-2",
+                        summary="Child",
+                        issue_type="Story",
+                        status="Done",
+                        status_category="Done",
+                    ),
+                ]
+            )
+        )
+
+        result = mixin.get_structure_issues("585")
+
+        assert result["total_items"] == 2
+        assert result["resolved_count"] == 2
+        assert result["items"][0]["key"] == "PROJ-1"
+        assert result["items"][0]["depth"] == 0
+        assert result["items"][1]["key"] == "PROJ-2"
+        assert result["items"][1]["depth"] == 1
+        assert "partial" not in result
+
+    def test_get_structure_issues_with_max_depth(self, mixin):
+        mixin.jira.get.return_value = {
+            "id": 1,
+            "name": "B",
+            "description": "",
+        }
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0,2:1:200:0,3:2:300:0",
+            "version": 1,
+        }
+        mixin.search_issues = MagicMock(
+            return_value=_search_result(
+                [
+                    _resolved_issue("100", "P-1"),
+                    _resolved_issue("200", "P-2"),
+                ]
+            )
+        )
+
+        result = mixin.get_structure_issues("1", max_depth=1)
+
+        assert result["total_items"] == 2
+        depths = [i["depth"] for i in result["items"]]
+        assert all(d <= 1 for d in depths)
+
+    def test_get_structure_issues_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_structure_issues("585")
+
+    def test_get_structure_issues_uses_search_issues(self, mixin):
+        """Resolution goes through search_issues (respects projects_filter)."""
+        mixin.jira.get.return_value = {
+            "id": 1,
+            "name": "B",
+            "description": "",
+        }
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0",
+            "version": 1,
+        }
+        mixin.search_issues = MagicMock(
+            return_value=_search_result([_resolved_issue("100", "P-1")])
+        )
+
+        mixin.get_structure_issues("1")
+
+        mixin.search_issues.assert_called_once()
+        call_args = mixin.search_issues.call_args
+        jql_arg = call_args.kwargs.get(
+            "jql", call_args.args[0] if call_args.args else ""
+        )
+        assert "id in" in jql_arg
+
+    def test_get_structure_issues_partial_failure(self, mixin):
+        """Failed batch surfaces partial=True and unresolved placeholders."""
+        mixin.jira.get.return_value = {
+            "id": 1,
+            "name": "B",
+            "description": "",
+        }
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0,2:1:200:0",
+            "version": 1,
+        }
+        mixin.search_issues = MagicMock(side_effect=RuntimeError("connection lost"))
+
+        result = mixin.get_structure_issues("1")
+
+        assert result["partial"] is True
+        assert result["unresolved_count"] == 2
+        assert result["resolved_count"] == 0
+        assert any("[unresolved]" == i["summary"] for i in result["items"])
+        for item in result["items"]:
+            assert "id=" not in item["summary"]

--- a/tests/unit/jira/test_structures.py
+++ b/tests/unit/jira/test_structures.py
@@ -1,0 +1,201 @@
+from unittest.mock import Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.structures import StructuresMixin
+
+
+class TestStructuresMixin:
+    @pytest.fixture
+    def mixin(self, mock_config, mock_atlassian_jira):
+        m = StructuresMixin(config=mock_config)
+        m.jira = mock_atlassian_jira
+        return m
+
+    # ---- get_structure ----
+
+    def test_get_structure_success(self, mixin):
+        mixin.jira.get.return_value = {
+            "id": 585,
+            "name": "My Structure",
+            "description": "A board",
+            "editable": True,
+            "isArchived": False,
+        }
+
+        result = mixin.get_structure("585")
+
+        assert result["id"] == 585
+        assert result["name"] == "My Structure"
+        assert result["editable"] is True
+
+    def test_get_structure_invalid_response(self, mixin):
+        mixin.jira.get.return_value = "bad"
+
+        result = mixin.get_structure("585")
+
+        assert result["error"] == "Invalid response"
+
+    def test_get_structure_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_structure("585")
+
+    # ---- get_structure_forest ----
+
+    def test_get_structure_forest_success(self, mixin):
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0,2:1:200:0,3:1:300:0",
+            "version": 42,
+        }
+
+        result = mixin.get_structure_forest("585")
+
+        assert result["total_rows"] == 3
+        assert result["rows"][0]["depth"] == 0
+        assert result["rows"][0]["item_id"] == "100"
+        assert result["rows"][1]["depth"] == 1
+        assert result["version"] == 42
+
+    def test_get_structure_forest_invalid_response(self, mixin):
+        mixin.jira.post.return_value = {"no_formula": True}
+
+        result = mixin.get_structure_forest("585")
+
+        assert result["error"] == "Invalid response"
+
+    def test_get_structure_forest_auth_error(self, mixin):
+        mixin.jira.post.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_structure_forest("585")
+
+    # ---- _parse_formula ----
+
+    def test_parse_formula_issue_rows(self):
+        rows = StructuresMixin._parse_formula("1:0:100:0,2:1:200:0")
+        assert len(rows) == 2
+        assert rows[0] == {
+            "row_id": "1",
+            "depth": 0,
+            "item_id": "100",
+            "item_type": "0",
+            "row_type": "issue",
+        }
+
+    def test_parse_formula_generator_rows(self):
+        rows = StructuresMixin._parse_formula("10:2:gen/abc")
+        assert len(rows) == 1
+        assert rows[0]["row_type"] == "generator"
+        assert rows[0]["item_ref"] == "gen/abc"
+
+    def test_parse_formula_empty(self):
+        assert StructuresMixin._parse_formula("") == []
+
+    def test_parse_formula_mixed(self):
+        rows = StructuresMixin._parse_formula("1:0:100:0,2:1:gen/x,3:0:200:0")
+        assert len(rows) == 3
+        assert rows[0]["row_type"] == "issue"
+        assert rows[1]["row_type"] == "generator"
+        assert rows[2]["row_type"] == "issue"
+
+    # ---- get_structure_issues ----
+
+    def test_get_structure_issues_success(self, mixin):
+        mixin.jira.get.return_value = {
+            "id": 585,
+            "name": "Board",
+            "description": "",
+            "editable": True,
+            "isArchived": False,
+        }
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0,2:1:200:0",
+            "version": 1,
+        }
+        mixin.jira.jql.return_value = {
+            "issues": [
+                {
+                    "id": "100",
+                    "key": "PROJ-1",
+                    "fields": {
+                        "summary": "Top level",
+                        "issuetype": {"name": "Epic"},
+                        "status": {
+                            "name": "Open",
+                            "statusCategory": {"name": "To Do"},
+                        },
+                        "project": {"key": "PROJ"},
+                    },
+                },
+                {
+                    "id": "200",
+                    "key": "PROJ-2",
+                    "fields": {
+                        "summary": "Child",
+                        "issuetype": {"name": "Story"},
+                        "status": {
+                            "name": "Done",
+                            "statusCategory": {"name": "Done"},
+                        },
+                        "project": {"key": "PROJ"},
+                    },
+                },
+            ],
+        }
+
+        result = mixin.get_structure_issues("585")
+
+        assert result["total_items"] == 2
+        assert result["resolved_count"] == 2
+        assert result["items"][0]["key"] == "PROJ-1"
+        assert result["items"][0]["depth"] == 0
+        assert result["items"][1]["key"] == "PROJ-2"
+        assert result["items"][1]["depth"] == 1
+
+    def test_get_structure_issues_with_max_depth(self, mixin):
+        mixin.jira.get.return_value = {
+            "id": 1,
+            "name": "B",
+            "description": "",
+        }
+        mixin.jira.post.return_value = {
+            "formula": "1:0:100:0,2:1:200:0,3:2:300:0",
+            "version": 1,
+        }
+        mixin.jira.jql.return_value = {
+            "issues": [
+                {
+                    "id": "100",
+                    "key": "P-1",
+                    "fields": {
+                        "summary": "A",
+                        "issuetype": {"name": "Task"},
+                        "status": {"name": "Open", "statusCategory": {"name": "To Do"}},
+                        "project": {"key": "P"},
+                    },
+                },
+                {
+                    "id": "200",
+                    "key": "P-2",
+                    "fields": {
+                        "summary": "B",
+                        "issuetype": {"name": "Task"},
+                        "status": {"name": "Open", "statusCategory": {"name": "To Do"}},
+                        "project": {"key": "P"},
+                    },
+                },
+            ],
+        }
+
+        result = mixin.get_structure_issues("1", max_depth=1)
+
+        assert result["total_items"] == 2
+        depths = [i["depth"] for i in result["items"]]
+        assert all(d <= 1 for d in depths)
+
+    def test_get_structure_issues_auth_error(self, mixin):
+        mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=401))
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_structure_issues("585")

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 23 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 23
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,16 +47,16 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 23
 
     def test_default_keyword(self, monkeypatch):
-        """Test 'default' keyword returns 6 default toolset names."""
+        """Test 'default' keyword returns 7 default toolset names."""
         monkeypatch.setenv("TOOLSETS", "default")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == DEFAULT_TOOLSETS
-        # 4 Jira defaults + 2 Confluence defaults
-        assert len(result) == 6
+        # 5 Jira defaults + 2 Confluence defaults
+        assert len(result) == 7
 
     def test_default_plus_extra(self, monkeypatch):
         """Test 'default,jira_agile' returns defaults + jira_agile."""
@@ -85,20 +85,21 @@ class TestGetEnabledToolsets:
             "jira_fields",
             "jira_comments",
             "jira_transitions",
+            "jira_filters",
             "confluence_pages",
             "confluence_comments",
         }
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 23 entries."""
+        assert len(ALL_TOOLSETS) == 23
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 17
         assert len(confluence_toolsets) == 6
 
 
@@ -249,7 +250,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 55, f"Expected 55 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

- Add two new toolsets: **Filters** (`jira_filters`, default: on) and **Structures** (`jira_structures`, default: off)
- Filters: get saved filter by ID, search filters by name (Cloud API + Server/DC favourite-filter fallback), list favourite filters
- Structures: get Almworks Structure board metadata, raw forest hierarchy, and fully resolved issue hierarchy
- Structure resolution routes through `search_issues()` so `JIRA_PROJECTS_FILTER` is respected
- Failed resolution batches produce generic placeholders and `partial=True` metadata instead of silently dropping rows
- Server/DC filter search explicitly marks results as `partial=True` since only favourites are searched

## Test plan

- [ ] 27 unit tests covering both mixins
- [ ] Verify `jira_get_filter` returns filter details with JQL
- [ ] Verify `jira_search_filters` works on Cloud and falls back gracefully on Server/DC
- [ ] Verify `jira_get_structure_issues` resolves hierarchy correctly
- [ ] Verify structure resolution respects `JIRA_PROJECTS_FILTER`

> **Note:** Tools reference docs update will be submitted as a separate PR after feature PRs are merged.