### PR TITLE
feat(jira): add get_issue_embedded_images tool for editor-pasted images

### DIFF
--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -69,7 +69,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `jira_agile` | No | `jira_get_agile_boards`, `jira_get_board_issues`, `jira_get_sprints_from_board`, `jira_get_sprint_issues`, `jira_create_sprint`, `jira_update_sprint`, `jira_add_issues_to_sprint` |
 | `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_create_remote_issue_link`, `jira_remove_issue_link` |
 | `jira_worklog` | No | `jira_get_worklog`, `jira_add_worklog` |
-| `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images` |
+| `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images`, `jira_get_issue_embedded_images` |
 | `jira_users` | No | `jira_get_user_profile` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
 | `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues` |

--- a/docs/tools/jira-attachments.mdx
+++ b/docs/tools/jira-attachments.mdx
@@ -36,3 +36,15 @@ Get all images attached to a Jira issue as inline image content.
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123'). Returns image attachments as inline ImageContent for LLM vision. |
 
 ---
+
+### Get Embedded Images
+
+Get images embedded in the Jira rich text editor as inline image content.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123'). Returns images pasted directly into the Jira editor (description and comments) that are NOT formal attachments. |
+
+---

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -79,6 +79,7 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
     "jira-attachments": [
         "jira_download_attachments",
         "jira_get_issue_images",
+        "jira_get_issue_embedded_images",
     ],
     "jira-service-desk": [
         "jira_get_service_desk_for_project",

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -5,6 +5,9 @@ import mimetypes
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from bs4 import BeautifulSoup
 
 from ..models.jira import JiraAttachment
 from ..utils.io import validate_safe_path
@@ -467,3 +470,193 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             "uploaded": uploaded,
             "failed": failed,
         }
+
+    def get_embedded_images(self, issue_key: str) -> dict[str, Any]:
+        """Fetch images embedded in the rich text editor (description + comments).
+
+        These are images pasted directly into Jira's editor that are NOT
+        stored as formal attachments.  They are served via internal servlets
+        like ``jeditor_file_provider`` and only appear as ``<img>`` tags in
+        the rendered HTML.
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123').
+
+        Returns:
+            A dictionary with:
+                success (bool)
+                issue_key (str)
+                total (int)
+                images (list[dict]): each dict has 'filename',
+                    'content_type', 'size', 'data' (bytes), and 'source'
+                failed (list[dict]): each dict has 'filename' and 'error'
+        """
+        logger.info(f"Fetching embedded images for {issue_key}")
+
+        try:
+            issue_data = self.jira.issue(
+                issue_key,
+                fields="description,comment",
+                expand="renderedFields",
+            )
+        except Exception as e:
+            logger.error(f"Error fetching issue {issue_key}: {e}")
+            return {"success": False, "error": str(e)}
+
+        if not isinstance(issue_data, dict):
+            msg = f"Unexpected return type from jira.issue: {type(issue_data)}"
+            logger.error(msg)
+            raise TypeError(msg)
+
+        rendered = issue_data.get("renderedFields") or {}
+        base_url = self.config.url
+
+        # Sammle URLs aus Description und Kommentaren
+        image_urls: list[dict[str, str]] = []
+
+        desc_html = rendered.get("description") or ""
+        if desc_html:
+            for entry in _extract_embedded_image_urls(desc_html, base_url):
+                entry["source"] = "description"
+                image_urls.append(entry)
+
+        comment_field = rendered.get("comment")
+        if isinstance(comment_field, dict):
+            comments_list = comment_field.get("comments", [])
+        elif isinstance(comment_field, list):
+            comments_list = comment_field
+        else:
+            comments_list = []
+
+        for comment in comments_list:
+            if not isinstance(comment, dict):
+                continue
+            body_html = comment.get("body") or ""
+            if body_html:
+                comment_id = comment.get("id", "")
+                for entry in _extract_embedded_image_urls(body_html, base_url):
+                    entry["source"] = "comment"
+                    entry["comment_id"] = str(comment_id)
+                    image_urls.append(entry)
+
+        if not image_urls:
+            return {
+                "success": True,
+                "issue_key": issue_key,
+                "total": 0,
+                "images": [],
+                "failed": [],
+                "message": "No embedded images found",
+            }
+
+        # Lade jedes Bild herunter
+        images: list[dict[str, Any]] = []
+        failed: list[dict[str, Any]] = []
+
+        for img_info in image_urls:
+            url = img_info["url"]
+            filename = img_info["filename"]
+
+            data = self.fetch_attachment_content(url)
+            if data is None:
+                failed.append({"filename": filename, "error": "Fetch failed"})
+                continue
+
+            if len(data) > ATTACHMENT_MAX_BYTES:
+                failed.append(
+                    {
+                        "filename": filename,
+                        "error": (
+                            f"Image is {len(data)} bytes which exceeds "
+                            "the 50 MB inline limit."
+                        ),
+                    }
+                )
+                continue
+
+            content_type = (
+                mimetypes.guess_type(filename)[0] or "image/png"
+            )
+            images.append(
+                {
+                    "filename": filename,
+                    "content_type": content_type,
+                    "size": len(data),
+                    "data": data,
+                    "source": img_info.get("source", "unknown"),
+                }
+            )
+
+        return {
+            "success": True,
+            "issue_key": issue_key,
+            "total": len(image_urls),
+            "images": images,
+            "failed": failed,
+        }
+
+
+def _extract_embedded_image_urls(
+    html: str, base_url: str
+) -> list[dict[str, str]]:
+    """Extract embedded image URLs from rendered HTML.
+
+    Parses ``<img>`` tags, keeps only same-host URLs that are NOT formal
+    attachment paths (``/secure/attachment/``, ``/rest/api/``), and returns
+    a list of dicts with ``url`` and ``filename`` keys.
+
+    Args:
+        html: Rendered HTML string from Jira's ``renderedFields``.
+        base_url: The Jira instance base URL for host comparison.
+
+    Returns:
+        List of ``{"url": ..., "filename": ...}`` dicts.
+    """
+    if not html:
+        return []
+
+    parsed_base = urlparse(base_url)
+    base_host = parsed_base.hostname or ""
+
+    soup = BeautifulSoup(html, "html.parser")
+    results: list[dict[str, str]] = []
+    seen_urls: set[str] = set()
+
+    for img in soup.find_all("img"):
+        src = img.get("src")
+        if not src or not isinstance(src, str):
+            continue
+
+        parsed_src = urlparse(src)
+        src_host = parsed_src.hostname or ""
+
+        # Nur gleicher Host — verhindert SSRF
+        if src_host.lower() != base_host.lower():
+            continue
+
+        # Formale Attachment-URLs ausschliessen
+        path_lower = parsed_src.path.lower()
+        if "/secure/attachment/" in path_lower or "/rest/api/" in path_lower:
+            continue
+
+        # Deduplizierung
+        if src in seen_urls:
+            continue
+        seen_urls.add(src)
+
+        # Dateiname extrahieren: fileName-Query-Param oder URL-Pfad-Basename
+        query_params = parse_qs(parsed_src.query)
+        file_name_list = query_params.get("fileName", [])
+        if file_name_list:
+            filename = file_name_list[0]
+        else:
+            basename = os.path.basename(parsed_src.path)
+            # Nur verwenden wenn es eine Dateiendung hat
+            if basename and "." in basename:
+                filename = basename
+            else:
+                filename = f"embedded_{len(results)}.png"
+
+        results.append({"url": src, "filename": filename})
+
+    return results

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -5,7 +5,7 @@ import mimetypes
 import os
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
@@ -511,7 +511,7 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         rendered = issue_data.get("renderedFields") or {}
         base_url = self.config.url
 
-        # Sammle URLs aus Description und Kommentaren
+        # Collect URLs from the rendered description and comments.
         image_urls: list[dict[str, str]] = []
 
         desc_html = rendered.get("description") or ""
@@ -549,7 +549,7 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
                 "message": "No embedded images found",
             }
 
-        # Lade jedes Bild herunter
+        # Download each embedded image.
         images: list[dict[str, Any]] = []
         failed: list[dict[str, Any]] = []
 
@@ -601,9 +601,8 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
 def _extract_embedded_image_urls(html: str, base_url: str) -> list[dict[str, str]]:
     """Extract embedded image URLs from rendered HTML.
 
-    Parses ``<img>`` tags, keeps only same-host URLs that are NOT formal
-    attachment paths (``/secure/attachment/``, ``/rest/api/``), and returns
-    a list of dicts with ``url`` and ``filename`` keys.
+    Parses ``<img>`` tags and keeps only same-origin URLs for Jira's embedded
+    image servlets. Relative URLs are resolved against the configured Jira URL.
 
     Args:
         html: Rendered HTML string from Jira's ``renderedFields``.
@@ -616,7 +615,25 @@ def _extract_embedded_image_urls(html: str, base_url: str) -> list[dict[str, str
         return []
 
     parsed_base = urlparse(base_url)
-    base_host = parsed_base.hostname or ""
+
+    def origin(parsed_url: Any) -> tuple[str, str, int | None] | None:
+        """Return a normalized origin, or None for malformed URLs."""
+        if (
+            parsed_url.scheme.lower() not in {"http", "https"}
+            or not parsed_url.hostname
+        ):
+            return None
+        try:
+            port = parsed_url.port
+        except ValueError:
+            return None
+        if port is None:
+            port = 443 if parsed_url.scheme.lower() == "https" else 80
+        return parsed_url.scheme.lower(), parsed_url.hostname.lower(), port
+
+    base_origin = origin(parsed_base)
+    if base_origin is None:
+        return []
 
     soup = BeautifulSoup(html, "html.parser")
     results: list[dict[str, str]] = []
@@ -627,36 +644,41 @@ def _extract_embedded_image_urls(html: str, base_url: str) -> list[dict[str, str
         if not src or not isinstance(src, str):
             continue
 
-        parsed_src = urlparse(src)
-        src_host = parsed_src.hostname or ""
+        resolved_src = urljoin(base_url.rstrip("/") + "/", src)
+        parsed_src = urlparse(resolved_src)
 
-        # Nur gleicher Host — verhindert SSRF
-        if src_host.lower() != base_host.lower():
+        # Restrict downloads to the configured Jira origin. This also blocks
+        # scheme changes and alternate ports on the same hostname.
+        if origin(parsed_src) != base_origin:
             continue
 
-        # Formale Attachment-URLs ausschliessen
+        # Only Jira's editor-image servlet paths are in scope. Avoid turning
+        # arbitrary same-origin <img> URLs into authenticated GET requests.
         path_lower = parsed_src.path.lower()
-        if "/secure/attachment/" in path_lower or "/rest/api/" in path_lower:
+        if not (
+            path_lower.endswith("/plugins/servlet/jeditor_file_provider")
+            or "/plugins/servlet/ckupload/" in path_lower
+        ):
             continue
 
-        # Deduplizierung
-        if src in seen_urls:
+        if resolved_src in seen_urls:
             continue
-        seen_urls.add(src)
+        seen_urls.add(resolved_src)
 
-        # Dateiname extrahieren: fileName-Query-Param oder URL-Pfad-Basename
+        # Extract a display filename from fileName or the URL path.
         query_params = parse_qs(parsed_src.query)
         file_name_list = query_params.get("fileName", [])
         if file_name_list:
-            filename = file_name_list[0]
+            filename = os.path.basename(file_name_list[0].replace("\\", "/"))
+            if not filename:
+                filename = f"embedded_{len(results)}.png"
         else:
             basename = os.path.basename(parsed_src.path)
-            # Nur verwenden wenn es eine Dateiendung hat
             if basename and "." in basename:
                 filename = basename
             else:
                 filename = f"embedded_{len(results)}.png"
 
-        results.append({"url": src, "filename": filename})
+        results.append({"url": resolved_src, "filename": filename})
 
     return results

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 
 from ..models.jira import JiraAttachment
 from ..utils.io import validate_safe_path
-from ..utils.media import ATTACHMENT_MAX_BYTES
+from ..utils.media import ATTACHMENT_MAX_BYTES, detect_mime_from_bytes
 from .client import JiraClient
 from .protocols import AttachmentsOperationsProto
 
@@ -575,7 +575,9 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
                 continue
 
             content_type = (
-                mimetypes.guess_type(filename)[0] or "image/png"
+                detect_mime_from_bytes(data)
+                or mimetypes.guess_type(filename)[0]
+                or "image/png"
             )
             images.append(
                 {
@@ -596,9 +598,7 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         }
 
 
-def _extract_embedded_image_urls(
-    html: str, base_url: str
-) -> list[dict[str, str]]:
+def _extract_embedded_image_urls(html: str, base_url: str) -> list[dict[str, str]]:
     """Extract embedded image URLs from rendered HTML.
 
     Parses ``<img>`` tags, keeps only same-host URLs that are NOT formal

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1038,6 +1038,95 @@ async def get_issue_images(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read", "attachments", "toolset:jira_attachments"},
+    annotations={"title": "Get Embedded Images", "readOnlyHint": True},
+)
+async def get_issue_embedded_images(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description=(
+                "Jira issue key (e.g., 'PROJ-123'). Returns images "
+                "pasted directly into the Jira editor (description "
+                "and comments) that are NOT formal attachments."
+            ),
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+) -> list[TextContent | ImageContent]:
+    """Get images embedded in the Jira rich text editor as inline image content.
+
+    Scans the rendered HTML of the issue description and comments for
+    ``<img>`` tags that point to Jira-internal URLs (e.g.
+    ``jeditor_file_provider``) which are not discoverable via the
+    attachments API.
+
+    Images are downloaded using the existing authenticated session and
+    returned as base64-encoded ImageContent for LLM vision.  Images
+    larger than 50 MB are skipped.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+
+    Returns:
+        A list with a text summary followed by one ImageContent per
+        successfully downloaded embedded image.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_embedded_images(issue_key)
+    contents: list[TextContent | ImageContent] = []
+
+    if not result.get("success"):
+        contents.append(
+            TextContent(
+                type="text",
+                text=json.dumps(result, indent=2, ensure_ascii=False),
+            )
+        )
+        return contents
+
+    images = result.get("images", [])
+    failed = result.get("failed", [])
+
+    for img in images:
+        data_bytes: bytes = img["data"]
+        encoded = base64.b64encode(data_bytes).decode("ascii")
+        mime_type = img.get("content_type", "image/png")
+
+        contents.append(
+            ImageContent(
+                type="image",
+                data=encoded,
+                mimeType=mime_type,
+            )
+        )
+
+    summary: dict[str, object] = {
+        "success": True,
+        "issue_key": issue_key,
+        "total_embedded": result.get("total", 0),
+        "downloaded": len(images),
+        "failed": failed,
+    }
+
+    if not images and not failed:
+        summary["message"] = result.get(
+            "message", "No embedded images found"
+        )
+
+    contents.insert(
+        0,
+        TextContent(
+            type="text",
+            text=json.dumps(summary, indent=2, ensure_ascii=False),
+        ),
+    )
+    return contents
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_agile"},
     annotations={"title": "Get Agile Boards", "readOnlyHint": True},
 )

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1112,9 +1112,7 @@ async def get_issue_embedded_images(
     }
 
     if not images and not failed:
-        summary["message"] = result.get(
-            "message", "No embedded images found"
-        )
+        summary["message"] = result.get("message", "No embedded images found")
 
     contents.insert(
         0,

--- a/src/mcp_atlassian/utils/media.py
+++ b/src/mcp_atlassian/utils/media.py
@@ -28,6 +28,35 @@ _IMAGE_EXTENSIONS = frozenset(
     {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
 )
 
+# Magic byte signatures for common image formats.
+_IMAGE_SIGNATURES: list[tuple[bytes, str]] = [
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+    (b"BM", "image/bmp"),
+]
+
+
+def detect_mime_from_bytes(data: bytes) -> str | None:
+    """Detect image MIME type from file magic bytes.
+
+    Checks the leading bytes of *data* against known image file
+    signatures.  WebP requires a special check because the magic
+    bytes are not contiguous.
+
+    Returns:
+        The detected MIME type string, or ``None`` when the format
+        is not recognised.
+    """
+    for signature, mime in _IMAGE_SIGNATURES:
+        if data[: len(signature)] == signature:
+            return mime
+    # WebP: starts with RIFF....WEBP
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
 
 def is_image_attachment(
     media_type: str | None, filename: str | None

--- a/tests/unit/jira/test_embedded_images.py
+++ b/tests/unit/jira/test_embedded_images.py
@@ -1,0 +1,272 @@
+"""Tests for embedded image extraction from Jira rich text editor fields."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.attachments import (
+    AttachmentsMixin,
+    _extract_embedded_image_urls,
+)
+
+# ---------------------------------------------------------------------------
+# Tests for _extract_embedded_image_urls()
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmbeddedImageUrls:
+    """Tests for the private URL extraction helper."""
+
+    BASE_URL = "https://jira.example.com"
+
+    def test_jeditor_url_extracted(self) -> None:
+        html = (
+            '<span class="image-wrap">'
+            '<img src="https://jira.example.com/plugins/servlet/'
+            'jeditor_file_provider?imgId=abc123&amp;fileName=screenshot.png"'
+            ' class="je-pasted-image" width="800">'
+            "</span>"
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert len(result) == 1
+        assert result[0]["filename"] == "screenshot.png"
+        assert "jeditor_file_provider" in result[0]["url"]
+
+    def test_ckupload_url_extracted(self) -> None:
+        html = (
+            '<img src="https://jira.example.com/plugins/servlet/'
+            'ckupload/pastedImage.png">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert len(result) == 1
+        assert result[0]["filename"] == "pastedImage.png"
+
+    def test_external_urls_filtered(self) -> None:
+        html = (
+            '<img src="https://external-site.com/image.png">'
+            '<img src="https://jira.example.com/plugins/servlet/'
+            'jeditor_file_provider?imgId=1&amp;fileName=local.png">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert len(result) == 1
+        assert result[0]["filename"] == "local.png"
+
+    def test_formal_attachment_urls_excluded(self) -> None:
+        html = (
+            '<img src="https://jira.example.com/secure/attachment/'
+            '12345/screenshot.png">'
+            '<img src="https://jira.example.com/rest/api/2/attachment/'
+            'content/67890">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert len(result) == 0
+
+    def test_empty_html(self) -> None:
+        assert _extract_embedded_image_urls("", self.BASE_URL) == []
+
+    def test_no_images_in_html(self) -> None:
+        html = "<p>Just some text without images</p>"
+        assert _extract_embedded_image_urls(html, self.BASE_URL) == []
+
+    def test_mixed_content(self) -> None:
+        """Embedded images kept, external and formal excluded."""
+        html = (
+            '<p>Description</p>'
+            '<img src="https://external.com/img.png">'
+            '<img src="https://jira.example.com/secure/attachment/1/a.png">'
+            '<img src="https://jira.example.com/plugins/servlet/'
+            'jeditor_file_provider?imgId=x&amp;fileName=pasted.png">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert len(result) == 1
+        assert result[0]["filename"] == "pasted.png"
+
+    def test_duplicate_urls_deduplicated(self) -> None:
+        url = (
+            "https://jira.example.com/plugins/servlet/"
+            "jeditor_file_provider?imgId=1&fileName=dup.png"
+        )
+        html = f'<img src="{url}"><img src="{url}">'
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert len(result) == 1
+
+    def test_filename_fallback_to_path_basename(self) -> None:
+        html = (
+            '<img src="https://jira.example.com/plugins/servlet/'
+            'ckupload/my_screenshot.png">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert result[0]["filename"] == "my_screenshot.png"
+
+    def test_filename_fallback_to_generated_name(self) -> None:
+        html = (
+            '<img src="https://jira.example.com/plugins/servlet/'
+            'jeditor_file_provider?imgId=abc">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert result[0]["filename"] == "embedded_0.png"
+
+    def test_img_without_src_skipped(self) -> None:
+        html = '<img alt="no source">'
+        assert _extract_embedded_image_urls(html, self.BASE_URL) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for AttachmentsMixin.get_embedded_images()
+# ---------------------------------------------------------------------------
+
+
+class TestGetEmbeddedImages:
+    """Tests for the get_embedded_images mixin method."""
+
+    @pytest.fixture
+    def attachments_mixin(self, jira_fetcher: JiraFetcher) -> AttachmentsMixin:
+        attachments_mixin = jira_fetcher
+        attachments_mixin.jira = MagicMock()
+        attachments_mixin.jira._session = MagicMock()
+        return attachments_mixin
+
+    def test_no_embedded_images(
+        self, attachments_mixin: AttachmentsMixin
+    ) -> None:
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {"description": "plain text", "comment": {"comments": []}},
+            "renderedFields": {
+                "description": "<p>plain text</p>",
+                "comment": {"comments": []},
+            },
+        }
+        result = attachments_mixin.get_embedded_images("PROJ-1")
+        assert result["success"] is True
+        assert result["total"] == 0
+        assert result["images"] == []
+
+    def test_embedded_image_from_description(
+        self, attachments_mixin: AttachmentsMixin
+    ) -> None:
+        base_url = attachments_mixin.config.url
+        img_url = (
+            f"{base_url}/plugins/servlet/jeditor_file_provider"
+            "?imgId=abc&fileName=shot.png"
+        )
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {"description": "text", "comment": {"comments": []}},
+            "renderedFields": {
+                "description": f'<p><img src="{img_url}"></p>',
+                "comment": {"comments": []},
+            },
+        }
+        # Simuliere erfolgreichen Download
+        fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        attachments_mixin.fetch_attachment_content = MagicMock(
+            return_value=fake_png
+        )
+
+        result = attachments_mixin.get_embedded_images("PROJ-1")
+
+        assert result["success"] is True
+        assert result["total"] == 1
+        assert len(result["images"]) == 1
+        assert result["images"][0]["filename"] == "shot.png"
+        assert result["images"][0]["source"] == "description"
+        assert result["images"][0]["data"] == fake_png
+
+    def test_embedded_image_from_comment(
+        self, attachments_mixin: AttachmentsMixin
+    ) -> None:
+        base_url = attachments_mixin.config.url
+        img_url = (
+            f"{base_url}/plugins/servlet/jeditor_file_provider"
+            "?imgId=xyz&fileName=comment_img.png"
+        )
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {"description": "", "comment": {"comments": []}},
+            "renderedFields": {
+                "description": "",
+                "comment": {
+                    "comments": [
+                        {
+                            "id": "12345",
+                            "body": f'<p><img src="{img_url}"></p>',
+                        }
+                    ]
+                },
+            },
+        }
+        fake_png = b"\x89PNG" + b"\x00" * 50
+        attachments_mixin.fetch_attachment_content = MagicMock(
+            return_value=fake_png
+        )
+
+        result = attachments_mixin.get_embedded_images("PROJ-2")
+
+        assert result["success"] is True
+        assert len(result["images"]) == 1
+        assert result["images"][0]["source"] == "comment"
+        assert result["images"][0]["filename"] == "comment_img.png"
+
+    def test_fetch_failure_recorded(
+        self, attachments_mixin: AttachmentsMixin
+    ) -> None:
+        base_url = attachments_mixin.config.url
+        img_url = (
+            f"{base_url}/plugins/servlet/jeditor_file_provider"
+            "?imgId=fail&fileName=broken.png"
+        )
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {},
+            "renderedFields": {
+                "description": f'<img src="{img_url}">',
+                "comment": {"comments": []},
+            },
+        }
+        attachments_mixin.fetch_attachment_content = MagicMock(
+            return_value=None
+        )
+
+        result = attachments_mixin.get_embedded_images("PROJ-3")
+
+        assert result["success"] is True
+        assert result["total"] == 1
+        assert len(result["images"]) == 0
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["filename"] == "broken.png"
+
+    def test_oversized_image_skipped(
+        self, attachments_mixin: AttachmentsMixin
+    ) -> None:
+        base_url = attachments_mixin.config.url
+        img_url = (
+            f"{base_url}/plugins/servlet/jeditor_file_provider"
+            "?imgId=big&fileName=huge.png"
+        )
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {},
+            "renderedFields": {
+                "description": f'<img src="{img_url}">',
+                "comment": {"comments": []},
+            },
+        }
+        # 51 MB
+        oversized_data = b"\x00" * (51 * 1024 * 1024)
+        attachments_mixin.fetch_attachment_content = MagicMock(
+            return_value=oversized_data
+        )
+
+        result = attachments_mixin.get_embedded_images("PROJ-4")
+
+        assert result["success"] is True
+        assert len(result["images"]) == 0
+        assert len(result["failed"]) == 1
+        assert "50 MB" in result["failed"][0]["error"]
+
+    def test_api_error_returns_failure(
+        self, attachments_mixin: AttachmentsMixin
+    ) -> None:
+        attachments_mixin.jira.issue.side_effect = Exception("API down")
+
+        result = attachments_mixin.get_embedded_images("PROJ-5")
+
+        assert result["success"] is False
+        assert "API down" in result["error"]

--- a/tests/unit/jira/test_embedded_images.py
+++ b/tests/unit/jira/test_embedded_images.py
@@ -9,6 +9,47 @@ from mcp_atlassian.jira.attachments import (
     AttachmentsMixin,
     _extract_embedded_image_urls,
 )
+from mcp_atlassian.utils.media import detect_mime_from_bytes
+
+# ---------------------------------------------------------------------------
+# Tests for detect_mime_from_bytes()
+# ---------------------------------------------------------------------------
+
+
+class TestDetectMimeFromBytes:
+    """Tests for the magic-byte MIME type detection helper."""
+
+    def test_png(self) -> None:
+        data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        assert detect_mime_from_bytes(data) == "image/png"
+
+    def test_jpeg(self) -> None:
+        data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        assert detect_mime_from_bytes(data) == "image/jpeg"
+
+    def test_gif87a(self) -> None:
+        data = b"GIF87a" + b"\x00" * 100
+        assert detect_mime_from_bytes(data) == "image/gif"
+
+    def test_gif89a(self) -> None:
+        data = b"GIF89a" + b"\x00" * 100
+        assert detect_mime_from_bytes(data) == "image/gif"
+
+    def test_bmp(self) -> None:
+        data = b"BM" + b"\x00" * 100
+        assert detect_mime_from_bytes(data) == "image/bmp"
+
+    def test_webp(self) -> None:
+        data = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 100
+        assert detect_mime_from_bytes(data) == "image/webp"
+
+    def test_unknown_returns_none(self) -> None:
+        data = b"\x00\x01\x02\x03" * 10
+        assert detect_mime_from_bytes(data) is None
+
+    def test_empty_returns_none(self) -> None:
+        assert detect_mime_from_bytes(b"") is None
+
 
 # ---------------------------------------------------------------------------
 # Tests for _extract_embedded_image_urls()
@@ -72,7 +113,7 @@ class TestExtractEmbeddedImageUrls:
     def test_mixed_content(self) -> None:
         """Embedded images kept, external and formal excluded."""
         html = (
-            '<p>Description</p>'
+            "<p>Description</p>"
             '<img src="https://external.com/img.png">'
             '<img src="https://jira.example.com/secure/attachment/1/a.png">'
             '<img src="https://jira.example.com/plugins/servlet/'
@@ -127,9 +168,7 @@ class TestGetEmbeddedImages:
         attachments_mixin.jira._session = MagicMock()
         return attachments_mixin
 
-    def test_no_embedded_images(
-        self, attachments_mixin: AttachmentsMixin
-    ) -> None:
+    def test_no_embedded_images(self, attachments_mixin: AttachmentsMixin) -> None:
         attachments_mixin.jira.issue.return_value = {
             "fields": {"description": "plain text", "comment": {"comments": []}},
             "renderedFields": {
@@ -159,9 +198,7 @@ class TestGetEmbeddedImages:
         }
         # Simuliere erfolgreichen Download
         fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-        attachments_mixin.fetch_attachment_content = MagicMock(
-            return_value=fake_png
-        )
+        attachments_mixin.fetch_attachment_content = MagicMock(return_value=fake_png)
 
         result = attachments_mixin.get_embedded_images("PROJ-1")
 
@@ -195,9 +232,7 @@ class TestGetEmbeddedImages:
             },
         }
         fake_png = b"\x89PNG" + b"\x00" * 50
-        attachments_mixin.fetch_attachment_content = MagicMock(
-            return_value=fake_png
-        )
+        attachments_mixin.fetch_attachment_content = MagicMock(return_value=fake_png)
 
         result = attachments_mixin.get_embedded_images("PROJ-2")
 
@@ -206,9 +241,7 @@ class TestGetEmbeddedImages:
         assert result["images"][0]["source"] == "comment"
         assert result["images"][0]["filename"] == "comment_img.png"
 
-    def test_fetch_failure_recorded(
-        self, attachments_mixin: AttachmentsMixin
-    ) -> None:
+    def test_fetch_failure_recorded(self, attachments_mixin: AttachmentsMixin) -> None:
         base_url = attachments_mixin.config.url
         img_url = (
             f"{base_url}/plugins/servlet/jeditor_file_provider"
@@ -221,9 +254,7 @@ class TestGetEmbeddedImages:
                 "comment": {"comments": []},
             },
         }
-        attachments_mixin.fetch_attachment_content = MagicMock(
-            return_value=None
-        )
+        attachments_mixin.fetch_attachment_content = MagicMock(return_value=None)
 
         result = attachments_mixin.get_embedded_images("PROJ-3")
 
@@ -233,9 +264,7 @@ class TestGetEmbeddedImages:
         assert len(result["failed"]) == 1
         assert result["failed"][0]["filename"] == "broken.png"
 
-    def test_oversized_image_skipped(
-        self, attachments_mixin: AttachmentsMixin
-    ) -> None:
+    def test_oversized_image_skipped(self, attachments_mixin: AttachmentsMixin) -> None:
         base_url = attachments_mixin.config.url
         img_url = (
             f"{base_url}/plugins/servlet/jeditor_file_provider"
@@ -270,3 +299,28 @@ class TestGetEmbeddedImages:
 
         assert result["success"] is False
         assert "API down" in result["error"]
+
+    def test_jpeg_data_with_png_filename_detected_as_jpeg(
+        self, attachments_mixin: AttachmentsMixin
+    ) -> None:
+        """JPEG image data must be reported as image/jpeg even when the
+        filename extension is .png (e.g. fallback-generated names)."""
+        base_url = attachments_mixin.config.url
+        img_url = f"{base_url}/plugins/servlet/jeditor_file_provider?imgId=abc"
+        attachments_mixin.jira.issue.return_value = {
+            "fields": {},
+            "renderedFields": {
+                "description": f'<img src="{img_url}">',
+                "comment": {"comments": []},
+            },
+        }
+        # JPEG magic bytes, but the URL has no fileName param so
+        # the fallback name will be embedded_0.png
+        fake_jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        attachments_mixin.fetch_attachment_content = MagicMock(return_value=fake_jpeg)
+
+        result = attachments_mixin.get_embedded_images("PROJ-6")
+
+        assert result["success"] is True
+        assert len(result["images"]) == 1
+        assert result["images"][0]["content_type"] == "image/jpeg"

--- a/tests/unit/jira/test_embedded_images.py
+++ b/tests/unit/jira/test_embedded_images.py
@@ -93,6 +93,43 @@ class TestExtractEmbeddedImageUrls:
         assert len(result) == 1
         assert result[0]["filename"] == "local.png"
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://jira.example.com/plugins/servlet/jeditor_file_provider?imgId=1",
+            "https://jira.example.com:8443/plugins/servlet/"
+            "jeditor_file_provider?imgId=1",
+            "https://jira.example.com/plugins/servlet/"
+            "jeditor_file_provider_other?imgId=1",
+            "https://jira.example.com/rest/api/2/myself",
+        ],
+    )
+    def test_non_embedded_or_different_origin_urls_filtered(self, url: str) -> None:
+        result = _extract_embedded_image_urls(f'<img src="{url}">', self.BASE_URL)
+        assert result == []
+
+    def test_relative_jeditor_url_resolved(self) -> None:
+        html = (
+            '<img src="plugins/servlet/jeditor_file_provider?'
+            'imgId=1&amp;fileName=relative.png">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert result == [
+            {
+                "url": "https://jira.example.com/plugins/servlet/"
+                "jeditor_file_provider?imgId=1&fileName=relative.png",
+                "filename": "relative.png",
+            }
+        ]
+
+    def test_filename_is_reduced_to_basename(self) -> None:
+        html = (
+            '<img src="https://jira.example.com/plugins/servlet/'
+            'jeditor_file_provider?imgId=1&amp;fileName=../nested/image.png">'
+        )
+        result = _extract_embedded_image_urls(html, self.BASE_URL)
+        assert result[0]["filename"] == "image.png"
+
     def test_formal_attachment_urls_excluded(self) -> None:
         html = (
             '<img src="https://jira.example.com/secure/attachment/'
@@ -196,7 +233,7 @@ class TestGetEmbeddedImages:
                 "comment": {"comments": []},
             },
         }
-        # Simuliere erfolgreichen Download
+        # Simulate a successful download.
         fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
         attachments_mixin.fetch_attachment_content = MagicMock(return_value=fake_png)
 

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -397,6 +397,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         get_board_issues,
         get_field_options,
         get_issue,
+        get_issue_embedded_images,
         get_issue_images,
         get_link_types,
         get_project_components,
@@ -434,6 +435,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(get_worklog)
     jira_sub_mcp.add_tool(download_attachments)
     jira_sub_mcp.add_tool(get_issue_images)
+    jira_sub_mcp.add_tool(get_issue_embedded_images)
     jira_sub_mcp.add_tool(get_field_options)
     jira_sub_mcp.add_tool(get_agile_boards)
     jira_sub_mcp.add_tool(get_board_issues)
@@ -1978,6 +1980,82 @@ async def test_get_issue_images_fetch_failure(jira_client, mock_jira_fetcher):
     assert summary["downloaded"] == 0
     assert len(summary["failed"]) == 1
     assert "Fetch failed" in summary["failed"][0]["error"]
+
+
+# ── jira_get_issue_embedded_images tests ─────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_issue_embedded_images_basic(jira_client, mock_jira_fetcher):
+    """Embedded image bytes are returned as inline image content."""
+    image_data = b"\x89PNG\r\n\x1a\n"
+    mock_jira_fetcher.get_embedded_images.return_value = {
+        "success": True,
+        "issue_key": "TEST-123",
+        "total": 1,
+        "images": [
+            {
+                "filename": "pasted.png",
+                "content_type": "image/png",
+                "size": len(image_data),
+                "data": image_data,
+                "source": "description",
+            }
+        ],
+        "failed": [],
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue_embedded_images", {"issue_key": "TEST-123"}
+    )
+
+    mock_jira_fetcher.get_embedded_images.assert_called_once_with("TEST-123")
+    summary = json.loads(response.content[0].text)
+    assert summary["total_embedded"] == 1
+    assert summary["downloaded"] == 1
+    assert response.content[1].type == "image"
+    assert response.content[1].mimeType == "image/png"
+
+
+@pytest.mark.anyio
+async def test_get_issue_embedded_images_no_images(jira_client, mock_jira_fetcher):
+    """A successful empty result includes an explanatory summary."""
+    mock_jira_fetcher.get_embedded_images.return_value = {
+        "success": True,
+        "issue_key": "TEST-123",
+        "total": 0,
+        "images": [],
+        "failed": [],
+        "message": "No embedded images found",
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue_embedded_images", {"issue_key": "TEST-123"}
+    )
+
+    summary = json.loads(response.content[0].text)
+    assert summary["downloaded"] == 0
+    assert summary["message"] == "No embedded images found"
+    assert len(response.content) == 1
+
+
+@pytest.mark.anyio
+async def test_get_issue_embedded_images_failure(jira_client, mock_jira_fetcher):
+    """Fetcher failures are returned to the MCP client as text."""
+    mock_jira_fetcher.get_embedded_images.return_value = {
+        "success": False,
+        "error": "API unavailable",
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue_embedded_images", {"issue_key": "TEST-123"}
+    )
+
+    assert json.loads(response.content[0].text) == {
+        "success": False,
+        "error": "API unavailable",
+    }
+    assert len(response.content) == 1
 
 
 # --- Tests for input/output parameter name alignment ---

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 50, f"Expected 50 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

Adds a new `jira_get_issue_embedded_images` MCP tool that extracts images pasted directly into the Jira rich-text editor (description and comments) which are **not** discoverable via the standard attachments API.

## Problem

When users paste screenshots or images directly into the Jira editor, these are stored as internal `jeditor_file_provider` references in the rendered HTML. The existing `jira_download_attachments` tool only covers formal attachments — embedded images are invisible to LLM-based workflows.

## Solution

- **New mixin method** `get_embedded_images()` in `AttachmentsMixin` that:
  - Fetches the rendered HTML of the issue description and comments
  - Parses `<img>` tags pointing to Jira-internal URLs
  - Downloads images using the authenticated session
  - Returns base64-encoded image data with metadata
  - Skips images larger than 50 MB

- **New MCP tool** `jira_get_issue_embedded_images` that wraps the mixin method and returns `ImageContent` for LLM vision analysis.

## Files Changed

- `src/mcp_atlassian/jira/attachments.py` — new `get_embedded_images()` method
- `src/mcp_atlassian/servers/jira.py` — new tool registration
- `tests/unit/jira/test_embedded_images.py` — unit tests
