### PR TITLE
test(servers): add middleware regression tests for SSRF short-circuit

### DIFF
--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -590,3 +590,128 @@ class TestUserTokenMiddleware:
         middleware.app.assert_called_once()
         passed_scope = middleware.app.call_args[0][0]
         assert passed_scope["state"]["user_atlassian_token"] == "valid-token"
+
+
+class TestUserTokenMiddlewareSsrfValidation:
+    """Regression tests for the SSRF short-circuit in UserTokenMiddleware.
+
+    Covers the auth_validation_error path set by ``_process_authentication_headers``
+    when ``validate_url_for_ssrf`` flags an X-Atlassian-Jira-Url or
+    X-Atlassian-Confluence-Url header. Ensures that future refactors of the
+    middleware cannot silently re-open the SSRF vector by skipping the early
+    return or dropping the auth_validation_error assignment.
+    """
+
+    @pytest.fixture
+    def middleware(self):
+        mock_app = AsyncMock()
+        mock_mcp_server = MagicMock()
+        mock_mcp_server.settings.streamable_http_path = "/mcp"
+        mock_mcp_server.get_streamable_http_path.return_value = "/mcp"
+        return UserTokenMiddleware(mock_app, mcp_server_ref=mock_mcp_server)
+
+    @pytest.fixture
+    def mock_scope(self):
+        return {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp",
+            "headers": [],
+            "state": {},
+        }
+
+    @pytest.fixture
+    def mock_receive(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_send(self):
+        return AsyncMock()
+
+    @pytest.mark.parametrize(
+        "header_name,url_value",
+        [
+            (b"x-atlassian-jira-url", b"file:///etc/passwd"),
+            (b"x-atlassian-jira-url", b"http://127.0.0.1:8080/api"),
+            (b"x-atlassian-jira-url", b"http://169.254.169.254/latest/meta-data/"),
+            (b"x-atlassian-jira-url", b"http://10.0.0.5/"),
+            (b"x-atlassian-jira-url", b"ftp://example.com/"),
+            (b"x-atlassian-confluence-url", b"http://localhost:9090/"),
+            (b"x-atlassian-confluence-url", b"http://169.254.169.254/"),
+        ],
+    )
+    @pytest.mark.anyio
+    async def test_ssrf_exploit_header_short_circuits_with_401(
+        self,
+        middleware,
+        mock_scope,
+        mock_receive,
+        mock_send,
+        header_name,
+        url_value,
+    ):
+        """Exploit URL in Jira/Confluence header must produce a 401 and skip the inner app."""
+        mock_scope["headers"] = [
+            (b"authorization", b"Bearer test-token"),
+            (header_name, url_value),
+        ]
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        middleware.app.assert_not_called()
+        assert mock_send.await_count >= 2
+
+        start_call = mock_send.await_args_list[0][0][0]
+        assert start_call["type"] == "http.response.start"
+        assert start_call["status"] == 401
+
+        body_call = mock_send.await_args_list[1][0][0]
+        assert body_call["type"] == "http.response.body"
+        body_json = json.loads(body_call["body"].decode("utf-8"))
+        assert "error" in body_json
+        assert "Forbidden" in body_json["error"]
+
+    @pytest.mark.parametrize(
+        "jira_url,confluence_url",
+        [
+            (b"https://example.atlassian.net", None),
+            (None, b"https://example.atlassian.net/wiki"),
+            (b"https://jira.example.com", b"https://confluence.example.com"),
+        ],
+    )
+    @pytest.mark.anyio
+    async def test_benign_urls_pass_through(
+        self,
+        middleware,
+        mock_scope,
+        mock_receive,
+        mock_send,
+        jira_url,
+        confluence_url,
+    ):
+        """Legitimate Atlassian Cloud / hostnamed URLs must not be short-circuited."""
+        headers = [(b"authorization", b"Bearer test-token")]
+        if jira_url is not None:
+            headers.append((b"x-atlassian-jira-url", jira_url))
+        if confluence_url is not None:
+            headers.append((b"x-atlassian-confluence-url", confluence_url))
+        mock_scope["headers"] = headers
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        middleware.app.assert_called_once()
+        passed_scope = middleware.app.call_args[0][0]
+        assert passed_scope["state"].get("auth_validation_error") in (None, "")
+
+    @pytest.mark.anyio
+    async def test_no_service_headers_does_not_trigger_ssrf_check(
+        self, middleware, mock_scope, mock_receive, mock_send
+    ):
+        """Requests without Jira/Confluence URL headers must skip the validator entirely."""
+        mock_scope["headers"] = [(b"authorization", b"Bearer test-token")]
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        middleware.app.assert_called_once()
+        passed_scope = middleware.app.call_args[0][0]
+        assert passed_scope["state"].get("auth_validation_error") in (None, "")

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -650,7 +650,7 @@ class TestUserTokenMiddlewareSsrfValidation:
         header_name,
         url_value,
     ):
-        """Exploit URL in Jira/Confluence header must produce a 401 and skip the inner app."""
+        """Exploit URL in Jira/Confluence header returns 401 and skips the app."""
         mock_scope["headers"] = [
             (b"authorization", b"Bearer test-token"),
             (header_name, url_value),
@@ -716,7 +716,7 @@ class TestUserTokenMiddlewareSsrfValidation:
     async def test_no_service_headers_does_not_trigger_ssrf_check(
         self, middleware, mock_scope, mock_receive, mock_send
     ):
-        """Requests without Jira/Confluence URL headers must skip the validator entirely."""
+        """Requests without Jira/Confluence URL headers skip the validator."""
         mock_scope["headers"] = [(b"authorization", b"Bearer test-token")]
 
         await middleware(mock_scope, mock_receive, mock_send)

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -688,8 +688,17 @@ class TestUserTokenMiddlewareSsrfValidation:
         mock_send,
         jira_url,
         confluence_url,
+        monkeypatch,
     ):
-        """Legitimate Atlassian Cloud / hostnamed URLs must not be short-circuited."""
+        """Legitimate Atlassian Cloud / self-hosted URLs must not be short-circuited.
+
+        The benign hosts are placed on the SSRF allowlist (MCP_ALLOWED_URL_DOMAINS)
+        so the assertion is deterministic and does not depend on live DNS
+        resolution in CI. The exploit cases above are blocked before any DNS
+        lookup (bad scheme / IP literal / blocked hostname), so they are
+        unaffected by the allowlist.
+        """
+        monkeypatch.setenv("MCP_ALLOWED_URL_DOMAINS", "example.com,atlassian.net")
         headers = [(b"authorization", b"Bearer test-token")]
         if jira_url is not None:
             headers.append((b"x-atlassian-jira-url", jira_url))


### PR DESCRIPTION
## Summary

Adds `TestUserTokenMiddlewareSsrfValidation` to `tests/unit/servers/test_main_server.py` to lock in the SSRF short-circuit at `main.py:524-539`. Test-only change; no source modifications.

## Why

The SSRF validator in `_process_authentication_headers` sets `scope["state"]["auth_validation_error"]` and returns early when a Jira/Confluence URL header points at a loopback, private RFC1918 range, cloud metadata endpoint, `file://`, or non-http(s) scheme. The outer middleware then serves a 401 via `_send_json_error_response` without invoking the inner ASGI app.

This flow is the fix for GHSA-7r34-79r5-rcc9. Today it lives under `test_urls.py` (utility-level) and `test_dependencies.py` (service-level) but has no test that exercises the middleware wiring end-to-end. Any future refactor that reorders the `validate_url_for_ssrf` call, drops the `auth_validation_error` assignment, or skips the early return would silently re-open the vector without failing CI.

## What the PR adds

7 parametrized exploit cases — `file://`, loopback, cloud metadata (169.254.169.254), private RFC1918, `ftp://`, `localhost` — across both `X-Atlassian-Jira-Url` and `X-Atlassian-Confluence-Url`. Each asserts:
- `middleware.app` is not called
- A 401 response is sent via the mocked ASGI send callable
- The JSON body contains a `"Forbidden"` error message

3 benign cases (valid Atlassian Cloud URL on Jira only, Confluence only, and both) assert the middleware passes through and does not set `auth_validation_error`.

1 no-header case asserts requests without Jira/Confluence URL headers skip the validator entirely.

## Files

| File | Change |
|---|---|
| `tests/unit/servers/test_main_server.py` | +125 lines — new test class appended |

No source changes. No new fixtures. No dependency bumps.

## Test plan

```
uv run pytest tests/unit/servers/test_main_server.py::TestUserTokenMiddlewareSsrfValidation -v
```

Sanity: removing the guard block from `_process_authentication_headers` should cause all 7 exploit cases to fail.

## Notes

- Happy to narrow or widen parametrization if the case list doesn't match team preference.
- Path-traversal middleware tests (`TestConfluenceAttachmentPathTraversal`) are out of scope here; flagging them as a possible follow-up.
