### PR TITLE
feat(jira): support [~accountid:UUID] mention syntax in markdown_to_adf

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -14,21 +14,28 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
     """Parse inline Markdown formatting into ADF inline nodes.
 
     Handles: bold (**), italic (*), inline code (`), links ([text](url)),
-    and strikethrough (~~).
+    strikethrough (~~), and Jira-flavored user mentions
+    ([~accountid:ACCOUNT_ID]).
+
+    The mention syntax mirrors what Jira's v2 wiki text returns when a real
+    ADF mention is read back, so the read and write paths are symmetric.
 
     Args:
         text: Raw text potentially containing inline Markdown formatting.
 
     Returns:
-        List of ADF inline nodes (text nodes with optional marks).
+        List of ADF inline nodes (text nodes with optional marks, plus
+        mention nodes when [~accountid:...] is present).
     """
     if not text:
         return []
 
     nodes: list[dict[str, Any]] = []
-    # Pattern order matters: bold before italic, code before others
+    # Pattern order matters: mention before link (both start with `[`),
+    # bold before italic, code before others
     inline_re = re.compile(
-        r"`(?P<code_inner>[^`]+)`"
+        r"\[~accountid:(?P<mention_id>[^\]]+)\]"
+        r"|`(?P<code_inner>[^`]+)`"
         r"|\*\*(?P<bold_inner>.+?)\*\*"
         r"|~~(?P<strike_inner>.+?)~~"
         r"|\[(?P<link_text>[^\]]+)\]\((?P<link_href>[^)]+)\)"
@@ -43,7 +50,14 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
             if plain:
                 nodes.append({"type": "text", "text": plain})
 
-        if m.group("code_inner") is not None:
+        if m.group("mention_id") is not None:
+            nodes.append(
+                {
+                    "type": "mention",
+                    "attrs": {"id": m.group("mention_id")},
+                }
+            )
+        elif m.group("code_inner") is not None:
             nodes.append(
                 {
                     "type": "text",

--- a/tests/e2e/cloud/test_adf_write.py
+++ b/tests/e2e/cloud/test_adf_write.py
@@ -296,3 +296,63 @@ class TestADFUpdateAndComment:
             assert comment_data.get("id") or comment_data.get("body")
         finally:
             await _delete_issue(mcp_client, key)
+
+    async def test_add_comment_accountid_mention(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """[~accountid:...] comment syntax creates a real Cloud mention."""
+        profile_result = await call_tool(
+            mcp_client,
+            "jira_get_user_profile",
+            {"user_identifier": "me"},
+        )
+        assert not profile_result.is_error
+        assert isinstance(profile_result.content[0], TextContent)
+        profile_data = json.loads(profile_result.content[0].text)
+        account_id = profile_data["user"]["account_id"]
+        assert account_id
+
+        key = await _create_issue_with_description(
+            mcp_client,
+            cloud_instance.project_key,
+            "issue for mention comment test",
+        )
+        try:
+            mention_token = f"[~accountid:{account_id}]"
+            comment_result = await call_tool(
+                mcp_client,
+                "jira_add_comment",
+                {
+                    "issue_key": key,
+                    "body": f"Hello {mention_token}",
+                },
+            )
+            assert not comment_result.is_error
+            assert isinstance(comment_result.content[0], TextContent)
+            comment_data = json.loads(comment_result.content[0].text)
+            assert comment_data.get("id")
+            comment_body = comment_data.get("body", "")
+            assert mention_token not in comment_body
+            assert "Hello" in comment_body
+            assert "@" in comment_body or account_id in comment_body
+
+            issue_result = await call_tool(
+                mcp_client,
+                "jira_get_issue",
+                {"issue_key": key, "fields": "comment", "comment_limit": 10},
+            )
+            assert not issue_result.is_error
+            assert isinstance(issue_result.content[0], TextContent)
+            issue_data = json.loads(issue_result.content[0].text)
+            stored_comment = next(
+                comment
+                for comment in issue_data["comments"]
+                if comment["id"] == comment_data["id"]
+            )
+            assert mention_token not in stored_comment["body"]
+            assert "Hello" in stored_comment["body"]
+            assert "@" in stored_comment["body"] or account_id in stored_comment["body"]
+        finally:
+            await _delete_issue(mcp_client, key)

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -206,6 +206,29 @@ class TestCommentsMixin:
         comments_mixin.preprocessor.markdown_to_jira.assert_not_called()
         assert result["body"] == "Heading and content"
 
+    def test_add_comment_with_accountid_mention_uses_adf_node(
+        self, comments_mixin: CommentsMixin
+    ) -> None:
+        """Test [~accountid:...] comments become ADF mention nodes on Cloud."""
+        mock_response = {
+            "id": "10001",
+            "body": "Mention comment",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "John Doe"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+
+        account_id = "712020:1cfc6d16-950f-4096-8e57-f2c6c60d8ffa"
+        comments_mixin.add_comment("TEST-123", f"Hello [~accountid:{account_id}]")
+
+        call_args = comments_mixin._post_api3.call_args
+        adf_body = call_args[0][1]["body"]
+        assert adf_body["content"][0]["content"] == [
+            {"type": "text", "text": "Hello "},
+            {"type": "mention", "attrs": {"id": account_id}},
+        ]
+        comments_mixin.preprocessor.markdown_to_jira.assert_not_called()
+
     def test_add_comment_with_empty_comment(self, comments_mixin):
         """Test add_comment with an empty comment (Cloud → minimal ADF)."""
         # Setup mock response for v3 API path

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -433,6 +433,62 @@ class TestMarkdownToAdf:
         link_mark = next(m for m in link_nodes[0]["marks"] if m["type"] == "link")
         assert link_mark["attrs"]["href"] == "https://example.com"
 
+    # -- Mentions -----------------------------------------------------------
+
+    def test_mention_modern_account_id(self):
+        """[~accountid:712020:UUID] emits an ADF mention node with id attr."""
+        account_id = "712020:1cfc6d16-950f-4096-8e57-f2c6c60d8ffa"
+        result = markdown_to_adf(f"[~accountid:{account_id}]")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"]["id"] == account_id
+
+    def test_mention_legacy_account_id(self):
+        """[~accountid:24-hex] (no 712020: prefix) is also accepted."""
+        account_id = "6315cc7b3310c2492b5b1513"
+        result = markdown_to_adf(f"[~accountid:{account_id}]")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"]["id"] == account_id
+
+    def test_mention_inline_with_surrounding_text(self):
+        """Mention preserves surrounding text nodes in the same paragraph."""
+        account_id = "712020:abc-def"
+        result = markdown_to_adf(f"hi [~accountid:{account_id}] please review")
+        para = result["content"][0]
+        types_in_order = [n["type"] for n in para["content"]]
+        assert types_in_order == ["text", "mention", "text"]
+        assert para["content"][0]["text"] == "hi "
+        assert para["content"][1]["attrs"]["id"] == account_id
+        assert para["content"][2]["text"] == " please review"
+
+    def test_mention_does_not_swallow_regular_link(self):
+        """[text](url) without the ~accountid: marker stays a link, not a mention."""
+        result = markdown_to_adf("[click](https://example.com)")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        links = [
+            n
+            for n in para["content"]
+            if n["type"] == "text"
+            and any(m["type"] == "link" for m in n.get("marks", []))
+        ]
+        assert mentions == []
+        assert len(links) == 1
+
+    def test_multiple_mentions_in_one_paragraph(self):
+        """Several mentions in one line each get their own mention node."""
+        a = "712020:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        b = "712020:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        result = markdown_to_adf(f"[~accountid:{a}] and [~accountid:{b}]")
+        para = result["content"][0]
+        mention_ids = [
+            n["attrs"]["id"] for n in para["content"] if n["type"] == "mention"
+        ]
+        assert mention_ids == [a, b]
+
     # -- Code blocks --------------------------------------------------------
 
     def test_code_block_with_lang(self):


### PR DESCRIPTION
## Description

Adds support for Jira's wiki-style mention syntax `[~accountid:ACCOUNT_ID]` to the Markdown-to-ADF converter. Previously, that syntax was preserved verbatim as plain text, so `jira_add_comment` could not actually `@`-mention a user — comments rendered the literal `[~accountid:...]` text in Jira UI with no notification.

After this change the converter emits a proper ADF `mention` node, which Jira Cloud renders as a clickable user pill and which triggers a real `@`-notification.

The syntax mirrors what the **read** path already returns when a real ADF mention is read back through Jira's v2 API: `preprocessing/jira.py` rewrites incoming mentions into `[~accountid:ID]` text. So now read and write are symmetric — the same string round-trips cleanly, no display-name lookup needed on the LLM side.

Fixes: #1208

## Relation to #1228

PR #1228 (open, no review yet) solves the same issue with a **different** input syntax: `@[Display Name](accountid:xxx)`. That syntax requires the caller to know the user's display name; this PR's `[~accountid:UUID]` only needs the account id, which is what `get_user_profile` and other read paths already surface. The two PRs are complementary — they touch the same regex but add non-conflicting alternatives — and can be merged together. Happy to rebase on top of #1228 if you'd prefer to land that one first.

## Changes

- Add `[~accountid:(?P<mention_id>[^\]]+)]` alternative to the inline regex in `_parse_inline_formatting()`. Placed first so it cannot be mis-matched as a regular `[text](url)` link.
- Emit `{type: \"mention\", attrs: {id: ...}}` ADF node when matched. This shape matches what `adf_to_text` already understands on the read path (`adf.py:313-316`).
- Both modern (`712020:UUID-with-dashes`) and legacy (`24-hex-bare`) account-id formats are accepted — the regex doesn't constrain the account-id contents.

## Testing

- [x] Unit tests added: 5 new cases in `TestMarkdownToAdf` covering modern format, legacy format, surrounding text, no false-positive on regular links, and multiple mentions in one paragraph.
- [x] All tests pass: \`uv run pytest\` → **2583 passed, 5 skipped, 0 failures**.
- [x] Pre-commit clean: ruff-format, ruff, mypy all pass on changed files.
- [ ] Live-tested on Jira Cloud — pending; will verify after merge or on a draft branch.

## Checklist

- [x] Code follows project style guidelines (ruff/mypy).
- [x] Tests added for the new feature.
- [x] All tests pass locally.
- [x] No documentation update needed (existing docstring updated to mention the new syntax).