### PR TITLE
feat(jira): add compare_issue_sets tool for JQL set diff

### DIFF
--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -46,6 +46,32 @@ Cloud supports cursor-based pagination via `page_token` for deterministic result
 
 ---
 
+### Compare Issue Sets
+
+Compare two JQL result sets and report issues that were added, removed, changed, or unchanged.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `jql_a` | `string` | Yes | JQL query defining the first issue set |
+| `jql_b` | `string` | Yes | JQL query defining the second issue set |
+| `compare_fields` | `string` | No | Comma-separated field names to compare; defaults to `status,assignee,priority,labels` |
+| `max_issues` | `integer` | No | Maximum issues to fetch per query (1-500); default: 200 |
+
+**Example:**
+
+```json
+{"jql_a": "project = PROJ AND sprint = 13", "jql_b": "project = PROJ AND sprint = 14", "compare_fields": "status,assignee,priority"}
+```
+
+<Tip>
+Enable the opt-in `jira_set_analysis` toolset to expose this tool.
+</Tip>
+
+
+---
+
 ### Search Fields
 
 Search Jira fields by keyword with fuzzy match.

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -50,6 +50,7 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
         "jira_get_create_fields",
         "jira_get_project_fields",
         "jira_search_projects",
+        "jira_compare_issue_sets",
     ],
     "jira-agile": [
         "jira_get_agile_boards",

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -26,6 +26,7 @@ from .projects import ProjectsMixin
 from .queues import QueuesMixin
 from .sla import SLAMixin
 from .search import SearchMixin
+from .set_analysis import SetAnalysisMixin
 from .sprints import SprintsMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
@@ -55,6 +56,7 @@ class JiraFetcher(
     MetricsMixin,
     SLAMixin,
     DevelopmentMixin,
+    SetAnalysisMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -28,6 +28,7 @@ from .projects import ProjectsMixin
 from .queues import QueuesMixin
 from .sla import SLAMixin
 from .search import SearchMixin
+from .set_analysis import SetAnalysisMixin
 from .sprints import SprintsMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
@@ -59,6 +60,7 @@ class JiraFetcher(
     SLAMixin,
     DevelopmentMixin,
     ProjectAnalysisMixin,
+    SetAnalysisMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.

--- a/src/mcp_atlassian/jira/set_analysis.py
+++ b/src/mcp_atlassian/jira/set_analysis.py
@@ -33,9 +33,8 @@ def _normalize_field_value(value: Any) -> str | list[str] | None:
         return None
     if isinstance(value, dict):
         for key in ("display_name", "value", "name"):
-            v = value.get(key)
-            if v is not None:
-                return _normalize_field_value(v)
+            if key in value:
+                return _normalize_field_value(value[key])
         return None
     if isinstance(value, list):
         normalized: list[str] = []

--- a/src/mcp_atlassian/jira/set_analysis.py
+++ b/src/mcp_atlassian/jira/set_analysis.py
@@ -1,0 +1,240 @@
+"""Module for Jira issue set comparison operations."""
+
+import logging
+from typing import Any
+
+from ..models.jira import JiraSearchResult
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+from .protocols import SearchOperationsProto
+
+logger = logging.getLogger("mcp-jira")
+
+# Server/DC caps each search response at this many issues.
+_SERVER_DC_PAGE_SIZE = 50
+
+# Fields used for comparison when none are specified.
+_DEFAULT_COMPARE_FIELDS = ["status", "assignee", "priority", "labels"]
+
+# Fields always fetched so that every issue node carries basic identity info.
+_BASE_FIELDS = ["summary", "status", "issuetype"]
+
+
+def _normalize_field_value(value: Any) -> str | list[str] | None:
+    """Normalize a field value for comparison.
+
+    Args:
+        value: The raw value from to_simplified_dict().
+
+    Returns:
+        A normalized comparable value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        for key in ("display_name", "value", "name"):
+            v = value.get(key)
+            if v is not None:
+                return _normalize_field_value(v)
+        return None
+    if isinstance(value, list):
+        normalized = []
+        for item in value:
+            if isinstance(item, dict):
+                for key in ("display_name", "name"):
+                    v = item.get(key)
+                    if v is not None:
+                        normalized.append(str(v))
+                        break
+                else:
+                    normalized.append(str(item))
+            else:
+                normalized.append(str(item))
+        return sorted(normalized)
+    return str(value)
+
+
+def _get_field_value(issue: dict[str, Any], field: str) -> Any:
+    """Get a requested Jira field from a simplified issue dictionary.
+
+    Jira's simplified representation renames a few built-in fields and stores
+    custom fields by ID even when they were requested by display name.
+
+    Args:
+        issue: Simplified Jira issue dictionary.
+        field: Jira field ID or display name requested by the caller.
+
+    Returns:
+        The field value, or ``None`` when the field is absent.
+    """
+    field_aliases = {
+        "attachment": "attachments",
+        "comment": "comments",
+        "fixVersions": "fix_versions",
+        "issuetype": "issue_type",
+    }
+    key = field_aliases.get(field, field)
+    if key in issue:
+        return issue[key]
+
+    normalized_field = field.casefold()
+    for value in issue.values():
+        if (
+            isinstance(value, dict)
+            and str(value.get("name", "")).casefold() == normalized_field
+        ):
+            return value
+    return None
+
+
+class SetAnalysisMixin(JiraClient, SearchOperationsProto):
+    """Mixin for comparing two sets of Jira issues."""
+
+    def _fetch_all_issues(
+        self,
+        jql: str,
+        fields: list[str],
+        max_issues: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch all issues for a JQL query up to max_issues.
+
+        On Cloud, ``search_issues`` paginates internally via
+        ``nextPageToken``, so a single call with ``limit=max_issues``
+        returns up to that many results.  On Server/DC the API caps
+        each response at 50, so we page with ``start``.
+
+        Args:
+            jql: The JQL query string.
+            fields: Fields to include in results.
+            max_issues: Upper bound on issues to fetch.
+
+        Returns:
+            List of simplified issue dicts.
+        """
+        result: JiraSearchResult = self.search_issues(
+            jql=jql,
+            fields=fields,
+            limit=max_issues,
+        )
+        all_issues: list[dict[str, Any]] = [
+            issue.to_simplified_dict() for issue in result.issues
+        ]
+
+        # Cloud paginates internally via nextPageToken — only page
+        # manually on Server/DC where each response caps at 50.
+        if not self.config.is_cloud:
+            while (
+                len(all_issues) < max_issues
+                and len(result.issues) >= _SERVER_DC_PAGE_SIZE
+            ):
+                result = self.search_issues(
+                    jql=jql,
+                    fields=fields,
+                    start=len(all_issues),
+                    limit=max_issues - len(all_issues),
+                )
+                if not result.issues:
+                    break
+                all_issues.extend(issue.to_simplified_dict() for issue in result.issues)
+
+        return all_issues[:max_issues]
+
+    @handle_auth_errors("Jira API")
+    def compare_issue_sets(
+        self,
+        jql_a: str,
+        jql_b: str,
+        compare_fields: list[str] | None = None,
+        max_issues: int = 200,
+    ) -> dict[str, Any]:
+        """Compare two sets of Jira issues defined by JQL queries.
+
+        Runs both queries and computes set differences: issues only in A,
+        only in B, present in both but with changed fields, and unchanged.
+
+        Args:
+            jql_a: JQL query defining set A.
+            jql_b: JQL query defining set B.
+            compare_fields: Field names to check for changes on issues
+                present in both sets. Defaults to status, assignee,
+                priority, and labels.
+            max_issues: Maximum issues to fetch per query.
+
+        Returns:
+            Dict with only_in_a, only_in_b, changed, unchanged_count,
+            and a summary sub-dict.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If there is an error executing the queries.
+        """
+        fields_to_compare = compare_fields or _DEFAULT_COMPARE_FIELDS
+        fields_to_fetch = list(dict.fromkeys(_BASE_FIELDS + fields_to_compare))
+
+        issues_a = self._fetch_all_issues(jql_a, fields_to_fetch, max_issues)
+        issues_b = self._fetch_all_issues(jql_b, fields_to_fetch, max_issues)
+
+        map_a: dict[str, dict[str, Any]] = {i["key"]: i for i in issues_a if "key" in i}
+        map_b: dict[str, dict[str, Any]] = {i["key"]: i for i in issues_b if "key" in i}
+
+        keys_a = set(map_a.keys())
+        keys_b = set(map_b.keys())
+
+        only_in_a_keys = sorted(keys_a - keys_b)
+        only_in_b_keys = sorted(keys_b - keys_a)
+        common_keys = sorted(keys_a & keys_b)
+
+        only_in_a = [
+            {"key": k, "summary": map_a[k].get("summary", "")} for k in only_in_a_keys
+        ]
+        only_in_b = [
+            {"key": k, "summary": map_b[k].get("summary", "")} for k in only_in_b_keys
+        ]
+
+        changed: list[dict[str, Any]] = []
+        unchanged_count = 0
+
+        for key in common_keys:
+            issue_a = map_a[key]
+            issue_b = map_b[key]
+            diffs: list[dict[str, Any]] = []
+
+            for field in fields_to_compare:
+                val_a = _normalize_field_value(_get_field_value(issue_a, field))
+                val_b = _normalize_field_value(_get_field_value(issue_b, field))
+                if val_a != val_b:
+                    diffs.append(
+                        {
+                            "field": field,
+                            "in_a": val_a,
+                            "in_b": val_b,
+                        }
+                    )
+
+            if diffs:
+                changed.append(
+                    {
+                        "key": key,
+                        "summary": issue_a.get("summary", ""),
+                        "changes": diffs,
+                    }
+                )
+            else:
+                unchanged_count += 1
+
+        return {
+            "jql_a": jql_a,
+            "jql_b": jql_b,
+            "set_a_count": len(map_a),
+            "set_b_count": len(map_b),
+            "only_in_a": only_in_a,
+            "only_in_b": only_in_b,
+            "changed": changed,
+            "unchanged_count": unchanged_count,
+            "summary": {
+                "only_in_a_count": len(only_in_a),
+                "only_in_b_count": len(only_in_b),
+                "changed_count": len(changed),
+                "unchanged_count": unchanged_count,
+            },
+        }

--- a/src/mcp_atlassian/jira/set_analysis.py
+++ b/src/mcp_atlassian/jira/set_analysis.py
@@ -38,16 +38,13 @@ def _normalize_field_value(value: Any) -> str | list[str] | None:
                 return _normalize_field_value(v)
         return None
     if isinstance(value, list):
-        normalized = []
+        normalized: list[str] = []
         for item in value:
-            if isinstance(item, dict):
-                for key in ("display_name", "name"):
-                    v = item.get(key)
-                    if v is not None:
-                        normalized.append(str(v))
-                        break
-                else:
-                    normalized.append(str(item))
+            normalized_item = _normalize_field_value(item)
+            if isinstance(normalized_item, list):
+                normalized.extend(normalized_item)
+            elif normalized_item is not None:
+                normalized.append(normalized_item)
             else:
                 normalized.append(str(item))
         return sorted(normalized)
@@ -69,16 +66,23 @@ def _get_field_value(issue: dict[str, Any], field: str) -> Any:
     """
     field_aliases = {
         "attachment": "attachments",
+        "attachments": "attachments",
         "comment": "comments",
-        "fixVersions": "fix_versions",
+        "comments": "comments",
+        "fixversions": "fix_versions",
+        "fix_versions": "fix_versions",
         "issuetype": "issue_type",
+        "issue_type": "issue_type",
+        "issue type": "issue_type",
     }
-    key = field_aliases.get(field, field)
+    normalized_field = field.strip().casefold()
+    key = field_aliases.get(normalized_field, field.strip())
     if key in issue:
         return issue[key]
 
-    normalized_field = field.casefold()
-    for value in issue.values():
+    for issue_key, value in issue.items():
+        if issue_key.casefold() == key.casefold():
+            return value
         if (
             isinstance(value, dict)
             and str(value.get("name", "")).casefold() == normalized_field

--- a/src/mcp_atlassian/jira/set_analysis.py
+++ b/src/mcp_atlassian/jira/set_analysis.py
@@ -1,0 +1,199 @@
+"""Module for Jira issue set comparison operations."""
+
+import logging
+from typing import Any
+
+from ..models.jira import JiraSearchResult
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+from .protocols import SearchOperationsProto
+
+logger = logging.getLogger("mcp-jira")
+
+# Fields used for comparison when none are specified.
+_DEFAULT_COMPARE_FIELDS = ["status", "assignee", "priority", "labels"]
+
+# Fields always fetched so that every issue node carries basic identity info.
+_BASE_FIELDS = ["summary", "status", "issuetype"]
+
+
+def _normalize_field_value(value: Any) -> str | list[str] | None:
+    """Normalize a field value for comparison.
+
+    Args:
+        value: The raw value from to_simplified_dict().
+
+    Returns:
+        A normalized comparable value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        for key in ("display_name", "name", "value"):
+            v = value.get(key)
+            if v is not None:
+                return str(v)
+        return None
+    if isinstance(value, list):
+        normalized = []
+        for item in value:
+            if isinstance(item, dict):
+                for key in ("display_name", "name"):
+                    v = item.get(key)
+                    if v is not None:
+                        normalized.append(str(v))
+                        break
+                else:
+                    normalized.append(str(item))
+            else:
+                normalized.append(str(item))
+        return sorted(normalized)
+    return str(value)
+
+
+class SetAnalysisMixin(JiraClient, SearchOperationsProto):
+    """Mixin for comparing two sets of Jira issues."""
+
+    def _fetch_all_issues(
+        self,
+        jql: str,
+        fields: list[str],
+        max_issues: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch all issues for a JQL query up to max_issues.
+
+        On Cloud, ``search_issues`` paginates internally via
+        ``nextPageToken``, so a single call with ``limit=max_issues``
+        returns up to that many results.  On Server/DC the API caps
+        each response at 50, so we page with ``start``.
+
+        Args:
+            jql: The JQL query string.
+            fields: Fields to include in results.
+            max_issues: Upper bound on issues to fetch.
+
+        Returns:
+            List of simplified issue dicts.
+        """
+        result: JiraSearchResult = self.search_issues(
+            jql=jql,
+            fields=fields,
+            limit=max_issues,
+        )
+        all_issues: list[dict[str, Any]] = [
+            issue.to_simplified_dict() for issue in result.issues
+        ]
+
+        # Server/DC caps at 50 per response — page if needed.
+        while len(all_issues) < max_issues and len(result.issues) >= 50:
+            result = self.search_issues(
+                jql=jql,
+                fields=fields,
+                start=len(all_issues),
+                limit=max_issues - len(all_issues),
+            )
+            if not result.issues:
+                break
+            all_issues.extend(issue.to_simplified_dict() for issue in result.issues)
+
+        return all_issues[:max_issues]
+
+    @handle_auth_errors("Jira API")
+    def compare_issue_sets(
+        self,
+        jql_a: str,
+        jql_b: str,
+        compare_fields: list[str] | None = None,
+        max_issues: int = 200,
+    ) -> dict[str, Any]:
+        """Compare two sets of Jira issues defined by JQL queries.
+
+        Runs both queries and computes set differences: issues only in A,
+        only in B, present in both but with changed fields, and unchanged.
+
+        Args:
+            jql_a: JQL query defining set A.
+            jql_b: JQL query defining set B.
+            compare_fields: Field names to check for changes on issues
+                present in both sets. Defaults to status, assignee,
+                priority, and labels.
+            max_issues: Maximum issues to fetch per query.
+
+        Returns:
+            Dict with only_in_a, only_in_b, changed, unchanged_count,
+            and a summary sub-dict.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If there is an error executing the queries.
+        """
+        fields_to_compare = compare_fields or _DEFAULT_COMPARE_FIELDS
+        fields_to_fetch = list(dict.fromkeys(_BASE_FIELDS + fields_to_compare))
+
+        issues_a = self._fetch_all_issues(jql_a, fields_to_fetch, max_issues)
+        issues_b = self._fetch_all_issues(jql_b, fields_to_fetch, max_issues)
+
+        map_a: dict[str, dict[str, Any]] = {i["key"]: i for i in issues_a if "key" in i}
+        map_b: dict[str, dict[str, Any]] = {i["key"]: i for i in issues_b if "key" in i}
+
+        keys_a = set(map_a.keys())
+        keys_b = set(map_b.keys())
+
+        only_in_a_keys = sorted(keys_a - keys_b)
+        only_in_b_keys = sorted(keys_b - keys_a)
+        common_keys = sorted(keys_a & keys_b)
+
+        only_in_a = [
+            {"key": k, "summary": map_a[k].get("summary", "")} for k in only_in_a_keys
+        ]
+        only_in_b = [
+            {"key": k, "summary": map_b[k].get("summary", "")} for k in only_in_b_keys
+        ]
+
+        changed: list[dict[str, Any]] = []
+        unchanged_count = 0
+
+        for key in common_keys:
+            issue_a = map_a[key]
+            issue_b = map_b[key]
+            diffs: list[dict[str, Any]] = []
+
+            for field in fields_to_compare:
+                val_a = _normalize_field_value(issue_a.get(field))
+                val_b = _normalize_field_value(issue_b.get(field))
+                if val_a != val_b:
+                    diffs.append(
+                        {
+                            "field": field,
+                            "in_a": val_a,
+                            "in_b": val_b,
+                        }
+                    )
+
+            if diffs:
+                changed.append(
+                    {
+                        "key": key,
+                        "summary": issue_a.get("summary", ""),
+                        "changes": diffs,
+                    }
+                )
+            else:
+                unchanged_count += 1
+
+        return {
+            "jql_a": jql_a,
+            "jql_b": jql_b,
+            "set_a_count": len(map_a),
+            "set_b_count": len(map_b),
+            "only_in_a": only_in_a,
+            "only_in_b": only_in_b,
+            "changed": changed,
+            "unchanged_count": unchanged_count,
+            "summary": {
+                "only_in_a_count": len(only_in_a),
+                "only_in_b_count": len(only_in_b),
+                "changed_count": len(changed),
+                "unchanged_count": unchanged_count,
+            },
+        }

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3273,3 +3273,77 @@ async def get_issues_development_info(
         logger.error(f"Error getting development info for issues: {str(e)}")
         error_result = {"success": False, "error": str(e)}
         return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_set_analysis"},
+    annotations={"title": "Compare Issue Sets", "readOnlyHint": True},
+)
+async def compare_issue_sets(
+    ctx: Context,
+    jql_a: Annotated[
+        str,
+        Field(
+            description=(
+                "First JQL query defining set A "
+                "(e.g., \"project = PROJ AND sprint = 'Sprint 13'\")"
+            )
+        ),
+    ],
+    jql_b: Annotated[
+        str,
+        Field(
+            description=(
+                "Second JQL query defining set B "
+                "(e.g., \"project = PROJ AND sprint = 'Sprint 14'\")"
+            )
+        ),
+    ],
+    compare_fields: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated field names to compare "
+                "for change detection (e.g., 'status,assignee,priority'). "
+                "Defaults to status, assignee, priority, labels."
+            ),
+        ),
+    ] = None,
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum issues to fetch per query (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 200,
+) -> str:
+    """Compare two sets of Jira issues defined by JQL queries.
+
+    Returns which issues are only in set A, only in set B, present in
+    both but with changed field values, and how many are unchanged.
+    Useful for sprint reviews, release planning, and backlog diffs.
+
+    Args:
+        ctx: The FastMCP context.
+        jql_a: JQL query for set A.
+        jql_b: JQL query for set B.
+        compare_fields: Comma-separated field names to compare.
+        max_issues: Max issues per query.
+
+    Returns:
+        JSON string with set comparison results.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    fields_list: list[str] | None = None
+    if compare_fields:
+        fields_list = [f.strip() for f in compare_fields.split(",") if f.strip()]
+
+    result = jira.compare_issue_sets(
+        jql_a=jql_a,
+        jql_b=jql_b,
+        compare_fields=fields_list,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -4507,7 +4507,8 @@ async def compare_issue_sets(
     if compare_fields:
         fields_list = [f.strip() for f in compare_fields.split(",") if f.strip()]
 
-    result = jira.compare_issue_sets(
+    result = await run_jira_fetcher_call(
+        jira.compare_issue_sets,
         jql_a=jql_a,
         jql_b=jql_b,
         compare_fields=fields_list,

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -4398,3 +4398,77 @@ async def get_cross_project_dependencies(
         max_issues=max_issues,
     )
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_set_analysis"},
+    annotations={"title": "Compare Issue Sets", "readOnlyHint": True},
+)
+async def compare_issue_sets(
+    ctx: Context,
+    jql_a: Annotated[
+        str,
+        Field(
+            description=(
+                "First JQL query defining set A "
+                "(e.g., \"project = PROJ AND sprint = 'Sprint 13'\")"
+            )
+        ),
+    ],
+    jql_b: Annotated[
+        str,
+        Field(
+            description=(
+                "Second JQL query defining set B "
+                "(e.g., \"project = PROJ AND sprint = 'Sprint 14'\")"
+            )
+        ),
+    ],
+    compare_fields: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated field names to compare "
+                "for change detection (e.g., 'status,assignee,priority'). "
+                "Defaults to status, assignee, priority, labels."
+            ),
+        ),
+    ] = None,
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum issues to fetch per query (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 200,
+) -> str:
+    """Compare two sets of Jira issues defined by JQL queries.
+
+    Returns which issues are only in set A, only in set B, present in
+    both but with changed field values, and how many are unchanged.
+    Useful for sprint reviews, release planning, and backlog diffs.
+
+    Args:
+        ctx: The FastMCP context.
+        jql_a: JQL query for set A.
+        jql_b: JQL query for set B.
+        compare_fields: Comma-separated field names to compare.
+        max_issues: Max issues per query.
+
+    Returns:
+        JSON string with set comparison results.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    fields_list: list[str] | None = None
+    if compare_fields:
+        fields_list = [f.strip() for f in compare_fields.split(",") if f.strip()]
+
+    result = jira.compare_issue_sets(
+        jql_a=jql_a,
+        jql_b=jql_b,
+        compare_fields=fields_list,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups tools into 22 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (15) ---
+# --- Jira toolsets (16) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -100,6 +100,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_set_analysis": ToolsetDefinition(
+        name="jira_set_analysis",
+        description="JQL result set comparison and diff",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (6) ---
@@ -152,7 +157,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 21 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 22 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -165,9 +170,9 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="all" -> all 21 names
+        TOOLSETS unset -> all 22 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 22 toolsets (with deprecation warning)
+        TOOLSETS="all" -> all 22 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
         TOOLSETS="typo_name" -> set() (fail-closed)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 95 tools into 24 named toolsets controlled via the TOOLSETS env var.
+Groups 96 tools into 25 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (16) ---
+# --- Jira toolsets (17) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -105,6 +105,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Project epic hierarchy and cross-project dependencies",
         default=False,
     ),
+    "jira_set_analysis": ToolsetDefinition(
+        name="jira_set_analysis",
+        description="JQL result set comparison and diff",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (8) ---
@@ -167,7 +172,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 24 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 25 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -180,8 +185,8 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 24 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 24 toolsets (with deprecation warning)
+        TOOLSETS unset -> all 25 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 25 toolsets (with deprecation warning)
         TOOLSETS="all" -> all 24 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile

--- a/tests/unit/jira/test_set_analysis.py
+++ b/tests/unit/jira/test_set_analysis.py
@@ -1,0 +1,297 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.set_analysis import _normalize_field_value
+from mcp_atlassian.models.jira import JiraSearchResult
+from mcp_atlassian.models.jira.issue import JiraIssue
+
+
+def _make_issue(key: str, **field_overrides: object) -> JiraIssue:
+    """Build a minimal JiraIssue with overridable fields."""
+    from mcp_atlassian.models.jira.common import (
+        JiraIssueType,
+        JiraPriority,
+        JiraStatus,
+        JiraUser,
+    )
+
+    defaults: dict[str, object] = {
+        "key": key,
+        "summary": f"Summary for {key}",
+        "status": JiraStatus(name="Open"),
+        "issue_type": JiraIssueType(name="Task"),
+        "assignee": JiraUser(display_name="Alice"),
+        "priority": JiraPriority(name="Medium"),
+        "labels": ["backend"],
+    }
+    defaults.update(field_overrides)
+    return JiraIssue(**defaults)  # type: ignore[arg-type]
+
+
+def _search_result(issues: list[JiraIssue]) -> JiraSearchResult:
+    return JiraSearchResult(
+        total=len(issues),
+        start_at=0,
+        max_results=50,
+        issues=issues,
+    )
+
+
+class TestNormalizeFieldValue:
+    def test_none(self) -> None:
+        assert _normalize_field_value(None) is None
+
+    def test_string(self) -> None:
+        assert _normalize_field_value("hello") == "hello"
+
+    def test_dict_with_display_name(self) -> None:
+        assert _normalize_field_value({"display_name": "Alice"}) == "Alice"
+
+    def test_dict_with_name(self) -> None:
+        assert _normalize_field_value({"name": "Open"}) == "Open"
+
+    def test_dict_prefers_custom_field_value_over_name(self) -> None:
+        value = {"name": "Deployment region", "value": "eu-central"}
+        assert _normalize_field_value(value) == "eu-central"
+
+    def test_list_of_strings_sorted(self) -> None:
+        result = _normalize_field_value(["z", "a", "m"])
+        assert result == ["a", "m", "z"]
+
+    def test_list_of_dicts(self) -> None:
+        result = _normalize_field_value([{"name": "B"}, {"name": "A"}])
+        assert result == ["A", "B"]
+
+
+class TestSetAnalysisMixin:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    def test_compare_disjoint_sets(self, mixin):
+        """Sets with no overlap produce only_in_a and only_in_b."""
+        issues_a = [_make_issue("A-1"), _make_issue("A-2")]
+        issues_b = [_make_issue("B-1")]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(issues_a)
+            return _search_result(issues_b)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("project = A", "project = B")
+
+        assert result["set_a_count"] == 2
+        assert result["set_b_count"] == 1
+        assert len(result["only_in_a"]) == 2
+        assert len(result["only_in_b"]) == 1
+        assert result["changed"] == []
+        assert result["unchanged_count"] == 0
+
+    def test_compare_identical_sets(self, mixin):
+        """Same issues with same fields produce unchanged only."""
+        issues = [_make_issue("X-1"), _make_issue("X-2")]
+
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["summary"]["only_in_a_count"] == 0
+        assert result["summary"]["only_in_b_count"] == 0
+        assert result["summary"]["changed_count"] == 0
+        assert result["summary"]["unchanged_count"] == 2
+
+    def test_compare_with_field_changes(self, mixin):
+        """Issues present in both sets with changed fields."""
+        from mcp_atlassian.models.jira.common import JiraStatus
+
+        issue_a = _make_issue("X-1", status=JiraStatus(name="Open"))
+        issue_b = _make_issue("X-1", status=JiraStatus(name="Done"))
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result([issue_a])
+            return _search_result([issue_b])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["summary"]["changed_count"] == 1
+        assert result["changed"][0]["key"] == "X-1"
+        changes = result["changed"][0]["changes"]
+        status_change = next(c for c in changes if c["field"] == "status")
+        assert status_change["in_a"] == "Open"
+        assert status_change["in_b"] == "Done"
+
+    def test_compare_mixed(self, mixin):
+        """Mix of added, removed, changed, and unchanged."""
+        from mcp_atlassian.models.jira.common import JiraStatus
+
+        issues_a = [
+            _make_issue("X-1", status=JiraStatus(name="Open")),
+            _make_issue("X-2"),
+            _make_issue("X-3"),
+        ]
+        issues_b = [
+            _make_issue("X-1", status=JiraStatus(name="Done")),
+            _make_issue("X-2"),
+            _make_issue("X-4"),
+        ]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(issues_a)
+            return _search_result(issues_b)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["summary"]["only_in_a_count"] == 1  # X-3
+        assert result["summary"]["only_in_b_count"] == 1  # X-4
+        assert result["summary"]["changed_count"] == 1  # X-1
+        assert result["summary"]["unchanged_count"] == 1  # X-2
+
+    def test_compare_selected_builtin_fields(self, mixin):
+        """Custom compare_fields restricts which fields are diffed."""
+        from mcp_atlassian.models.jira.common import JiraPriority, JiraStatus
+
+        issue_a = _make_issue(
+            "X-1",
+            status=JiraStatus(name="Open"),
+            priority=JiraPriority(name="High"),
+        )
+        issue_b = _make_issue(
+            "X-1",
+            status=JiraStatus(name="Done"),
+            priority=JiraPriority(name="High"),
+        )
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result([issue_a])
+            return _search_result([issue_b])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("q1", "q2", compare_fields=["priority"])
+        assert result["summary"]["changed_count"] == 0
+        assert result["summary"]["unchanged_count"] == 1
+
+    @pytest.mark.parametrize("field", ["customfield_10001", "Deployment region"])
+    def test_compare_custom_field_by_id_or_name(self, mixin, field):
+        """Custom fields compare their values when selected by ID or name."""
+        issue_a = _make_issue(
+            "X-1",
+            custom_fields={
+                "customfield_10001": {
+                    "name": "Deployment region",
+                    "value": "eu-central",
+                }
+            },
+            requested_fields=["summary", field],
+        )
+        issue_b = _make_issue(
+            "X-1",
+            custom_fields={
+                "customfield_10001": {
+                    "name": "Deployment region",
+                    "value": "us-east",
+                }
+            },
+            requested_fields=["summary", field],
+        )
+        mixin.search_issues = MagicMock(
+            side_effect=[_search_result([issue_a]), _search_result([issue_b])]
+        )
+
+        result = mixin.compare_issue_sets("q1", "q2", compare_fields=[field])
+
+        assert result["changed"] == [
+            {
+                "key": "X-1",
+                "summary": "Summary for X-1",
+                "changes": [
+                    {
+                        "field": field,
+                        "in_a": "eu-central",
+                        "in_b": "us-east",
+                    }
+                ],
+            }
+        ]
+
+    def test_compare_empty_results(self, mixin):
+        """Both queries returning empty."""
+        mixin.search_issues = MagicMock(return_value=_search_result([]))
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["set_a_count"] == 0
+        assert result["set_b_count"] == 0
+        assert result["summary"]["unchanged_count"] == 0
+
+    def test_compare_auth_error(self, mixin):
+        """401 raises MCPAtlassianAuthenticationError."""
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.compare_issue_sets("q1", "q2")
+
+    def test_fetch_all_issues_pagination(self, mixin):
+        """_fetch_all_issues pages through results on Server/DC."""
+        mixin.config = MagicMock(is_cloud=False)
+
+        page1 = [_make_issue(f"X-{i}") for i in range(50)]
+        page2 = [_make_issue(f"X-{i}") for i in range(50, 75)]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(page1)
+            return _search_result(page2)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin._fetch_all_issues("q", ["summary"], 100)
+
+        assert len(result) == 75
+        assert mixin.search_issues.call_count == 2
+
+    def test_fetch_all_issues_cloud_no_repaging(self, mixin):
+        """On Cloud, _fetch_all_issues must not manually re-page."""
+        mixin.config = MagicMock(is_cloud=True)
+
+        all_issues = [_make_issue(f"X-{i}") for i in range(80)]
+        mixin.search_issues = MagicMock(return_value=_search_result(all_issues))
+
+        result = mixin._fetch_all_issues("q", ["summary"], 200)
+
+        assert len(result) == 80
+        assert mixin.search_issues.call_count == 1

--- a/tests/unit/jira/test_set_analysis.py
+++ b/tests/unit/jira/test_set_analysis.py
@@ -57,6 +57,10 @@ class TestNormalizeFieldValue:
         value = {"name": "Deployment region", "value": "eu-central"}
         assert _normalize_field_value(value) == "eu-central"
 
+    def test_dict_preserves_explicit_none_value(self) -> None:
+        value = {"name": "Deployment region", "value": None}
+        assert _normalize_field_value(value) is None
+
     def test_list_of_strings_sorted(self) -> None:
         result = _normalize_field_value(["z", "a", "m"])
         assert result == ["a", "m", "z"]

--- a/tests/unit/jira/test_set_analysis.py
+++ b/tests/unit/jira/test_set_analysis.py
@@ -65,6 +65,14 @@ class TestNormalizeFieldValue:
         result = _normalize_field_value([{"name": "B"}, {"name": "A"}])
         assert result == ["A", "B"]
 
+    def test_list_of_value_dicts(self) -> None:
+        result = _normalize_field_value([{"value": "B"}, {"value": "A"}])
+        assert result == ["A", "B"]
+
+    @pytest.mark.parametrize("value", ["", 0, False])
+    def test_falsy_values(self, value: object) -> None:
+        assert _normalize_field_value(value) == str(value)
+
 
 class TestSetAnalysisMixin:
     @pytest.fixture

--- a/tests/unit/jira/test_set_analysis.py
+++ b/tests/unit/jira/test_set_analysis.py
@@ -1,0 +1,236 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.set_analysis import _normalize_field_value
+from mcp_atlassian.models.jira import JiraSearchResult
+from mcp_atlassian.models.jira.issue import JiraIssue
+
+
+def _make_issue(key: str, **field_overrides: object) -> JiraIssue:
+    """Build a minimal JiraIssue with overridable fields."""
+    from mcp_atlassian.models.jira.common import (
+        JiraIssueType,
+        JiraPriority,
+        JiraStatus,
+        JiraUser,
+    )
+
+    defaults: dict[str, object] = {
+        "key": key,
+        "summary": f"Summary for {key}",
+        "status": JiraStatus(name="Open"),
+        "issue_type": JiraIssueType(name="Task"),
+        "assignee": JiraUser(display_name="Alice"),
+        "priority": JiraPriority(name="Medium"),
+        "labels": ["backend"],
+    }
+    defaults.update(field_overrides)
+    return JiraIssue(**defaults)  # type: ignore[arg-type]
+
+
+def _search_result(issues: list[JiraIssue]) -> JiraSearchResult:
+    return JiraSearchResult(
+        total=len(issues),
+        start_at=0,
+        max_results=50,
+        issues=issues,
+    )
+
+
+class TestNormalizeFieldValue:
+    def test_none(self) -> None:
+        assert _normalize_field_value(None) is None
+
+    def test_string(self) -> None:
+        assert _normalize_field_value("hello") == "hello"
+
+    def test_dict_with_display_name(self) -> None:
+        assert _normalize_field_value({"display_name": "Alice"}) == "Alice"
+
+    def test_dict_with_name(self) -> None:
+        assert _normalize_field_value({"name": "Open"}) == "Open"
+
+    def test_list_of_strings_sorted(self) -> None:
+        result = _normalize_field_value(["z", "a", "m"])
+        assert result == ["a", "m", "z"]
+
+    def test_list_of_dicts(self) -> None:
+        result = _normalize_field_value([{"name": "B"}, {"name": "A"}])
+        assert result == ["A", "B"]
+
+
+class TestSetAnalysisMixin:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    def test_compare_disjoint_sets(self, mixin):
+        """Sets with no overlap produce only_in_a and only_in_b."""
+        issues_a = [_make_issue("A-1"), _make_issue("A-2")]
+        issues_b = [_make_issue("B-1")]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(issues_a)
+            return _search_result(issues_b)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("project = A", "project = B")
+
+        assert result["set_a_count"] == 2
+        assert result["set_b_count"] == 1
+        assert len(result["only_in_a"]) == 2
+        assert len(result["only_in_b"]) == 1
+        assert result["changed"] == []
+        assert result["unchanged_count"] == 0
+
+    def test_compare_identical_sets(self, mixin):
+        """Same issues with same fields produce unchanged only."""
+        issues = [_make_issue("X-1"), _make_issue("X-2")]
+
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["summary"]["only_in_a_count"] == 0
+        assert result["summary"]["only_in_b_count"] == 0
+        assert result["summary"]["changed_count"] == 0
+        assert result["summary"]["unchanged_count"] == 2
+
+    def test_compare_with_field_changes(self, mixin):
+        """Issues present in both sets with changed fields."""
+        from mcp_atlassian.models.jira.common import JiraStatus
+
+        issue_a = _make_issue("X-1", status=JiraStatus(name="Open"))
+        issue_b = _make_issue("X-1", status=JiraStatus(name="Done"))
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result([issue_a])
+            return _search_result([issue_b])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["summary"]["changed_count"] == 1
+        assert result["changed"][0]["key"] == "X-1"
+        changes = result["changed"][0]["changes"]
+        status_change = next(c for c in changes if c["field"] == "status")
+        assert status_change["in_a"] == "Open"
+        assert status_change["in_b"] == "Done"
+
+    def test_compare_mixed(self, mixin):
+        """Mix of added, removed, changed, and unchanged."""
+        from mcp_atlassian.models.jira.common import JiraStatus
+
+        issues_a = [
+            _make_issue("X-1", status=JiraStatus(name="Open")),
+            _make_issue("X-2"),
+            _make_issue("X-3"),
+        ]
+        issues_b = [
+            _make_issue("X-1", status=JiraStatus(name="Done")),
+            _make_issue("X-2"),
+            _make_issue("X-4"),
+        ]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(issues_a)
+            return _search_result(issues_b)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["summary"]["only_in_a_count"] == 1  # X-3
+        assert result["summary"]["only_in_b_count"] == 1  # X-4
+        assert result["summary"]["changed_count"] == 1  # X-1
+        assert result["summary"]["unchanged_count"] == 1  # X-2
+
+    def test_compare_custom_fields(self, mixin):
+        """Custom compare_fields restricts which fields are diffed."""
+        from mcp_atlassian.models.jira.common import JiraPriority, JiraStatus
+
+        issue_a = _make_issue(
+            "X-1",
+            status=JiraStatus(name="Open"),
+            priority=JiraPriority(name="High"),
+        )
+        issue_b = _make_issue(
+            "X-1",
+            status=JiraStatus(name="Done"),
+            priority=JiraPriority(name="High"),
+        )
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result([issue_a])
+            return _search_result([issue_b])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.compare_issue_sets("q1", "q2", compare_fields=["priority"])
+        assert result["summary"]["changed_count"] == 0
+        assert result["summary"]["unchanged_count"] == 1
+
+    def test_compare_empty_results(self, mixin):
+        """Both queries returning empty."""
+        mixin.search_issues = MagicMock(return_value=_search_result([]))
+
+        result = mixin.compare_issue_sets("q1", "q2")
+
+        assert result["set_a_count"] == 0
+        assert result["set_b_count"] == 0
+        assert result["summary"]["unchanged_count"] == 0
+
+    def test_compare_auth_error(self, mixin):
+        """401 raises MCPAtlassianAuthenticationError."""
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.compare_issue_sets("q1", "q2")
+
+    def test_fetch_all_issues_pagination(self, mixin):
+        """_fetch_all_issues pages through results."""
+        page1 = [_make_issue(f"X-{i}") for i in range(50)]
+        page2 = [_make_issue(f"X-{i}") for i in range(50, 75)]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(page1)
+            return _search_result(page2)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin._fetch_all_issues("q", ["summary"], 100)
+
+        assert len(result) == 75
+        assert mixin.search_issues.call_count == 2

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -109,6 +109,22 @@ def mock_jira_fetcher():
         return mock_search_result
 
     mock_fetcher.search_issues.side_effect = mock_search_issues
+    mock_fetcher.compare_issue_sets.return_value = {
+        "jql_a": "project = TEST",
+        "jql_b": "project = DEMO",
+        "set_a_count": 1,
+        "set_b_count": 1,
+        "only_in_a": [],
+        "only_in_b": [],
+        "changed": [],
+        "unchanged_count": 1,
+        "summary": {
+            "only_in_a_count": 0,
+            "only_in_b_count": 0,
+            "changed_count": 0,
+            "unchanged_count": 1,
+        },
+    }
 
     # Configure create_issue
     def mock_create_issue(
@@ -459,6 +475,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         batch_create_issues,
         batch_create_versions,
         batch_get_changelogs,
+        compare_issue_sets,
         create_customer_request,
         create_issue,
         create_issue_link,
@@ -536,6 +553,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(create_customer_request)
     jira_sub_mcp.add_tool(batch_create_issues)
     jira_sub_mcp.add_tool(batch_get_changelogs)
+    jira_sub_mcp.add_tool(compare_issue_sets)
     jira_sub_mcp.add_tool(update_issue)
     jira_sub_mcp.add_tool(assign_issue)
     jira_sub_mcp.add_tool(delete_issue)
@@ -681,6 +699,29 @@ async def test_search(jira_client, mock_jira_fetcher):
         expand=None,
         projects_filter=None,
         page_token=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_compare_issue_sets(jira_client, mock_jira_fetcher):
+    """Test the set comparison tool delegates to the fetcher."""
+    response = await jira_client.call_tool(
+        "jira_compare_issue_sets",
+        {
+            "jql_a": "project = TEST",
+            "jql_b": "project = DEMO",
+            "compare_fields": "status, assignee",
+            "max_issues": 25,
+        },
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content["summary"]["unchanged_count"] == 1
+    mock_jira_fetcher.compare_issue_sets.assert_called_once_with(
+        jql_a="project = TEST",
+        jql_b="project = DEMO",
+        compare_fields=["status", "assignee"],
+        max_issues=25,
     )
 
 

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 22 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 22 entries."""
+        assert len(ALL_TOOLSETS) == 22
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 16
         assert len(confluence_toolsets) == 6
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 50, f"Expected 50 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 24 toolset names."""
+        """Test 'all' keyword returns all 25 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 24
+        assert len(result) == 25
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 24
+        assert len(result) == 25
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 24 entries."""
-        assert len(ALL_TOOLSETS) == 24
+        """Verify ALL_TOOLSETS has exactly 25 entries."""
+        assert len(ALL_TOOLSETS) == 25
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 16
+        assert len(jira_toolsets) == 17
         assert len(confluence_toolsets) == 8
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 63, f"Expected 63 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 64, f"Expected 64 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

- Add `jira_compare_issue_sets` for diffing two JQL result sets
- Return issues only in A, only in B, field differences for shared issues, and the unchanged count
- Paginate Cloud searches internally and Server/Data Center searches by offset
- Compare built-in and custom fields selected by field ID or display name
- Add the opt-in `jira_set_analysis` toolset and generated-tool documentation mapping

## Test plan

- [x] Targeted Jira set analysis, Jira server, and toolset unit tests (181 passed)
- [x] Full unit suite (3,253 passed, 5 skipped)
- [x] Integration suite collected (23 credential-gated tests skipped)
- [x] Cloud end-to-end suite (88 passed, 15 optional variants skipped)
- [x] Data Center end-to-end suite (98 passed, 104 non-DC tests skipped)
- [x] Ruff formatting, Ruff lint, and strict mypy checks
- [x] Tool documentation completeness check (97 tools mapped)
