### PR TITLE
feat(jira): add link graph traversal and issue tree tools

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -20,6 +20,7 @@ from .fields import FieldsMixin
 from .forms_api import FormsApiMixin  # Forms REST API
 from .formatting import FormattingMixin
 from .issues import IssuesMixin
+from .link_analysis import LinkAnalysisMixin
 from .links import LinksMixin
 from .metrics import MetricsMixin
 from .projects import ProjectsMixin
@@ -55,6 +56,7 @@ class JiraFetcher(
     MetricsMixin,
     SLAMixin,
     DevelopmentMixin,
+    LinkAnalysisMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -21,6 +21,7 @@ from .fields import FieldsMixin
 from .forms_api import FormsApiMixin  # Forms REST API
 from .formatting import FormattingMixin
 from .issues import IssuesMixin
+from .link_analysis import LinkAnalysisMixin
 from .links import LinksMixin
 from .metrics import MetricsMixin
 from .project_analysis import ProjectAnalysisMixin
@@ -59,6 +60,7 @@ class JiraFetcher(
     SLAMixin,
     DevelopmentMixin,
     ProjectAnalysisMixin,
+    LinkAnalysisMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.

--- a/src/mcp_atlassian/jira/link_analysis.py
+++ b/src/mcp_atlassian/jira/link_analysis.py
@@ -128,7 +128,51 @@ class LinkAnalysisMixin(JiraClient):
             )
             for issue in search.issues:
                 result[issue.key] = issue.to_simplified_dict()
+
+        missing_keys = sorted(set(keys) - set(result))
+        if missing_keys:
+            missing = ", ".join(missing_keys)
+            message = f"Jira did not return requested issue(s): {missing}"
+            raise ValueError(message)
+
         return result
+
+    def _fetch_native_child_keys(
+        self,
+        parent_key: str,
+        max_issues: int,
+    ) -> list[str]:
+        """Fetch issue keys whose native Jira parent is *parent_key*.
+
+        The ``parent`` JQL field is available in both Jira Cloud and
+        Server/Data Center.  Cloud search handles its own continuation
+        tokens; Server/Data Center requires explicit paging.
+        """
+        if max_issues <= 0:
+            return []
+
+        jql = f'parent = "{parent_key}"'
+        child_keys: list[str] = []
+        start = 0
+
+        while len(child_keys) < max_issues:
+            result: JiraSearchResult = self.search_issues(  # type: ignore[attr-defined]
+                jql=jql,
+                fields=_LINK_FIELDS,
+                start=start,
+                limit=max_issues - len(child_keys),
+            )
+
+            page_keys = [issue.key for issue in result.issues if issue.key]
+            for child_key in page_keys:
+                if child_key not in child_keys:
+                    child_keys.append(child_key)
+
+            if self.config.is_cloud or len(result.issues) < _SERVER_DC_PAGE_SIZE:
+                break
+            start += len(result.issues)
+
+        return child_keys[:max_issues]
 
     @staticmethod
     def _extract_links(
@@ -204,6 +248,7 @@ class LinkAnalysisMixin(JiraClient):
 
         Raises:
             ValueError: If direction_filter is invalid.
+            ValueError: If Jira does not return a requested issue.
             MCPAtlassianAuthenticationError: If authentication fails.
             Exception: On API errors.
         """
@@ -326,6 +371,7 @@ class LinkAnalysisMixin(JiraClient):
             list, and ``total_nodes``.
 
         Raises:
+            ValueError: If Jira does not return a requested issue.
             MCPAtlassianAuthenticationError: If authentication fails.
             Exception: On API errors.
         """
@@ -357,16 +403,29 @@ class LinkAnalysisMixin(JiraClient):
                     if target not in visited:
                         child_keys.add(target)
                 elif not link["is_hierarchy"]:
-                    cross_links.append(
-                        {
-                            "source": key,
-                            "target": target,
-                            "link_type": link["link_type"],
-                            "direction": link["direction"],
-                        }
+                    cross_link_id = (
+                        min(key, target),
+                        max(key, target),
+                        link["link_type"].casefold(),
                     )
+                    if cross_link_id not in seen_cross_links:
+                        seen_cross_links.add(cross_link_id)
+                        cross_links.append(
+                            {
+                                "source": key,
+                                "target": target,
+                                "link_type": link["link_type"],
+                                "direction": link["direction"],
+                            }
+                        )
 
             if depth < max_depth:
+                child_keys.update(
+                    self._fetch_native_child_keys(
+                        key,
+                        max_issues - len(visited),
+                    )
+                )
                 for ck in sorted(child_keys):
                     child_node = _build(ck, depth + 1)
                     if child_node is not None:
@@ -375,16 +434,11 @@ class LinkAnalysisMixin(JiraClient):
             node["children"] = children
             return node
 
+        seen_cross_links: set[tuple[str, str, str]] = set()
         root = _build(issue_key, 0)
         if root is None:
-            root = {
-                "key": issue_key,
-                "summary": "",
-                "status": "Unknown",
-                "issue_type": "Unknown",
-                "depth": 0,
-                "children": [],
-            }
+            message = f"Jira did not return requested issue: {issue_key}"
+            raise ValueError(message)
 
         return {
             "root": root,

--- a/src/mcp_atlassian/jira/link_analysis.py
+++ b/src/mcp_atlassian/jira/link_analysis.py
@@ -1,0 +1,393 @@
+"""Module for Jira issue link graph traversal and analysis."""
+
+from collections import deque
+from typing import Any
+
+from ..models.jira import JiraSearchResult
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+from .constants import CHILD_OF_PHRASES, PARENT_OF_PHRASES
+
+_SERVER_DC_PAGE_SIZE = 50
+
+# Legacy map kept for backward compatibility with callers that import
+# ``CONTAINMENT_LINKS``.  Keys are lower-cased phrases; values are the
+# direction in which the *target* is a child when the phrase appears in
+# ``type.name`` (not a directional label).
+CONTAINMENT_LINKS: dict[str, str] = {
+    "is parent of": "outward",
+    "parent": "outward",
+    "contains": "outward",
+    "is child of": "inward",
+    "is contained by": "inward",
+}
+
+_LINK_FIELDS = [
+    "summary",
+    "status",
+    "issuetype",
+    "issuelinks",
+    "parent",
+    "subtasks",
+]
+
+
+def _node_from_issue(issue_dict: dict[str, Any], depth: int) -> dict[str, Any]:
+    """Build a lightweight node dict from a simplified issue."""
+    status = issue_dict.get("status")
+    status_name = "Unknown"
+    if isinstance(status, dict):
+        status_name = status.get("name", "Unknown")
+
+    itype = issue_dict.get("issue_type")
+    type_name = "Unknown"
+    if isinstance(itype, dict):
+        type_name = itype.get("name", "Unknown")
+
+    return {
+        "key": issue_dict.get("key", ""),
+        "summary": issue_dict.get("summary", ""),
+        "status": status_name,
+        "issue_type": type_name,
+        "depth": depth,
+    }
+
+
+def _is_child_direction(
+    link_type_name: str,
+    direction: str,
+    inward_label: str = "",
+    outward_label: str = "",
+) -> bool:
+    """Return True if a link with this type+direction means target is a child.
+
+    The label for *this* direction describes the current issue's role
+    relative to the target:
+
+    * ``direction="outward"``: ``outward_label`` applies.
+      "is parent of" → we are parent → target is child.
+    * ``direction="inward"``: ``inward_label`` applies.
+      "is parent of" → we are parent → target is child.
+
+    When no directional labels are set, ``type.name`` is checked as a
+    fallback for link types whose name is itself a parent-of phrase.
+    """
+    if direction == "outward":
+        own_label = outward_label.lower()
+    else:
+        own_label = inward_label.lower()
+
+    if own_label in PARENT_OF_PHRASES:
+        return True
+
+    # Fallback: if type.name is a parent-of phrase and matches the
+    # expected direction from CONTAINMENT_LINKS, treat as containment.
+    # Only applies when directional labels are absent.
+    if not own_label:
+        expected_dir = CONTAINMENT_LINKS.get(link_type_name.lower())
+        if expected_dir is not None and expected_dir == direction:
+            return True
+
+    return False
+
+
+def _is_hierarchy_direction(
+    link_type_name: str,
+    direction: str,
+    inward_label: str = "",
+    outward_label: str = "",
+) -> bool:
+    """Return whether the link represents either side of a hierarchy."""
+    own_label = (
+        outward_label.lower() if direction == "outward" else inward_label.lower()
+    )
+    if own_label in PARENT_OF_PHRASES or own_label in CHILD_OF_PHRASES:
+        return True
+
+    return not own_label and link_type_name.lower() in CONTAINMENT_LINKS
+
+
+class LinkAnalysisMixin(JiraClient):
+    """Mixin for recursive issue-link graph traversal."""
+
+    def _batch_fetch_issues(
+        self,
+        keys: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Fetch multiple issues by key via JQL ``key in (...)``."""
+        if not keys:
+            return {}
+        result: dict[str, dict[str, Any]] = {}
+        for i in range(0, len(keys), _SERVER_DC_PAGE_SIZE):
+            chunk = keys[i : i + _SERVER_DC_PAGE_SIZE]
+            jql = "key in ({})".format(",".join(chunk))
+            search: JiraSearchResult = self.search_issues(  # type: ignore[attr-defined]
+                jql=jql,
+                fields=_LINK_FIELDS,
+                limit=len(chunk),
+            )
+            for issue in search.issues:
+                result[issue.key] = issue.to_simplified_dict()
+        return result
+
+    @staticmethod
+    def _extract_links(
+        issue_dict: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Normalise ``issuelinks`` into a flat list of link descriptors."""
+        links: list[dict[str, Any]] = []
+
+        for raw_link in issue_dict.get("issuelinks", []):
+            lt = raw_link.get("type")
+            link_type_name = ""
+            inward_label = ""
+            outward_label = ""
+            if isinstance(lt, dict):
+                link_type_name = lt.get("name", "")
+                inward_label = lt.get("inward", "")
+                outward_label = lt.get("outward", "")
+
+            for direction, field in [
+                ("outward", "outward_issue"),
+                ("inward", "inward_issue"),
+            ]:
+                target = raw_link.get(field)
+                if not target:
+                    continue
+                target_key = target.get("key", "")
+                if target_key:
+                    links.append(
+                        {
+                            "target_key": target_key,
+                            "link_type": link_type_name,
+                            "direction": direction,
+                            "is_child": _is_child_direction(
+                                link_type_name,
+                                direction,
+                                inward_label,
+                                outward_label,
+                            ),
+                            "is_hierarchy": _is_hierarchy_direction(
+                                link_type_name,
+                                direction,
+                                inward_label,
+                                outward_label,
+                            ),
+                        }
+                    )
+
+        return links
+
+    @handle_auth_errors("Jira API")
+    def trace_issue_links(
+        self,
+        issue_key: str,
+        max_depth: int = 3,
+        link_type_filter: list[str] | None = None,
+        direction_filter: str | None = None,
+        max_issues: int = 100,
+    ) -> dict[str, Any]:
+        """BFS traversal of issue links returning a flat graph.
+
+        Args:
+            issue_key: Root issue key.
+            max_depth: Maximum hops to follow (1-5).
+            link_type_filter: Only follow links whose type name is in
+                this list (case-insensitive).  ``None`` means all.
+            direction_filter: ``"inward"``, ``"outward"``, or ``None``
+                for both.
+            max_issues: Safety limit on total visited nodes.
+
+        Returns:
+            Dict with ``root``, ``nodes`` (list), ``edges`` (list),
+            ``total_nodes``, and ``total_edges``.
+
+        Raises:
+            ValueError: If direction_filter is invalid.
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API errors.
+        """
+        if direction_filter and direction_filter not in ("inward", "outward"):
+            message = (
+                f"direction_filter must be 'inward', 'outward', or None; "
+                f"got '{direction_filter}'"
+            )
+            raise ValueError(message)
+
+        type_filter_lower: set[str] | None = None
+        if link_type_filter:
+            type_filter_lower = {t.lower() for t in link_type_filter}
+
+        visited: dict[str, dict[str, Any]] = {}
+        edges: list[dict[str, str]] = []
+        seen_edges: set[tuple[str, str, str]] = set()
+        queue: deque[tuple[str, int]] = deque([(issue_key, 0)])
+
+        while queue:
+            current_key, depth = queue.popleft()
+            if current_key in visited or len(visited) >= max_issues:
+                continue
+
+            # Collect all unvisited keys at this depth for batch fetch.
+            batch_keys = [current_key]
+            remainder: list[tuple[str, int]] = []
+            while queue:
+                nk, nd = queue.popleft()
+                if nk in visited or len(visited) + len(batch_keys) >= max_issues:
+                    remainder.append((nk, nd))
+                elif nd == depth:
+                    batch_keys.append(nk)
+                else:
+                    remainder.append((nk, nd))
+            for item in remainder:
+                queue.append(item)
+
+            fetched = self._batch_fetch_issues(batch_keys)
+
+            for bk in batch_keys:
+                if bk in visited or len(visited) >= max_issues:
+                    continue
+                issue_dict = fetched.get(bk)
+                if issue_dict is None:
+                    continue
+
+                visited[bk] = _node_from_issue(issue_dict, depth)
+
+                if depth >= max_depth:
+                    continue
+
+                for link in self._extract_links(issue_dict):
+                    target = link["target_key"]
+
+                    if type_filter_lower and (
+                        link["link_type"].lower() not in type_filter_lower
+                    ):
+                        continue
+                    if direction_filter and link["direction"] != direction_filter:
+                        continue
+
+                    # Deduplicate mirrored edges.
+                    edge_id = (
+                        min(bk, target),
+                        max(bk, target),
+                        link["link_type"],
+                    )
+                    if edge_id not in seen_edges:
+                        seen_edges.add(edge_id)
+                        edges.append(
+                            {
+                                "source": bk,
+                                "target": target,
+                                "link_type": link["link_type"],
+                                "direction": link["direction"],
+                            }
+                        )
+
+                    if target not in visited:
+                        queue.append((target, depth + 1))
+
+        # Only keep edges where both endpoints were visited.
+        visited_keys = set(visited.keys())
+        edges = [
+            e
+            for e in edges
+            if e["source"] in visited_keys and e["target"] in visited_keys
+        ]
+
+        return {
+            "root": issue_key,
+            "max_depth": max_depth,
+            "nodes": list(visited.values()),
+            "edges": edges,
+            "total_nodes": len(visited),
+            "total_edges": len(edges),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_issue_tree(
+        self,
+        issue_key: str,
+        max_depth: int = 3,
+        max_issues: int = 100,
+    ) -> dict[str, Any]:
+        """Build a hierarchical tree following containment links only.
+
+        Containment links (parent/child, contains) form the tree spine.
+        Non-containment links are recorded as ``cross_links``
+        annotations but are **not** traversed.
+
+        Args:
+            issue_key: Root issue key.
+            max_depth: Maximum tree depth (1-5).
+            max_issues: Safety limit on visited nodes.
+
+        Returns:
+            Dict with ``root`` (recursive tree node), ``cross_links``
+            list, and ``total_nodes``.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API errors.
+        """
+        visited: set[str] = set()
+        cross_links: list[dict[str, str]] = []
+
+        def _build(key: str, depth: int) -> dict[str, Any] | None:
+            if key in visited or len(visited) >= max_issues:
+                return None
+
+            fetched = self._batch_fetch_issues([key])
+            issue_dict = fetched.get(key)
+            if issue_dict is None:
+                return None
+
+            visited.add(key)
+            node = _node_from_issue(issue_dict, depth)
+            children: list[dict[str, Any]] = []
+            child_keys: set[str] = set()
+
+            for st in issue_dict.get("subtasks", []):
+                st_key = st.get("key", "") if isinstance(st, dict) else ""
+                if st_key and st_key not in visited:
+                    child_keys.add(st_key)
+
+            for link in self._extract_links(issue_dict):
+                target = link["target_key"]
+                if link["is_child"]:
+                    if target not in visited:
+                        child_keys.add(target)
+                elif not link["is_hierarchy"]:
+                    cross_links.append(
+                        {
+                            "source": key,
+                            "target": target,
+                            "link_type": link["link_type"],
+                            "direction": link["direction"],
+                        }
+                    )
+
+            if depth < max_depth:
+                for ck in sorted(child_keys):
+                    child_node = _build(ck, depth + 1)
+                    if child_node is not None:
+                        children.append(child_node)
+
+            node["children"] = children
+            return node
+
+        root = _build(issue_key, 0)
+        if root is None:
+            root = {
+                "key": issue_key,
+                "summary": "",
+                "status": "Unknown",
+                "issue_type": "Unknown",
+                "depth": 0,
+                "children": [],
+            }
+
+        return {
+            "root": root,
+            "cross_links": cross_links,
+            "total_nodes": len(visited),
+        }

--- a/src/mcp_atlassian/jira/link_analysis.py
+++ b/src/mcp_atlassian/jira/link_analysis.py
@@ -1,0 +1,334 @@
+"""Module for Jira issue link graph traversal and analysis."""
+
+import logging
+from collections import deque
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..models.jira import JiraSearchResult
+from ..utils.decorators import handle_auth_errors
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+# Containment link classification.  Keys are lower-cased link type
+# names; values are the direction that implies "target is a child".
+CONTAINMENT_LINKS: dict[str, str] = {
+    "is parent of": "outward",
+    "parent": "outward",
+    "contains": "outward",
+    "is child of": "inward",
+    "is contained by": "inward",
+}
+
+_LINK_FIELDS = [
+    "summary",
+    "status",
+    "issuetype",
+    "issuelinks",
+    "parent",
+    "subtasks",
+]
+
+
+def _node_from_issue(issue_dict: dict[str, Any], depth: int) -> dict[str, Any]:
+    """Build a lightweight node dict from a simplified issue."""
+    status = issue_dict.get("status")
+    status_name = "Unknown"
+    if isinstance(status, dict):
+        status_name = status.get("name", "Unknown")
+
+    itype = issue_dict.get("issue_type")
+    type_name = "Unknown"
+    if isinstance(itype, dict):
+        type_name = itype.get("name", "Unknown")
+
+    return {
+        "key": issue_dict.get("key", ""),
+        "summary": issue_dict.get("summary", ""),
+        "status": status_name,
+        "issue_type": type_name,
+        "depth": depth,
+    }
+
+
+def _is_child_direction(link_type_name: str, direction: str) -> bool:
+    """Return True if a link with this type+direction means target is a child."""
+    expected_dir = CONTAINMENT_LINKS.get(link_type_name.lower())
+    return expected_dir is not None and expected_dir == direction
+
+
+class LinkAnalysisMixin(JiraClient):
+    """Mixin for recursive issue-link graph traversal."""
+
+    def _batch_fetch_issues(
+        self,
+        keys: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Fetch multiple issues by key via JQL ``key in (...)``."""
+        if not keys:
+            return {}
+        result: dict[str, dict[str, Any]] = {}
+        for i in range(0, len(keys), 50):
+            chunk = keys[i : i + 50]
+            jql = "key in ({})".format(",".join(chunk))
+            try:
+                search: JiraSearchResult = self.search_issues(  # type: ignore[attr-defined]
+                    jql=jql,
+                    fields=_LINK_FIELDS,
+                    limit=len(chunk),
+                )
+                for issue in search.issues:
+                    result[issue.key] = issue.to_simplified_dict()
+            except HTTPError:
+                raise
+            except Exception:
+                logger.warning("Failed to batch-fetch issues: %s", chunk)
+        return result
+
+    @staticmethod
+    def _extract_links(
+        issue_dict: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Normalise ``issuelinks`` into a flat list of link descriptors."""
+        links: list[dict[str, Any]] = []
+
+        for raw_link in issue_dict.get("issuelinks", []):
+            lt = raw_link.get("type")
+            link_type_name = ""
+            if isinstance(lt, dict):
+                link_type_name = lt.get("name", "")
+
+            for direction, field in [
+                ("outward", "outward_issue"),
+                ("inward", "inward_issue"),
+            ]:
+                target = raw_link.get(field)
+                if not target:
+                    continue
+                target_key = target.get("key", "")
+                if target_key:
+                    links.append(
+                        {
+                            "target_key": target_key,
+                            "link_type": link_type_name,
+                            "direction": direction,
+                            "is_child": _is_child_direction(link_type_name, direction),
+                        }
+                    )
+
+        return links
+
+    @handle_auth_errors("Jira API")
+    def trace_issue_links(
+        self,
+        issue_key: str,
+        max_depth: int = 3,
+        link_type_filter: list[str] | None = None,
+        direction_filter: str | None = None,
+        max_issues: int = 100,
+    ) -> dict[str, Any]:
+        """BFS traversal of issue links returning a flat graph.
+
+        Args:
+            issue_key: Root issue key.
+            max_depth: Maximum hops to follow (1-5).
+            link_type_filter: Only follow links whose type name is in
+                this list (case-insensitive).  ``None`` means all.
+            direction_filter: ``"inward"``, ``"outward"``, or ``None``
+                for both.
+            max_issues: Safety limit on total visited nodes.
+
+        Returns:
+            Dict with ``root``, ``nodes`` (list), ``edges`` (list),
+            ``total_nodes``, and ``total_edges``.
+
+        Raises:
+            ValueError: If direction_filter is invalid.
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API errors.
+        """
+        if direction_filter and direction_filter not in ("inward", "outward"):
+            raise ValueError(
+                f"direction_filter must be 'inward', 'outward', or None; "
+                f"got '{direction_filter}'"
+            )
+
+        type_filter_lower: set[str] | None = None
+        if link_type_filter:
+            type_filter_lower = {t.lower() for t in link_type_filter}
+
+        visited: dict[str, dict[str, Any]] = {}
+        edges: list[dict[str, str]] = []
+        seen_edges: set[tuple[str, str, str]] = set()
+        queue: deque[tuple[str, int]] = deque([(issue_key, 0)])
+
+        while queue:
+            current_key, depth = queue.popleft()
+            if current_key in visited or len(visited) >= max_issues:
+                continue
+
+            # Collect all unvisited keys at this depth for batch fetch.
+            batch_keys = [current_key]
+            remainder: list[tuple[str, int]] = []
+            while queue:
+                nk, nd = queue.popleft()
+                if nk in visited or len(visited) + len(batch_keys) >= max_issues:
+                    remainder.append((nk, nd))
+                elif nd == depth:
+                    batch_keys.append(nk)
+                else:
+                    remainder.append((nk, nd))
+            for item in remainder:
+                queue.append(item)
+
+            fetched = self._batch_fetch_issues(batch_keys)
+
+            for bk in batch_keys:
+                if bk in visited or len(visited) >= max_issues:
+                    continue
+                issue_dict = fetched.get(bk)
+                if issue_dict is None:
+                    continue
+
+                visited[bk] = _node_from_issue(issue_dict, depth)
+
+                if depth >= max_depth:
+                    continue
+
+                for link in self._extract_links(issue_dict):
+                    target = link["target_key"]
+
+                    if type_filter_lower and (
+                        link["link_type"].lower() not in type_filter_lower
+                    ):
+                        continue
+                    if direction_filter and link["direction"] != direction_filter:
+                        continue
+
+                    # Deduplicate mirrored edges.
+                    edge_id = (
+                        min(bk, target),
+                        max(bk, target),
+                        link["link_type"],
+                    )
+                    if edge_id not in seen_edges:
+                        seen_edges.add(edge_id)
+                        edges.append(
+                            {
+                                "source": bk,
+                                "target": target,
+                                "link_type": link["link_type"],
+                                "direction": link["direction"],
+                            }
+                        )
+
+                    if target not in visited:
+                        queue.append((target, depth + 1))
+
+        # Only keep edges where both endpoints were visited.
+        visited_keys = set(visited.keys())
+        edges = [
+            e
+            for e in edges
+            if e["source"] in visited_keys and e["target"] in visited_keys
+        ]
+
+        return {
+            "root": issue_key,
+            "max_depth": max_depth,
+            "nodes": list(visited.values()),
+            "edges": edges,
+            "total_nodes": len(visited),
+            "total_edges": len(edges),
+        }
+
+    @handle_auth_errors("Jira API")
+    def get_issue_tree(
+        self,
+        issue_key: str,
+        max_depth: int = 3,
+        max_issues: int = 100,
+    ) -> dict[str, Any]:
+        """Build a hierarchical tree following containment links only.
+
+        Containment links (parent/child, contains) form the tree spine.
+        Non-containment links are recorded as ``cross_links``
+        annotations but are **not** traversed.
+
+        Args:
+            issue_key: Root issue key.
+            max_depth: Maximum tree depth (1-5).
+            max_issues: Safety limit on visited nodes.
+
+        Returns:
+            Dict with ``root`` (recursive tree node), ``cross_links``
+            list, and ``total_nodes``.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: On API errors.
+        """
+        visited: set[str] = set()
+        cross_links: list[dict[str, str]] = []
+
+        def _build(key: str, depth: int) -> dict[str, Any] | None:
+            if key in visited or len(visited) >= max_issues:
+                return None
+
+            fetched = self._batch_fetch_issues([key])
+            issue_dict = fetched.get(key)
+            if issue_dict is None:
+                return None
+
+            visited.add(key)
+            node = _node_from_issue(issue_dict, depth)
+            children: list[dict[str, Any]] = []
+            child_keys: set[str] = set()
+
+            for st in issue_dict.get("subtasks", []):
+                st_key = st.get("key", "") if isinstance(st, dict) else ""
+                if st_key and st_key not in visited:
+                    child_keys.add(st_key)
+
+            for link in self._extract_links(issue_dict):
+                target = link["target_key"]
+                if link["is_child"]:
+                    if target not in visited:
+                        child_keys.add(target)
+                else:
+                    cross_links.append(
+                        {
+                            "source": key,
+                            "target": target,
+                            "link_type": link["link_type"],
+                            "direction": link["direction"],
+                        }
+                    )
+
+            if depth < max_depth:
+                for ck in sorted(child_keys):
+                    child_node = _build(ck, depth + 1)
+                    if child_node is not None:
+                        children.append(child_node)
+
+            node["children"] = children
+            return node
+
+        root = _build(issue_key, 0)
+        if root is None:
+            root = {
+                "key": issue_key,
+                "summary": "",
+                "status": "Unknown",
+                "issue_type": "Unknown",
+                "depth": 0,
+                "children": [],
+            }
+
+        return {
+            "root": root,
+            "cross_links": cross_links,
+            "total_nodes": len(visited),
+        }

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3273,3 +3273,141 @@ async def get_issues_development_info(
         logger.error(f"Error getting development info for issues: {str(e)}")
         error_result = {"success": False, "error": str(e)}
         return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_link_analysis"},
+    annotations={"title": "Trace Issue Links", "readOnlyHint": True},
+)
+async def trace_issue_links(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Root issue key to start traversal from (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    max_depth: Annotated[
+        int,
+        Field(
+            description="Maximum link traversal depth (1-5)",
+            ge=1,
+            le=5,
+        ),
+    ] = 3,
+    link_type_filter: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated link type names to follow "
+                "(e.g., 'Blocks,Depends on'). Omit to follow all types."
+            ),
+        ),
+    ] = None,
+    direction_filter: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Restrict traversal direction: "
+                "'inward', 'outward', or omit for both."
+            ),
+        ),
+    ] = None,
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum number of issues to visit (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 100,
+) -> str:
+    """Traverse issue links recursively and return a flat graph.
+
+    Performs a breadth-first traversal from the root issue, following
+    issue links up to max_depth hops.  Returns all visited nodes and
+    edges.  Useful for dependency tracing, impact analysis, and
+    understanding link chains across projects.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Root issue key.
+        max_depth: Max hops.
+        link_type_filter: Comma-separated type names to restrict traversal.
+        direction_filter: Direction restriction.
+        max_issues: Safety limit.
+
+    Returns:
+        JSON string with nodes, edges, and counts.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    types_list: list[str] | None = None
+    if link_type_filter:
+        types_list = [t.strip() for t in link_type_filter.split(",") if t.strip()]
+
+    result = jira.trace_issue_links(
+        issue_key=issue_key,
+        max_depth=max_depth,
+        link_type_filter=types_list,
+        direction_filter=direction_filter,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_link_analysis"},
+    annotations={"title": "Get Issue Tree", "readOnlyHint": True},
+)
+async def get_issue_tree(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Root issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    max_depth: Annotated[
+        int,
+        Field(
+            description="Maximum tree depth (1-5)",
+            ge=1,
+            le=5,
+        ),
+    ] = 3,
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum number of issues to visit (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 100,
+) -> str:
+    """Build a hierarchical issue tree following containment links.
+
+    Containment links (parent/child, epic, split) form the tree spine.
+    Non-containment links are returned as cross_links annotations but
+    are not traversed.  Useful for navigating hierarchical Jira
+    structures (initiative → epic → story) while seeing lateral
+    dependencies.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Root issue key.
+        max_depth: Max tree depth.
+        max_issues: Safety limit.
+
+    Returns:
+        JSON string with recursive tree root, cross_links, and count.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_issue_tree(
+        issue_key=issue_key,
+        max_depth=max_depth,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -4398,3 +4398,141 @@ async def get_cross_project_dependencies(
         max_issues=max_issues,
     )
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_link_analysis"},
+    annotations={"title": "Trace Issue Links", "readOnlyHint": True},
+)
+async def trace_issue_links(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Root issue key to start traversal from (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    max_depth: Annotated[
+        int,
+        Field(
+            description="Maximum link traversal depth (1-5)",
+            ge=1,
+            le=5,
+        ),
+    ] = 3,
+    link_type_filter: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated link type names to follow "
+                "(e.g., 'Blocks,Depends on'). Omit to follow all types."
+            ),
+        ),
+    ] = None,
+    direction_filter: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Restrict traversal direction: "
+                "'inward', 'outward', or omit for both."
+            ),
+        ),
+    ] = None,
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum number of issues to visit (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 100,
+) -> str:
+    """Traverse issue links recursively and return a flat graph.
+
+    Performs a breadth-first traversal from the root issue, following
+    issue links up to max_depth hops.  Returns all visited nodes and
+    edges.  Useful for dependency tracing, impact analysis, and
+    understanding link chains across projects.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Root issue key.
+        max_depth: Max hops.
+        link_type_filter: Comma-separated type names to restrict traversal.
+        direction_filter: Direction restriction.
+        max_issues: Safety limit.
+
+    Returns:
+        JSON string with nodes, edges, and counts.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    types_list: list[str] | None = None
+    if link_type_filter:
+        types_list = [t.strip() for t in link_type_filter.split(",") if t.strip()]
+
+    result = jira.trace_issue_links(
+        issue_key=issue_key,
+        max_depth=max_depth,
+        link_type_filter=types_list,
+        direction_filter=direction_filter,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_link_analysis"},
+    annotations={"title": "Get Issue Tree", "readOnlyHint": True},
+)
+async def get_issue_tree(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Root issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    max_depth: Annotated[
+        int,
+        Field(
+            description="Maximum tree depth (1-5)",
+            ge=1,
+            le=5,
+        ),
+    ] = 3,
+    max_issues: Annotated[
+        int,
+        Field(
+            description="Maximum number of issues to visit (1-500)",
+            ge=1,
+            le=500,
+        ),
+    ] = 100,
+) -> str:
+    """Build a hierarchical issue tree following containment links.
+
+    Containment links (parent/child, epic, split) form the tree spine.
+    Non-containment links are returned as cross_links annotations but
+    are not traversed.  Useful for navigating hierarchical Jira
+    structures (initiative → epic → story) while seeing lateral
+    dependencies.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Root issue key.
+        max_depth: Max tree depth.
+        max_issues: Safety limit.
+
+    Returns:
+        JSON string with recursive tree root, cross_links, and count.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_issue_tree(
+        issue_key=issue_key,
+        max_depth=max_depth,
+        max_issues=max_issues,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups tools into 22 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (15) ---
+# --- Jira toolsets (16) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -100,6 +100,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_link_analysis": ToolsetDefinition(
+        name="jira_link_analysis",
+        description="Link graph traversal and issue tree analysis",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (6) ---
@@ -152,7 +157,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 21 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 22 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -165,9 +170,9 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="all" -> all 21 names
+        TOOLSETS unset -> all 22 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 22 toolsets (with deprecation warning)
+        TOOLSETS="all" -> all 22 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
         TOOLSETS="typo_name" -> set() (fail-closed)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 95 tools into 24 named toolsets controlled via the TOOLSETS env var.
+Groups 97 tools into 25 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (16) ---
+# --- Jira toolsets (17) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -105,6 +105,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Project epic hierarchy and cross-project dependencies",
         default=False,
     ),
+    "jira_link_analysis": ToolsetDefinition(
+        name="jira_link_analysis",
+        description="Link graph traversal and issue tree analysis",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (8) ---
@@ -167,7 +172,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 24 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 25 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -180,9 +185,9 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 24 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 24 toolsets (with deprecation warning)
-        TOOLSETS="all" -> all 24 names
+        TOOLSETS unset -> all 25 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 25 toolsets (with deprecation warning)
+        TOOLSETS="all" -> all 25 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
         TOOLSETS="typo_name" -> set() (fail-closed)

--- a/tests/unit/jira/test_link_analysis.py
+++ b/tests/unit/jira/test_link_analysis.py
@@ -47,6 +47,7 @@ def _issue(
     key: str,
     links: list[JiraIssueLink] | None = None,
     subtasks: list[dict] | None = None,
+    parent: str | None = None,
 ) -> JiraIssue:
     return JiraIssue(
         key=key,
@@ -55,6 +56,7 @@ def _issue(
         issue_type=JiraIssueType(name="Task"),
         issuelinks=links or [],
         subtasks=subtasks or [],
+        parent={"key": parent} if parent else None,
     )
 
 
@@ -212,6 +214,19 @@ class TestTraceIssueLinks:
         with pytest.raises(RuntimeError, match="API unavailable"):
             mixin.trace_issue_links("A-1")
 
+    def test_missing_root_raises(self, mixin):
+        self._setup_issues(mixin, {})
+
+        with pytest.raises(ValueError, match="A-1"):
+            mixin.trace_issue_links("A-1")
+
+    def test_missing_linked_issue_raises(self, mixin):
+        a = _issue("A-1", [_link(outward_key="MISSING-1")])
+        self._setup_issues(mixin, _issue_store(a))
+
+        with pytest.raises(ValueError, match="MISSING-1"):
+            mixin.trace_issue_links("A-1")
+
 
 class TestGetIssueTree:
     @pytest.fixture
@@ -220,6 +235,15 @@ class TestGetIssueTree:
 
     def _setup_issues(self, mixin, store: dict[str, JiraIssue]) -> None:
         def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            if jql.startswith("parent = "):
+                parent_key = jql.split('"')[1]
+                return _search(
+                    [
+                        issue
+                        for issue in store.values()
+                        if issue.parent and issue.parent.get("key") == parent_key
+                    ]
+                )
             keys = jql.removeprefix("key in (").removesuffix(")").split(",")
             return _search([store[key] for key in keys if key in store])
 
@@ -268,6 +292,29 @@ class TestGetIssueTree:
 
         child_keys = [ch["key"] for ch in result["root"]["children"]]
         assert "A-2" in child_keys
+
+    def test_native_parent_relationship_as_children(self, mixin):
+        """Tree follows native parent fields through a shared JQL query."""
+        a = _issue("A-1")
+        b = _issue("B-1", parent="A-1")
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.get_issue_tree("A-1", max_depth=1)
+
+        assert [child["key"] for child in result["root"]["children"]] == ["B-1"]
+
+    def test_missing_root_raises(self, mixin):
+        self._setup_issues(mixin, {})
+
+        with pytest.raises(ValueError, match="A-1"):
+            mixin.get_issue_tree("A-1")
+
+    def test_missing_containment_child_raises(self, mixin):
+        a = _issue("A-1", [_link(outward_key="MISSING-1", name="is parent of")])
+        self._setup_issues(mixin, _issue_store(a))
+
+        with pytest.raises(ValueError, match="MISSING-1"):
+            mixin.get_issue_tree("A-1")
 
     def test_max_depth_respected(self, mixin):
         """Tree doesn't recurse past max_depth."""
@@ -406,6 +453,24 @@ class TestGetIssueTree:
 
         assert result["root"]["children"][0]["key"] == "B-1"
         assert result["cross_links"] == []
+
+    def test_mirrored_lateral_link_is_deduplicated(self, mixin):
+        """A lateral link reported from both endpoints appears once."""
+        a = _issue(
+            "A-1",
+            [
+                _link(outward_key="B-1", name="is parent of"),
+                _link(outward_key="B-1", name="Related"),
+            ],
+        )
+        b = _issue("B-1", [_link(inward_key="A-1", name="Related")])
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.get_issue_tree("A-1", max_depth=1)
+
+        assert len(result["cross_links"]) == 1
+        assert result["cross_links"][0]["source"] == "A-1"
+        assert result["cross_links"][0]["target"] == "B-1"
 
     def test_auth_error(self, mixin):
         mixin.search_issues = MagicMock(

--- a/tests/unit/jira/test_link_analysis.py
+++ b/tests/unit/jira/test_link_analysis.py
@@ -1,0 +1,415 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.models.jira.common import JiraIssueType, JiraStatus
+from mcp_atlassian.models.jira.issue import JiraIssue
+from mcp_atlassian.models.jira.link import (
+    JiraIssueLink,
+    JiraIssueLinkType,
+    JiraLinkedIssue,
+    JiraLinkedIssueFields,
+)
+from mcp_atlassian.models.jira.search import JiraSearchResult
+
+
+def _link(
+    *,
+    name: str = "Blocks",
+    inward_key: str | None = None,
+    outward_key: str | None = None,
+    inward_label: str = "",
+    outward_label: str = "",
+) -> JiraIssueLink:
+    lt = JiraIssueLinkType(name=name, inward=inward_label, outward=outward_label)
+    inward = (
+        JiraLinkedIssue(
+            key=inward_key,
+            fields=JiraLinkedIssueFields(summary=f"S {inward_key}"),
+        )
+        if inward_key
+        else None
+    )
+    outward = (
+        JiraLinkedIssue(
+            key=outward_key,
+            fields=JiraLinkedIssueFields(summary=f"S {outward_key}"),
+        )
+        if outward_key
+        else None
+    )
+    return JiraIssueLink(type=lt, inward_issue=inward, outward_issue=outward)
+
+
+def _issue(
+    key: str,
+    links: list[JiraIssueLink] | None = None,
+    subtasks: list[dict] | None = None,
+) -> JiraIssue:
+    return JiraIssue(
+        key=key,
+        summary=f"Issue {key}",
+        status=JiraStatus(name="Open"),
+        issue_type=JiraIssueType(name="Task"),
+        issuelinks=links or [],
+        subtasks=subtasks or [],
+    )
+
+
+def _search(issues: list[JiraIssue]) -> JiraSearchResult:
+    return JiraSearchResult(
+        total=len(issues), start_at=0, max_results=50, issues=issues
+    )
+
+
+def _issue_store(*issues: JiraIssue) -> dict[str, JiraIssue]:
+    return {i.key: i for i in issues}
+
+
+class TestTraceIssueLinks:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    def _setup_issues(self, mixin, store: dict[str, JiraIssue]) -> None:
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            keys = jql.removeprefix("key in (").removesuffix(")").split(",")
+            return _search([store[key] for key in keys if key in store])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+    def test_single_hop(self, mixin):
+        """Trace one issue linked to another."""
+        a = _issue("A-1", [_link(outward_key="B-1")])
+        b = _issue("B-1")
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.trace_issue_links("A-1", max_depth=1)
+
+        assert result["total_nodes"] == 2
+        assert result["total_edges"] == 1
+        keys = {n["key"] for n in result["nodes"]}
+        assert keys == {"A-1", "B-1"}
+
+    def test_depth_respected(self, mixin):
+        """BFS stops at max_depth."""
+        a = _issue("A-1", [_link(outward_key="B-1")])
+        b = _issue("B-1", [_link(outward_key="C-1")])
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=1)
+
+        keys = {n["key"] for n in result["nodes"]}
+        assert "A-1" in keys
+        assert "B-1" in keys
+        assert "C-1" not in keys
+
+    def test_cycle_detection(self, mixin):
+        """Cycles don't cause infinite loops."""
+        a = _issue("A-1", [_link(outward_key="B-1")])
+        b = _issue("B-1", [_link(outward_key="A-1")])
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.trace_issue_links("A-1", max_depth=5)
+
+        assert result["total_nodes"] == 2
+
+    def test_max_issues_limit(self, mixin):
+        """Traversal stops when max_issues reached."""
+        a = _issue("A-1", [_link(outward_key="B-1"), _link(outward_key="C-1")])
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=5, max_issues=2)
+
+        assert result["total_nodes"] <= 2
+
+    def test_fetches_all_issues_in_each_depth_batch(self, mixin):
+        """Every issue returned by a depth-level batch is visited."""
+        a = _issue("A-1", [_link(outward_key="B-1"), _link(outward_key="C-1")])
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=1)
+
+        assert {node["key"] for node in result["nodes"]} == {"A-1", "B-1", "C-1"}
+        assert mixin.search_issues.call_count == 2
+
+    def test_type_filter(self, mixin):
+        """Only follows specified link types."""
+        a = _issue(
+            "A-1",
+            [
+                _link(outward_key="B-1", name="Blocks"),
+                _link(outward_key="C-1", name="Related"),
+            ],
+        )
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links(
+            "A-1", max_depth=2, link_type_filter=["Blocks"]
+        )
+
+        keys = {n["key"] for n in result["nodes"]}
+        assert "B-1" in keys
+        assert "C-1" not in keys
+
+    def test_direction_filter(self, mixin):
+        """Only follows specified direction."""
+        a = _issue(
+            "A-1",
+            [
+                _link(outward_key="B-1", name="Blocks"),
+                _link(inward_key="C-1", name="Related"),
+            ],
+        )
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=2, direction_filter="outward")
+
+        keys = {n["key"] for n in result["nodes"]}
+        assert "B-1" in keys
+        assert "C-1" not in keys
+
+    def test_invalid_direction_filter(self, mixin):
+        """Invalid direction_filter raises ValueError."""
+        with pytest.raises(ValueError, match="direction_filter"):
+            mixin.trace_issue_links("A-1", direction_filter="OUTWARD")
+
+    def test_edges_only_reference_visited_nodes(self, mixin):
+        """Edges to unvisited nodes (due to max_issues) are filtered out."""
+        a = _issue("A-1", [_link(outward_key="B-1"), _link(outward_key="C-1")])
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=5, max_issues=1)
+
+        visited_keys = {n["key"] for n in result["nodes"]}
+        for edge in result["edges"]:
+            assert edge["source"] in visited_keys
+            assert edge["target"] in visited_keys
+
+    def test_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.trace_issue_links("A-1")
+
+    def test_non_http_api_error_propagates(self, mixin):
+        mixin.search_issues = MagicMock(side_effect=RuntimeError("API unavailable"))
+
+        with pytest.raises(RuntimeError, match="API unavailable"):
+            mixin.trace_issue_links("A-1")
+
+
+class TestGetIssueTree:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    def _setup_issues(self, mixin, store: dict[str, JiraIssue]) -> None:
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            keys = jql.removeprefix("key in (").removesuffix(")").split(",")
+            return _search([store[key] for key in keys if key in store])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+    def test_containment_only(self, mixin):
+        """Tree follows containment links, not non-containment."""
+        a = _issue(
+            "A-1",
+            [
+                _link(outward_key="B-1", name="is parent of"),
+                _link(outward_key="C-1", name="Related"),
+            ],
+        )
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "B-1" in child_keys
+        assert "C-1" not in child_keys
+
+    def test_cross_links_annotated(self, mixin):
+        """Non-containment links appear in cross_links."""
+        a = _issue(
+            "A-1",
+            [_link(outward_key="C-1", name="Related")],
+        )
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, c))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        assert len(result["cross_links"]) == 1
+        assert result["cross_links"][0]["target"] == "C-1"
+
+    def test_subtasks_as_children(self, mixin):
+        """Subtasks appear as tree children."""
+        a = _issue("A-1", subtasks=[{"key": "A-2"}])
+        a2 = _issue("A-2")
+        self._setup_issues(mixin, _issue_store(a, a2))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "A-2" in child_keys
+
+    def test_max_depth_respected(self, mixin):
+        """Tree doesn't recurse past max_depth."""
+        a = _issue("A-1", [_link(outward_key="B-1", name="is parent of")])
+        b = _issue("B-1", [_link(outward_key="C-1", name="is parent of")])
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.get_issue_tree("A-1", max_depth=1)
+
+        assert result["root"]["children"][0]["key"] == "B-1"
+        assert result["root"]["children"][0]["children"] == []
+
+    def test_cycle_in_tree(self, mixin):
+        """Cycles in containment links don't cause infinite recursion."""
+        a = _issue("A-1", [_link(outward_key="B-1", name="is parent of")])
+        b = _issue("B-1", [_link(outward_key="A-1", name="is parent of")])
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.get_issue_tree("A-1", max_depth=5)
+
+        assert result["total_nodes"] == 2
+
+    def test_hierarchy_via_directional_labels(self, mixin):
+        """Containment detected via type.outward even when type.name is generic."""
+        a = _issue(
+            "A-1",
+            [
+                _link(
+                    outward_key="B-1",
+                    name="Hierarchy",
+                    outward_label="is parent of",
+                    inward_label="is child of",
+                ),
+            ],
+        )
+        b = _issue("B-1")
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "B-1" in child_keys
+
+    def test_split_to_treated_as_child(self, mixin):
+        """outward 'Split to' links are containment — target is a child."""
+        a = _issue(
+            "A-1",
+            [
+                _link(
+                    outward_key="B-1",
+                    name="Issue split",
+                    outward_label="Split to",
+                    inward_label="Split from",
+                ),
+            ],
+        )
+        b = _issue("B-1")
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "B-1" in child_keys
+
+    def test_split_from_not_treated_as_child(self, mixin):
+        """inward 'Split from' means the inward issue is our parent, not child."""
+        a = _issue(
+            "A-1",
+            [
+                _link(
+                    inward_key="P-1",
+                    name="Issue split",
+                    outward_label="Split to",
+                    inward_label="Split from",
+                ),
+            ],
+        )
+        p = _issue("P-1")
+        self._setup_issues(mixin, _issue_store(a, p))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "P-1" not in child_keys
+
+    def test_inward_child_of_not_treated_as_child(self, mixin):
+        """inward_issue with inward='is child of' is our parent, not child."""
+        a = _issue(
+            "A-1",
+            [
+                _link(
+                    inward_key="P-1",
+                    name="Hierarchy",
+                    outward_label="is parent of",
+                    inward_label="is child of",
+                ),
+            ],
+        )
+        p = _issue("P-1")
+        self._setup_issues(mixin, _issue_store(a, p))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "P-1" not in child_keys
+        assert result["cross_links"] == []
+
+    def test_mirrored_parent_link_is_not_a_cross_link(self, mixin):
+        """A child's hierarchy link back to its parent isn't lateral."""
+        a = _issue(
+            "A-1",
+            [
+                _link(
+                    outward_key="B-1",
+                    name="Hierarchy",
+                    outward_label="is parent of",
+                    inward_label="is child of",
+                )
+            ],
+        )
+        b = _issue(
+            "B-1",
+            [
+                _link(
+                    inward_key="A-1",
+                    name="Hierarchy",
+                    outward_label="is parent of",
+                    inward_label="is child of",
+                )
+            ],
+        )
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        assert result["root"]["children"][0]["key"] == "B-1"
+        assert result["cross_links"] == []
+
+    def test_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_issue_tree("A-1")

--- a/tests/unit/jira/test_link_analysis.py
+++ b/tests/unit/jira/test_link_analysis.py
@@ -1,0 +1,283 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.models.jira.common import JiraIssueType, JiraStatus
+from mcp_atlassian.models.jira.issue import JiraIssue
+from mcp_atlassian.models.jira.link import (
+    JiraIssueLink,
+    JiraIssueLinkType,
+    JiraLinkedIssue,
+    JiraLinkedIssueFields,
+)
+from mcp_atlassian.models.jira.search import JiraSearchResult
+
+
+def _link(
+    *,
+    name: str = "Blocks",
+    inward_key: str | None = None,
+    outward_key: str | None = None,
+) -> JiraIssueLink:
+    lt = JiraIssueLinkType(name=name)
+    inward = (
+        JiraLinkedIssue(
+            key=inward_key,
+            fields=JiraLinkedIssueFields(summary=f"S {inward_key}"),
+        )
+        if inward_key
+        else None
+    )
+    outward = (
+        JiraLinkedIssue(
+            key=outward_key,
+            fields=JiraLinkedIssueFields(summary=f"S {outward_key}"),
+        )
+        if outward_key
+        else None
+    )
+    return JiraIssueLink(type=lt, inward_issue=inward, outward_issue=outward)
+
+
+def _issue(
+    key: str,
+    links: list[JiraIssueLink] | None = None,
+    subtasks: list[dict] | None = None,
+) -> JiraIssue:
+    return JiraIssue(
+        key=key,
+        summary=f"Issue {key}",
+        status=JiraStatus(name="Open"),
+        issue_type=JiraIssueType(name="Task"),
+        issuelinks=links or [],
+        subtasks=subtasks or [],
+    )
+
+
+def _search(issues: list[JiraIssue]) -> JiraSearchResult:
+    return JiraSearchResult(
+        total=len(issues), start_at=0, max_results=50, issues=issues
+    )
+
+
+def _issue_store(*issues: JiraIssue) -> dict[str, JiraIssue]:
+    return {i.key: i for i in issues}
+
+
+class TestTraceIssueLinks:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    def _setup_issues(self, mixin, store: dict[str, JiraIssue]) -> None:
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            for k, v in store.items():
+                if k in jql:
+                    return _search([v])
+            return _search([])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+    def test_single_hop(self, mixin):
+        """Trace one issue linked to another."""
+        a = _issue("A-1", [_link(outward_key="B-1")])
+        b = _issue("B-1")
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.trace_issue_links("A-1", max_depth=1)
+
+        assert result["total_nodes"] == 2
+        assert result["total_edges"] == 1
+        keys = {n["key"] for n in result["nodes"]}
+        assert keys == {"A-1", "B-1"}
+
+    def test_depth_respected(self, mixin):
+        """BFS stops at max_depth."""
+        a = _issue("A-1", [_link(outward_key="B-1")])
+        b = _issue("B-1", [_link(outward_key="C-1")])
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=1)
+
+        keys = {n["key"] for n in result["nodes"]}
+        assert "A-1" in keys
+        assert "B-1" in keys
+        assert "C-1" not in keys
+
+    def test_cycle_detection(self, mixin):
+        """Cycles don't cause infinite loops."""
+        a = _issue("A-1", [_link(outward_key="B-1")])
+        b = _issue("B-1", [_link(outward_key="A-1")])
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.trace_issue_links("A-1", max_depth=5)
+
+        assert result["total_nodes"] == 2
+
+    def test_max_issues_limit(self, mixin):
+        """Traversal stops when max_issues reached."""
+        a = _issue("A-1", [_link(outward_key="B-1"), _link(outward_key="C-1")])
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=5, max_issues=2)
+
+        assert result["total_nodes"] <= 2
+
+    def test_type_filter(self, mixin):
+        """Only follows specified link types."""
+        a = _issue(
+            "A-1",
+            [
+                _link(outward_key="B-1", name="Blocks"),
+                _link(outward_key="C-1", name="Related"),
+            ],
+        )
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links(
+            "A-1", max_depth=2, link_type_filter=["Blocks"]
+        )
+
+        keys = {n["key"] for n in result["nodes"]}
+        assert "B-1" in keys
+        assert "C-1" not in keys
+
+    def test_direction_filter(self, mixin):
+        """Only follows specified direction."""
+        a = _issue(
+            "A-1",
+            [
+                _link(outward_key="B-1", name="Blocks"),
+                _link(inward_key="C-1", name="Related"),
+            ],
+        )
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=2, direction_filter="outward")
+
+        keys = {n["key"] for n in result["nodes"]}
+        assert "B-1" in keys
+        assert "C-1" not in keys
+
+    def test_invalid_direction_filter(self, mixin):
+        """Invalid direction_filter raises ValueError."""
+        with pytest.raises(ValueError, match="direction_filter"):
+            mixin.trace_issue_links("A-1", direction_filter="OUTWARD")
+
+    def test_edges_only_reference_visited_nodes(self, mixin):
+        """Edges to unvisited nodes (due to max_issues) are filtered out."""
+        a = _issue("A-1", [_link(outward_key="B-1"), _link(outward_key="C-1")])
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.trace_issue_links("A-1", max_depth=5, max_issues=1)
+
+        visited_keys = {n["key"] for n in result["nodes"]}
+        for edge in result["edges"]:
+            assert edge["source"] in visited_keys
+            assert edge["target"] in visited_keys
+
+    def test_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.trace_issue_links("A-1")
+
+
+class TestGetIssueTree:
+    @pytest.fixture
+    def mixin(self, jira_fetcher):
+        return jira_fetcher
+
+    def _setup_issues(self, mixin, store: dict[str, JiraIssue]) -> None:
+        def fake_search(jql, fields=None, start=0, limit=50, **kw):
+            for k, v in store.items():
+                if k in jql:
+                    return _search([v])
+            return _search([])
+
+        mixin.search_issues = MagicMock(side_effect=fake_search)
+
+    def test_containment_only(self, mixin):
+        """Tree follows containment links, not non-containment."""
+        a = _issue(
+            "A-1",
+            [
+                _link(outward_key="B-1", name="is parent of"),
+                _link(outward_key="C-1", name="Related"),
+            ],
+        )
+        b = _issue("B-1")
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "B-1" in child_keys
+        assert "C-1" not in child_keys
+
+    def test_cross_links_annotated(self, mixin):
+        """Non-containment links appear in cross_links."""
+        a = _issue(
+            "A-1",
+            [_link(outward_key="C-1", name="Related")],
+        )
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, c))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        assert len(result["cross_links"]) == 1
+        assert result["cross_links"][0]["target"] == "C-1"
+
+    def test_subtasks_as_children(self, mixin):
+        """Subtasks appear as tree children."""
+        a = _issue("A-1", subtasks=[{"key": "A-2"}])
+        a2 = _issue("A-2")
+        self._setup_issues(mixin, _issue_store(a, a2))
+
+        result = mixin.get_issue_tree("A-1", max_depth=2)
+
+        child_keys = [ch["key"] for ch in result["root"]["children"]]
+        assert "A-2" in child_keys
+
+    def test_max_depth_respected(self, mixin):
+        """Tree doesn't recurse past max_depth."""
+        a = _issue("A-1", [_link(outward_key="B-1", name="is parent of")])
+        b = _issue("B-1", [_link(outward_key="C-1", name="is parent of")])
+        c = _issue("C-1")
+        self._setup_issues(mixin, _issue_store(a, b, c))
+
+        result = mixin.get_issue_tree("A-1", max_depth=1)
+
+        assert result["root"]["children"][0]["key"] == "B-1"
+        assert result["root"]["children"][0]["children"] == []
+
+    def test_cycle_in_tree(self, mixin):
+        """Cycles in containment links don't cause infinite recursion."""
+        a = _issue("A-1", [_link(outward_key="B-1", name="is parent of")])
+        b = _issue("B-1", [_link(outward_key="A-1", name="is parent of")])
+        self._setup_issues(mixin, _issue_store(a, b))
+
+        result = mixin.get_issue_tree("A-1", max_depth=5)
+
+        assert result["total_nodes"] == 2
+
+    def test_auth_error(self, mixin):
+        mixin.search_issues = MagicMock(
+            side_effect=HTTPError(response=Mock(status_code=401))
+        )
+        with pytest.raises(MCPAtlassianAuthenticationError):
+            mixin.get_issue_tree("A-1")

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 22 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 22 entries."""
+        assert len(ALL_TOOLSETS) == 22
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 16
         assert len(confluence_toolsets) == 6
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 51, f"Expected 51 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 24 toolset names."""
+        """Test 'all' keyword returns all 25 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 24
+        assert len(result) == 25
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 24
+        assert len(result) == 25
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 24 entries."""
-        assert len(ALL_TOOLSETS) == 24
+        """Verify ALL_TOOLSETS has exactly 25 entries."""
+        assert len(ALL_TOOLSETS) == 25
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 16
+        assert len(jira_toolsets) == 17
         assert len(confluence_toolsets) == 8
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 63, f"Expected 63 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 65, f"Expected 65 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

- Add `jira_trace_issue_links` for breadth-first issue-link graph traversal with type, direction, depth, and issue-count controls
- Add `jira_get_issue_tree` for direction-aware containment trees with lateral links reported separately
- Reuse the shared hierarchy phrase configuration added by #1286, including `HIERARCHY_LINK_PHRASES`
- Register both read-only tools in the opt-in `jira_link_analysis` toolset

## Maintainer updates

- Rebased onto current `main` and integrated the overlapping project-analysis hierarchy constants and toolset registry
- Propagate all Jira lookup failures instead of returning partial or empty graphs silently
- Exclude mirrored child-to-parent hierarchy links from lateral `cross_links`
- Strengthen depth-batch, error-propagation, and mirrored-link regression coverage

## Verification

- [x] Focused unit tests: 52 passed
- [x] Full unit suite: 3292 passed, 5 skipped
- [x] Integration suite: 23 credential-gated tests skipped cleanly
- [x] Pre-commit hooks: passed (Ruff, formatting, mypy)
- [x] Jira Cloud end-to-end suite: 89 passed, 15 skipped
- [x] Jira Server/Data Center end-to-end suite: 99 passed, 105 skipped

Tools reference documentation can follow separately after the feature merges.