### PR TITLE
fix(confluence): handle ri:userkey and ri:username in user mentions

### DIFF
--- a/src/mcp_atlassian/confluence/users.py
+++ b/src/mcp_atlassian/confluence/users.py
@@ -51,6 +51,26 @@ class UsersMixin(ConfluenceClient):
         """
         return self.confluence.get_user_details_by_username(username, expand)
 
+    def get_user_details_by_userkey(
+        self, userkey: str, expand: str | None = None
+    ) -> dict[str, Any]:
+        """Get user details by userkey.
+
+        This is used for Confluence Server/DC instances where userkey
+        is the internal identifier for a user.
+
+        Args:
+            userkey: The userkey of the user.
+            expand: Optional expand for get status of user. Possible param is "status".
+
+        Returns:
+            User details as a dictionary.
+
+        Raises:
+            Various exceptions from the Atlassian API if user doesn't exist or if there are permission issues.
+        """
+        return self.confluence.get_user_details_by_userkey(userkey, expand)
+
     def get_current_user_info(self) -> dict[str, Any]:
         """
         Retrieve details for the currently authenticated user by calling Confluence's '/rest/api/user/current' endpoint.

--- a/src/mcp_atlassian/confluence/users.py
+++ b/src/mcp_atlassian/confluence/users.py
@@ -67,7 +67,8 @@ class UsersMixin(ConfluenceClient):
             User details as a dictionary.
 
         Raises:
-            Various exceptions from the Atlassian API if user doesn't exist or if there are permission issues.
+            Various exceptions from the Atlassian API if user doesn't exist or
+            if there are permission issues.
         """
         return self.confluence.get_user_details_by_userkey(userkey, expand)
 

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -74,6 +74,10 @@ class ConfluenceClient(Protocol):
         """Get user details by username (for Server/DC compatibility)."""
         ...
 
+    def get_user_details_by_userkey(self, userkey: str) -> dict[str, Any]:
+        """Get user details by userkey (for Server/DC compatibility)."""
+        ...
+
 
 class BasePreprocessor:
     """Base class for text preprocessing operations."""
@@ -137,6 +141,9 @@ class BasePreprocessor:
         """
         Process user mentions in BeautifulSoup object.
 
+        Handles both Cloud (ri:account-id) and Server/DC (ri:userkey,
+        ri:username) user reference formats.
+
         Args:
             soup: BeautifulSoup object containing HTML
             confluence_client: Optional Confluence client for user lookups
@@ -146,25 +153,26 @@ class BasePreprocessor:
 
         for user_element in user_mentions:
             user_ref = user_element.find("ri:user")
-            if user_ref and user_ref.get("ri:account-id"):
-                # Case 1: Direct user reference without link-body
-                account_id = user_ref.get("ri:account-id")
-                if isinstance(account_id, str):
-                    self._replace_user_mention(
-                        user_element, account_id, confluence_client
-                    )
-                    continue
+            if not user_ref:
+                continue
 
-            # Case 2: User reference with link-body containing @
-            link_body = user_element.find("ac:link-body")
-            if link_body and "@" in link_body.get_text(strip=True):
-                user_ref = user_element.find("ri:user")
-                if user_ref and user_ref.get("ri:account-id"):
-                    account_id = user_ref.get("ri:account-id")
-                    if isinstance(account_id, str):
-                        self._replace_user_mention(
-                            user_element, account_id, confluence_client
-                        )
+            account_id = user_ref.get("ri:account-id")
+            userkey = user_ref.get("ri:userkey")
+            username = user_ref.get("ri:username")
+
+            if account_id and isinstance(account_id, str):
+                # Cloud: use account-id
+                self._replace_user_mention(user_element, account_id, confluence_client)
+            elif userkey and isinstance(userkey, str):
+                # Server/DC: use userkey (internal key, needs /rest/api/user?key=)
+                self._replace_user_mention_by_userkey(
+                    user_element, userkey, confluence_client
+                )
+            elif username and isinstance(username, str):
+                # Server/DC fallback: use username
+                self._replace_user_mention_by_username(
+                    user_element, username, confluence_client
+                )
 
     def _process_user_profile_macros_in_soup(
         self, soup: BeautifulSoup, confluence_client: ConfluenceClient | None = None
@@ -201,8 +209,9 @@ class BasePreprocessor:
 
             account_id = user_ref.get("ri:account-id")
             userkey = user_ref.get("ri:userkey")  # Fallback for Confluence Server/DC
+            username = user_ref.get("ri:username")  # Fallback for older Server/DC
 
-            user_identifier_for_log = account_id or userkey
+            user_identifier_for_log = account_id or userkey or username
             display_name = None
 
             if confluence_client and user_identifier_for_log:
@@ -213,9 +222,15 @@ class BasePreprocessor:
                         )
                         display_name = user_details.get("displayName")
                     elif userkey and isinstance(userkey, str):
-                        # For Confluence Server/DC, userkey might be the username
-                        user_details = confluence_client.get_user_details_by_username(
+                        # For Confluence Server/DC, use userkey endpoint
+                        user_details = confluence_client.get_user_details_by_userkey(
                             userkey
+                        )
+                        display_name = user_details.get("displayName")
+                    elif username and isinstance(username, str):
+                        # For older Confluence Server/DC, use username endpoint
+                        user_details = confluence_client.get_user_details_by_username(
+                            username
                         )
                         display_name = user_details.get("displayName")
                 except Exception as e:
@@ -283,6 +298,61 @@ class BasePreprocessor:
         # Fallback: just use the account ID
         new_text = f"@user_{account_id}"
         user_element.replace_with(new_text)
+
+    def _replace_user_mention_by_userkey(
+        self,
+        user_element: Tag,
+        userkey: str,
+        confluence_client: ConfluenceClient | None = None,
+    ) -> None:
+        """
+        Replace a user mention using userkey (Server/DC).
+
+        Uses the /rest/api/user?key= endpoint to resolve the display name.
+
+        Args:
+            user_element: The HTML element containing the user mention
+            userkey: The user's internal userkey
+            confluence_client: Optional Confluence client for user lookups
+        """
+        try:
+            if confluence_client is not None:
+                user_details = confluence_client.get_user_details_by_userkey(userkey)
+                display_name = user_details.get("displayName", "")
+                if display_name:
+                    user_element.replace_with(f"@{display_name}")
+                    return
+            user_element.replace_with(f"@user_{userkey}")
+        except Exception as e:
+            logger.warning(f"Error processing user mention by userkey: {str(e)}")
+            user_element.replace_with(f"@user_{userkey}")
+
+    def _replace_user_mention_by_username(
+        self,
+        user_element: Tag,
+        username: str,
+        confluence_client: ConfluenceClient | None = None,
+    ) -> None:
+        """
+        Replace a user mention using username/userkey (Server/DC).
+
+        Args:
+            user_element: The HTML element containing the user mention
+            username: The user's username or userkey
+            confluence_client: Optional Confluence client for user lookups
+        """
+        try:
+            if confluence_client is not None:
+                user_details = confluence_client.get_user_details_by_username(username)
+                display_name = user_details.get("displayName", "")
+                if display_name:
+                    user_element.replace_with(f"@{display_name}")
+                    return
+            # Fallback: use the username directly
+            user_element.replace_with(f"@{username}")
+        except Exception as e:
+            logger.warning(f"Error processing user mention by username: {str(e)}")
+            user_element.replace_with(f"@{username}")
 
     def _find_attachment_url(
         self,

--- a/tests/unit/confluence/test_users.py
+++ b/tests/unit/confluence/test_users.py
@@ -1,5 +1,6 @@
 """Unit tests for the Confluence users module."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -223,6 +224,64 @@ class TestUsersMixin:
         )
         assert result == mock_user_data_server
 
+    def test_get_user_details_by_userkey_success(
+        self, users_mixin: Any, mock_user_data_server: dict[str, Any]
+    ) -> None:
+        """Test successfully getting user details by userkey."""
+        # Arrange
+        userkey = "testuser-key-12345"
+        users_mixin.confluence.get_user_details_by_userkey.return_value = (
+            mock_user_data_server
+        )
+
+        # Act
+        result = users_mixin.get_user_details_by_userkey(userkey)
+
+        # Assert
+        users_mixin.confluence.get_user_details_by_userkey.assert_called_once_with(
+            userkey, None
+        )
+        assert result == mock_user_data_server
+        assert result["userKey"] == userkey
+        assert result["displayName"] == "Test User"
+
+    def test_get_user_details_by_userkey_with_expand(
+        self, users_mixin: Any, mock_user_data_server: dict[str, Any]
+    ) -> None:
+        """Test getting user details by userkey with status expansion."""
+        # Arrange
+        userkey = "testuser-key-12345"
+        expand = "status"
+        mock_data_with_status = mock_user_data_server.copy()
+        mock_data_with_status["status"] = "Active"
+        users_mixin.confluence.get_user_details_by_userkey.return_value = (
+            mock_data_with_status
+        )
+
+        # Act
+        result = users_mixin.get_user_details_by_userkey(userkey, expand=expand)
+
+        # Assert
+        users_mixin.confluence.get_user_details_by_userkey.assert_called_once_with(
+            userkey, expand
+        )
+        assert result == mock_data_with_status
+        assert result["status"] == "Active"
+
+    def test_get_user_details_by_userkey_invalid_userkey(
+        self, users_mixin: Any
+    ) -> None:
+        """Test getting user details with invalid userkey."""
+        # Arrange
+        invalid_userkey = "nonexistent-user-key"
+        users_mixin.confluence.get_user_details_by_userkey.side_effect = Exception(
+            "User not found"
+        )
+
+        # Act/Assert
+        with pytest.raises(Exception, match="User not found"):
+            users_mixin.get_user_details_by_userkey(invalid_userkey)
+
     def test_get_current_user_info_success(self, users_mixin, mock_current_user_data):
         """Test successfully getting current user info."""
         # Arrange
@@ -394,6 +453,38 @@ class TestUsersMixin:
         )
         assert result == expected_data
 
+    @pytest.mark.parametrize(
+        "expand_param",
+        [
+            None,
+            "status",
+            "",  # Empty string
+        ],
+    )
+    def test_get_user_details_by_userkey_expand_parameter_handling(
+        self,
+        users_mixin: Any,
+        mock_user_data_server: dict[str, Any],
+        expand_param: str | None,
+    ) -> None:
+        """Test that expand parameter is properly handled for userkey lookup."""
+        # Arrange
+        userkey = "testuser-key-12345"
+        expected_data = mock_user_data_server.copy()
+        if expand_param == "status":
+            expected_data["status"] = "Active"
+
+        users_mixin.confluence.get_user_details_by_userkey.return_value = expected_data
+
+        # Act
+        result = users_mixin.get_user_details_by_userkey(userkey, expand_param)
+
+        # Assert
+        users_mixin.confluence.get_user_details_by_userkey.assert_called_once_with(
+            userkey, expand_param
+        )
+        assert result == expected_data
+
     def test_users_mixin_inheritance(self, users_mixin):
         """Test that UsersMixin properly inherits from ConfluenceClient."""
         # Verify that UsersMixin is indeed a ConfluenceClient
@@ -410,6 +501,7 @@ class TestUsersMixin:
         # Verify the mixin has the expected methods
         assert hasattr(UsersMixin, "get_user_details_by_accountid")
         assert hasattr(UsersMixin, "get_user_details_by_username")
+        assert hasattr(UsersMixin, "get_user_details_by_userkey")
         assert hasattr(UsersMixin, "get_current_user_info")
 
         # Verify method signatures
@@ -428,6 +520,14 @@ class TestUsersMixin:
         params = list(sig.parameters.keys())
         assert "self" in params
         assert "username" in params
+        assert "expand" in params
+        assert sig.parameters["expand"].default is None
+
+        # Check get_user_details_by_userkey signature
+        sig = inspect.signature(UsersMixin.get_user_details_by_userkey)
+        params = list(sig.parameters.keys())
+        assert "self" in params
+        assert "userkey" in params
         assert "expand" in params
         assert sig.parameters["expand"].default is None
 
@@ -560,6 +660,13 @@ class TestUsersMixin:
         users_mixin.get_user_details_by_username(username, expand)
         users_mixin.confluence.get_user_details_by_username.assert_called_with(
             username, expand
+        )
+
+        # Test userkey method delegation
+        userkey = "test-user-key"
+        users_mixin.get_user_details_by_userkey(userkey, expand)
+        users_mixin.confluence.get_user_details_by_userkey.assert_called_with(
+            userkey, expand
         )
 
         # Test current user method delegation - need to mock the return value

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -445,6 +445,34 @@ def process():
         assert "@Test User user789" in processed_markdown
         assert "@Test User admin" in processed_markdown
 
+    def test_confluence_user_mentions_serverdc_aclink(self, confluence_preprocessor):
+        """Test Server/DC user mentions via ac:link with ri:userkey and ri:username."""
+        html_content = """<p>Server/DC mention with userkey:</p>
+<ac:link>
+    <ri:user ri:userkey="8a286d85984c4df30198bc47dba33367"/>
+</ac:link>
+
+<p>Server/DC mention with username:</p>
+<ac:link>
+    <ri:user ri:username="test.user"/>
+</ac:link>
+
+<p>Cloud mention with account-id:</p>
+<ac:link>
+    <ri:user ri:account-id="5b10a2844c20165700ede21g"/>
+</ac:link>"""
+
+        processed_html, processed_markdown = (
+            confluence_preprocessor.process_html_content(html_content)
+        )
+
+        # Verify Server/DC userkey mention is resolved
+        assert "@Test User 8a286d85984c4df30198bc47dba33367" in processed_markdown
+        # Verify Server/DC username mention is resolved
+        assert "@Test User test.user" in processed_markdown
+        # Verify Cloud mention still works
+        assert "@Test User 5b10a2844c20165700ede21g" in processed_markdown
+
     def test_confluence_markdown_roundtrip(self, confluence_preprocessor):
         """Test Markdown to Confluence storage format and processing."""
         markdown_content = """# Main Title

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -462,16 +462,40 @@ def process():
     <ri:user ri:account-id="5b10a2844c20165700ede21g"/>
 </ac:link>"""
 
-        processed_html, processed_markdown = (
-            confluence_preprocessor.process_html_content(html_content)
+        class ServerDcUserClient:
+            def __init__(self) -> None:
+                self.account_ids: list[str] = []
+                self.userkeys: list[str] = []
+                self.usernames: list[str] = []
+
+            def get_user_details_by_accountid(self, account_id: str) -> dict[str, str]:
+                self.account_ids.append(account_id)
+                return {"displayName": f"Cloud User {account_id}"}
+
+            def get_user_details_by_userkey(self, userkey: str) -> dict[str, str]:
+                self.userkeys.append(userkey)
+                return {"displayName": f"Server Userkey {userkey}"}
+
+            def get_user_details_by_username(self, username: str) -> dict[str, str]:
+                self.usernames.append(username)
+                return {"displayName": f"Server Username {username}"}
+
+        client = ServerDcUserClient()
+        _processed_html, processed_markdown = (
+            confluence_preprocessor.process_html_content(
+                html_content, confluence_client=client
+            )
         )
 
         # Verify Server/DC userkey mention is resolved
-        assert "@Test User 8a286d85984c4df30198bc47dba33367" in processed_markdown
+        assert "@Server Userkey 8a286d85984c4df30198bc47dba33367" in processed_markdown
         # Verify Server/DC username mention is resolved
-        assert "@Test User test.user" in processed_markdown
+        assert "@Server Username test.user" in processed_markdown
         # Verify Cloud mention still works
-        assert "@Test User 5b10a2844c20165700ede21g" in processed_markdown
+        assert "@Cloud User 5b10a2844c20165700ede21g" in processed_markdown
+        assert client.userkeys == ["8a286d85984c4df30198bc47dba33367"]
+        assert client.usernames == ["test.user"]
+        assert client.account_ids == ["5b10a2844c20165700ede21g"]
 
     def test_confluence_markdown_roundtrip(self, confluence_preprocessor):
         """Test Markdown to Confluence storage format and processing."""

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -453,7 +453,7 @@ def test_process_confluence_profile_macro_fallback():
 
 
 def test_process_user_profile_macro_multiple():
-    """Test processing multiple User Profile Macros with account-id and userkey."""
+    """Test processing multiple User Profile Macros with account-id, userkey, and username."""
     from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
 
     html = (
@@ -468,6 +468,12 @@ def test_process_user_profile_macro_multiple():
         '<ac:parameter ac:name="user">'
         '<ri:user ri:userkey="test-userkey-456" />'
         "</ac:parameter>"
+        "</ac:structured-macro>. "
+        "And a third: "
+        '<ac:structured-macro ac:name="profile" ac:schema-version="1">'
+        '<ac:parameter ac:name="user">'
+        '<ri:user ri:username="test-username-789" />'
+        "</ac:parameter>"
         "</ac:structured-macro>."
         "</p>"
     )
@@ -480,10 +486,17 @@ def test_process_user_profile_macro_multiple():
                 else {}
             )
 
-        def get_user_details_by_username(self, username):
+        def get_user_details_by_userkey(self, userkey):
             return (
                 {"displayName": "Test User Two"}
-                if username == "test-userkey-456"
+                if userkey == "test-userkey-456"
+                else {}
+            )
+
+        def get_user_details_by_username(self, username):
+            return (
+                {"displayName": "Test User Three"}
+                if username == "test-username-789"
                 else {}
             )
 
@@ -493,8 +506,10 @@ def test_process_user_profile_macro_multiple():
     )
     assert "@Test User One" in processed_html
     assert "@Test User Two" in processed_html
+    assert "@Test User Three" in processed_html
     assert "@Test User One" in processed_markdown
     assert "@Test User Two" in processed_markdown
+    assert "@Test User Three" in processed_markdown
 
 
 def test_markdown_to_confluence_no_automatic_anchors():

--- a/tests/utils/mocks.py
+++ b/tests/utils/mocks.py
@@ -244,3 +244,11 @@ class MockConfluenceClient:
             "accountType": "atlassian",
             "accountStatus": "active",
         }
+
+    def get_user_details_by_userkey(self, userkey: str) -> dict[str, str]:
+        """Mock user details by userkey (Server/DC)."""
+        return {
+            "displayName": f"Test User {userkey}",
+            "accountType": "atlassian",
+            "accountStatus": "active",
+        }


### PR DESCRIPTION
## Description

Fixes Server/DC user mention resolution, a separate issue from #842 (which covers mention loss during Markdown round-trip on Cloud).
On Server/DC, `<ac:link>` mentions use `ri:userkey` or `ri:username` instead of `ri:account-id`. Two bugs existed:
1. `_process_user_mentions_in_soup` only handled `ri:account-id`, silently dropping Server/DC mentions
2. `_process_user_profile_macros_in_soup` passed `ri:userkey` to the wrong REST endpoint (`?username=` instead of `?key=`), causing 404s
Fixes: #1297
Related: #842

## Changes
- Added `get_user_details_by_userkey()` to `ConfluenceClient` protocol and `UsersMixin`, exposing the existing `atlassian-python-api` method
- Updated `_process_user_mentions_in_soup` to handle `ri:userkey` and `ri:username` in `<ac:link>` tags
- Updated `_process_user_profile_macros_in_soup` to use correct endpoint for `ri:userkey` and added `ri:username` support
- Added `_replace_user_mention_by_userkey` and `_replace_user_mention_by_username` methods

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: Verified against Confluence Server/DC instance with `ri:userkey` mentions resolving correctly via `/rest/api/user?key=`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
