### PR TITLE
feat(auth): add multi-user mode for URL-only server deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,9 +101,11 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #ATLASSIAN_OAUTH_ENABLE=true
 
 # URL-only multi-user mode — requires the service URLs above but no credentials.
-# Each HTTP client provides credentials through its Authorization header. Cloud
-# OAuth clients also provide X-Atlassian-Cloud-Id. URL override headers are
-# ignored so clients cannot redirect the server to another Atlassian instance.
+# Each HTTP client provides credentials through its Authorization header. URL
+# override headers are ignored, and for Cloud OAuth the tenant (Cloud ID) is
+# pinned to the configured URL (resolved from the site, or from
+# ATLASSIAN_OAUTH_CLOUD_ID if set), so clients cannot redirect the server to
+# another Atlassian instance.
 #MCP_ATLASSIAN_MULTI_USER_MODE=true
 
 # =============================================

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,8 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 #   2. OAuth BYOT (if access token is set — Cloud with cloud_id, DC without)
 #   3. Username/API Token (Basic Auth) - Recommended for Cloud
 #   4. Personal Access Token (if URL is Server/DC and PAT is set)
-#   5. ATLASSIAN_OAUTH_ENABLE=true (minimal BYOT — tokens provided per-request)
+#   5. MCP_ATLASSIAN_MULTI_USER_MODE=true (URL-only, per-request credentials)
+#   6. ATLASSIAN_OAUTH_ENABLE=true (legacy minimal BYOT)
 
 # --- METHOD 1: API TOKEN (Recommended for Atlassian Cloud) ---
 # Get API tokens from: https://id.atlassian.com/manage-profile/security/api-tokens
@@ -98,6 +99,12 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # Minimal BYOT mode — enables OAuth without any credentials or URLs.
 # The external system (e.g., MCP Gateway) provides tokens per-request via headers.
 #ATLASSIAN_OAUTH_ENABLE=true
+
+# URL-only multi-user mode — requires the service URLs above but no credentials.
+# Each HTTP client provides credentials through its Authorization header. Cloud
+# OAuth clients also provide X-Atlassian-Cloud-Id. URL override headers are
+# ignored so clients cannot redirect the server to another Atlassian instance.
+#MCP_ATLASSIAN_MULTI_USER_MODE=true
 
 # =============================================
 # SERVER/DATA CENTER SPECIFIC SETTINGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ENV PYTHONUNBUFFERED=1
 #     your-image --transport streamable-http --port 9000
 # Clients then send one of:
 #   Authorization: Basic <base64(email:api_token)>   (Cloud)
-#   Authorization: Bearer <oauth_token> + X-Atlassian-Cloud-Id (Cloud)
+#   Authorization: Bearer <oauth_token> (Cloud OAuth; Cloud ID resolved server-side)
 #   Authorization: Token <personal_access_token>     (Server/DC)
 
 ENTRYPOINT ["mcp-atlassian"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,16 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Disable Python output buffering for proper stdio communication
 ENV PYTHONUNBUFFERED=1
 
-# For minimal OAuth setup without environment variables, use:
-# docker run -e ATLASSIAN_OAUTH_ENABLE=true -p 8000:8000 your-image
-# Then provide authentication via headers:
-# Authorization: Bearer <your_oauth_token>
-# X-Atlassian-Cloud-Id: <your_cloud_id>
+# Multi-user mode: server holds no credentials; each client supplies its own
+# per request via headers. Example:
+#   docker run -p 9000:9000 \
+#     -e JIRA_URL=https://your-company.atlassian.net \
+#     -e CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
+#     -e MCP_ATLASSIAN_MULTI_USER_MODE=true \
+#     your-image --transport streamable-http --port 9000
+# Clients then send one of:
+#   Authorization: Basic <base64(email:api_token)>   (Cloud)
+#   Authorization: Bearer <oauth_token> + X-Atlassian-Cloud-Id (Cloud)
+#   Authorization: Token <personal_access_token>     (Server/DC)
 
 ENTRYPOINT ["mcp-atlassian"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,41 @@ Ask your AI assistant to:
 - **"Create a bug ticket for the login issue"**
 - **"Update the status of PROJ-123 to Done"**
 
+## Multi-User Mode (URL-only Server)
+
+Deploy one shared remote MCP server that holds **no credentials** — each MCP
+client supplies its own Atlassian username + API token (or PAT / OAuth token)
+per request. Useful for teams sharing a single hosted MCP service while each
+person acts under their own Atlassian permissions.
+
+```bash
+JIRA_URL=https://your-company.atlassian.net \
+CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
+uvx mcp-atlassian --transport streamable-http --multi-user --port 9000
+```
+
+Then each client sends its own credentials per request:
+
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Basic <base64(email:api_token)>"
+      }
+    }
+  }
+}
+```
+
+`Authorization: Bearer <oauth_token>` with `X-Atlassian-Cloud-Id: <cloud_id>`,
+and `Authorization: Token <pat>`, are also supported. The server enforces its
+configured `JIRA_URL` / `CONFLUENCE_URL` and ignores per-request URL override
+headers for SSRF protection. See
+[HTTP Transport](https://mcp-atlassian.soomiles.com/docs/http-transport#multi-user-mode-url-only-server)
+for full details.
+
 ## Documentation
 
 Full documentation is available at **[mcp-atlassian.soomiles.com](https://mcp-atlassian.soomiles.com)**.

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Then each client sends its own credentials per request:
 }
 ```
 
-`Authorization: Bearer <oauth_token>` with `X-Atlassian-Cloud-Id: <cloud_id>`,
-and `Authorization: Token <pat>`, are also supported. The server enforces its
-configured `JIRA_URL` / `CONFLUENCE_URL` and ignores per-request URL override
-headers for SSRF protection. See
+`Authorization: Bearer <oauth_token>` (Cloud OAuth) and `Authorization: Token
+<pat>` (Server/DC) are also supported. The server enforces its configured
+`JIRA_URL` / `CONFLUENCE_URL` and ignores per-request URL override headers for
+SSRF protection. For Cloud OAuth the tenant (Cloud ID) is pinned to the
+configured URL, so `X-Atlassian-Cloud-Id` is optional and a mismatching one is
+rejected. See
 [HTTP Transport](https://mcp-atlassian.soomiles.com/docs/http-transport#multi-user-mode-url-only-server)
 for full details.
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -142,23 +142,44 @@ ATLASSIAN_OAUTH_ACCESS_TOKEN=your_pre_existing_access_token
 Token refresh is your responsibility - the server does not handle it for BYOT.
 </Warning>
 
-### Multi-Cloud OAuth
+### Multi-User Mode (URL-only Server)
 
-For multi-tenant applications where users provide their own OAuth tokens:
+Deploy one remote MCP server that holds no Atlassian credentials. Each MCP
+client supplies its own credentials per request via HTTP headers — Basic
+(`email:api_token`), PAT, or OAuth Bearer.
 
-1. Enable minimal OAuth mode:
+1. Enable multi-user mode:
    ```bash
    # Using uvx
-   ATLASSIAN_OAUTH_ENABLE=true uvx mcp-atlassian --transport streamable-http --port 9000
+   JIRA_URL=https://your-company.atlassian.net \
+   CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
+   uvx mcp-atlassian --transport streamable-http --multi-user --port 9000
 
    # Or using Docker
-   docker run -e ATLASSIAN_OAUTH_ENABLE=true -p 9000:9000 \
+   docker run -p 9000:9000 \
+     -e JIRA_URL=https://your-company.atlassian.net \
+     -e CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
+     -e MCP_ATLASSIAN_MULTI_USER_MODE=true \
      ghcr.io/sooperset/mcp-atlassian:latest \
      --transport streamable-http --port 9000
    ```
 
-2. Users provide authentication via HTTP headers:
-   - `Authorization: Bearer <user_oauth_token>`
-   - `X-Atlassian-Cloud-Id: <user_cloud_id>`
+   Existing `ATLASSIAN_OAUTH_ENABLE=true` deployments remain supported. They
+   retain their legacy per-request URL-header behavior; use the new flag when
+   the server must pin all requests to its configured URLs.
 
-See [HTTP Transport](/docs/http-transport) for more details on multi-user authentication.
+2. Each client sends one of the following headers per request:
+   - `Authorization: Basic <base64(email:api_token)>` (Cloud)
+   - `Authorization: Bearer <user_oauth_token>` plus
+     `X-Atlassian-Cloud-Id: <user_cloud_id>` (Cloud)
+   - `Authorization: Token <user_personal_access_token>` (Server/Data Center)
+
+<Note>
+For SSRF protection, URL-only multi-user mode ignores
+`X-Atlassian-Jira-Url` and `X-Atlassian-Confluence-Url` headers; the server
+enforces the URLs configured at startup. Requires HTTP transport (sse /
+streamable-http).
+</Note>
+
+See [HTTP Transport](/docs/http-transport#multi-user-mode-url-only-server) for
+full details and per-client config examples (Cursor, Claude Desktop, VS Code).

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -170,15 +170,18 @@ client supplies its own credentials per request via HTTP headers — Basic
 
 2. Each client sends one of the following headers per request:
    - `Authorization: Basic <base64(email:api_token)>` (Cloud)
-   - `Authorization: Bearer <user_oauth_token>` plus
-     `X-Atlassian-Cloud-Id: <user_cloud_id>` (Cloud)
+   - `Authorization: Bearer <user_oauth_token>` (Cloud OAuth). The Cloud ID is
+     pinned to the configured URL server-side, so `X-Atlassian-Cloud-Id` is
+     optional; if sent, it must match the configured site.
    - `Authorization: Token <user_personal_access_token>` (Server/Data Center)
 
 <Note>
 For SSRF protection, URL-only multi-user mode ignores
 `X-Atlassian-Jira-Url` and `X-Atlassian-Confluence-Url` headers; the server
-enforces the URLs configured at startup. Requires HTTP transport (sse /
-streamable-http).
+enforces the URLs configured at startup. For Cloud OAuth the tenant (Cloud ID)
+is likewise pinned to the configured URL — resolved from the site or from
+`ATLASSIAN_OAUTH_CLOUD_ID` — and a request that targets a different tenant is
+rejected. Requires HTTP transport (sse / streamable-http).
 </Note>
 
 See [HTTP Transport](/docs/http-transport#multi-user-mode-url-only-server) for

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -284,6 +284,12 @@ Atlassian permissions.
 - For SSRF protection, the server **ignores** `X-Atlassian-Jira-Url` and
   `X-Atlassian-Confluence-Url` headers in this mode and always uses the
   configured `JIRA_URL` / `CONFLUENCE_URL`.
+- **Cloud OAuth:** the tenant (Cloud ID) is **pinned to the configured URL**.
+  The server resolves it from the site itself (or from `ATLASSIAN_OAUTH_CLOUD_ID`
+  if set), so clients need only send `Authorization: Bearer <oauth_token>`. If a
+  client also sends `X-Atlassian-Cloud-Id`, it must match the configured site —
+  requests targeting a different tenant are rejected. This guarantees a client
+  cannot redirect the server to another Atlassian instance.
 - Requests without recognised credential headers are rejected with a clear
   message instructing the client to add an `Authorization` header.
 - Each request runs under its sender's own Atlassian permissions; the server

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -304,14 +304,11 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp import ClientSession
 
 user_token = "user-specific-oauth-token"
-user_cloud_id = "user-specific-cloud-id"
-
 async def main():
     async with streamablehttp_client(
         "http://localhost:9000/mcp",
         headers={
-            "Authorization": f"Bearer {user_token}",
-            "X-Atlassian-Cloud-Id": user_cloud_id
+            "Authorization": f"Bearer {user_token}"
         }
     ) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
@@ -326,7 +323,8 @@ asyncio.run(main())
 ```
 
 <Note>
-- The server uses fallback authentication when requests don't include user-specific credentials
+- Requests without user-specific credentials are rejected.
 - User tokens are isolated per request - no cross-tenant data leakage
-- Falls back to global `ATLASSIAN_OAUTH_CLOUD_ID` if header not provided
+- The server resolves the Cloud ID from the configured URL, or uses the
+  operator-provided `ATLASSIAN_OAUTH_CLOUD_ID` pin.
 </Note>

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -217,6 +217,8 @@ Atlassian permissions.
     Equivalent environment variable form:
 
     ```bash
+    JIRA_URL=https://your-company.atlassian.net \
+    CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
     MCP_ATLASSIAN_MULTI_USER_MODE=true uvx mcp-atlassian \
       --transport streamable-http --port 9000
     ```

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -198,6 +198,96 @@ For multi-tenant applications where each user connects to their own Atlassian cl
    - `Authorization: Bearer <user_oauth_token>`
    - `X-Atlassian-Cloud-Id: <user_cloud_id>`
 
+### Multi-User Mode (URL-only Server)
+
+For deployments where the server holds **no Atlassian credentials at all** and
+every MCP client supplies its own username + API token (or PAT, or OAuth
+token), enable multi-user mode. This is the recommended setup when multiple
+people share one remote MCP service and each must act under their own
+Atlassian permissions.
+
+<Steps>
+  <Step title="Start the server with only URLs">
+    ```bash
+    JIRA_URL=https://your-company.atlassian.net \
+    CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
+    uvx mcp-atlassian --transport streamable-http --multi-user --port 9000
+    ```
+
+    Equivalent environment variable form:
+
+    ```bash
+    MCP_ATLASSIAN_MULTI_USER_MODE=true uvx mcp-atlassian \
+      --transport streamable-http --port 9000
+    ```
+
+    Existing `ATLASSIAN_OAUTH_ENABLE=true` deployments remain supported. They
+    retain their legacy per-request URL-header behavior; use the new flag when
+    the server must pin all requests to its configured URLs.
+  </Step>
+  <Step title="Configure each MCP client to send credentials per request">
+    <Tabs>
+      <Tab title="Cursor / VS Code">
+        ```json
+        {
+          "mcpServers": {
+            "atlassian": {
+              "url": "https://mcp.example.com/mcp",
+              "headers": {
+                "Authorization": "Basic <base64(email:api_token)>"
+              }
+            }
+          }
+        }
+        ```
+      </Tab>
+      <Tab title="Claude Desktop (mcp-remote)">
+        ```json
+        {
+          "mcpServers": {
+            "atlassian": {
+              "command": "npx",
+              "args": [
+                "mcp-remote",
+                "https://mcp.example.com/mcp",
+                "--header",
+                "Authorization: Basic <base64(email:api_token)>"
+              ]
+            }
+          }
+        }
+        ```
+      </Tab>
+      <Tab title="Server/DC PAT">
+        ```json
+        {
+          "mcpServers": {
+            "atlassian": {
+              "url": "https://mcp.example.com/mcp",
+              "headers": {
+                "Authorization": "Token <USER_PERSONAL_ACCESS_TOKEN>"
+              }
+            }
+          }
+        }
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+</Steps>
+
+<Note>
+- Multi-user mode requires HTTP transport (`sse` or `streamable-http`); `stdio`
+  has no per-request headers.
+- For SSRF protection, the server **ignores** `X-Atlassian-Jira-Url` and
+  `X-Atlassian-Confluence-Url` headers in this mode and always uses the
+  configured `JIRA_URL` / `CONFLUENCE_URL`.
+- Requests without recognised credential headers are rejected with a clear
+  message instructing the client to add an `Authorization` header.
+- Each request runs under its sender's own Atlassian permissions; the server
+  stores no credentials.
+</Note>
+
 ### Python Example
 
 ```python

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -232,6 +232,13 @@ async def _run_stdio_with_stdin_guard(run_kwargs: dict[str, object]) -> None:
     help="Atlassian Cloud OAuth 2.0 access token (if you have your own you'd like to "
     "use for the session.)",
 )
+@click.option(
+    "--multi-user",
+    is_flag=True,
+    help="Multi-user mode: server only needs JIRA_URL/CONFLUENCE_URL; each MCP "
+    "client supplies its own credentials per request via the 'Authorization' "
+    "header. Requires HTTP transport.",
+)
 def main(
     verbose: int,
     env_file: str | None,
@@ -262,6 +269,7 @@ def main(
     oauth_scope: str | None,
     oauth_cloud_id: str | None,
     oauth_access_token: str | None,
+    multi_user: bool,
 ) -> None:
     """MCP Atlassian Server - Jira and Confluence functionality for MCP
 
@@ -335,6 +343,13 @@ def main(
         final_transport = "stdio"
     logger.debug(f"Final transport determined: {final_transport}")
 
+    final_multi_user = is_env_truthy("MCP_ATLASSIAN_MULTI_USER_MODE") or bool(
+        click_ctx and was_option_provided(click_ctx, "multi_user") and multi_user
+    )
+    if final_multi_user and final_transport == "stdio":
+        logger.error("Multi-user mode requires sse or streamable-http transport")
+        sys.exit(1)
+
     # Stateless precedence
     final_stateless = is_env_truthy("STATELESS", "false")
     if click_ctx and was_option_provided(click_ctx, "stateless"):
@@ -403,6 +418,8 @@ def main(
         os.environ["ATLASSIAN_OAUTH_CLOUD_ID"] = oauth_cloud_id
     if click_ctx and was_option_provided(click_ctx, "oauth_access_token"):
         os.environ["ATLASSIAN_OAUTH_ACCESS_TOKEN"] = oauth_access_token
+    if click_ctx and was_option_provided(click_ctx, "multi_user") and multi_user:
+        os.environ["MCP_ATLASSIAN_MULTI_USER_MODE"] = "true"
     if click_ctx and was_option_provided(click_ctx, "read_only"):
         os.environ["READ_ONLY_MODE"] = str(read_only).lower()
     if click_ctx and was_option_provided(click_ctx, "confluence_ssl_verify"):

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -5,7 +5,13 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import get_custom_headers, is_env_ssl_verify, is_env_truthy
+from ..utils.env import (
+    get_custom_headers,
+    is_env_ssl_verify,
+    is_env_truthy,
+    is_multi_user_mode,
+    is_url_only_multi_user_mode,
+)
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -24,7 +30,9 @@ class ConfluenceConfig:
     """
 
     url: str  # Base URL for Confluence
-    auth_type: Literal["basic", "pat", "oauth"]  # Authentication type
+    # Authentication type. None means multi-user mode: credentials are
+    # supplied per-request via headers, not from server-side config.
+    auth_type: Literal["basic", "pat", "oauth"] | None
     username: str | None = None  # Email or username
     api_token: str | None = None  # API token used as password
     personal_token: str | None = None  # Personal access token (Server/DC)
@@ -98,7 +106,7 @@ class ConfluenceConfig:
             ValueError: If any required environment variable is missing
         """
         url = os.getenv("CONFLUENCE_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        if not url and (is_url_only_multi_user_mode() or not is_multi_user_mode()):
             error_msg = (
                 "Missing required CONFLUENCE_URL environment variable. "
                 "Set CONFLUENCE_URL to your Confluence base URL, for example "
@@ -120,12 +128,16 @@ class ConfluenceConfig:
         # Use the shared utility function directly
         is_cloud = is_atlassian_cloud_url(url) if url else False
 
+        multi_user = is_multi_user_mode()
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
             if oauth_config:
                 auth_type = "oauth"
             elif username and api_token:
                 auth_type = "basic"
+            elif multi_user:
+                # Credentials will be supplied per-request via headers.
+                auth_type = None
             else:
                 missing_fields: list[str] = []
                 if not username:
@@ -135,12 +147,11 @@ class ConfluenceConfig:
                 missing_fields_text = ", ".join(missing_fields)
                 error_msg = (
                     "Cloud authentication requires CONFLUENCE_USERNAME and "
-                    "CONFLUENCE_API_TOKEN, or OAuth configuration "
-                    "(set ATLASSIAN_OAUTH_ENABLE=true for user-provided tokens). "
+                    "CONFLUENCE_API_TOKEN, or OAuth configuration, or "
+                    "multi-user mode (set MCP_ATLASSIAN_MULTI_USER_MODE=true "
+                    "to let clients supply credentials per-request via headers). "
                     "Confluence Cloud authentication is incomplete. Missing: "
-                    f"{missing_fields_text}. "
-                    "Set CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN, or "
-                    "enable OAuth with ATLASSIAN_OAUTH_ENABLE=true."
+                    f"{missing_fields_text}."
                 )
                 raise ValueError(error_msg)
         else:  # Server/Data Center
@@ -156,14 +167,17 @@ class ConfluenceConfig:
                 auth_type = "oauth"
             elif username and api_token:
                 auth_type = "basic"
+            elif multi_user:
+                # Credentials will be supplied per-request via headers.
+                auth_type = None
             else:
                 error_msg = (
                     "Server/Data Center authentication requires "
                     "CONFLUENCE_PERSONAL_TOKEN or CONFLUENCE_USERNAME and "
-                    "CONFLUENCE_API_TOKEN. "
-                    "Confluence Server/Data Center authentication is incomplete. "
-                    "Set CONFLUENCE_PERSONAL_TOKEN, or set both "
-                    "CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN."
+                    "CONFLUENCE_API_TOKEN, or multi-user mode (set "
+                    "MCP_ATLASSIAN_MULTI_USER_MODE=true to let clients supply "
+                    "credentials per-request via headers). Confluence "
+                    "Server/Data Center authentication is incomplete."
                 )
                 raise ValueError(error_msg)
 
@@ -231,6 +245,11 @@ class ConfluenceConfig:
             bool: True if authentication is fully configured, False otherwise.
         """
         logger = logging.getLogger("mcp-atlassian.confluence.config")
+        if self.auth_type is None and is_multi_user_mode():
+            logger.debug(
+                "Multi-user mode: per-request credentials expected via headers"
+            )
+            return True
         if self.auth_type == "oauth":
             if self.oauth_config:
                 # Minimal OAuth (user-provided tokens mode)

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -5,7 +5,12 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import get_custom_headers, is_env_ssl_verify
+from ..utils.env import (
+    get_custom_headers,
+    is_env_ssl_verify,
+    is_multi_user_mode,
+    is_url_only_multi_user_mode,
+)
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -96,7 +101,9 @@ class JiraConfig:
     """
 
     url: str  # Base URL for Jira
-    auth_type: Literal["basic", "pat", "oauth"]  # Authentication type
+    # Authentication type. None means multi-user mode: credentials are
+    # supplied per-request via headers, not from server-side config.
+    auth_type: Literal["basic", "pat", "oauth"] | None
     username: str | None = None  # Email or username (Cloud)
     api_token: str | None = None  # API token (Cloud)
     personal_token: str | None = None  # Personal access token (Server/DC)
@@ -166,7 +173,7 @@ class JiraConfig:
             ValueError: If required environment variables are missing or invalid
         """
         url = os.getenv("JIRA_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        if not url and (is_url_only_multi_user_mode() or not is_multi_user_mode()):
             error_msg = (
                 "Missing required JIRA_URL environment variable. "
                 "Set JIRA_URL to your Jira base URL, for example "
@@ -186,12 +193,16 @@ class JiraConfig:
         # Use the shared utility function directly
         is_cloud = is_atlassian_cloud_url(url) if url else False
 
+        multi_user = is_multi_user_mode()
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
             if oauth_config:
                 auth_type = "oauth"
             elif username and api_token:
                 auth_type = "basic"
+            elif multi_user:
+                # Credentials will be supplied per-request via headers.
+                auth_type = None
             else:
                 missing_fields: list[str] = []
                 if not username:
@@ -201,12 +212,11 @@ class JiraConfig:
                 missing_fields_text = ", ".join(missing_fields)
                 error_msg = (
                     "Cloud authentication requires JIRA_USERNAME and "
-                    "JIRA_API_TOKEN, or OAuth configuration "
-                    "(set ATLASSIAN_OAUTH_ENABLE=true for user-provided tokens). "
+                    "JIRA_API_TOKEN, or OAuth configuration, or multi-user "
+                    "mode (set MCP_ATLASSIAN_MULTI_USER_MODE=true to let "
+                    "clients supply credentials per-request via headers). "
                     "Jira Cloud authentication is incomplete. Missing: "
-                    f"{missing_fields_text}. "
-                    "Set JIRA_USERNAME and JIRA_API_TOKEN, or enable OAuth with "
-                    "ATLASSIAN_OAUTH_ENABLE=true."
+                    f"{missing_fields_text}."
                 )
                 raise ValueError(error_msg)
         else:  # Server/Data Center
@@ -222,13 +232,16 @@ class JiraConfig:
                 auth_type = "oauth"
             elif username and api_token:
                 auth_type = "basic"
+            elif multi_user:
+                # Credentials will be supplied per-request via headers.
+                auth_type = None
             else:
                 error_msg = (
                     "Server/Data Center authentication requires "
-                    "JIRA_PERSONAL_TOKEN or JIRA_USERNAME and JIRA_API_TOKEN. "
-                    "Jira Server/Data Center authentication is incomplete. "
-                    "Set JIRA_PERSONAL_TOKEN, or set both JIRA_USERNAME and "
-                    "JIRA_API_TOKEN."
+                    "JIRA_PERSONAL_TOKEN or JIRA_USERNAME and JIRA_API_TOKEN, "
+                    "or multi-user mode (set MCP_ATLASSIAN_MULTI_USER_MODE=true "
+                    "to let clients supply credentials per-request via headers). "
+                    "Jira Server/Data Center authentication is incomplete."
                 )
                 raise ValueError(error_msg)
 
@@ -290,6 +303,11 @@ class JiraConfig:
             bool: True if authentication is fully configured, False otherwise.
         """
         logger = logging.getLogger("mcp-atlassian.jira.config")
+        if self.auth_type is None and is_multi_user_mode():
+            logger.debug(
+                "Multi-user mode: per-request credentials expected via headers"
+            )
+            return True
         if self.auth_type == "oauth":
             if self.oauth_config:
                 # Minimal OAuth (user-provided tokens mode)

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -439,16 +439,23 @@ def _create_user_config_for_fetcher(
             raise ValueError(
                 "OAuth access token missing in credentials for user auth_type 'oauth'"
             )
-        if (
-            not base_config
-            or not hasattr(base_config, "oauth_config")
-            or not getattr(base_config, "oauth_config", None)
-        ):
+        global_oauth_cfg = getattr(base_config, "oauth_config", None)
+        if global_oauth_cfg is None and cloud_id:
+            # URL-only multi-user configs intentionally have no server-side
+            # OAuth configuration. The request's access token and Cloud ID are
+            # sufficient to construct the Atlassian gateway client.
+            global_oauth_cfg = OAuthConfig(
+                client_id="",
+                client_secret="",
+                redirect_uri="",
+                scope="",
+                cloud_id=cloud_id,
+            )
+        if global_oauth_cfg is None:
             raise ValueError(
                 f"Global OAuth config for {type(base_config).__name__} is missing, "
-                "but user auth_type is 'oauth'."
+                "but user auth_type is 'oauth' and no Cloud ID was supplied."
             )
-        global_oauth_cfg = base_config.oauth_config
 
         # Determine if this is DC OAuth (base_url set, no cloud_id)
         is_dc_oauth = getattr(global_oauth_cfg, "is_data_center", False) is True

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -18,7 +18,11 @@ from starlette.requests import Request
 from mcp_atlassian.confluence import ConfluenceConfig, ConfluenceFetcher
 from mcp_atlassian.jira import JiraConfig, JiraFetcher
 from mcp_atlassian.servers.context import MainAppContext
-from mcp_atlassian.utils.env import is_env_ssl_verify, is_env_truthy
+from mcp_atlassian.utils.env import (
+    is_env_ssl_verify,
+    is_env_truthy,
+    is_multi_user_mode,
+)
 from mcp_atlassian.utils.oauth import OAuthConfig
 from mcp_atlassian.utils.urls import validate_url_for_ssrf
 
@@ -699,12 +703,13 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
             f"Attempting global {spec.name}Fetcher for non-HTTP."
         )
 
-    # Fallback to global fetcher
+    # Fallback to global fetcher. Skip configs with no server-side auth_type:
+    # those exist only in multi-user mode and require per-request credentials.
     app_ctx = _get_app_lifespan_ctx(ctx)
     global_config_fallback = (
         getattr(app_ctx, spec.config_attr, None) if app_ctx else None
     )
-    if global_config_fallback:
+    if global_config_fallback and global_config_fallback.auth_type is not None:
         # An HTTP request that reaches here has no per-user identity: serving it
         # with the operator's global credentials lets any unauthenticated caller
         # transact as the operator. Refuse unless explicitly opted in. Non-HTTP
@@ -723,6 +728,22 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
             f"{global_config_fallback.auth_type}"
         )
         return spec.fetcher_class(config=global_config_fallback)
+
+    if is_multi_user_mode():
+        logger.warning(
+            f"{spec.name} request rejected: multi-user mode requires "
+            "per-request credentials but none were supplied."
+        )
+        msg = (
+            f"{spec.name} request missing credentials. The server is running "
+            "in multi-user mode and expects every request to include one of: "
+            "'Authorization: Basic <base64(email:api_token)>' (Cloud), "
+            "'Authorization: Bearer <oauth_token>' with "
+            "'X-Atlassian-Cloud-Id: <cloud_id>' (Cloud), or "
+            "'Authorization: Token <pat>' (Server/Data Center). "
+            "Configure your MCP client to send the appropriate header."
+        )
+        raise ValueError(msg)
 
     logger.error(f"{spec.name} configuration could not be resolved.")
     raise ValueError(

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -23,7 +23,7 @@ from mcp_atlassian.utils.env import (
     is_env_truthy,
     is_multi_user_mode,
 )
-from mcp_atlassian.utils.oauth import OAuthConfig
+from mcp_atlassian.utils.oauth import OAuthConfig, resolve_cloud_id_for_url
 from mcp_atlassian.utils.urls import validate_url_for_ssrf
 
 if TYPE_CHECKING:
@@ -440,21 +440,44 @@ def _create_user_config_for_fetcher(
                 "OAuth access token missing in credentials for user auth_type 'oauth'"
             )
         global_oauth_cfg = getattr(base_config, "oauth_config", None)
-        if global_oauth_cfg is None and cloud_id:
-            # URL-only multi-user configs intentionally have no server-side
-            # OAuth configuration. The request's access token and Cloud ID are
-            # sufficient to construct the Atlassian gateway client.
+        if global_oauth_cfg is None and base_config.auth_type is None:
+            # URL-only multi-user configs intentionally have no server-side OAuth
+            # configuration (auth_type is None). The operator pins the tenant via
+            # the configured *_URL, so resolve *that* site's Cloud ID server-side.
+            # The Cloud client always calls
+            # https://api.atlassian.com/ex/<service>/<cloud_id> and ignores the
+            # pinned URL, so trusting a client-supplied Cloud ID here would let a
+            # caller redirect the server to another Atlassian tenant. Pin the
+            # Cloud ID to the configured site and reject any request that targets
+            # a different one.
+            pinned_cloud_id = resolve_cloud_id_for_url(base_config.url)
+            if not pinned_cloud_id:
+                raise ValueError(
+                    "Cloud OAuth in URL-only multi-user mode requires the server "
+                    "to know the configured site's Cloud ID. Set "
+                    "ATLASSIAN_OAUTH_CLOUD_ID to the Cloud ID for "
+                    f"{base_config.url}, or ensure its /_edge/tenant_info "
+                    "endpoint is reachable."
+                )
+            if cloud_id and cloud_id != pinned_cloud_id:
+                raise ValueError(
+                    "Requested Cloud ID does not match the server's configured "
+                    "Atlassian site. In URL-only multi-user mode the tenant is "
+                    "pinned to the configured URL and cannot be overridden per "
+                    "request."
+                )
+            cloud_id = pinned_cloud_id
             global_oauth_cfg = OAuthConfig(
                 client_id="",
                 client_secret="",
                 redirect_uri="",
                 scope="",
-                cloud_id=cloud_id,
+                cloud_id=pinned_cloud_id,
             )
         if global_oauth_cfg is None:
             raise ValueError(
                 f"Global OAuth config for {type(base_config).__name__} is missing, "
-                "but user auth_type is 'oauth' and no Cloud ID was supplied."
+                "but user auth_type is 'oauth'."
             )
 
         # Determine if this is DC OAuth (base_url set, no cloud_id)

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -22,9 +22,10 @@ from mcp_atlassian.utils.env import (
     is_env_ssl_verify,
     is_env_truthy,
     is_multi_user_mode,
+    is_url_only_multi_user_mode,
 )
 from mcp_atlassian.utils.oauth import OAuthConfig, resolve_cloud_id_for_url
-from mcp_atlassian.utils.urls import validate_url_for_ssrf
+from mcp_atlassian.utils.urls import is_atlassian_cloud_url, validate_url_for_ssrf
 
 if TYPE_CHECKING:
     from mcp_atlassian.confluence.config import (
@@ -373,6 +374,13 @@ def _resolve_bearer_auth_type(
     if cloud_id:
         return "oauth"
 
+    # Strict URL-only mode pins the Cloud ID from the configured site, so the
+    # client does not need to repeat it in a header. Keep Bearer as OAuth for a
+    # pinned Cloud URL so _create_user_config_for_fetcher() can resolve the
+    # authoritative Cloud ID server-side. Bearer remains a PAT for Server/DC.
+    if is_url_only_multi_user_mode() and is_atlassian_cloud_url(base_config.url):
+        return "oauth"
+
     # Check if global config has OAuth set up
     global_oauth = getattr(base_config, "oauth_config", None)
     if global_oauth is not None:
@@ -440,10 +448,13 @@ def _create_user_config_for_fetcher(
                 "OAuth access token missing in credentials for user auth_type 'oauth'"
             )
         global_oauth_cfg = getattr(base_config, "oauth_config", None)
-        if global_oauth_cfg is None and base_config.auth_type is None:
-            # URL-only multi-user configs intentionally have no server-side OAuth
-            # configuration (auth_type is None). The operator pins the tenant via
-            # the configured *_URL, so resolve *that* site's Cloud ID server-side.
+        url_only_cloud_config = (
+            is_url_only_multi_user_mode() or base_config.auth_type is None
+        ) and is_atlassian_cloud_url(base_config.url)
+        if url_only_cloud_config:
+            # The operator pins the tenant via the configured *_URL, so resolve
+            # *that* site's Cloud ID server-side even if a legacy or complete
+            # global OAuth config is also present.
             # The Cloud client always calls
             # https://api.atlassian.com/ex/<service>/<cloud_id> and ignores the
             # pinned URL, so trusting a client-supplied Cloud ID here would let a
@@ -467,13 +478,14 @@ def _create_user_config_for_fetcher(
                     "request."
                 )
             cloud_id = pinned_cloud_id
-            global_oauth_cfg = OAuthConfig(
-                client_id="",
-                client_secret="",
-                redirect_uri="",
-                scope="",
-                cloud_id=pinned_cloud_id,
-            )
+            if global_oauth_cfg is None:
+                global_oauth_cfg = OAuthConfig(
+                    client_id="",
+                    client_secret="",
+                    redirect_uri="",
+                    scope="",
+                    cloud_id=pinned_cloud_id,
+                )
         if global_oauth_cfg is None:
             raise ValueError(
                 f"Global OAuth config for {type(base_config).__name__} is missing, "
@@ -768,8 +780,7 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
             f"{spec.name} request missing credentials. The server is running "
             "in multi-user mode and expects every request to include one of: "
             "'Authorization: Basic <base64(email:api_token)>' (Cloud), "
-            "'Authorization: Bearer <oauth_token>' with "
-            "'X-Atlassian-Cloud-Id: <cloud_id>' (Cloud), or "
+            "'Authorization: Bearer <oauth_token>' (Cloud), or "
             "'Authorization: Token <pat>' (Server/Data Center). "
             "Configure your MCP client to send the appropriate header."
         )

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -530,9 +530,12 @@ class UserTokenMiddleware:
             return False
 
         try:
-            mcp_path = self.mcp_server_ref.get_streamable_http_path()
             request_path = AtlassianMCP._normalize_http_path(scope.get("path", ""))
-            return request_path == mcp_path
+            auth_paths = {
+                self.mcp_server_ref.get_streamable_http_path(),
+                AtlassianMCP._normalize_http_path(fastmcp_settings.message_path),
+            }
+            return request_path in auth_paths
         except (AttributeError, ValueError) as e:
             logger.warning(f"Error checking auth path: {e}")
             return False

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -26,7 +26,7 @@ from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.jira.config import JiraConfig
-from mcp_atlassian.utils.env import is_env_truthy
+from mcp_atlassian.utils.env import is_env_truthy, is_url_only_multi_user_mode
 from mcp_atlassian.utils.environment import get_available_services
 from mcp_atlassian.utils.io import is_read_only_mode
 from mcp_atlassian.utils.logging import mask_sensitive
@@ -122,6 +122,13 @@ async def health_check(request: Request) -> JSONResponse:
 @asynccontextmanager
 async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict[str, Any]]:
     logger.info("Main Atlassian MCP server lifespan starting...")
+    if is_url_only_multi_user_mode():
+        logger.info(
+            "Multi-user mode enabled: server expects per-request credentials "
+            "via the 'Authorization' header. Cloud OAuth also requires "
+            "'X-Atlassian-Cloud-Id'. URL override headers are ignored; HTTP "
+            "transport (sse / streamable-http) is required."
+        )
     services = get_available_services()
     read_only = is_read_only_mode()
     enabled_tools = get_enabled_tools()
@@ -569,6 +576,18 @@ class UserTokenMiddleware:
                 if confluence_url_header
                 else None
             )
+
+            # In multi-user mode, the server enforces JIRA_URL/CONFLUENCE_URL
+            # for SSRF protection. URL override headers are ignored so a client
+            # cannot redirect the server to an arbitrary Atlassian instance.
+            if is_url_only_multi_user_mode() and (jira_url_str or confluence_url_str):
+                logger.warning(
+                    "Multi-user mode: ignoring URL override headers "
+                    "(X-Atlassian-Jira-Url / X-Atlassian-Confluence-Url). "
+                    "Server uses configured JIRA_URL / CONFLUENCE_URL."
+                )
+                jira_url_str = None
+                confluence_url_str = None
 
             # Validate URLs to prevent SSRF
             if jira_url_str:

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -125,9 +125,9 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict[str,
     if is_url_only_multi_user_mode():
         logger.info(
             "Multi-user mode enabled: server expects per-request credentials "
-            "via the 'Authorization' header. Cloud OAuth also requires "
-            "'X-Atlassian-Cloud-Id'. URL override headers are ignored; HTTP "
-            "transport (sse / streamable-http) is required."
+            "via the 'Authorization' header. Cloud OAuth tenant information "
+            "is resolved from the configured URL. URL override headers are "
+            "ignored; HTTP transport (sse / streamable-http) is required."
         )
     services = get_available_services()
     read_only = is_read_only_mode()

--- a/src/mcp_atlassian/utils/env.py
+++ b/src/mcp_atlassian/utils/env.py
@@ -38,6 +38,34 @@ def is_env_extended_truthy(env_var_name: str, default: str = "") -> bool:
     return os.getenv(env_var_name, default).lower() in ("true", "1", "yes", "y", "on")
 
 
+def is_url_only_multi_user_mode() -> bool:
+    """Check whether strict URL-only multi-user mode is enabled.
+
+    Returns:
+        True when ``MCP_ATLASSIAN_MULTI_USER_MODE`` is enabled.
+    """
+    return is_env_truthy("MCP_ATLASSIAN_MULTI_USER_MODE")
+
+
+def is_multi_user_mode() -> bool:
+    """Check whether any per-request credential mode is enabled.
+
+    Strict URL-only mode requires `JIRA_URL` / `CONFLUENCE_URL`. Both modes
+    expect every MCP client to supply its own credentials per request via the
+    `Authorization` header. Cloud OAuth also requires
+    `X-Atlassian-Cloud-Id`. URL override headers are ignored in strict
+    URL-only mode. Tools remain available without global credentials.
+
+    The legacy `ATLASSIAN_OAUTH_ENABLE` mode is also recognised for service
+    discovery. Unlike strict URL-only mode, it retains support for per-request
+    URL headers for backwards compatibility.
+
+    Returns:
+        True when either per-request credential mode is enabled.
+    """
+    return is_url_only_multi_user_mode() or is_env_truthy("ATLASSIAN_OAUTH_ENABLE")
+
+
 def is_env_ssl_verify(env_var_name: str, default: str = "true") -> bool:
     """Check SSL verification setting with secure defaults.
 

--- a/src/mcp_atlassian/utils/env.py
+++ b/src/mcp_atlassian/utils/env.py
@@ -52,9 +52,10 @@ def is_multi_user_mode() -> bool:
 
     Strict URL-only mode requires `JIRA_URL` / `CONFLUENCE_URL`. Both modes
     expect every MCP client to supply its own credentials per request via the
-    `Authorization` header. Cloud OAuth also requires
-    `X-Atlassian-Cloud-Id`. URL override headers are ignored in strict
-    URL-only mode. Tools remain available without global credentials.
+    `Authorization` header. Strict URL-only mode resolves the Cloud OAuth
+    tenant from the configured URL, while legacy mode accepts it from
+    `X-Atlassian-Cloud-Id`. URL override headers are ignored in strict URL-only
+    mode. Tools remain available without global credentials.
 
     The legacy `ATLASSIAN_OAUTH_ENABLE` mode is also recognised for service
     discovery. Unlike strict URL-only mode, it retains support for per-request

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -117,7 +117,11 @@ def get_available_services(
             "per-request credentials via headers"
         )
 
-    if not confluence_is_setup and is_env_truthy("ATLASSIAN_OAUTH_ENABLE"):
+    if (
+        not confluence_is_setup
+        and not is_url_only_multi_user_mode()
+        and is_env_truthy("ATLASSIAN_OAUTH_ENABLE")
+    ):
         confluence_is_setup = True
         logger.info(
             "Using Confluence minimal OAuth configuration "
@@ -159,7 +163,11 @@ def get_available_services(
             "per-request credentials via headers"
         )
 
-    if not jira_is_setup and is_env_truthy("ATLASSIAN_OAUTH_ENABLE"):
+    if (
+        not jira_is_setup
+        and not is_url_only_multi_user_mode()
+        and is_env_truthy("ATLASSIAN_OAUTH_ENABLE")
+    ):
         jira_is_setup = True
         logger.info(
             "Using Jira minimal OAuth configuration "

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -3,6 +3,7 @@
 import logging
 import os
 
+from .env import is_env_truthy, is_url_only_multi_user_mode
 from .urls import is_atlassian_cloud_url
 
 logger = logging.getLogger("mcp-atlassian.utils.environment")
@@ -109,11 +110,14 @@ def get_available_services(
             pat_env="CONFLUENCE_PERSONAL_TOKEN",
         )
 
-    if not confluence_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
+    if not confluence_is_setup and confluence_url and is_url_only_multi_user_mode():
+        confluence_is_setup = True
+        logger.info(
+            "Using Confluence URL-only multi-user mode - expecting "
+            "per-request credentials via headers"
+        )
+
+    if not confluence_is_setup and is_env_truthy("ATLASSIAN_OAUTH_ENABLE"):
         confluence_is_setup = True
         logger.info(
             "Using Confluence minimal OAuth configuration "
@@ -148,11 +152,14 @@ def get_available_services(
             pat_env="JIRA_PERSONAL_TOKEN",
         )
 
-    if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
+    if not jira_is_setup and jira_url and is_url_only_multi_user_mode():
+        jira_is_setup = True
+        logger.info(
+            "Using Jira URL-only multi-user mode - expecting "
+            "per-request credentials via headers"
+        )
+
+    if not jira_is_setup and is_env_truthy("ATLASSIAN_OAUTH_ENABLE"):
         jira_is_setup = True
         logger.info(
             "Using Jira minimal OAuth configuration "

--- a/src/mcp_atlassian/utils/oauth.py
+++ b/src/mcp_atlassian/utils/oauth.py
@@ -48,6 +48,71 @@ HTTP_READ_TIMEOUT = 20
 HTTP_TIMEOUT = (HTTP_CONNECT_TIMEOUT, HTTP_READ_TIMEOUT)
 KEYRING_SERVICE_NAME = "mcp-atlassian-oauth"
 
+# Unauthenticated endpoint on an Atlassian Cloud site that returns the site's
+# tenant (Cloud) ID: ``GET https://<site>/_edge/tenant_info`` -> ``{"cloudId": ...}``.
+TENANT_INFO_PATH = "/_edge/tenant_info"
+
+# Cache resolved Cloud IDs per site origin so the request path avoids repeat
+# lookups. URL-only multi-user deployments pin a single site, so this stays tiny.
+_CLOUD_ID_CACHE: dict[str, str] = {}
+
+
+def resolve_cloud_id_for_url(url: str) -> str | None:
+    """Resolve the authoritative Atlassian Cloud ID for a configured site URL.
+
+    In URL-only multi-user mode the operator pins the Atlassian site via
+    ``JIRA_URL`` / ``CONFLUENCE_URL``. Cloud OAuth clients ultimately call
+    ``https://api.atlassian.com/ex/<service>/<cloud_id>``, so the server must
+    determine the Cloud ID for its *configured* site rather than trusting a
+    client-supplied ``X-Atlassian-Cloud-Id`` header, which could otherwise
+    redirect requests to a different tenant.
+
+    Resolution order:
+
+    1. ``ATLASSIAN_OAUTH_CLOUD_ID`` environment variable — an explicit
+       server-side pin (no network call).
+    2. The site's unauthenticated ``/_edge/tenant_info`` endpoint (cached).
+
+    Args:
+        url: The configured Atlassian site base URL.
+
+    Returns:
+        The Cloud ID string, or ``None`` if the URL is not an Atlassian Cloud
+        site or the Cloud ID could not be resolved.
+    """
+    env_cloud_id = os.getenv("ATLASSIAN_OAUTH_CLOUD_ID")
+    if env_cloud_id:
+        return env_cloud_id
+
+    if not url or not is_atlassian_cloud_url(url):
+        return None
+
+    parsed = urllib.parse.urlparse(url)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    if origin in _CLOUD_ID_CACHE:
+        return _CLOUD_ID_CACHE[origin]
+
+    tenant_info_url = f"{origin}{TENANT_INFO_PATH}"
+    try:
+        response = requests.get(tenant_info_url, timeout=HTTP_TIMEOUT)
+        response.raise_for_status()
+        cloud_id = response.json().get("cloudId")
+    except (requests.RequestException, ValueError) as e:
+        logger.warning(
+            "Failed to resolve Cloud ID for %s via %s: %s",
+            origin,
+            TENANT_INFO_PATH,
+            e,
+        )
+        return None
+
+    if cloud_id:
+        _CLOUD_ID_CACHE[origin] = cloud_id
+        return cloud_id
+
+    logger.warning("No cloudId returned by %s", tenant_info_url)
+    return None
+
 
 @dataclass
 class OAuthConfig:

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -104,6 +104,82 @@ def test_from_env_missing_server_auth():
             ConfluenceConfig.from_env()
 
 
+def test_from_env_multi_user_url_only_cloud():
+    """Multi-user mode: server only needs CONFLUENCE_URL, no creds required."""
+    with patch.dict(
+        "os.environ",
+        {
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+            "MCP_ATLASSIAN_MULTI_USER_MODE": "true",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.url == "https://test.atlassian.net/wiki"
+        assert config.auth_type is None
+        assert config.username is None
+        assert config.api_token is None
+        assert config.is_auth_configured() is True
+
+
+def test_from_env_multi_user_url_only_server():
+    """Multi-user mode also works for Server/DC URLs."""
+    with patch.dict(
+        "os.environ",
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "MCP_ATLASSIAN_MULTI_USER_MODE": "true",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.auth_type is None
+        assert config.is_auth_configured() is True
+
+
+def test_from_env_multi_user_requires_url():
+    """Strict multi-user mode rejects a server without a pinned Confluence URL."""
+    with patch.dict(
+        "os.environ",
+        {"MCP_ATLASSIAN_MULTI_USER_MODE": "true"},
+        clear=True,
+    ):
+        with pytest.raises(ValueError, match="Missing required CONFLUENCE_URL"):
+            ConfluenceConfig.from_env()
+
+
+def test_from_env_multi_user_legacy_oauth_enable_alias():
+    """ATLASSIAN_OAUTH_ENABLE remains a backwards-compatible alias."""
+    with patch.dict(
+        "os.environ",
+        {
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.is_auth_configured() is True
+
+
+def test_from_env_multi_user_does_not_override_basic():
+    """When full creds are present, basic auth wins regardless of multi-user flag."""
+    with patch.dict(
+        "os.environ",
+        {
+            "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+            "CONFLUENCE_USERNAME": "test_username",
+            "CONFLUENCE_API_TOKEN": "test_token",
+            "MCP_ATLASSIAN_MULTI_USER_MODE": "true",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.auth_type == "basic"
+        assert config.username == "test_username"
+        assert config.api_token == "test_token"
+
+
 def test_is_cloud():
     """Test that is_cloud property returns correct value."""
     # Arrange & Act - Cloud URL

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -96,6 +96,84 @@ def test_from_env_missing_server_auth():
             JiraConfig.from_env()
 
 
+def test_from_env_multi_user_url_only_cloud():
+    """Multi-user mode: server only needs JIRA_URL, no creds required."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://test.atlassian.net",
+            "MCP_ATLASSIAN_MULTI_USER_MODE": "true",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.url == "https://test.atlassian.net"
+        assert config.auth_type is None
+        assert config.username is None
+        assert config.api_token is None
+        assert config.is_auth_configured() is True
+
+
+def test_from_env_multi_user_url_only_server():
+    """Multi-user mode also works for Server/DC URLs."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "MCP_ATLASSIAN_MULTI_USER_MODE": "true",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.auth_type is None
+        assert config.is_auth_configured() is True
+
+
+def test_from_env_multi_user_requires_url():
+    """Strict multi-user mode rejects a server without a pinned Jira URL."""
+    with patch.dict(
+        os.environ,
+        {"MCP_ATLASSIAN_MULTI_USER_MODE": "true"},
+        clear=True,
+    ):
+        with pytest.raises(ValueError, match="Missing required JIRA_URL"):
+            JiraConfig.from_env()
+
+
+def test_from_env_multi_user_legacy_oauth_enable_alias():
+    """ATLASSIAN_OAUTH_ENABLE remains a backwards-compatible alias."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://test.atlassian.net",
+            "ATLASSIAN_OAUTH_ENABLE": "true",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        # Either auth_type=None (multi-user) or "oauth" (minimal OAuth) is fine,
+        # but is_auth_configured must accept it so tools remain available.
+        assert config.is_auth_configured() is True
+
+
+def test_from_env_multi_user_does_not_override_basic():
+    """When full creds are present, basic auth wins regardless of multi-user flag."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_USERNAME": "test_username",
+            "JIRA_API_TOKEN": "test_token",
+            "MCP_ATLASSIAN_MULTI_USER_MODE": "true",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.auth_type == "basic"
+        assert config.username == "test_username"
+        assert config.api_token == "test_token"
+
+
 def test_is_cloud():
     """Test that is_cloud property returns correct value."""
     # Arrange & Act - Cloud URL

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -251,6 +251,42 @@ class TestCreateUserConfigForFetcher:
         )  # Should preserve minimal config
 
     @pytest.mark.parametrize(
+        ("base_config", "expected_type"),
+        [
+            (
+                JiraConfig(
+                    url="https://test.atlassian.net",
+                    auth_type=None,
+                ),
+                JiraConfig,
+            ),
+            (
+                ConfluenceConfig(
+                    url="https://test.atlassian.net/wiki",
+                    auth_type=None,
+                ),
+                ConfluenceConfig,
+            ),
+        ],
+    )
+    def test_oauth_url_only_config_uses_request_cloud_id(
+        self, base_config, expected_type
+    ):
+        """Cloud OAuth works without server-side OAuth client configuration."""
+        result = _create_user_config_for_fetcher(
+            base_config=base_config,
+            auth_type="oauth",
+            credentials={"oauth_access_token": "user-access-token"},
+            cloud_id="user-cloud-id",
+        )
+
+        assert isinstance(result, expected_type)
+        assert result.auth_type == "oauth"
+        assert result.oauth_config is not None
+        assert result.oauth_config.access_token == "user-access-token"
+        assert result.oauth_config.cloud_id == "user-cloud-id"
+
+    @pytest.mark.parametrize(
         "byo_config,cloud_id_arg,expected_cloud_id,expected_base_url",
         [
             pytest.param(

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -269,22 +269,122 @@ class TestCreateUserConfigForFetcher:
             ),
         ],
     )
-    def test_oauth_url_only_config_uses_request_cloud_id(
-        self, base_config, expected_type
+    def test_oauth_url_only_config_pins_server_cloud_id(
+        self, base_config, expected_type, monkeypatch
     ):
-        """Cloud OAuth works without server-side OAuth client configuration."""
+        """URL-only Cloud OAuth pins the Cloud ID to the configured site.
+
+        The server resolves the configured site's Cloud ID (here via the
+        ``ATLASSIAN_OAUTH_CLOUD_ID`` server-side pin) and uses it instead of
+        trusting a client-supplied Cloud ID.
+        """
+        monkeypatch.setenv("ATLASSIAN_OAUTH_CLOUD_ID", "server-pinned-cloud-id")
+
         result = _create_user_config_for_fetcher(
             base_config=base_config,
             auth_type="oauth",
             credentials={"oauth_access_token": "user-access-token"},
-            cloud_id="user-cloud-id",
+            cloud_id="server-pinned-cloud-id",
         )
 
         assert isinstance(result, expected_type)
         assert result.auth_type == "oauth"
         assert result.oauth_config is not None
         assert result.oauth_config.access_token == "user-access-token"
-        assert result.oauth_config.cloud_id == "user-cloud-id"
+        assert result.oauth_config.cloud_id == "server-pinned-cloud-id"
+
+    @pytest.mark.parametrize(
+        ("base_config", "expected_type"),
+        [
+            (
+                JiraConfig(url="https://test.atlassian.net", auth_type=None),
+                JiraConfig,
+            ),
+            (
+                ConfluenceConfig(url="https://test.atlassian.net/wiki", auth_type=None),
+                ConfluenceConfig,
+            ),
+        ],
+    )
+    def test_oauth_url_only_config_derives_cloud_id_without_header(
+        self, base_config, expected_type, monkeypatch
+    ):
+        """URL-only Cloud OAuth works even when the client omits the Cloud ID.
+
+        The tenant is pinned to the configured URL, so a client only needs to
+        supply an access token; the server derives the Cloud ID itself.
+        """
+        monkeypatch.setenv("ATLASSIAN_OAUTH_CLOUD_ID", "server-pinned-cloud-id")
+
+        result = _create_user_config_for_fetcher(
+            base_config=base_config,
+            auth_type="oauth",
+            credentials={"oauth_access_token": "user-access-token"},
+            cloud_id=None,
+        )
+
+        assert isinstance(result, expected_type)
+        assert result.oauth_config is not None
+        assert result.oauth_config.cloud_id == "server-pinned-cloud-id"
+
+    @pytest.mark.parametrize(
+        "base_config",
+        [
+            JiraConfig(url="https://test.atlassian.net", auth_type=None),
+            ConfluenceConfig(url="https://test.atlassian.net/wiki", auth_type=None),
+        ],
+        ids=["jira", "confluence"],
+    )
+    def test_oauth_url_only_rejects_mismatched_tenant(self, base_config, monkeypatch):
+        """Regression: a client cannot redirect the server to another tenant.
+
+        In URL-only multi-user mode the Cloud ID is pinned to the configured
+        site. A request carrying a different Cloud ID must be rejected rather
+        than silently used to build an ``api.atlassian.com/ex/...`` URL for a
+        foreign tenant.
+        """
+        monkeypatch.setenv("ATLASSIAN_OAUTH_CLOUD_ID", "server-pinned-cloud-id")
+
+        with pytest.raises(ValueError, match="does not match the server's configured"):
+            _create_user_config_for_fetcher(
+                base_config=base_config,
+                auth_type="oauth",
+                credentials={"oauth_access_token": "attacker-token"},
+                cloud_id="attacker-controlled-cloud-id",
+            )
+
+    @pytest.mark.parametrize(
+        "base_config",
+        [
+            JiraConfig(url="https://test.atlassian.net", auth_type=None),
+            ConfluenceConfig(url="https://test.atlassian.net/wiki", auth_type=None),
+        ],
+        ids=["jira", "confluence"],
+    )
+    def test_oauth_url_only_requires_resolvable_cloud_id(
+        self, base_config, monkeypatch
+    ):
+        """URL-only Cloud OAuth fails clearly when the Cloud ID is unknown.
+
+        With no server-side pin and no reachable tenant lookup, the server
+        cannot determine the configured site's tenant, so it must refuse rather
+        than fall back to trusting the client.
+        """
+        monkeypatch.delenv("ATLASSIAN_OAUTH_CLOUD_ID", raising=False)
+
+        with patch(
+            "mcp_atlassian.servers.dependencies.resolve_cloud_id_for_url",
+            return_value=None,
+        ):
+            with pytest.raises(
+                ValueError, match="requires the server to know the configured"
+            ):
+                _create_user_config_for_fetcher(
+                    base_config=base_config,
+                    auth_type="oauth",
+                    credentials={"oauth_access_token": "user-access-token"},
+                    cloud_id="user-cloud-id",
+                )
 
     @pytest.mark.parametrize(
         "byo_config,cloud_id_arg,expected_cloud_id,expected_base_url",

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -356,6 +356,49 @@ class TestCreateUserConfigForFetcher:
     @pytest.mark.parametrize(
         "base_config",
         [
+            JiraConfig(
+                url="https://test.atlassian.net",
+                auth_type="oauth",
+                oauth_config=OAuthConfig(
+                    client_id="",
+                    client_secret="",
+                    redirect_uri="",
+                    scope="",
+                ),
+            ),
+            ConfluenceConfig(
+                url="https://test.atlassian.net/wiki",
+                auth_type="oauth",
+                oauth_config=OAuthConfig(
+                    client_id="",
+                    client_secret="",
+                    redirect_uri="",
+                    scope="",
+                ),
+            ),
+        ],
+        ids=["jira", "confluence"],
+    )
+    def test_strict_url_only_rejects_mismatched_tenant_with_legacy_oauth_config(
+        self,
+        base_config: JiraConfig | ConfluenceConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Strict URL pinning takes precedence over a legacy OAuth config."""
+        monkeypatch.setenv("MCP_ATLASSIAN_MULTI_USER_MODE", "true")
+        monkeypatch.setenv("ATLASSIAN_OAUTH_CLOUD_ID", "server-pinned-cloud-id")
+
+        with pytest.raises(ValueError, match="does not match the server's configured"):
+            _create_user_config_for_fetcher(
+                base_config=base_config,
+                auth_type="oauth",
+                credentials={"oauth_access_token": "attacker-token"},
+                cloud_id="attacker-controlled-cloud-id",
+            )
+
+    @pytest.mark.parametrize(
+        "base_config",
+        [
             JiraConfig(url="https://test.atlassian.net", auth_type=None),
             ConfluenceConfig(url="https://test.atlassian.net/wiki", auth_type=None),
         ],
@@ -1784,6 +1827,83 @@ class TestResolveBearerAuthType:
         )
         result = _resolve_bearer_auth_type(config, "oauth", cloud_id="from-header")
         assert result == "oauth"
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            JiraConfig(
+                url="https://test.atlassian.net",
+                auth_type=None,
+            ),
+            ConfluenceConfig(
+                url="https://test.atlassian.net/wiki",
+                auth_type=None,
+            ),
+            JiraConfig(
+                url="https://test.atlassian.net",
+                auth_type="oauth",
+                oauth_config=OAuthConfig(
+                    client_id="",
+                    client_secret="",
+                    redirect_uri="",
+                    scope="",
+                ),
+            ),
+            ConfluenceConfig(
+                url="https://test.atlassian.net/wiki",
+                auth_type="oauth",
+                oauth_config=OAuthConfig(
+                    client_id="",
+                    client_secret="",
+                    redirect_uri="",
+                    scope="",
+                ),
+            ),
+        ],
+        ids=[
+            "jira-no-global-oauth",
+            "confluence-no-global-oauth",
+            "jira-legacy-oauth",
+            "confluence-legacy-oauth",
+        ],
+    )
+    def test_url_only_cloud_bearer_without_cloud_id_stays_oauth(
+        self,
+        config: JiraConfig | ConfluenceConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Strict URL-only mode resolves Cloud ID after Bearer disambiguation."""
+        monkeypatch.setenv("MCP_ATLASSIAN_MULTI_USER_MODE", "true")
+
+        result = _resolve_bearer_auth_type(config, "oauth")
+
+        assert result == "oauth"
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            JiraConfig(
+                url="https://jira.corp.example.com",
+                auth_type=None,
+            ),
+            ConfluenceConfig(
+                url="https://confluence.corp.example.com",
+                auth_type=None,
+            ),
+        ],
+        ids=["jira", "confluence"],
+    )
+    def test_url_only_dc_bearer_without_cloud_id_is_pat(
+        self,
+        config: JiraConfig | ConfluenceConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Strict URL-only mode keeps Bearer compatibility for Server/DC PATs."""
+        monkeypatch.setenv("MCP_ATLASSIAN_MULTI_USER_MODE", "true")
+
+        result = _resolve_bearer_auth_type(config, "oauth")
+
+        assert result == "pat"
 
     def test_pat_auth_type_passes_through(self):
         """PAT auth_type is never re-mapped."""

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -1541,6 +1541,56 @@ class TestBasicAuthMultiUser:
             await get_jira_fetcher(mock_context)
 
 
+class TestMultiUserCredentialRequirement:
+    """Regression tests for URL-only configs without server credentials."""
+
+    @pytest.mark.parametrize(
+        ("service", "config"),
+        [
+            (
+                "Jira",
+                JiraConfig(
+                    url="https://test.atlassian.net",
+                    auth_type=None,
+                ),
+            ),
+            (
+                "Confluence",
+                ConfluenceConfig(
+                    url="https://test.atlassian.net/wiki",
+                    auth_type=None,
+                ),
+            ),
+        ],
+    )
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    async def test_missing_request_credentials_do_not_use_global_config(
+        self,
+        mock_get_http_request,
+        service,
+        config,
+        mock_context,
+        mock_request,
+        config_factory,
+        monkeypatch,
+    ) -> None:
+        """An auth-less global config must never become a request fetcher."""
+        monkeypatch.setenv("MCP_ATLASSIAN_MULTI_USER_MODE", "true")
+        _setup_mock_request_state(mock_request)
+        mock_get_http_request.return_value = mock_request
+
+        if service == "Jira":
+            app_context = config_factory.create_app_context(jira_config=config)
+            get_fetcher = get_jira_fetcher
+        else:
+            app_context = config_factory.create_app_context(confluence_config=config)
+            get_fetcher = get_confluence_fetcher
+        _setup_mock_context(mock_context, app_context)
+
+        with pytest.raises(ValueError, match=f"{service} request missing credentials"):
+            await get_fetcher(mock_context)
+
+
 class TestResolveBearerAuthType:
     """Tests for _resolve_bearer_auth_type bearer token disambiguation."""
 

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -591,6 +591,20 @@ class TestUserTokenMiddleware:
             is True
         )
 
+    def test_should_process_auth_accepts_sse_message_path(self):
+        """SSE clients send tool calls to the configured message endpoint."""
+        mock_app = AsyncMock()
+        mock_mcp_server = MagicMock()
+        mock_mcp_server.get_streamable_http_path.return_value = "/mcp"
+        middleware = UserTokenMiddleware(mock_app, mcp_server_ref=mock_mcp_server)
+
+        assert (
+            middleware._should_process_auth(
+                {"type": "http", "method": "POST", "path": "/messages/"}
+            )
+            is True
+        )
+
     @pytest.mark.anyio
     @pytest.mark.parametrize(
         "env_value,should_skip",

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -775,3 +775,44 @@ class TestUserTokenMiddlewareSsrfValidation:
         middleware.app.assert_called_once()
         passed_scope = middleware.app.call_args[0][0]
         assert passed_scope["state"].get("auth_validation_error") in (None, "")
+
+    @pytest.mark.anyio
+    async def test_url_only_multi_user_ignores_url_override_headers(
+        self, middleware, mock_scope, mock_receive, mock_send, monkeypatch
+    ):
+        """Strict URL-only mode drops client-selected Atlassian URLs."""
+        monkeypatch.setenv("MCP_ATLASSIAN_MULTI_USER_MODE", "true")
+        monkeypatch.delenv("ATLASSIAN_OAUTH_ENABLE", raising=False)
+        mock_scope["headers"] = [
+            (b"authorization", b"Bearer test-token"),
+            (b"x-atlassian-jira-url", b"https://other.atlassian.net"),
+        ]
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        middleware.app.assert_called_once()
+        passed_scope = middleware.app.call_args[0][0]
+        service_headers = passed_scope["state"]["atlassian_service_headers"]
+        assert "X-Atlassian-Jira-Url" not in service_headers
+
+    @pytest.mark.anyio
+    async def test_legacy_oauth_mode_keeps_url_override_headers(
+        self, middleware, mock_scope, mock_receive, mock_send, monkeypatch
+    ):
+        """Legacy per-request auth retains URL headers for compatibility."""
+        monkeypatch.delenv("MCP_ATLASSIAN_MULTI_USER_MODE", raising=False)
+        monkeypatch.setenv("ATLASSIAN_OAUTH_ENABLE", "true")
+        monkeypatch.setenv("MCP_ALLOWED_URL_DOMAINS", "atlassian.net")
+        mock_scope["headers"] = [
+            (b"authorization", b"Bearer test-token"),
+            (b"x-atlassian-jira-url", b"https://other.atlassian.net"),
+        ]
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        middleware.app.assert_called_once()
+        passed_scope = middleware.app.call_args[0][0]
+        service_headers = passed_scope["state"]["atlassian_service_headers"]
+        assert service_headers["X-Atlassian-Jira-Url"] == (
+            "https://other.atlassian.net"
+        )

--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -103,6 +103,28 @@ class TestMainTransportSelection:
                 # Should exit with code 1 (error)
                 assert exc_info.value.code == 1
 
+    @pytest.mark.parametrize(
+        ("environment", "argv"),
+        [
+            ({"TRANSPORT": "stdio"}, ["mcp-atlassian", "--multi-user"]),
+            (
+                {
+                    "TRANSPORT": "stdio",
+                    "MCP_ATLASSIAN_MULTI_USER_MODE": "true",
+                },
+                ["mcp-atlassian"],
+            ),
+        ],
+    )
+    def test_multi_user_rejects_stdio(self, environment, argv):
+        """URL-only multi-user mode requires an HTTP transport."""
+        with patch.dict("os.environ", environment, clear=True):
+            with patch("sys.argv", argv):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 1
+
     def test_cli_overrides_env_transport(self, mock_server, mock_asyncio_run):
         """Test that CLI transport argument overrides environment variable."""
         with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):

--- a/tests/unit/utils/test_env.py
+++ b/tests/unit/utils/test_env.py
@@ -4,6 +4,8 @@ from mcp_atlassian.utils.env import (
     is_env_extended_truthy,
     is_env_ssl_verify,
     is_env_truthy,
+    is_multi_user_mode,
+    is_url_only_multi_user_mode,
 )
 
 
@@ -166,6 +168,34 @@ class TestIsEnvSslVerify:
         monkeypatch.setenv("TEST_VAR", "")
         # Empty string is not in the false values, so should be True
         assert is_env_ssl_verify("TEST_VAR") is True
+
+
+class TestIsMultiUserMode:
+    """Tests for is_multi_user_mode."""
+
+    def test_unset_returns_false(self, monkeypatch):
+        monkeypatch.delenv("MCP_ATLASSIAN_MULTI_USER_MODE", raising=False)
+        monkeypatch.delenv("ATLASSIAN_OAUTH_ENABLE", raising=False)
+        assert is_multi_user_mode() is False
+
+    def test_new_flag_truthy(self, monkeypatch):
+        monkeypatch.delenv("ATLASSIAN_OAUTH_ENABLE", raising=False)
+        for value in ["true", "1", "yes", "TRUE"]:
+            monkeypatch.setenv("MCP_ATLASSIAN_MULTI_USER_MODE", value)
+            assert is_multi_user_mode() is True
+            assert is_url_only_multi_user_mode() is True
+
+    def test_legacy_oauth_enable_aliases_multi_user(self, monkeypatch):
+        monkeypatch.delenv("MCP_ATLASSIAN_MULTI_USER_MODE", raising=False)
+        monkeypatch.setenv("ATLASSIAN_OAUTH_ENABLE", "true")
+        assert is_multi_user_mode() is True
+        assert is_url_only_multi_user_mode() is False
+
+    def test_falsy_values_return_false(self, monkeypatch):
+        for value in ["false", "0", "no", ""]:
+            monkeypatch.setenv("MCP_ATLASSIAN_MULTI_USER_MODE", value)
+            monkeypatch.setenv("ATLASSIAN_OAUTH_ENABLE", value)
+            assert is_multi_user_mode() is False
 
 
 class TestEdgeCases:

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -457,6 +457,34 @@ class TestGetAvailableServicesWithHeaders:
                 "Using Jira minimal OAuth configuration",
             )
 
+    def test_url_only_multi_user_requires_service_urls(self, caplog):
+        """Strict multi-user mode only advertises services with pinned URLs."""
+        with MockEnvironment.clean_env():
+            import os
+
+            os.environ["MCP_ATLASSIAN_MULTI_USER_MODE"] = "true"
+
+            result = get_available_services()
+            _assert_service_availability(
+                result, confluence_expected=False, jira_expected=False
+            )
+
+    def test_url_only_multi_user_with_service_urls(self, caplog):
+        """Strict multi-user mode advertises URL-configured services."""
+        with MockEnvironment.clean_env():
+            import os
+
+            os.environ["MCP_ATLASSIAN_MULTI_USER_MODE"] = "true"
+            os.environ["JIRA_URL"] = "https://test.atlassian.net"
+            os.environ["CONFLUENCE_URL"] = "https://test.atlassian.net/wiki"
+
+            result = get_available_services()
+            _assert_service_availability(
+                result, confluence_expected=True, jira_expected=True
+            )
+            assert "Using Confluence URL-only multi-user mode" in caplog.text
+            assert "Using Jira URL-only multi-user mode" in caplog.text
+
     def test_oauth_enable_with_cloud_url_no_creds(self, caplog):
         """Test BYOT OAuth mode — URL present but no credentials, ATLASSIAN_OAUTH_ENABLE=true."""
         with MockEnvironment.clean_env():

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -469,6 +469,19 @@ class TestGetAvailableServicesWithHeaders:
                 result, confluence_expected=False, jira_expected=False
             )
 
+    def test_url_only_multi_user_takes_precedence_over_legacy_mode(self, caplog):
+        """The strict flag still requires URLs when the legacy flag is also set."""
+        with MockEnvironment.clean_env():
+            import os
+
+            os.environ["MCP_ATLASSIAN_MULTI_USER_MODE"] = "true"
+            os.environ["ATLASSIAN_OAUTH_ENABLE"] = "true"
+
+            result = get_available_services()
+            _assert_service_availability(
+                result, confluence_expected=False, jira_expected=False
+            )
+
     def test_url_only_multi_user_with_service_urls(self, caplog):
         """Strict multi-user mode advertises URL-configured services."""
         with MockEnvironment.clean_env():

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from mcp_atlassian.utils import oauth as oauth_module
 from mcp_atlassian.utils.oauth import (
     CLOUD_AUTHORIZE_URL,
     CLOUD_TOKEN_URL,
@@ -19,6 +20,7 @@ from mcp_atlassian.utils.oauth import (
     OAuthConfig,
     configure_oauth_session,
     get_oauth_config_from_env,
+    resolve_cloud_id_for_url,
 )
 
 
@@ -1256,3 +1258,80 @@ class TestTokenFilePermissionsRegression:
             "OAuth token file must not be group/world-readable (expected 0o600); "
             f"got {oct(mode)}"
         )
+
+
+class TestResolveCloudIdForUrl:
+    """Tests for resolve_cloud_id_for_url (URL-only multi-user tenant pinning)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Keep the module-level Cloud ID cache from leaking across tests."""
+        oauth_module._CLOUD_ID_CACHE.clear()
+        yield
+        oauth_module._CLOUD_ID_CACHE.clear()
+
+    def test_env_pin_takes_precedence_without_network(self, monkeypatch):
+        """An explicit ATLASSIAN_OAUTH_CLOUD_ID pin skips the network lookup."""
+        monkeypatch.setenv("ATLASSIAN_OAUTH_CLOUD_ID", "env-cloud-id")
+
+        with patch("mcp_atlassian.utils.oauth.requests.get") as mock_get:
+            result = resolve_cloud_id_for_url("https://test.atlassian.net")
+
+        assert result == "env-cloud-id"
+        mock_get.assert_not_called()
+
+    def test_resolves_from_tenant_info_endpoint(self, monkeypatch):
+        """Falls back to the site's /_edge/tenant_info endpoint."""
+        monkeypatch.delenv("ATLASSIAN_OAUTH_CLOUD_ID", raising=False)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"cloudId": "resolved-cloud-id"}
+
+        with patch(
+            "mcp_atlassian.utils.oauth.requests.get", return_value=mock_response
+        ) as mock_get:
+            result = resolve_cloud_id_for_url("https://test.atlassian.net")
+
+        assert result == "resolved-cloud-id"
+        mock_get.assert_called_once()
+        assert (
+            mock_get.call_args[0][0] == "https://test.atlassian.net/_edge/tenant_info"
+        )
+
+    def test_caches_resolved_cloud_id(self, monkeypatch):
+        """A resolved Cloud ID is cached so the endpoint is hit only once."""
+        monkeypatch.delenv("ATLASSIAN_OAUTH_CLOUD_ID", raising=False)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"cloudId": "resolved-cloud-id"}
+
+        with patch(
+            "mcp_atlassian.utils.oauth.requests.get", return_value=mock_response
+        ) as mock_get:
+            first = resolve_cloud_id_for_url("https://test.atlassian.net")
+            second = resolve_cloud_id_for_url("https://test.atlassian.net")
+
+        assert first == second == "resolved-cloud-id"
+        mock_get.assert_called_once()
+
+    def test_returns_none_for_non_cloud_url(self, monkeypatch):
+        """Server/Data Center URLs have no Cloud ID; no network call is made."""
+        monkeypatch.delenv("ATLASSIAN_OAUTH_CLOUD_ID", raising=False)
+
+        with patch("mcp_atlassian.utils.oauth.requests.get") as mock_get:
+            result = resolve_cloud_id_for_url("https://jira.internal.example.com")
+
+        assert result is None
+        mock_get.assert_not_called()
+
+    def test_returns_none_on_lookup_failure(self, monkeypatch):
+        """Network/parse failures resolve to None (caller then refuses)."""
+        monkeypatch.delenv("ATLASSIAN_OAUTH_CLOUD_ID", raising=False)
+
+        with patch(
+            "mcp_atlassian.utils.oauth.requests.get",
+            side_effect=requests.RequestException("boom"),
+        ):
+            result = resolve_cloud_id_for_url("https://test.atlassian.net")
+
+        assert result is None

--- a/tests/utils/mocks.py
+++ b/tests/utils/mocks.py
@@ -86,6 +86,7 @@ class MockEnvironment:
             "ATLASSIAN_OAUTH_SCOPE",
             "ATLASSIAN_OAUTH_CLOUD_ID",
             "ATLASSIAN_OAUTH_ENABLE",
+            "MCP_ATLASSIAN_MULTI_USER_MODE",
         ]
 
         # Remove auth vars from environment


### PR DESCRIPTION
## Motivation

Teams hosting one shared remote MCP service should not need to store a service
account or restart the server for every user. This PR adds a URL-only mode in
which the operator pins the Jira and Confluence instances while each HTTP client
supplies its own Atlassian credentials per request.

## Usage

```bash
JIRA_URL=https://your-company.atlassian.net \
CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
uvx mcp-atlassian --transport streamable-http --multi-user --port 9000
```

Clients send one of:

- `Authorization: Basic <base64(email:api_token)>` for Cloud
- `Authorization: Bearer <oauth_token>` for Cloud OAuth; the server resolves
  and pins the Cloud ID from its configured URL
- `Authorization: Token <pat>` for Server/Data Center

## What changed

- Add `MCP_ATLASSIAN_MULTI_USER_MODE` and the `--multi-user` CLI flag.
- Allow Jira and Confluence configs to represent a pinned URL without
  server-side credentials.
- Resolve and validate a user-specific fetcher from each request's credentials.
- Build Cloud OAuth clients from a request token while resolving the tenant from
  the operator-configured URL.
- Reject mismatching request Cloud IDs, including when legacy or complete global
  OAuth configuration is also present.
- Treat a Cloud bearer token without `X-Atlassian-Cloud-Id` as OAuth in strict
  mode while retaining bearer-PAT compatibility for Server/Data Center.
- Process per-request credentials for both Streamable HTTP and SSE message
  endpoints.
- Reject requests that omit credentials instead of falling back to an
  auth-less global config.
- Require an HTTP transport and reject `stdio` in URL-only multi-user mode.
- Ignore per-request Jira and Confluence URL overrides in this mode so clients
  cannot redirect the server to another host.
- Give strict URL-only mode precedence when the legacy OAuth flag is also set.
- Document the deployment and client configuration in the README, auth docs,
  HTTP transport docs, Dockerfile, and `.env.example`.

## Compatibility

- Existing deployments with complete global credentials are unchanged; those
  credentials continue to take precedence.
- Existing `ATLASSIAN_OAUTH_ENABLE=true` deployments remain supported and keep
  their legacy per-request URL-header behavior.
- The stricter URL and tenant pinning applies only to the new URL-only mode.

## Verification

- `uv run pre-commit run --all-files` — passed (Ruff, formatting, strict mypy)
- `uv run pytest tests/unit/ -q` — 3,267 passed, 5 skipped
- `uv run pytest tests/integration/ -q` — 23 optional real-data tests skipped
- `uv run pytest tests/e2e --dc-e2e -q` — 98 passed, 103 Cloud-only skipped
- `uv run pytest tests/e2e/cloud --cloud-e2e -q`: 87 passed, 15 skipped