### PR TITLE
Use v2 api for get page children

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -876,51 +876,83 @@ class PagesMixin(ConfluenceClient):
             List of ConfluencePage models containing the child pages and folders
         """
         try:
-            # Use the Atlassian Python API's get_page_child_by_type method
-            # First, get child pages
-            page_results = self.confluence.get_page_child_by_type(
-                page_id=page_id, type="page", start=start, limit=limit, expand=expand
-            )
-
-            # Handle both pagination modes for pages
-            if isinstance(page_results, dict) and "results" in page_results:
+            v2_adapter = self._v2_adapter
+            if v2_adapter:
+                logger.debug(
+                    "Using v2 API for OAuth authentication to get children "
+                    f"for '{page_id}'"
+                )
+                page_results = v2_adapter.get_page_direct_children(
+                    page_id=page_id,
+                    limit=limit,
+                    cursor=str(start) if start > 0 else None,
+                )
                 child_items = page_results.get("results", [])
+
+                if not include_folders:
+                    child_items = [
+                        item for item in child_items if item.get("type") == "page"
+                    ]
             else:
-                child_items = page_results or []
+                # Use the Atlassian Python API's get_page_child_by_type method
+                # First, get child pages
+                page_results = self.confluence.get_page_child_by_type(
+                    page_id=page_id,
+                    type="page",
+                    start=start,
+                    limit=limit,
+                    expand=expand,
+                )
 
-            # Also get child folders if requested
-            if include_folders:
-                try:
-                    folder_results = self.confluence.get_page_child_by_type(
-                        page_id=page_id,
-                        type="folder",
-                        start=start,
-                        limit=limit,
-                        expand=expand,
-                    )
+                # Handle both pagination modes for pages
+                if isinstance(page_results, dict) and "results" in page_results:
+                    child_items = page_results.get("results", [])
+                else:
+                    child_items = page_results or []
 
-                    # Handle both pagination modes for folders
-                    if isinstance(folder_results, dict) and "results" in folder_results:
-                        child_folders = folder_results.get("results", [])
-                    else:
-                        child_folders = folder_results or []
+                # Also get child folders if requested
+                if include_folders:
+                    try:
+                        folder_results = self.confluence.get_page_child_by_type(
+                            page_id=page_id,
+                            type="folder",
+                            start=start,
+                            limit=limit,
+                            expand=expand,
+                        )
 
-                    # Combine pages and folders
-                    child_items = child_items + child_folders
-                except Exception as folder_err:
-                    # Log but don't fail if folder fetching fails
-                    # (e.g., older Confluence versions might not support folders)
-                    logger.debug(
-                        f"Could not fetch child folders for page {page_id}: {folder_err}"
-                    )
+                        # Handle both pagination modes for folders
+                        if (
+                            isinstance(folder_results, dict)
+                            and "results" in folder_results
+                        ):
+                            child_folders = folder_results.get("results", [])
+                        else:
+                            child_folders = folder_results or []
+
+                        # Combine pages and folders
+                        child_items = child_items + child_folders
+                    except Exception as folder_err:
+                        # Log but don't fail if folder fetching fails
+                        # (e.g., older Confluence versions might not support folders)
+                        logger.debug(
+                            "Could not fetch child folders for page "
+                            f"{page_id}: {folder_err}"
+                        )
+
+            # Get space key from the first result if available
+            space_key = ""
+            if child_items:
+                first_item = child_items[0]
+                if "space" in first_item:
+                    space_key = first_item.get("space", {}).get("key", "")
+                elif expandable := first_item.get("_expandable", {}):
+                    if space_path := expandable.get("space"):
+                        if space_path.startswith("/rest/api/space/"):
+                            space_key = space_path.split("/rest/api/space/")[1]
 
             # Process results
             page_models = []
-            space_key = ""
-
-            # Get space key from the first result if available
-            if child_items and "space" in child_items[0]:
-                space_key = child_items[0].get("space", {}).get("key", "")
 
             # Process each child item (page or folder)
             for item in child_items:
@@ -944,6 +976,7 @@ class PagesMixin(ConfluenceClient):
                     include_body=True,
                     content_override=content_override,
                     content_format="markdown" if convert_to_markdown else "storage",
+                    is_cloud=self.config.is_cloud,
                 )
 
                 page_models.append(page_model)
@@ -953,7 +986,7 @@ class PagesMixin(ConfluenceClient):
         except Exception as e:
             logger.error(f"Error fetching child pages for page {page_id}: {str(e)}")
             logger.debug("Full exception details:", exc_info=True)
-            return []
+            raise
 
     @handle_auth_errors("Confluence API")
     def get_space_page_tree(

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -3,6 +3,7 @@
 import difflib
 import logging
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import requests
 from bs4 import BeautifulSoup, Tag
@@ -32,6 +33,134 @@ class PagesMixin(ConfluenceClient):
                 session=self.confluence._session, base_url=self.confluence.url
             )
         return None
+
+    @property
+    def _page_children_v2_adapter(self) -> ConfluenceV2Adapter | None:
+        """Get v2 API adapter for Cloud page-children lookups.
+
+        Returns:
+            ConfluenceV2Adapter instance for Cloud, None for Server/Data Center.
+        """
+        if self.config.is_cloud:
+            return ConfluenceV2Adapter(
+                session=self.confluence._session, base_url=self.confluence.url
+            )
+        return None
+
+    @staticmethod
+    def _v2_next_cursor(response: dict[str, Any]) -> str | None:
+        """Extract the next cursor from a Confluence v2 paginated response."""
+        links = response.get("_links", {})
+        if not isinstance(links, dict):
+            return None
+
+        next_link = links.get("next")
+        if not isinstance(next_link, str) or not next_link:
+            return None
+
+        cursor = parse_qs(urlparse(next_link).query).get("cursor", [None])[0]
+        return cursor or None
+
+    @staticmethod
+    def _is_requested_child_type(
+        item: dict[str, Any], *, include_folders: bool
+    ) -> bool:
+        """Return whether a v2 direct-child item matches the tool contract."""
+        item_type = item.get("type", "page")
+        return item_type == "page" or (include_folders and item_type == "folder")
+
+    def _get_v2_page_children_items(
+        self,
+        v2_adapter: ConfluenceV2Adapter,
+        page_id: str,
+        start: int,
+        limit: int,
+        expand: str,
+        *,
+        include_folders: bool,
+    ) -> list[dict[str, Any]]:
+        """Fetch v2 direct children while preserving the v1 start/limit contract."""
+        if limit <= 0:
+            return []
+
+        child_items: list[dict[str, Any]] = []
+        cursor: str | None = None
+        seen_cursors: set[str | None] = set()
+        items_to_skip = max(start, 0)
+
+        while len(child_items) < limit:
+            if cursor in seen_cursors:
+                logger.warning(
+                    "Stopping v2 child pagination for page '%s' after repeated "
+                    "cursor '%s'",
+                    page_id,
+                    cursor,
+                )
+                break
+            seen_cursors.add(cursor)
+
+            page_results = v2_adapter.get_page_direct_children(
+                page_id=page_id,
+                limit=limit,
+                cursor=cursor,
+            )
+            raw_items = page_results.get("results", [])
+            if not isinstance(raw_items, list):
+                break
+
+            requested_items = [
+                item
+                for item in raw_items
+                if isinstance(item, dict)
+                and self._is_requested_child_type(item, include_folders=include_folders)
+            ]
+
+            if items_to_skip:
+                if len(requested_items) <= items_to_skip:
+                    items_to_skip -= len(requested_items)
+                    cursor = self._v2_next_cursor(page_results)
+                    if not cursor:
+                        break
+                    continue
+
+                requested_items = requested_items[items_to_skip:]
+                items_to_skip = 0
+
+            remaining = limit - len(child_items)
+            child_items.extend(requested_items[:remaining])
+
+            if len(child_items) >= limit:
+                break
+
+            cursor = self._v2_next_cursor(page_results)
+            if not cursor:
+                break
+
+        if "body" in expand:
+            return self._enrich_v2_child_pages_with_content(v2_adapter, child_items)
+
+        return child_items
+
+    def _enrich_v2_child_pages_with_content(
+        self,
+        v2_adapter: ConfluenceV2Adapter,
+        child_items: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Fetch page details for v2 direct-child page items when body is requested."""
+        enriched_items: list[dict[str, Any]] = []
+
+        for item in child_items:
+            if item.get("type", "page") != "page" or not item.get("id"):
+                enriched_items.append(item)
+                continue
+
+            page = v2_adapter.get_page(
+                page_id=str(item["id"]),
+                expand="body.storage,version,space",
+            )
+            enriched_items.append({**item, **page})
+
+        return enriched_items
 
     @handle_auth_errors("Confluence API")
     def get_page_content(
@@ -876,23 +1005,17 @@ class PagesMixin(ConfluenceClient):
             List of ConfluencePage models containing the child pages and folders
         """
         try:
-            v2_adapter = self._v2_adapter
+            v2_adapter = self._page_children_v2_adapter
             if v2_adapter:
-                logger.debug(
-                    "Using v2 API for OAuth authentication to get children "
-                    f"for '{page_id}'"
-                )
-                page_results = v2_adapter.get_page_direct_children(
+                logger.debug(f"Using v2 API to get children for Cloud page '{page_id}'")
+                child_items = self._get_v2_page_children_items(
+                    v2_adapter=v2_adapter,
                     page_id=page_id,
+                    start=start,
                     limit=limit,
-                    cursor=str(start) if start > 0 else None,
+                    expand=expand,
+                    include_folders=include_folders,
                 )
-                child_items = page_results.get("results", [])
-
-                if not include_folders:
-                    child_items = [
-                        item for item in child_items if item.get("type") == "page"
-                    ]
             else:
                 # Use the Atlassian Python API's get_page_child_by_type method
                 # First, get child pages

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -253,14 +253,14 @@ class ConfluenceV2Adapter:
                 logger.error(f"Error updating page '{page_id}': {e}")
             raise ValueError(f"Failed to update page '{page_id}': {e}") from e
 
-    def _get_space_key_from_id(self, space_id: str) -> str:
-        """Get space key from space ID using v2 API.
+    def _get_space_from_id(self, space_id: str) -> dict[str, str]:
+        """Get space metadata from space ID using v2 API.
 
         Args:
             space_id: The space ID to look up
 
         Returns:
-            The space key
+            Space metadata containing at least ``id`` and ``key``.
 
         Raises:
             ValueError: If space not found or API error
@@ -272,13 +272,17 @@ class ConfluenceV2Adapter:
             response = self.session.get(url)
             response.raise_for_status()
 
-            data = response.json()
+            data: dict[str, Any] = response.json()
             space_key = data.get("key")
 
             if not space_key:
                 raise ValueError(f"No key found for space ID '{space_id}'")
 
-            return space_key
+            return {
+                "id": space_id,
+                "key": str(space_key),
+                "name": str(data.get("name") or f"Space {space_key}"),
+            }
 
         except Exception as e:
             if isinstance(e, HTTPError) and e.response is not None:
@@ -289,7 +293,11 @@ class ConfluenceV2Adapter:
             else:
                 logger.error(f"Error getting space key for ID '{space_id}': {e}")
             # Return the space_id as fallback
-            return space_id
+            return {"id": space_id, "key": space_id, "name": f"Space {space_id}"}
+
+    def _get_space_key_from_id(self, space_id: str) -> str:
+        """Get space key from space ID using v2 API."""
+        return self._get_space_from_id(space_id)["key"]
 
     def get_page(
         self,
@@ -353,6 +361,82 @@ class ConfluenceV2Adapter:
             else:
                 logger.error(f"Error getting page '{page_id}': {e}")
             raise ValueError(f"Failed to get page '{page_id}': {e}") from e
+
+    def get_page_direct_children(
+        self,
+        page_id: str,
+        *,
+        limit: int | None = None,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Get a page's direct children using the v2 API.
+
+        Args:
+            page_id: The ID of the page whose direct children to retrieve.
+            limit: Optional maximum number of direct children to return.
+            cursor: Optional pagination cursor.
+
+        Returns:
+            The direct-children response from the v2 API.
+
+        Raises:
+            ValueError: If the request fails.
+        """
+        try:
+            url = f"{self.base_url}/api/v2/pages/{page_id}/direct-children"
+            params: dict[str, Any] = {}
+
+            if limit is not None:
+                params["limit"] = limit
+            if cursor is not None:
+                params["cursor"] = cursor
+
+            response = self.session.get(url, params=params or None)
+            response.raise_for_status()
+
+            logger.debug(
+                "Successfully retrieved direct children for page "
+                f"'{page_id}' with v2 API"
+            )
+
+            data: dict[str, Any] = response.json()
+            results = data.get("results", [])
+            if isinstance(results, list):
+                spaces_by_id: dict[str, dict[str, str]] = {}
+                normalized_results: list[dict[str, Any]] = []
+
+                for item in results:
+                    if not isinstance(item, dict):
+                        continue
+
+                    normalized_item = dict(item)
+                    space_id = normalized_item.get("spaceId")
+
+                    if space_id is not None and str(space_id):
+                        space_id_str = str(space_id)
+                        if space_id_str not in spaces_by_id:
+                            spaces_by_id[space_id_str] = self._get_space_from_id(
+                                space_id_str
+                            )
+
+                        normalized_item["space"] = spaces_by_id[space_id_str]
+
+                    normalized_results.append(normalized_item)
+
+                data["results"] = normalized_results
+
+            return data
+
+        except Exception as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                logger.error(
+                    f"HTTP error getting direct children for page '{page_id}': {e}\n"
+                    f"Response: {e.response.text}"
+                )
+            else:
+                logger.error(f"Error getting direct children for page '{page_id}': {e}")
+            error_msg = f"Failed to get direct children for page '{page_id}': {e}"
+            raise ValueError(error_msg) from e
 
     def delete_page(self, page_id: str) -> bool:
         """Delete a page using the v2 API.

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -1,8 +1,7 @@
-"""Confluence REST API v2 adapter for OAuth authentication.
+"""Confluence REST API v2 adapter.
 
-This module provides direct v2 API calls to handle the deprecated v1 endpoints
-when using OAuth authentication. The v1 endpoints have been removed for OAuth
-but still work for API token authentication.
+This module provides direct v2 API calls for Cloud endpoints where the
+corresponding v1 endpoints are deprecated or unavailable.
 """
 
 import logging
@@ -17,7 +16,7 @@ logger = logging.getLogger("mcp-atlassian")
 
 
 class ConfluenceV2Adapter:
-    """Adapter for Confluence REST API v2 operations when using OAuth."""
+    """Adapter for Confluence REST API v2 operations."""
 
     def __init__(self, session: requests.Session, base_url: str) -> None:
         """Initialize the v2 adapter.
@@ -400,6 +399,21 @@ class ConfluenceV2Adapter:
             )
 
             data: dict[str, Any] = response.json()
+            response_links = getattr(response, "links", None)
+            if isinstance(response_links, dict):
+                next_link_data = response_links.get("next", {})
+                next_link = (
+                    next_link_data.get("url")
+                    if isinstance(next_link_data, dict)
+                    else None
+                )
+                if next_link:
+                    links = data.get("_links", {})
+                    if not isinstance(links, dict):
+                        links = {}
+                    links.setdefault("next", next_link)
+                    data["_links"] = links
+
             results = data.get("results", [])
             if isinstance(results, list):
                 spaces_by_id: dict[str, dict[str, str]] = {}

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -136,14 +136,22 @@ class ConfluencePage(ApiModel, TimestampMixin):
 
         # Extract space information first to ensure it's available for URL construction
         space_data = data.get("space", {})
-        if not space_data:
-            # Try to extract space info from _expandable if available
+        if not isinstance(space_data, dict):
+            space_data = {}
+
+        # Some child/list endpoints return partial space objects, such as
+        # {"id": "123"}, which would otherwise suppress the _expandable fallback.
+        if not space_data.get("key"):
             if expandable := data.get("_expandable", {}):
                 if space_path := expandable.get("space"):
                     # Extract space key from REST API path
                     if space_path.startswith("/rest/api/space/"):
                         space_key = space_path.split("/rest/api/space/")[1]
-                        space_data = {"key": space_key, "name": f"Space {space_key}"}
+                        space_data = {
+                            **space_data,
+                            "key": space_key,
+                            "name": space_data.get("name") or f"Space {space_key}",
+                        }
 
         # Create space model
         space = ConfluenceSpace.from_api_response(space_data)

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -326,7 +326,12 @@ async def get_page_children(
             convert_to_markdown=convert_to_markdown,
             include_folders=include_folders,
         )
-        child_pages = [page.to_simplified_dict() for page in pages]
+        child_pages = []
+        for page in pages:
+            child_page = page.to_simplified_dict()
+            child_page.pop("space", None)
+            child_page.pop("url", None)
+            child_pages.append(child_page)
         result = {
             "parent_id": parent_id,
             "count": len(child_pages),

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -326,12 +326,7 @@ async def get_page_children(
             convert_to_markdown=convert_to_markdown,
             include_folders=include_folders,
         )
-        child_pages = []
-        for page in pages:
-            child_page = page.to_simplified_dict()
-            child_page.pop("space", None)
-            child_page.pop("url", None)
-            child_pages.append(child_page)
+        child_pages = [page.to_simplified_dict() for page in pages]
         result = {
             "parent_id": parent_id,
             "count": len(child_pages),

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from pathlib import Path
 
@@ -143,6 +144,18 @@ class TestConfluenceCloudPageHierarchy:
         )
         resource_tracker.add_confluence_page(child.id)
         assert child.id is not None
+
+        children = []
+        for _ in range(6):
+            children = confluence_fetcher.get_page_children(
+                page_id=parent.id,
+                include_folders=False,
+            )
+            if any(page.id == child.id for page in children):
+                break
+            time.sleep(2)
+
+        assert any(page.id == child.id for page in children)
 
 
 class TestConfluenceCloudLabels:

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from pathlib import Path
 
@@ -127,6 +128,18 @@ class TestConfluenceDCPageHierarchy:
         )
         resource_tracker.add_confluence_page(child.id)
         assert child.id is not None
+
+        children = []
+        for _ in range(6):
+            children = confluence_fetcher.get_page_children(
+                page_id=parent.id,
+                include_folders=False,
+            )
+            if any(page.id == child.id for page in children):
+                break
+            time.sleep(2)
+
+        assert any(page.id == child.id for page in children)
 
 
 class TestConfluenceDCLabels:

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -478,7 +478,7 @@ class TestPagesMixin:
         """Test successfully getting child pages and folders."""
         # Arrange
         parent_id = "123456"
-        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+        pages_mixin.config.url = "https://confluence.example.com"
 
         # Mock the response from get_page_child_by_type for pages
         child_pages_data = {
@@ -540,7 +540,7 @@ class TestPagesMixin:
         """Test getting child pages only (without folders)."""
         # Arrange
         parent_id = "123456"
-        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+        pages_mixin.config.url = "https://confluence.example.com"
 
         # Mock the response from get_page_child_by_type
         child_pages_data = {
@@ -573,7 +573,7 @@ class TestPagesMixin:
         """Test getting child pages with content."""
         # Arrange
         parent_id = "123456"
-        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+        pages_mixin.config.url = "https://confluence.example.com"
 
         # Mock the response with body content
         child_pages_data = {
@@ -620,6 +620,7 @@ class TestPagesMixin:
         """Test getting child pages when there are none."""
         # Arrange
         parent_id = "123456"
+        pages_mixin.config.url = "https://confluence.example.com"
 
         # Mock empty response for both pages and folders
         pages_mixin.confluence.get_page_child_by_type.return_value = {"results": []}
@@ -634,6 +635,7 @@ class TestPagesMixin:
         """Test error handling when getting child pages."""
         # Arrange
         parent_id = "123456"
+        pages_mixin.config.url = "https://confluence.example.com"
 
         # Mock an exception on the first call (pages)
         pages_mixin.confluence.get_page_child_by_type.side_effect = Exception(
@@ -674,7 +676,7 @@ class TestPagesMixin:
         }
 
         with patch.object(
-            PagesMixin, "_v2_adapter", new_callable=PropertyMock
+            PagesMixin, "_page_children_v2_adapter", new_callable=PropertyMock
         ) as mock_prop:
             mock_prop.return_value = mock_v2_adapter
             results = pages_mixin.get_page_children(page_id=parent_id, limit=10)
@@ -694,6 +696,47 @@ class TestPagesMixin:
             "https://example.atlassian.net/wiki/spaces/TEST/pages/789012"
         )
 
+    def test_get_page_children_cloud_basic_uses_v2_direct_children(self, pages_mixin):
+        """Test all Cloud auth modes use the v2 direct-children endpoint."""
+        parent_id = "123456"
+        pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
+        pages_mixin.config.auth_type = "basic"
+        pages_mixin.config.is_cloud = True
+        pages_mixin.confluence.url = "https://example.atlassian.net/wiki"
+
+        mock_v2_adapter = MagicMock()
+        mock_v2_adapter.get_page_direct_children.return_value = {
+            "results": [
+                {
+                    "id": "789012",
+                    "title": "Child Page 1",
+                    "type": "page",
+                    "space": {"id": "42", "key": "TEST", "name": "Test Space"},
+                    "spaceId": "42",
+                    "status": "current",
+                }
+            ]
+        }
+
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceV2Adapter",
+            return_value=mock_v2_adapter,
+        ) as adapter_cls:
+            results = pages_mixin.get_page_children(page_id=parent_id, limit=10)
+
+        adapter_cls.assert_called_once_with(
+            session=pages_mixin.confluence._session,
+            base_url="https://example.atlassian.net/wiki",
+        )
+        mock_v2_adapter.get_page_direct_children.assert_called_once_with(
+            page_id=parent_id,
+            limit=10,
+            cursor=None,
+        )
+        pages_mixin.confluence.get_page_child_by_type.assert_not_called()
+        assert len(results) == 1
+        assert results[0].id == "789012"
+
     def test_get_page_children_cloud_filters_folders_when_disabled(self, pages_mixin):
         """Test Cloud OAuth child lookup filters folders client-side."""
         pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
@@ -709,7 +752,7 @@ class TestPagesMixin:
         }
 
         with patch.object(
-            PagesMixin, "_v2_adapter", new_callable=PropertyMock
+            PagesMixin, "_page_children_v2_adapter", new_callable=PropertyMock
         ) as mock_prop:
             mock_prop.return_value = mock_v2_adapter
             results = pages_mixin.get_page_children(
@@ -718,6 +761,129 @@ class TestPagesMixin:
 
         assert len(results) == 1
         assert results[0].type == "page"
+
+    def test_get_page_children_cloud_filters_to_pages_and_folders(self, pages_mixin):
+        """Test v2 direct children keep the tool scoped to pages and folders."""
+        pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
+        pages_mixin.config.auth_type = "oauth"
+        pages_mixin.config.is_cloud = True
+
+        mock_v2_adapter = MagicMock()
+        mock_v2_adapter.get_page_direct_children.return_value = {
+            "results": [
+                {"id": "1", "title": "Page Child", "type": "page"},
+                {"id": "2", "title": "Database Child", "type": "database"},
+                {"id": "3", "title": "Folder Child", "type": "folder"},
+                {"id": "4", "title": "Whiteboard Child", "type": "whiteboard"},
+            ]
+        }
+
+        with patch.object(
+            PagesMixin, "_page_children_v2_adapter", new_callable=PropertyMock
+        ) as mock_prop:
+            mock_prop.return_value = mock_v2_adapter
+            results = pages_mixin.get_page_children(page_id="123456")
+
+        assert [page.id for page in results] == ["1", "3"]
+        assert [page.type for page in results] == ["page", "folder"]
+
+    def test_get_page_children_cloud_emulates_start_with_v2_cursor(self, pages_mixin):
+        """Test numeric start pagination is translated to v2 cursor traversal."""
+        pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
+        pages_mixin.config.auth_type = "oauth"
+        pages_mixin.config.is_cloud = True
+
+        mock_v2_adapter = MagicMock()
+        mock_v2_adapter.get_page_direct_children.side_effect = [
+            {
+                "results": [
+                    {"id": "1", "title": "First", "type": "page"},
+                    {"id": "2", "title": "Second", "type": "page"},
+                ],
+                "_links": {
+                    "next": ("/wiki/api/v2/pages/123456/direct-children?cursor=abc123")
+                },
+            },
+            {
+                "results": [
+                    {"id": "3", "title": "Third", "type": "page"},
+                    {"id": "4", "title": "Fourth", "type": "page"},
+                ],
+            },
+        ]
+
+        with patch.object(
+            PagesMixin, "_page_children_v2_adapter", new_callable=PropertyMock
+        ) as mock_prop:
+            mock_prop.return_value = mock_v2_adapter
+            results = pages_mixin.get_page_children(page_id="123456", start=1, limit=2)
+
+        assert [page.id for page in results] == ["2", "3"]
+        assert mock_v2_adapter.get_page_direct_children.call_args_list[0].kwargs == {
+            "page_id": "123456",
+            "limit": 2,
+            "cursor": None,
+        }
+        assert mock_v2_adapter.get_page_direct_children.call_args_list[1].kwargs == {
+            "page_id": "123456",
+            "limit": 2,
+            "cursor": "abc123",
+        }
+
+    def test_get_page_children_cloud_fetches_page_content_when_requested(
+        self, pages_mixin
+    ):
+        """Test v2 direct children fetch page details when body content is requested."""
+        pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
+        pages_mixin.config.auth_type = "oauth"
+        pages_mixin.config.is_cloud = True
+
+        mock_v2_adapter = MagicMock()
+        mock_v2_adapter.get_page_direct_children.return_value = {
+            "results": [
+                {
+                    "id": "789012",
+                    "title": "Child Page",
+                    "type": "page",
+                    "space": {"id": "42", "key": "TEST", "name": "Test Space"},
+                    "spaceId": "42",
+                    "status": "current",
+                }
+            ]
+        }
+        mock_v2_adapter.get_page.return_value = {
+            "id": "789012",
+            "title": "Child Page",
+            "type": "page",
+            "space": {"id": "42", "key": "TEST", "name": "Test Space"},
+            "body": {"storage": {"value": "<p>Cloud content</p>"}},
+            "version": {"number": 1},
+        }
+        pages_mixin.preprocessor.process_html_content.return_value = (
+            "<p>Cloud content</p>",
+            "Cloud content",
+        )
+
+        with patch.object(
+            PagesMixin, "_page_children_v2_adapter", new_callable=PropertyMock
+        ) as mock_prop:
+            mock_prop.return_value = mock_v2_adapter
+            results = pages_mixin.get_page_children(
+                page_id="123456", expand="body.storage"
+            )
+
+        assert len(results) == 1
+        assert results[0].content == "Cloud content"
+        mock_v2_adapter.get_page.assert_called_once_with(
+            page_id="789012",
+            expand="body.storage,version,space",
+        )
+        pages_mixin.preprocessor.process_html_content.assert_called_once_with(
+            "<p>Cloud content</p>",
+            space_key="TEST",
+            confluence_client=pages_mixin.confluence,
+            content_id="789012",
+        )
 
     def test_get_page_children_cloud_partial_space_uses_expandable_fallback(
         self, pages_mixin
@@ -742,7 +908,7 @@ class TestPagesMixin:
         }
 
         with patch.object(
-            PagesMixin, "_v2_adapter", new_callable=PropertyMock
+            PagesMixin, "_page_children_v2_adapter", new_callable=PropertyMock
         ) as mock_prop:
             mock_prop.return_value = mock_v2_adapter
             results = pages_mixin.get_page_children(page_id="123456")
@@ -758,7 +924,7 @@ class TestPagesMixin:
         """Test that folder fetch errors don't fail the whole operation."""
         # Arrange
         parent_id = "123456"
-        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+        pages_mixin.config.url = "https://confluence.example.com"
 
         # Mock pages success, folders failure
         child_pages_data = {

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -1,6 +1,6 @@
 """Unit tests for the PagesMixin class."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -640,11 +640,119 @@ class TestPagesMixin:
             "API Error"
         )
 
-        # Act
-        results = pages_mixin.get_page_children(page_id=parent_id)
+        # Act/Assert
+        with pytest.raises(Exception, match="API Error"):
+            pages_mixin.get_page_children(page_id=parent_id)
 
-        # Assert - should return empty list on error, not raise exception
-        assert len(results) == 0
+    def test_get_page_children_cloud_uses_v2_direct_children(self, pages_mixin):
+        """Test Cloud OAuth child lookup uses the v2 direct-children endpoint."""
+        parent_id = "123456"
+        pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
+        pages_mixin.config.auth_type = "oauth"
+        pages_mixin.config.is_cloud = True
+
+        mock_v2_adapter = MagicMock()
+        mock_v2_adapter.get_page_direct_children.return_value = {
+            "results": [
+                {
+                    "id": "789012",
+                    "title": "Child Page 1",
+                    "type": "page",
+                    "space": {"id": "42", "key": "TEST", "name": "Test Space"},
+                    "spaceId": "42",
+                    "status": "current",
+                },
+                {
+                    "id": "111222",
+                    "title": "Child Folder 1",
+                    "type": "folder",
+                    "space": {"id": "42", "key": "TEST", "name": "Test Space"},
+                    "spaceId": "42",
+                    "status": "current",
+                },
+            ]
+        }
+
+        with patch.object(
+            PagesMixin, "_v2_adapter", new_callable=PropertyMock
+        ) as mock_prop:
+            mock_prop.return_value = mock_v2_adapter
+            results = pages_mixin.get_page_children(page_id=parent_id, limit=10)
+
+        mock_v2_adapter.get_page_direct_children.assert_called_once_with(
+            page_id=parent_id,
+            limit=10,
+            cursor=None,
+        )
+        assert len(results) == 2
+        assert results[0].type == "page"
+        assert results[1].type == "folder"
+        assert results[0].space is not None
+        assert results[0].space.key == "TEST"
+        assert results[0].space.name == "Test Space"
+        assert results[0].url == (
+            "https://example.atlassian.net/wiki/spaces/TEST/pages/789012"
+        )
+
+    def test_get_page_children_cloud_filters_folders_when_disabled(self, pages_mixin):
+        """Test Cloud OAuth child lookup filters folders client-side."""
+        pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
+        pages_mixin.config.auth_type = "oauth"
+        pages_mixin.config.is_cloud = True
+
+        mock_v2_adapter = MagicMock()
+        mock_v2_adapter.get_page_direct_children.return_value = {
+            "results": [
+                {"id": "1", "title": "Page Child", "type": "page"},
+                {"id": "2", "title": "Folder Child", "type": "folder"},
+            ]
+        }
+
+        with patch.object(
+            PagesMixin, "_v2_adapter", new_callable=PropertyMock
+        ) as mock_prop:
+            mock_prop.return_value = mock_v2_adapter
+            results = pages_mixin.get_page_children(
+                page_id="123456", include_folders=False
+            )
+
+        assert len(results) == 1
+        assert results[0].type == "page"
+
+    def test_get_page_children_cloud_partial_space_uses_expandable_fallback(
+        self, pages_mixin
+    ):
+        """Test partial space payloads still produce correct Cloud space metadata."""
+        pages_mixin.config = MagicMock(url="https://example.atlassian.net/wiki")
+        pages_mixin.config.auth_type = "oauth"
+        pages_mixin.config.is_cloud = True
+
+        mock_v2_adapter = MagicMock()
+        mock_v2_adapter.get_page_direct_children.return_value = {
+            "results": [
+                {
+                    "id": "2645262347",
+                    "title": "AS_008 Import",
+                    "type": "page",
+                    "status": "current",
+                    "space": {"id": "42"},
+                    "_expandable": {"space": "/rest/api/space/IOT"},
+                }
+            ]
+        }
+
+        with patch.object(
+            PagesMixin, "_v2_adapter", new_callable=PropertyMock
+        ) as mock_prop:
+            mock_prop.return_value = mock_v2_adapter
+            results = pages_mixin.get_page_children(page_id="123456")
+
+        assert len(results) == 1
+        assert results[0].space is not None
+        assert results[0].space.key == "IOT"
+        assert results[0].url == (
+            "https://example.atlassian.net/wiki/spaces/IOT/pages/2645262347"
+        )
 
     def test_get_page_children_folder_error_graceful(self, pages_mixin):
         """Test that folder fetch errors don't fail the whole operation."""

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -148,7 +148,9 @@ class TestConfluenceV2Adapter:
         # Verify we still get a result
         assert result["id"] == "123456"
 
-    def test_get_page_direct_children_resolves_space_key(self, v2_adapter, mock_session):
+    def test_get_page_direct_children_resolves_space_key(
+        self, v2_adapter, mock_session
+    ):
         """Test v2 direct children are normalized with space metadata."""
         children_response = Mock()
         children_response.status_code = 200
@@ -179,7 +181,9 @@ class TestConfluenceV2Adapter:
         }
         assert mock_session.get.call_count == 2
 
-    def test_get_page_direct_children_handles_repeated_space_ids(self, v2_adapter, mock_session):
+    def test_get_page_direct_children_handles_repeated_space_ids(
+        self, v2_adapter, mock_session
+    ):
         """Test v2 direct children resolve each space ID once."""
         children_response = Mock()
         children_response.status_code = 200
@@ -203,7 +207,9 @@ class TestConfluenceV2Adapter:
         assert result["results"][0]["space"]["name"] == "Test Space"
         assert mock_session.get.call_count == 2
 
-    def test_get_page_direct_children_handles_numeric_space_id(self, v2_adapter, mock_session):
+    def test_get_page_direct_children_handles_numeric_space_id(
+        self, v2_adapter, mock_session
+    ):
         """Test numeric space IDs are normalized before lookup."""
         children_response = Mock()
         children_response.status_code = 200

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -148,6 +148,92 @@ class TestConfluenceV2Adapter:
         # Verify we still get a result
         assert result["id"] == "123456"
 
+    def test_get_page_direct_children_resolves_space_key(self, v2_adapter, mock_session):
+        """Test v2 direct children are normalized with space metadata."""
+        children_response = Mock()
+        children_response.status_code = 200
+        children_response.json.return_value = {
+            "results": [
+                {
+                    "id": "123456",
+                    "status": "current",
+                    "title": "Child Page",
+                    "type": "page",
+                    "spaceId": "789",
+                }
+            ]
+        }
+
+        space_response = Mock()
+        space_response.status_code = 200
+        space_response.json.return_value = {"key": "TEST", "name": "Test Space"}
+
+        mock_session.get.side_effect = [children_response, space_response]
+
+        result = v2_adapter.get_page_direct_children("999")
+
+        assert result["results"][0]["space"] == {
+            "id": "789",
+            "key": "TEST",
+            "name": "Test Space",
+        }
+        assert mock_session.get.call_count == 2
+
+    def test_get_page_direct_children_handles_repeated_space_ids(self, v2_adapter, mock_session):
+        """Test v2 direct children resolve each space ID once."""
+        children_response = Mock()
+        children_response.status_code = 200
+        children_response.json.return_value = {
+            "results": [
+                {"id": "1", "title": "A", "type": "page", "spaceId": "789"},
+                {"id": "2", "title": "B", "type": "folder", "spaceId": "789"},
+            ]
+        }
+
+        space_response = Mock()
+        space_response.status_code = 200
+        space_response.json.return_value = {"key": "TEST", "name": "Test Space"}
+
+        mock_session.get.side_effect = [children_response, space_response]
+
+        result = v2_adapter.get_page_direct_children("999")
+
+        assert result["results"][0]["space"]["key"] == "TEST"
+        assert result["results"][1]["space"]["key"] == "TEST"
+        assert result["results"][0]["space"]["name"] == "Test Space"
+        assert mock_session.get.call_count == 2
+
+    def test_get_page_direct_children_handles_numeric_space_id(self, v2_adapter, mock_session):
+        """Test numeric space IDs are normalized before lookup."""
+        children_response = Mock()
+        children_response.status_code = 200
+        children_response.json.return_value = {
+            "results": [
+                {
+                    "id": "123456",
+                    "status": "current",
+                    "title": "Child Page",
+                    "type": "page",
+                    "spaceId": 789,
+                }
+            ]
+        }
+
+        space_response = Mock()
+        space_response.status_code = 200
+        space_response.json.return_value = {"key": "TEST", "name": "Test Space"}
+
+        mock_session.get.side_effect = [children_response, space_response]
+
+        result = v2_adapter.get_page_direct_children("999")
+
+        assert result["results"][0]["space"] == {
+            "id": "789",
+            "key": "TEST",
+            "name": "Test Space",
+        }
+        assert mock_session.get.call_args_list[1][0][0].endswith("/api/v2/spaces/789")
+
     @pytest.mark.parametrize(
         "method,call_kwargs,expected_path",
         [

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -240,6 +240,30 @@ class TestConfluenceV2Adapter:
         }
         assert mock_session.get.call_args_list[1][0][0].endswith("/api/v2/spaces/789")
 
+    def test_get_page_direct_children_preserves_next_link_header(
+        self, v2_adapter, mock_session
+    ):
+        """Test v2 pagination can use the response Link header."""
+        children_response = Mock()
+        children_response.status_code = 200
+        children_response.links = {
+            "next": {
+                "url": (
+                    "https://example.atlassian.net/wiki/api/v2/pages/999/"
+                    "direct-children?cursor=next-token"
+                )
+            }
+        }
+        children_response.json.return_value = {
+            "results": [{"id": "123456", "status": "current", "title": "Child Page"}]
+        }
+
+        mock_session.get.return_value = children_response
+
+        result = v2_adapter.get_page_direct_children("999")
+
+        assert result["_links"]["next"].endswith("cursor=next-token")
+
     @pytest.mark.parametrize(
         "method,call_kwargs,expected_path",
         [

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -32,6 +32,7 @@ def mock_confluence_fetcher():
         "id": "123456",
         "title": "Test Page Mock Title",
         "url": "https://example.atlassian.net/wiki/spaces/TEST/pages/123456/Test+Page",
+        "space": {"key": "TEST", "name": "Test Space"},
         "content": {
             "value": "This is a test page content in Markdown",
             "format": "markdown",
@@ -463,8 +464,13 @@ async def test_get_page_children(client, mock_confluence_fetcher):
     assert "results" in result_data
     assert len(result_data["results"]) > 0
     assert result_data["results"][0]["title"] == "Test Page Mock Title"
-    assert "space" not in result_data["results"][0]
-    assert "url" not in result_data["results"][0]
+    assert result_data["results"][0]["space"] == {
+        "key": "TEST",
+        "name": "Test Space",
+    }
+    assert result_data["results"][0]["url"] == (
+        "https://example.atlassian.net/wiki/spaces/TEST/pages/123456/Test+Page"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -463,6 +463,8 @@ async def test_get_page_children(client, mock_confluence_fetcher):
     assert "results" in result_data
     assert len(result_data["results"]) > 0
     assert result_data["results"][0]["title"] == "Test Page Mock Title"
+    assert "space" not in result_data["results"][0]
+    assert "url" not in result_data["results"][0]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

This PR fixes the empty page children bug for Confluence Cloud instances.

Fixes: #1303

## Changes

* Raise error on failures instead of returning an empty result set
* Use v2 API for Confluence Cloud. Use v1 for data center.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
