### PR TITLE
feat(jira): add project epic hierarchy and cross-project dependency tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,6 +208,15 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 #   false           -> always the legacy link
 #CONFLUENCE_ATTACHMENT_DOWNLOAD_USE_V1=true
 
+# --- Hierarchy Link Classification ---
+# Extend the built-in hierarchy link phrases for issue tree and project
+# analysis tools. Format: comma-separated "parent:<phrase>" or "child:<phrase>".
+# "parent" means the target issue is the child; "child" means the target is the parent.
+# Built-in phrases (always active): is parent of, parent, contains, split to, epic,
+#   is child of, is contained by, split from.
+# Example: HIERARCHY_LINK_PHRASES=parent:rolls up to,child:is part of
+#HIERARCHY_LINK_PHRASES=
+
 # --- SLA Metrics Configuration ---
 # Configure how SLA metrics are calculated for Jira issues.
 # Default metrics to calculate (comma-separated).

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -22,6 +22,7 @@ from .formatting import FormattingMixin
 from .issues import IssuesMixin
 from .links import LinksMixin
 from .metrics import MetricsMixin
+from .project_analysis import ProjectAnalysisMixin
 from .projects import ProjectsMixin
 from .queues import QueuesMixin
 from .sla import SLAMixin
@@ -55,6 +56,7 @@ class JiraFetcher(
     MetricsMixin,
     SLAMixin,
     DevelopmentMixin,
+    ProjectAnalysisMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -23,6 +23,7 @@ from .formatting import FormattingMixin
 from .issues import IssuesMixin
 from .links import LinksMixin
 from .metrics import MetricsMixin
+from .project_analysis import ProjectAnalysisMixin
 from .projects import ProjectsMixin
 from .queues import QueuesMixin
 from .sla import SLAMixin
@@ -57,6 +58,7 @@ class JiraFetcher(
     MetricsMixin,
     SLAMixin,
     DevelopmentMixin,
+    ProjectAnalysisMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.

--- a/src/mcp_atlassian/jira/constants.py
+++ b/src/mcp_atlassian/jira/constants.py
@@ -1,5 +1,8 @@
 """Constants specific to Jira operations."""
 
+import logging
+import os
+
 # Based on https://support.atlassian.com/jira-software-cloud/docs/what-is-advanced-search-in-jira-cloud/
 # "Reserved words" section — verified 2026-02-23
 # Using lowercase for case-insensitive matching
@@ -200,6 +203,100 @@ RESERVED_JQL_WORDS = {
     "will",
     "with",
 }
+
+# ---------------------------------------------------------------------------
+# Hierarchy link classification
+# ---------------------------------------------------------------------------
+#
+# How it works:
+#   When traversing issue links, the label for the direction being
+#   evaluated tells us the current issue's role:
+#
+#     outward_issue + outward_label "is parent of"  → target is CHILD
+#     inward_issue  + inward_label  "is child of"   → target is PARENT
+#
+# Built-in phrases (cover all standard Jira link types):
+#
+#   PARENT-OF (target is child)     CHILD-OF (target is parent)
+#   ─────────────────────────────   ─────────────────────────────
+#   is parent of                    is child of
+#   parent                          is contained by
+#   contains                        split from
+#   split to
+#   epic
+#
+# Custom phrases — extend via env var:
+#
+#   HIERARCHY_LINK_PHRASES="parent:rolls up to,child:is part of"
+#
+#   Format: comma-separated, each entry is  parent:<phrase>
+#                                        or child:<phrase>
+# ---------------------------------------------------------------------------
+
+_hierarchy_logger = logging.getLogger("mcp-jira")
+
+_BUILTIN_PARENT_OF: set[str] = {
+    "is parent of",
+    "parent",
+    "contains",
+    "split to",
+    "epic",
+}
+
+_BUILTIN_CHILD_OF: set[str] = {
+    "is child of",
+    "is contained by",
+    "split from",
+}
+
+
+def _load_custom_hierarchy_phrases() -> tuple[set[str], set[str]]:
+    """Parse ``HIERARCHY_LINK_PHRASES`` into parent-of and child-of sets."""
+    raw = os.getenv("HIERARCHY_LINK_PHRASES", "")
+    parent_extra: set[str] = set()
+    child_extra: set[str] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if ":" not in token:
+            _hierarchy_logger.warning(
+                "HIERARCHY_LINK_PHRASES: ignoring malformed entry '%s' "
+                "(expected 'parent:<phrase>' or 'child:<phrase>')",
+                token,
+            )
+            continue
+        role, phrase = token.split(":", 1)
+        role = role.strip().lower()
+        phrase = phrase.strip().lower()
+        if not phrase:
+            continue
+        if role == "parent":
+            parent_extra.add(phrase)
+        elif role == "child":
+            child_extra.add(phrase)
+        else:
+            _hierarchy_logger.warning(
+                "HIERARCHY_LINK_PHRASES: unknown role '%s' in '%s' "
+                "(expected 'parent' or 'child')",
+                role,
+                token,
+            )
+    if parent_extra or child_extra:
+        _hierarchy_logger.info(
+            "HIERARCHY_LINK_PHRASES: added %d parent-of and %d child-of phrases",
+            len(parent_extra),
+            len(child_extra),
+        )
+    return parent_extra, child_extra
+
+
+_custom_parent, _custom_child = _load_custom_hierarchy_phrases()
+
+PARENT_OF_PHRASES: frozenset[str] = frozenset(_BUILTIN_PARENT_OF | _custom_parent)
+CHILD_OF_PHRASES: frozenset[str] = frozenset(_BUILTIN_CHILD_OF | _custom_child)
+HIERARCHY_LINK_PHRASES: frozenset[str] = PARENT_OF_PHRASES | CHILD_OF_PHRASES
+
 
 # Set of default fields returned by Jira read operations when no specific fields are requested.
 DEFAULT_READ_JIRA_FIELDS: set[str] = {

--- a/src/mcp_atlassian/jira/project_analysis.py
+++ b/src/mcp_atlassian/jira/project_analysis.py
@@ -1,0 +1,353 @@
+"""Module for Jira project-level analysis operations."""
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..models.jira import JiraSearchResult
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+from .constants import CHILD_OF_PHRASES
+
+logger = logging.getLogger("mcp-jira")
+
+_SERVER_DC_PAGE_SIZE = 50
+
+_LINK_FIELDS = [
+    "summary",
+    "status",
+    "issuetype",
+    "issuelinks",
+    "parent",
+]
+
+
+def _project_key_from_issue_key(issue_key: str) -> str:
+    """Extract the project key portion of an issue key."""
+    return issue_key.rsplit("-", 1)[0] if "-" in issue_key else issue_key
+
+
+class ProjectAnalysisMixin(JiraClient):
+    """Mixin for project-level Jira analysis."""
+
+    # ------------------------------------------------------------------
+    # Shared helper
+    # ------------------------------------------------------------------
+
+    def _fetch_project_issues_with_links(
+        self,
+        jql: str,
+        max_issues: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch issues matching *jql* with link data, handling pagination.
+
+        Args:
+            jql: JQL query to execute.
+            max_issues: Upper bound on the number of issues.
+
+        Returns:
+            List of simplified issue dicts (via ``to_simplified_dict``).
+        """
+        result: JiraSearchResult = self.search_issues(  # type: ignore[attr-defined]
+            jql=jql,
+            fields=_LINK_FIELDS,
+            limit=max_issues,
+        )
+        all_issues: list[dict[str, Any]] = [
+            issue.to_simplified_dict() for issue in result.issues
+        ]
+
+        # Cloud paginates internally via nextPageToken — only page
+        # manually on Server/DC where each response caps at 50.
+        if not self.config.is_cloud:
+            while (
+                len(all_issues) < max_issues
+                and len(result.issues) >= _SERVER_DC_PAGE_SIZE
+            ):
+                result = self.search_issues(  # type: ignore[attr-defined]
+                    jql=jql,
+                    fields=_LINK_FIELDS,
+                    start=len(all_issues),
+                    limit=max_issues - len(all_issues),
+                )
+                if not result.issues:
+                    break
+                all_issues.extend(issue.to_simplified_dict() for issue in result.issues)
+
+        return all_issues[:max_issues]
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    @handle_auth_errors("Jira API")
+    def get_project_epic_hierarchy(
+        self,
+        project_key: str,
+        max_epics: int = 200,
+    ) -> dict[str, Any]:
+        """Group a project's epics under their cross-project parent issues.
+
+        Fetches all epics in *project_key*, inspects their ``parent``
+        field and ``issuelinks`` for cross-project containment
+        relationships, then groups them by parent.  Epics with no
+        detected parent appear under an *Unlinked* group.
+
+        Args:
+            project_key: Jira project key (e.g. ``PROJ``).
+            max_epics: Maximum number of epics to fetch.
+
+        Returns:
+            Dict with ``project_key``, ``total_epics``, and ``groups``
+            (each group has a ``parent`` dict and an ``epics`` list).
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API or query errors.
+        """
+        jql = f'project = "{project_key}" AND issuetype = Epic ORDER BY updated DESC'
+        epic_dicts = self._fetch_project_issues_with_links(jql, max_epics)
+
+        parent_keys: set[str] = set()
+        epic_to_parent: dict[str, str | None] = {}
+
+        for epic in epic_dicts:
+            parent_key = self._detect_parent_key(epic, project_key)
+            key = epic.get("key", "")
+            epic_to_parent[key] = parent_key
+            if parent_key:
+                parent_keys.add(parent_key)
+
+        parent_info = self._batch_fetch_summaries(parent_keys)
+
+        groups: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+        for epic in epic_dicts:
+            key = epic.get("key", "")
+            parent_key = epic_to_parent.get(key)
+            groups[parent_key].append(
+                {
+                    "key": key,
+                    "summary": epic.get("summary", ""),
+                    "status": self._extract_status_name(epic),
+                }
+            )
+
+        result_groups: list[dict[str, Any]] = []
+        for pk in sorted(groups, key=lambda k: (k is None, k or "")):
+            if pk is None:
+                result_groups.append(
+                    {
+                        "parent": None,
+                        "group_name": "Unlinked",
+                        "epics": groups[pk],
+                    }
+                )
+            else:
+                info = parent_info.get(pk, {})
+                result_groups.append(
+                    {
+                        "parent": {
+                            "key": pk,
+                            "summary": info.get("summary", ""),
+                            "project": _project_key_from_issue_key(pk),
+                        },
+                        "epics": groups[pk],
+                    }
+                )
+
+        return {
+            "project_key": project_key,
+            "total_epics": len(epic_dicts),
+            "groups": result_groups,
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_cross_project_dependencies(
+        self,
+        project_key: str,
+        max_issues: int = 200,
+    ) -> dict[str, Any]:
+        """Find all cross-project issue links for a project.
+
+        Scans issues in *project_key*, extracts every issue link whose
+        target belongs to a different project, and groups them by
+        target project and link type.
+
+        Args:
+            project_key: Jira project key (e.g. ``PROJ``).
+            max_issues: Maximum issues to scan.
+
+        Returns:
+            Dict with ``project_key``, ``total_issues_scanned``,
+            ``total_cross_project_links``, and ``by_project`` grouped
+            results.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API or query errors.
+        """
+        jql = f'project = "{project_key}" ORDER BY updated DESC'
+        issues = self._fetch_project_issues_with_links(jql, max_issues)
+
+        by_project: dict[str, dict[str, list[dict[str, str]]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        total_links = 0
+
+        for issue in issues:
+            issue_key = issue.get("key", "")
+            for link_info in self._extract_cross_project_links(issue, project_key):
+                target_proj = _project_key_from_issue_key(link_info["target_key"])
+                by_project[target_proj][link_info["link_type"]].append(
+                    {
+                        "source": issue_key,
+                        "target": link_info["target_key"],
+                        "direction": link_info["direction"],
+                    }
+                )
+                total_links += 1
+
+        by_project_output: dict[str, Any] = {}
+        for proj in sorted(by_project):
+            link_types = by_project[proj]
+            by_project_output[proj] = {
+                "total_links": sum(len(v) for v in link_types.values()),
+                "by_link_type": dict(link_types),
+            }
+
+        return {
+            "project_key": project_key,
+            "total_issues_scanned": len(issues),
+            "total_cross_project_links": total_links,
+            "by_project": by_project_output,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _detect_parent_key(
+        epic_dict: dict[str, Any],
+        own_project: str,
+    ) -> str | None:
+        """Detect a cross-project parent from an epic's data.
+
+        Checks the ``parent`` field first, then issue links whose
+        direction indicates the *current* epic is the child.
+        """
+        parent = epic_dict.get("parent")
+        if isinstance(parent, dict):
+            parent_key = parent.get("key", "")
+            if parent_key and _project_key_from_issue_key(parent_key) != own_project:
+                return parent_key
+
+        for link in epic_dict.get("issuelinks", []):
+            lt = link.get("type")
+            if not isinstance(lt, dict):
+                continue
+            link_name = lt.get("name", "").lower()
+            inward_label = lt.get("inward", "").lower()
+            outward_label = lt.get("outward", "").lower()
+
+            # For inward_issue: accept if the inward label (or name)
+            # says we are the child (e.g. "is child of").
+            inward = link.get("inward_issue")
+            if inward:
+                inward_key = inward.get("key", "")
+                if (
+                    inward_key
+                    and _project_key_from_issue_key(inward_key) != own_project
+                ):
+                    labels = {link_name, inward_label}
+                    if labels & CHILD_OF_PHRASES:
+                        return inward_key
+
+            # For outward_issue: accept if the outward label (or name)
+            # says we are the child (e.g. "is child of").
+            outward = link.get("outward_issue")
+            if outward:
+                outward_key = outward.get("key", "")
+                if (
+                    outward_key
+                    and _project_key_from_issue_key(outward_key) != own_project
+                ):
+                    labels = {link_name, outward_label}
+                    if labels & CHILD_OF_PHRASES:
+                        return outward_key
+
+        return None
+
+    @staticmethod
+    def _extract_cross_project_links(
+        issue_dict: dict[str, Any],
+        own_project: str,
+    ) -> list[dict[str, str]]:
+        """Return cross-project link info from an issue's simplified dict."""
+        results: list[dict[str, str]] = []
+        for link in issue_dict.get("issuelinks", []):
+            link_type_name = ""
+            lt = link.get("type")
+            if isinstance(lt, dict):
+                link_type_name = lt.get("name", "")
+
+            for direction, link_key_field in [
+                ("outward", "outward_issue"),
+                ("inward", "inward_issue"),
+            ]:
+                target = link.get(link_key_field)
+                if not target:
+                    continue
+                target_key = target.get("key", "")
+                if not target_key:
+                    continue
+                target_proj = _project_key_from_issue_key(target_key)
+                if target_proj != own_project:
+                    results.append(
+                        {
+                            "target_key": target_key,
+                            "link_type": link_type_name,
+                            "direction": direction,
+                        }
+                    )
+        return results
+
+    @staticmethod
+    def _extract_status_name(issue_dict: dict[str, Any]) -> str:
+        status = issue_dict.get("status")
+        if isinstance(status, dict):
+            return status.get("name", "Unknown")
+        return "Unknown"
+
+    def _batch_fetch_summaries(
+        self,
+        keys: set[str],
+    ) -> dict[str, dict[str, str]]:
+        """Fetch summary info for a set of issue keys."""
+        if not keys:
+            return {}
+
+        result: dict[str, dict[str, str]] = {}
+        keys_list = sorted(keys)
+
+        for i in range(0, len(keys_list), _SERVER_DC_PAGE_SIZE):
+            chunk = keys_list[i : i + _SERVER_DC_PAGE_SIZE]
+            jql = "key in ({})".format(",".join(chunk))
+            try:
+                search = self.search_issues(  # type: ignore[attr-defined]
+                    jql=jql,
+                    fields=["summary", "status"],
+                    limit=len(chunk),
+                )
+                for issue in search.issues:
+                    result[issue.key] = {
+                        "summary": issue.summary,
+                        "status": issue.status.name if issue.status else "",
+                    }
+            except HTTPError:
+                raise
+            except Exception:
+                logger.warning("Failed to resolve parent summaries for %s", chunk)
+        return result

--- a/src/mcp_atlassian/jira/project_analysis.py
+++ b/src/mcp_atlassian/jira/project_analysis.py
@@ -1,17 +1,12 @@
 """Module for Jira project-level analysis operations."""
 
-import logging
 from collections import defaultdict
 from typing import Any
-
-from requests.exceptions import HTTPError
 
 from ..models.jira import JiraSearchResult
 from ..utils.decorators import handle_auth_errors
 from .client import JiraClient
 from .constants import CHILD_OF_PHRASES
-
-logger = logging.getLogger("mcp-jira")
 
 _SERVER_DC_PAGE_SIZE = 50
 
@@ -335,19 +330,14 @@ class ProjectAnalysisMixin(JiraClient):
         for i in range(0, len(keys_list), _SERVER_DC_PAGE_SIZE):
             chunk = keys_list[i : i + _SERVER_DC_PAGE_SIZE]
             jql = "key in ({})".format(",".join(chunk))
-            try:
-                search = self.search_issues(  # type: ignore[attr-defined]
-                    jql=jql,
-                    fields=["summary", "status"],
-                    limit=len(chunk),
-                )
-                for issue in search.issues:
-                    result[issue.key] = {
-                        "summary": issue.summary,
-                        "status": issue.status.name if issue.status else "",
-                    }
-            except HTTPError:
-                raise
-            except Exception:
-                logger.warning("Failed to resolve parent summaries for %s", chunk)
+            search = self.search_issues(  # type: ignore[attr-defined]
+                jql=jql,
+                fields=["summary", "status"],
+                limit=len(chunk),
+            )
+            for issue in search.issues:
+                result[issue.key] = {
+                    "summary": issue.summary,
+                    "status": issue.status.name if issue.status else "",
+                }
         return result

--- a/src/mcp_atlassian/jira/project_analysis.py
+++ b/src/mcp_atlassian/jira/project_analysis.py
@@ -1,0 +1,337 @@
+"""Module for Jira project-level analysis operations."""
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..models.jira import JiraSearchResult
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+_HIERARCHY_LINK_NAMES: set[str] = {
+    "is child of",
+    "is parent of",
+    "parent",
+    "contains",
+    "is contained by",
+    "split from",
+    "split to",
+    "epic",
+}
+
+_LINK_FIELDS = [
+    "summary",
+    "status",
+    "issuetype",
+    "issuelinks",
+    "parent",
+]
+
+
+def _project_key_from_issue_key(issue_key: str) -> str:
+    """Extract the project key portion of an issue key."""
+    return issue_key.rsplit("-", 1)[0] if "-" in issue_key else issue_key
+
+
+class ProjectAnalysisMixin(JiraClient):
+    """Mixin for project-level Jira analysis."""
+
+    # ------------------------------------------------------------------
+    # Shared helper
+    # ------------------------------------------------------------------
+
+    def _fetch_project_issues_with_links(
+        self,
+        jql: str,
+        max_issues: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch issues matching *jql* with link data, handling pagination.
+
+        Args:
+            jql: JQL query to execute.
+            max_issues: Upper bound on the number of issues.
+
+        Returns:
+            List of simplified issue dicts (via ``to_simplified_dict``).
+        """
+        result: JiraSearchResult = self.search_issues(  # type: ignore[attr-defined]
+            jql=jql,
+            fields=_LINK_FIELDS,
+            limit=max_issues,
+        )
+        all_issues: list[dict[str, Any]] = [
+            issue.to_simplified_dict() for issue in result.issues
+        ]
+
+        # Server/DC caps at 50 per response — page if needed.
+        while len(all_issues) < max_issues and len(result.issues) >= 50:
+            result = self.search_issues(  # type: ignore[attr-defined]
+                jql=jql,
+                fields=_LINK_FIELDS,
+                start=len(all_issues),
+                limit=max_issues - len(all_issues),
+            )
+            if not result.issues:
+                break
+            all_issues.extend(issue.to_simplified_dict() for issue in result.issues)
+
+        return all_issues[:max_issues]
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    @handle_auth_errors("Jira API")
+    def get_project_epic_hierarchy(
+        self,
+        project_key: str,
+        max_epics: int = 200,
+    ) -> dict[str, Any]:
+        """Group a project's epics under their cross-project parent issues.
+
+        Fetches all epics in *project_key*, inspects their ``parent``
+        field and ``issuelinks`` for cross-project containment
+        relationships, then groups them by parent.  Epics with no
+        detected parent appear under an *Unlinked* group.
+
+        Args:
+            project_key: Jira project key (e.g. ``PROJ``).
+            max_epics: Maximum number of epics to fetch.
+
+        Returns:
+            Dict with ``project_key``, ``total_epics``, and ``groups``
+            (each group has a ``parent`` dict and an ``epics`` list).
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API or query errors.
+        """
+        jql = f'project = "{project_key}" AND issuetype = Epic ORDER BY updated DESC'
+        epic_dicts = self._fetch_project_issues_with_links(jql, max_epics)
+
+        parent_keys: set[str] = set()
+        epic_to_parent: dict[str, str | None] = {}
+
+        for epic in epic_dicts:
+            parent_key = self._detect_parent_key(epic, project_key)
+            key = epic.get("key", "")
+            epic_to_parent[key] = parent_key
+            if parent_key:
+                parent_keys.add(parent_key)
+
+        parent_info = self._batch_fetch_summaries(parent_keys)
+
+        groups: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+        for epic in epic_dicts:
+            key = epic.get("key", "")
+            parent_key = epic_to_parent.get(key)
+            groups[parent_key].append(
+                {
+                    "key": key,
+                    "summary": epic.get("summary", ""),
+                    "status": self._extract_status_name(epic),
+                }
+            )
+
+        result_groups: list[dict[str, Any]] = []
+        for pk in sorted(groups, key=lambda k: (k is None, k or "")):
+            if pk is None:
+                result_groups.append(
+                    {
+                        "parent": None,
+                        "group_name": "Unlinked",
+                        "epics": groups[pk],
+                    }
+                )
+            else:
+                info = parent_info.get(pk, {})
+                result_groups.append(
+                    {
+                        "parent": {
+                            "key": pk,
+                            "summary": info.get("summary", ""),
+                            "project": _project_key_from_issue_key(pk),
+                        },
+                        "epics": groups[pk],
+                    }
+                )
+
+        return {
+            "project_key": project_key,
+            "total_epics": len(epic_dicts),
+            "groups": result_groups,
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_cross_project_dependencies(
+        self,
+        project_key: str,
+        max_issues: int = 200,
+    ) -> dict[str, Any]:
+        """Find all cross-project issue links for a project.
+
+        Scans issues in *project_key*, extracts every issue link whose
+        target belongs to a different project, and groups them by
+        target project and link type.
+
+        Args:
+            project_key: Jira project key (e.g. ``PROJ``).
+            max_issues: Maximum issues to scan.
+
+        Returns:
+            Dict with ``project_key``, ``total_issues_scanned``,
+            ``total_cross_project_links``, and ``by_project`` grouped
+            results.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API or query errors.
+        """
+        jql = f'project = "{project_key}" ORDER BY updated DESC'
+        issues = self._fetch_project_issues_with_links(jql, max_issues)
+
+        by_project: dict[str, dict[str, list[dict[str, str]]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        total_links = 0
+
+        for issue in issues:
+            issue_key = issue.get("key", "")
+            for link_info in self._extract_cross_project_links(issue, project_key):
+                target_proj = _project_key_from_issue_key(link_info["target_key"])
+                by_project[target_proj][link_info["link_type"]].append(
+                    {
+                        "source": issue_key,
+                        "target": link_info["target_key"],
+                        "direction": link_info["direction"],
+                    }
+                )
+                total_links += 1
+
+        by_project_output: dict[str, Any] = {}
+        for proj in sorted(by_project):
+            link_types = by_project[proj]
+            by_project_output[proj] = {
+                "total_links": sum(len(v) for v in link_types.values()),
+                "by_link_type": dict(link_types),
+            }
+
+        return {
+            "project_key": project_key,
+            "total_issues_scanned": len(issues),
+            "total_cross_project_links": total_links,
+            "by_project": by_project_output,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _detect_parent_key(
+        epic_dict: dict[str, Any],
+        own_project: str,
+    ) -> str | None:
+        """Detect a cross-project parent from an epic's data.
+
+        Checks the ``parent`` field first, then inward issue links
+        for containment-style relationships.
+        """
+        parent = epic_dict.get("parent")
+        if isinstance(parent, dict):
+            parent_key = parent.get("key", "")
+            if parent_key and _project_key_from_issue_key(parent_key) != own_project:
+                return parent_key
+
+        for link in epic_dict.get("issuelinks", []):
+            lt = link.get("type")
+            link_type_name = ""
+            if isinstance(lt, dict):
+                link_type_name = lt.get("name", "")
+            if link_type_name.lower() not in _HIERARCHY_LINK_NAMES:
+                continue
+
+            inward = link.get("inward_issue")
+            if not inward:
+                continue
+            target_key = inward.get("key", "")
+            if target_key and _project_key_from_issue_key(target_key) != own_project:
+                return target_key
+
+        return None
+
+    @staticmethod
+    def _extract_cross_project_links(
+        issue_dict: dict[str, Any],
+        own_project: str,
+    ) -> list[dict[str, str]]:
+        """Return cross-project link info from an issue's simplified dict."""
+        results: list[dict[str, str]] = []
+        for link in issue_dict.get("issuelinks", []):
+            link_type_name = ""
+            lt = link.get("type")
+            if isinstance(lt, dict):
+                link_type_name = lt.get("name", "")
+
+            for direction, link_key_field in [
+                ("outward", "outward_issue"),
+                ("inward", "inward_issue"),
+            ]:
+                target = link.get(link_key_field)
+                if not target:
+                    continue
+                target_key = target.get("key", "")
+                if not target_key:
+                    continue
+                target_proj = _project_key_from_issue_key(target_key)
+                if target_proj != own_project:
+                    results.append(
+                        {
+                            "target_key": target_key,
+                            "link_type": link_type_name,
+                            "direction": direction,
+                        }
+                    )
+        return results
+
+    @staticmethod
+    def _extract_status_name(issue_dict: dict[str, Any]) -> str:
+        status = issue_dict.get("status")
+        if isinstance(status, dict):
+            return status.get("name", "Unknown")
+        return "Unknown"
+
+    def _batch_fetch_summaries(
+        self,
+        keys: set[str],
+    ) -> dict[str, dict[str, str]]:
+        """Fetch summary info for a set of issue keys."""
+        if not keys:
+            return {}
+
+        result: dict[str, dict[str, str]] = {}
+        keys_list = sorted(keys)
+
+        for i in range(0, len(keys_list), 50):
+            chunk = keys_list[i : i + 50]
+            jql = "key in ({})".format(",".join(chunk))
+            try:
+                search = self.search_issues(  # type: ignore[attr-defined]
+                    jql=jql,
+                    fields=["summary", "status"],
+                    limit=len(chunk),
+                )
+                for issue in search.issues:
+                    result[issue.key] = {
+                        "summary": issue.summary,
+                        "status": issue.status.name if issue.status else "",
+                    }
+            except HTTPError:
+                raise
+            except Exception:
+                logger.warning("Failed to resolve parent summaries for %s", chunk)
+        return result

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3273,3 +3273,100 @@ async def get_issues_development_info(
         logger.error(f"Error getting development info for issues: {str(e)}")
         error_result = {"success": False, "error": str(e)}
         return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_project_analysis"},
+    annotations={
+        "title": "Get Project Epic Hierarchy",
+        "readOnlyHint": True,
+    },
+)
+async def get_project_epic_hierarchy(
+    ctx: Context,
+    project_key: Annotated[
+        str,
+        Field(
+            description="Jira project key (e.g., 'PROJ')",
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+    max_epics: Annotated[
+        int,
+        Field(
+            description="Maximum number of epics to fetch (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 200,
+) -> str:
+    """Group a project's epics under their cross-project parent issues.
+
+    Fetches all epics in the project, detects their parent issue via
+    the parent field or inward issue links, then groups them by parent.
+    Epics with no detected parent appear under "Unlinked". Useful for
+    understanding how a project's epics roll up to initiatives in
+    another project.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: The project key.
+        max_epics: Max epics to fetch.
+
+    Returns:
+        JSON string with grouped epic hierarchy.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_project_epic_hierarchy(
+        project_key=project_key,
+        max_epics=max_epics,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_project_analysis"},
+    annotations={
+        "title": "Get Cross-Project Dependencies",
+        "readOnlyHint": True,
+    },
+)
+async def get_cross_project_dependencies(
+    ctx: Context,
+    project_key: Annotated[
+        str,
+        Field(
+            description="Jira project key (e.g., 'PROJ')",
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum issues to scan for links (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 200,
+) -> str:
+    """Find all cross-project issue links for a project.
+
+    Scans issues in the project, extracts every issue link whose
+    target belongs to a different project, and groups them by target
+    project and link type. Useful for dependency analysis across
+    multi-project Jira setups.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: The project key.
+        max_issues: Max issues to scan.
+
+    Returns:
+        JSON string with cross-project dependency map.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_cross_project_dependencies(
+        project_key=project_key,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -4301,3 +4301,100 @@ async def get_issues_development_info(
         logger.error(f"Error getting development info for issues: {str(e)}")
         error_result = {"success": False, "error": str(e)}
         return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_project_analysis"},
+    annotations={
+        "title": "Get Project Epic Hierarchy",
+        "readOnlyHint": True,
+    },
+)
+async def get_project_epic_hierarchy(
+    ctx: Context,
+    project_key: Annotated[
+        str,
+        Field(
+            description="Jira project key (e.g., 'PROJ')",
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+    max_epics: Annotated[
+        int,
+        Field(
+            description="Maximum number of epics to fetch (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 200,
+) -> str:
+    """Group a project's epics under their cross-project parent issues.
+
+    Fetches all epics in the project, detects their parent issue via
+    the parent field or inward issue links, then groups them by parent.
+    Epics with no detected parent appear under "Unlinked". Useful for
+    understanding how a project's epics roll up to initiatives in
+    another project.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: The project key.
+        max_epics: Max epics to fetch.
+
+    Returns:
+        JSON string with grouped epic hierarchy.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_project_epic_hierarchy(
+        project_key=project_key,
+        max_epics=max_epics,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_project_analysis"},
+    annotations={
+        "title": "Get Cross-Project Dependencies",
+        "readOnlyHint": True,
+    },
+)
+async def get_cross_project_dependencies(
+    ctx: Context,
+    project_key: Annotated[
+        str,
+        Field(
+            description="Jira project key (e.g., 'PROJ')",
+            pattern=PROJECT_KEY_PATTERN,
+        ),
+    ],
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum issues to scan for links (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 200,
+) -> str:
+    """Find all cross-project issue links for a project.
+
+    Scans issues in the project, extracts every issue link whose
+    target belongs to a different project, and groups them by target
+    project and link type. Useful for dependency analysis across
+    multi-project Jira setups.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: The project key.
+        max_issues: Max issues to scan.
+
+    Returns:
+        JSON string with cross-project dependency map.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_cross_project_dependencies(
+        project_key=project_key,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups tools into 22 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (15) ---
+# --- Jira toolsets (16) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -100,6 +100,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_project_analysis": ToolsetDefinition(
+        name="jira_project_analysis",
+        description="Project epic hierarchy and cross-project dependencies",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (6) ---
@@ -152,7 +157,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 21 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 22 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -165,9 +170,9 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="all" -> all 21 names
+        TOOLSETS unset -> all 22 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 22 toolsets (with deprecation warning)
+        TOOLSETS="all" -> all 22 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
         TOOLSETS="typo_name" -> set() (fail-closed)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 93 tools into 23 named toolsets controlled via the TOOLSETS env var.
+Groups 95 tools into 24 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (15) ---
+# --- Jira toolsets (16) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -100,6 +100,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_project_analysis": ToolsetDefinition(
+        name="jira_project_analysis",
+        description="Project epic hierarchy and cross-project dependencies",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (8) ---
@@ -162,7 +167,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 23 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 24 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -175,9 +180,9 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 23 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 23 toolsets (with deprecation warning)
-        TOOLSETS="all" -> all 23 names
+        TOOLSETS unset -> all 24 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 24 toolsets (with deprecation warning)
+        TOOLSETS="all" -> all 24 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
         TOOLSETS="typo_name" -> set() (fail-closed)

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -64,6 +64,31 @@ class TestJiraCloudBehavior:
         )
 
 
+class TestJiraCloudProjectAnalysis:
+    """Project analysis through Jira Cloud search pagination."""
+
+    def test_project_analysis(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        hierarchy = jira_fetcher.get_project_epic_hierarchy(
+            cloud_instance.project_key,
+            max_epics=10,
+        )
+        dependencies = jira_fetcher.get_cross_project_dependencies(
+            cloud_instance.project_key,
+            max_issues=10,
+        )
+
+        assert hierarchy["project_key"] == cloud_instance.project_key
+        assert hierarchy["total_epics"] <= 10
+        assert isinstance(hierarchy["groups"], list)
+        assert dependencies["project_key"] == cloud_instance.project_key
+        assert dependencies["total_issues_scanned"] <= 10
+        assert isinstance(dependencies["by_project"], dict)
+
+
 class TestJiraCloudEpicOperations:
     """Epic creation on Cloud."""
 

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -76,6 +76,31 @@ class TestJiraDCBehavior:
             )
 
 
+class TestJiraDCProjectAnalysis:
+    """Project analysis through Jira Data Center offset pagination."""
+
+    def test_project_analysis(
+        self,
+        jira_fetcher: JiraFetcher,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        hierarchy = jira_fetcher.get_project_epic_hierarchy(
+            dc_instance.project_key,
+            max_epics=10,
+        )
+        dependencies = jira_fetcher.get_cross_project_dependencies(
+            dc_instance.project_key,
+            max_issues=10,
+        )
+
+        assert hierarchy["project_key"] == dc_instance.project_key
+        assert hierarchy["total_epics"] <= 10
+        assert isinstance(hierarchy["groups"], list)
+        assert dependencies["project_key"] == dc_instance.project_key
+        assert dependencies["total_issues_scanned"] <= 10
+        assert isinstance(dependencies["by_project"], dict)
+
+
 class TestJiraDCEpicOperations:
     """Epic creation with DC custom fields."""
 

--- a/tests/unit/jira/test_project_analysis.py
+++ b/tests/unit/jira/test_project_analysis.py
@@ -1,0 +1,368 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.project_analysis import _project_key_from_issue_key
+from mcp_atlassian.models.jira.common import JiraIssueType, JiraStatus
+from mcp_atlassian.models.jira.issue import JiraIssue
+from mcp_atlassian.models.jira.link import (
+    JiraIssueLink,
+    JiraIssueLinkType,
+    JiraLinkedIssue,
+    JiraLinkedIssueFields,
+)
+from mcp_atlassian.models.jira.search import JiraSearchResult
+
+
+def _make_link(
+    *,
+    link_type_name: str = "Blocks",
+    inward_key: str | None = None,
+    outward_key: str | None = None,
+    inward_label: str = "",
+    outward_label: str = "",
+) -> JiraIssueLink:
+    lt = JiraIssueLinkType(
+        name=link_type_name, inward=inward_label, outward=outward_label
+    )
+    inward = (
+        JiraLinkedIssue(
+            key=inward_key,
+            fields=JiraLinkedIssueFields(summary=f"Summary {inward_key}"),
+        )
+        if inward_key
+        else None
+    )
+    outward = (
+        JiraLinkedIssue(
+            key=outward_key,
+            fields=JiraLinkedIssueFields(summary=f"Summary {outward_key}"),
+        )
+        if outward_key
+        else None
+    )
+    return JiraIssueLink(type=lt, inward_issue=inward, outward_issue=outward)
+
+
+def _epic(key: str, links: list[JiraIssueLink] | None = None) -> JiraIssue:
+    return JiraIssue(
+        key=key,
+        summary=f"Epic {key}",
+        status=JiraStatus(name="In Progress"),
+        issue_type=JiraIssueType(name="Epic"),
+        issuelinks=links or [],
+    )
+
+
+def _issue(key: str, links: list[JiraIssueLink] | None = None) -> JiraIssue:
+    return JiraIssue(
+        key=key,
+        summary=f"Issue {key}",
+        status=JiraStatus(name="Open"),
+        issue_type=JiraIssueType(name="Task"),
+        issuelinks=links or [],
+    )
+
+
+def _search_result(issues: list[JiraIssue]) -> JiraSearchResult:
+    return JiraSearchResult(
+        total=len(issues), start_at=0, max_results=50, issues=issues
+    )
+
+
+class TestProjectKeyFromIssueKey:
+    def test_standard(self) -> None:
+        assert _project_key_from_issue_key("PROJ-123") == "PROJ"
+
+    def test_multi_segment(self) -> None:
+        assert _project_key_from_issue_key("MY-PROJ-45") == "MY-PROJ"
+
+    def test_no_dash(self) -> None:
+        assert _project_key_from_issue_key("NODASH") == "NODASH"
+
+
+class TestProjectAnalysisMixin:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    # ---- get_project_epic_hierarchy ----
+
+    def test_epic_hierarchy_groups_by_parent(self, mixin):
+        """Epics with cross-project inward links group under parent."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [_make_link(inward_key="INIT-1", link_type_name="Split from")],
+            ),
+            _epic(
+                "PROJ-20",
+                [_make_link(inward_key="INIT-1", link_type_name="Split from")],
+            ),
+        ]
+        parent_issue = JiraIssue(
+            key="INIT-1",
+            summary="Initiative A",
+            status=JiraStatus(name="Open"),
+        )
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if "issuetype = Epic" in jql:
+                return _search_result(epics)
+            return _search_result([parent_issue])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["total_epics"] == 2
+        assert len(result["groups"]) == 1
+        group = result["groups"][0]
+        assert group["parent"]["key"] == "INIT-1"
+        assert len(group["epics"]) == 2
+
+    def test_epic_hierarchy_unlinked_group(self, mixin):
+        """Epics with no cross-project parent go into Unlinked."""
+        epics = [_epic("PROJ-10")]
+
+        mixin.search_issues = MagicMock(return_value=_search_result(epics))
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert len(result["groups"]) == 1
+        assert result["groups"][0]["group_name"] == "Unlinked"
+
+    def test_epic_hierarchy_same_project_link_ignored(self, mixin):
+        """Links within the same project are not treated as parents."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [_make_link(inward_key="PROJ-1", link_type_name="Related")],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(epics))
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["groups"][0]["group_name"] == "Unlinked"
+
+    def test_epic_hierarchy_parent_via_directional_label(self, mixin):
+        """Parent detected via type.inward label even when type.name is generic."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [
+                    _make_link(
+                        inward_key="INIT-1",
+                        link_type_name="Hierarchy",
+                        inward_label="is child of",
+                        outward_label="is parent of",
+                    )
+                ],
+            ),
+        ]
+        parent_issue = JiraIssue(
+            key="INIT-1",
+            summary="Initiative A",
+            status=JiraStatus(name="Open"),
+        )
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if "issuetype = Epic" in jql:
+                return _search_result(epics)
+            return _search_result([parent_issue])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["total_epics"] == 1
+        group = result["groups"][0]
+        assert group["parent"]["key"] == "INIT-1"
+
+    def test_epic_hierarchy_parent_via_outward_issue(self, mixin):
+        """Parent detected via outward_issue when link type matches."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [
+                    _make_link(
+                        outward_key="INIT-2",
+                        link_type_name="is child of",
+                    )
+                ],
+            ),
+        ]
+        parent_issue = JiraIssue(
+            key="INIT-2",
+            summary="Initiative B",
+            status=JiraStatus(name="Open"),
+        )
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if "issuetype = Epic" in jql:
+                return _search_result(epics)
+            return _search_result([parent_issue])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["total_epics"] == 1
+        group = result["groups"][0]
+        assert group["parent"]["key"] == "INIT-2"
+
+    def test_epic_hierarchy_outward_parent_of_not_treated_as_parent(self, mixin):
+        """Outward 'is parent of' means we are the parent, not the child."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [
+                    _make_link(
+                        outward_key="CHILD-1",
+                        link_type_name="Hierarchy",
+                        inward_label="is child of",
+                        outward_label="is parent of",
+                    )
+                ],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(epics))
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["groups"][0]["group_name"] == "Unlinked"
+
+    def test_epic_hierarchy_empty(self, mixin):
+        """No epics in project."""
+        mixin.search_issues = MagicMock(return_value=_search_result([]))
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["total_epics"] == 0
+        assert result["groups"] == []
+
+    def test_epic_hierarchy_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_project_epic_hierarchy("PROJ")
+
+    # ---- get_cross_project_dependencies ----
+
+    def test_cross_deps_basic(self, mixin):
+        """Detects outward and inward cross-project links."""
+        issues = [
+            _issue(
+                "PROJ-1",
+                [
+                    _make_link(
+                        outward_key="OTHER-5",
+                        link_type_name="Blocks",
+                    ),
+                    _make_link(
+                        inward_key="THIRD-1",
+                        link_type_name="Depends on",
+                    ),
+                ],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.get_cross_project_dependencies("PROJ")
+
+        assert result["total_cross_project_links"] == 2
+        assert "OTHER" in result["by_project"]
+        assert "THIRD" in result["by_project"]
+
+    def test_cross_deps_no_cross_links(self, mixin):
+        """All links within the same project → empty result."""
+        issues = [
+            _issue(
+                "PROJ-1",
+                [_make_link(outward_key="PROJ-2", link_type_name="Blocks")],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.get_cross_project_dependencies("PROJ")
+
+        assert result["total_cross_project_links"] == 0
+        assert result["by_project"] == {}
+
+    def test_cross_deps_grouped_by_project_and_type(self, mixin):
+        """Multiple links group correctly."""
+        issues = [
+            _issue(
+                "PROJ-1",
+                [_make_link(outward_key="EXT-1", link_type_name="Blocks")],
+            ),
+            _issue(
+                "PROJ-2",
+                [_make_link(outward_key="EXT-2", link_type_name="Blocks")],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.get_cross_project_dependencies("PROJ")
+
+        ext = result["by_project"]["EXT"]
+        assert ext["total_links"] == 2
+        assert len(ext["by_link_type"]["Blocks"]) == 2
+
+    def test_cross_deps_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_cross_project_dependencies("PROJ")
+
+    # ---- pagination ----
+
+    def test_fetch_with_pagination(self, mixin):
+        """_fetch_project_issues_with_links pages correctly on Server/DC."""
+        mixin.config = MagicMock(is_cloud=False)
+
+        page1 = [_issue(f"P-{i}") for i in range(50)]
+        page2 = [_issue(f"P-{i}") for i in range(50, 60)]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(page1)
+            return _search_result(page2)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin._fetch_project_issues_with_links("key in ()", 100)
+        assert len(result) == 60
+        assert mixin.search_issues.call_count == 2
+
+    def test_fetch_cloud_no_repaging(self, mixin):
+        """On Cloud, _fetch_project_issues_with_links must not re-page."""
+        mixin.config = MagicMock(is_cloud=True)
+
+        all_issues = [_issue(f"P-{i}") for i in range(80)]
+        mixin.search_issues = MagicMock(return_value=_search_result(all_issues))
+
+        result = mixin._fetch_project_issues_with_links("key in ()", 200)
+        assert len(result) == 80
+        assert mixin.search_issues.call_count == 1

--- a/tests/unit/jira/test_project_analysis.py
+++ b/tests/unit/jira/test_project_analysis.py
@@ -4,6 +4,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.constants import _load_custom_hierarchy_phrases
 from mcp_atlassian.jira.project_analysis import _project_key_from_issue_key
 from mcp_atlassian.models.jira.common import JiraIssueType, JiraStatus
 from mcp_atlassian.models.jira.issue import JiraIssue
@@ -81,6 +82,32 @@ class TestProjectKeyFromIssueKey:
 
     def test_no_dash(self) -> None:
         assert _project_key_from_issue_key("NODASH") == "NODASH"
+
+
+class TestCustomHierarchyPhrases:
+    def test_loads_parent_and_child_phrases(self, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "HIERARCHY_LINK_PHRASES",
+            "parent:Rolls Up To, child: Is Part Of",
+        )
+
+        parent_phrases, child_phrases = _load_custom_hierarchy_phrases()
+
+        assert parent_phrases == {"rolls up to"}
+        assert child_phrases == {"is part of"}
+
+    def test_ignores_malformed_phrases(self, monkeypatch, caplog) -> None:
+        monkeypatch.setenv(
+            "HIERARCHY_LINK_PHRASES",
+            "missing-role,other:phrase,parent:",
+        )
+
+        parent_phrases, child_phrases = _load_custom_hierarchy_phrases()
+
+        assert parent_phrases == set()
+        assert child_phrases == set()
+        assert "ignoring malformed entry 'missing-role'" in caplog.text
+        assert "unknown role 'other'" in caplog.text
 
 
 class TestProjectAnalysisMixin:
@@ -261,6 +288,24 @@ class TestProjectAnalysisMixin:
             side_effect=HTTPError(response=Mock(status_code=401))
         )
         with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_project_epic_hierarchy("PROJ")
+
+    def test_epic_hierarchy_parent_lookup_auth_error(self, mixin):
+        """Authentication errors resolving parents must not return partial data."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [_make_link(inward_key="INIT-1", link_type_name="Split from")],
+            )
+        ]
+        mixin.search_issues = MagicMock(
+            side_effect=[
+                _search_result(epics),
+                MCPAtlassianAuthenticationError("token expired"),
+            ]
+        )
+
+        with pytest.raises(MCPAtlassianAuthenticationError, match="token expired"):
             mixin.get_project_epic_hierarchy("PROJ")
 
     # ---- get_cross_project_dependencies ----

--- a/tests/unit/jira/test_project_analysis.py
+++ b/tests/unit/jira/test_project_analysis.py
@@ -1,0 +1,256 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.project_analysis import _project_key_from_issue_key
+from mcp_atlassian.models.jira.common import JiraIssueType, JiraStatus
+from mcp_atlassian.models.jira.issue import JiraIssue
+from mcp_atlassian.models.jira.link import (
+    JiraIssueLink,
+    JiraIssueLinkType,
+    JiraLinkedIssue,
+    JiraLinkedIssueFields,
+)
+from mcp_atlassian.models.jira.search import JiraSearchResult
+
+
+def _make_link(
+    *,
+    link_type_name: str = "Blocks",
+    inward_key: str | None = None,
+    outward_key: str | None = None,
+) -> JiraIssueLink:
+    lt = JiraIssueLinkType(name=link_type_name)
+    inward = (
+        JiraLinkedIssue(
+            key=inward_key,
+            fields=JiraLinkedIssueFields(summary=f"Summary {inward_key}"),
+        )
+        if inward_key
+        else None
+    )
+    outward = (
+        JiraLinkedIssue(
+            key=outward_key,
+            fields=JiraLinkedIssueFields(summary=f"Summary {outward_key}"),
+        )
+        if outward_key
+        else None
+    )
+    return JiraIssueLink(type=lt, inward_issue=inward, outward_issue=outward)
+
+
+def _epic(key: str, links: list[JiraIssueLink] | None = None) -> JiraIssue:
+    return JiraIssue(
+        key=key,
+        summary=f"Epic {key}",
+        status=JiraStatus(name="In Progress"),
+        issue_type=JiraIssueType(name="Epic"),
+        issuelinks=links or [],
+    )
+
+
+def _issue(key: str, links: list[JiraIssueLink] | None = None) -> JiraIssue:
+    return JiraIssue(
+        key=key,
+        summary=f"Issue {key}",
+        status=JiraStatus(name="Open"),
+        issue_type=JiraIssueType(name="Task"),
+        issuelinks=links or [],
+    )
+
+
+def _search_result(issues: list[JiraIssue]) -> JiraSearchResult:
+    return JiraSearchResult(
+        total=len(issues), start_at=0, max_results=50, issues=issues
+    )
+
+
+class TestProjectKeyFromIssueKey:
+    def test_standard(self) -> None:
+        assert _project_key_from_issue_key("PROJ-123") == "PROJ"
+
+    def test_multi_segment(self) -> None:
+        assert _project_key_from_issue_key("MY-PROJ-45") == "MY-PROJ"
+
+    def test_no_dash(self) -> None:
+        assert _project_key_from_issue_key("NODASH") == "NODASH"
+
+
+class TestProjectAnalysisMixin:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    # ---- get_project_epic_hierarchy ----
+
+    def test_epic_hierarchy_groups_by_parent(self, mixin):
+        """Epics with cross-project inward links group under parent."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [_make_link(inward_key="INIT-1", link_type_name="Split from")],
+            ),
+            _epic(
+                "PROJ-20",
+                [_make_link(inward_key="INIT-1", link_type_name="Split from")],
+            ),
+        ]
+        parent_issue = JiraIssue(
+            key="INIT-1",
+            summary="Initiative A",
+            status=JiraStatus(name="Open"),
+        )
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if "issuetype = Epic" in jql:
+                return _search_result(epics)
+            return _search_result([parent_issue])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["total_epics"] == 2
+        assert len(result["groups"]) == 1
+        group = result["groups"][0]
+        assert group["parent"]["key"] == "INIT-1"
+        assert len(group["epics"]) == 2
+
+    def test_epic_hierarchy_unlinked_group(self, mixin):
+        """Epics with no cross-project parent go into Unlinked."""
+        epics = [_epic("PROJ-10")]
+
+        mixin.search_issues = MagicMock(return_value=_search_result(epics))
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert len(result["groups"]) == 1
+        assert result["groups"][0]["group_name"] == "Unlinked"
+
+    def test_epic_hierarchy_same_project_link_ignored(self, mixin):
+        """Links within the same project are not treated as parents."""
+        epics = [
+            _epic(
+                "PROJ-10",
+                [_make_link(inward_key="PROJ-1", link_type_name="Related")],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(epics))
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["groups"][0]["group_name"] == "Unlinked"
+
+    def test_epic_hierarchy_empty(self, mixin):
+        """No epics in project."""
+        mixin.search_issues = MagicMock(return_value=_search_result([]))
+
+        result = mixin.get_project_epic_hierarchy("PROJ")
+
+        assert result["total_epics"] == 0
+        assert result["groups"] == []
+
+    def test_epic_hierarchy_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_project_epic_hierarchy("PROJ")
+
+    # ---- get_cross_project_dependencies ----
+
+    def test_cross_deps_basic(self, mixin):
+        """Detects outward and inward cross-project links."""
+        issues = [
+            _issue(
+                "PROJ-1",
+                [
+                    _make_link(
+                        outward_key="OTHER-5",
+                        link_type_name="Blocks",
+                    ),
+                    _make_link(
+                        inward_key="THIRD-1",
+                        link_type_name="Depends on",
+                    ),
+                ],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.get_cross_project_dependencies("PROJ")
+
+        assert result["total_cross_project_links"] == 2
+        assert "OTHER" in result["by_project"]
+        assert "THIRD" in result["by_project"]
+
+    def test_cross_deps_no_cross_links(self, mixin):
+        """All links within the same project → empty result."""
+        issues = [
+            _issue(
+                "PROJ-1",
+                [_make_link(outward_key="PROJ-2", link_type_name="Blocks")],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.get_cross_project_dependencies("PROJ")
+
+        assert result["total_cross_project_links"] == 0
+        assert result["by_project"] == {}
+
+    def test_cross_deps_grouped_by_project_and_type(self, mixin):
+        """Multiple links group correctly."""
+        issues = [
+            _issue(
+                "PROJ-1",
+                [_make_link(outward_key="EXT-1", link_type_name="Blocks")],
+            ),
+            _issue(
+                "PROJ-2",
+                [_make_link(outward_key="EXT-2", link_type_name="Blocks")],
+            ),
+        ]
+        mixin.search_issues = MagicMock(return_value=_search_result(issues))
+
+        result = mixin.get_cross_project_dependencies("PROJ")
+
+        ext = result["by_project"]["EXT"]
+        assert ext["total_links"] == 2
+        assert len(ext["by_link_type"]["Blocks"]) == 2
+
+    def test_cross_deps_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_cross_project_dependencies("PROJ")
+
+    # ---- pagination ----
+
+    def test_fetch_with_pagination(self, mixin):
+        """_fetch_project_issues_with_links pages correctly."""
+        page1 = [_issue(f"P-{i}") for i in range(50)]
+        page2 = [_issue(f"P-{i}") for i in range(50, 60)]
+
+        call_count = 0
+
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _search_result(page1)
+            return _search_result(page2)
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+        result = mixin._fetch_project_issues_with_links("key in ()", 100)
+        assert len(result) == 60
+        assert mixin.search_issues.call_count == 2

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 22 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 22 entries."""
+        assert len(ALL_TOOLSETS) == 22
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 16
         assert len(confluence_toolsets) == 6
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 51, f"Expected 51 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 23 toolset names."""
+        """Test 'all' keyword returns all 24 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 23
+        assert len(result) == 24
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 23
+        assert len(result) == 24
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 23 entries."""
-        assert len(ALL_TOOLSETS) == 23
+        """Verify ALL_TOOLSETS has exactly 24 entries."""
+        assert len(ALL_TOOLSETS) == 24
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 16
         assert len(confluence_toolsets) == 8
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 61, f"Expected 61 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 63, f"Expected 63 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

- Add `jira_get_project_epic_hierarchy` and `jira_get_cross_project_dependencies` tools
- Epic hierarchy groups a project's epics under their cross-project parent issues, with direction-aware link classification
- Cross-project dependencies scans all issues and groups links by target project and link type
- Hierarchy phrase sets (parent-of / child-of) shared from `constants.py`, with custom link types configurable via `HIERARCHY_LINK_PHRASES`
- Cloud search paginates internally, while Server/Data Center uses offset pagination
- Propagate parent-summary lookup failures instead of returning incomplete hierarchy data
- Add `HIERARCHY_LINK_PHRASES` to `.env.example`

## Test plan

- [x] 20 project-analysis unit tests, including direction-aware parent detection, hierarchy inversion, custom phrase parsing, lookup error propagation, and Cloud no-repaging
- [x] Full unit and integration suite: 3260 passed, 28 skipped
- [x] Jira Cloud E2E suite: 12 passed, including live project analysis
- [x] Jira Data Center E2E suite: 11 passed, 1 environment-dependent skip, including live project analysis
- [x] Ruff, formatting, and strict mypy checks

> **Note:** Tools reference docs update will be submitted as a separate PR after feature PRs are merged.