### PR TITLE
feat(jira): add ADF expand block support

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -56,7 +56,7 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 | `summary` | `string` | Yes | Summary/title of the issue |
 | `issue_type` | `string` | Yes | Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). The available types depend on your project configuration. For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields. |
 | `assignee` | `string` | No | (Optional) Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...') |
-| `description` | `string` | No | Issue description in Markdown format |
+| `description` | `string` | No | Issue description in Markdown format. On Jira Cloud, use `{expand:Title}...{expand}` for a collapsible section. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API') |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: `{"priority": {"name": "High"}}` - Add labels: `{"labels": ["frontend", "urgent"]}` - Link to parent (for any issue type): `{"parent": "PROJ-123"}` - Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}` - Set Fix Version/s: `{"fixVersions": [{"id": "10020"}]}` - Custom fields: `{"customfield_10010": "value"}` |
 **Example:**
@@ -69,6 +69,8 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 Use Markdown in the description - it's automatically converted to ADF (Cloud)
 or wiki markup (Server/DC). On Jira Cloud, mention users with
 `[~accountid:ACCOUNT_ID]` or `@[Display Name](accountid:ACCOUNT_ID)`.
+Use `{expand:Title}` and `{expand}` around content to create a collapsible
+section on Jira Cloud.
 For epics, provide `epic_name` parameter.
 </Tip>
 
@@ -91,7 +93,7 @@ Update an existing Jira issue including changing status, adding Epic links, upda
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format. Example: `'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}'` |
+| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format; on Jira Cloud, use `{expand:Title}...{expand}` for a collapsible section. Example: `'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}'` |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}`. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names (e.g., 'Frontend,API') |
 | `attachments` | `string` | No | (Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt'] |

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -163,7 +163,8 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
     """Convert Markdown text to ADF (Atlassian Document Format) document.
 
     Implements a line-by-line parser that handles common Markdown constructs.
-    No external dependencies required.
+    Jira Cloud expand blocks can be written as
+    ``{expand:Title}...{expand}``. No external dependencies required.
 
     Args:
         markdown_text: Markdown-formatted text to convert.
@@ -182,6 +183,29 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
 
     while i < len(lines):
         line = lines[i]
+
+        # --- Expand/collapse block ({expand:Title}...{expand}) ---
+        expand_match = re.match(r"^\{expand(?::(.+?))?\}\s*$", line)
+        if expand_match:
+            expand_title = expand_match.group(1) or ""
+            expand_lines: list[str] = []
+            i += 1
+            while i < len(lines) and not re.match(r"^\{expand\}\s*$", lines[i]):
+                expand_lines.append(lines[i])
+                i += 1
+            # Skip closing {expand}
+            if i < len(lines):
+                i += 1
+            # Recursively parse the inner content as ADF
+            inner_markdown = "\n".join(expand_lines)
+            inner_doc = markdown_to_adf(inner_markdown)
+            expand_node: dict[str, Any] = {
+                "type": "expand",
+                "attrs": {"title": expand_title},
+                "content": inner_doc.get("content", []),
+            }
+            doc["content"].append(expand_node)
+            continue
 
         # --- Fenced code block ---
         if line.startswith("```"):

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1704,7 +1704,13 @@ async def create_issue(
     ] = None,
     description: Annotated[
         str | None,
-        Field(description="Issue description in Markdown format", default=None),
+        Field(
+            description=(
+                "Issue description in Markdown format. On Jira Cloud, use "
+                "'{expand:Title}...{expand}' for a collapsible section."
+            ),
+            default=None,
+        ),
     ] = None,
     components: Annotated[
         str | None,
@@ -1946,7 +1952,8 @@ async def update_issue(
         Field(
             description=(
                 "JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). "
-                "For 'description', provide text in Markdown format. "
+                "For 'description', provide text in Markdown format; on Jira Cloud, "
+                "use '{expand:Title}...{expand}' for a collapsible section. "
                 'Example: \'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\\nMarkdown text"}\''
             )
         ),

--- a/tests/e2e/cloud/test_adf_write.py
+++ b/tests/e2e/cloud/test_adf_write.py
@@ -226,6 +226,30 @@ class TestADFCreateIssue:
         finally:
             await _delete_issue(mcp_client, key)
 
+    async def test_create_issue_expand(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """Expand syntax creates content accepted and returned by Jira Cloud."""
+        key = await _create_issue_with_description(
+            mcp_client,
+            cloud_instance.project_key,
+            (
+                "{expand:Deployment details}\n"
+                "Expand body survives Cloud write.\n"
+                "- first step\n"
+                "- second step\n"
+                "{expand}"
+            ),
+        )
+        try:
+            desc = await _read_issue_description(mcp_client, key)
+            assert "Expand body survives Cloud write." in desc
+            assert "first step" in desc
+        finally:
+            await _delete_issue(mcp_client, key)
+
     async def test_create_issue_mixed(
         self,
         mcp_client: Client,

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -641,6 +641,40 @@ class TestMarkdownToAdf:
         rule_nodes = [n for n in result["content"] if n["type"] == "rule"]
         assert len(rule_nodes) >= 1
 
+    # -- Expand/collapse block ----------------------------------------------
+
+    def test_expand_with_title(self) -> None:
+        """Expand block with title produces an expand node."""
+        md = "{expand:Details}\n* bullet one\n* bullet two\n{expand}"
+        result = markdown_to_adf(md)
+        expand = next(n for n in result["content"] if n["type"] == "expand")
+        assert expand["attrs"]["title"] == "Details"
+        assert any(n["type"] == "bulletList" for n in expand["content"])
+
+    def test_expand_without_title(self) -> None:
+        """Expand block without a title uses an empty string."""
+        md = "{expand}\nSome content\n{expand}"
+        result = markdown_to_adf(md)
+        expand = next(n for n in result["content"] if n["type"] == "expand")
+        assert expand["attrs"]["title"] == ""
+        assert any(n["type"] == "paragraph" for n in expand["content"])
+
+    def test_expand_with_nested_formatting(self) -> None:
+        """Expand block recursively parses inner markdown."""
+        md = "{expand:Steps}\n## Heading\n1. First\n1. Second\n{expand}"
+        result = markdown_to_adf(md)
+        expand = next(n for n in result["content"] if n["type"] == "expand")
+        inner_types = [n["type"] for n in expand["content"]]
+        assert "heading" in inner_types
+        assert "orderedList" in inner_types
+
+    def test_expand_preserves_surrounding_content(self) -> None:
+        """Content before and after expand block is preserved."""
+        md = "Before\n{expand:Title}\nInside\n{expand}\nAfter"
+        result = markdown_to_adf(md)
+        types = [n["type"] for n in result["content"]]
+        assert types == ["paragraph", "expand", "paragraph"]
+
     # -- Mixed formatting ---------------------------------------------------
 
     def test_mixed_formatting(self):


### PR DESCRIPTION
## Description

Adds native collapsible sections to Jira Cloud issue descriptions converted from Markdown.

## Changes

- Recognize `{expand:Title}...{expand}` and untitled `{expand}...{expand}` blocks in `markdown_to_adf()`.
- Recursively convert supported Markdown inside expand blocks, including headings, lists, and code blocks.
- Document the Cloud-only syntax in the create/update tool schemas and Jira issue guide.
- Add unit coverage and a live Jira Cloud write/readback regression test.

The raw ADF update guard from the original PR is no longer part of this diff because current `main` already supports explicit ADF descriptions and includes regression coverage.

## Verification

- `uv run pytest tests/unit/models/test_adf.py tests/unit/servers/test_jira_server.py -xvs` — 232 passed
- `uv run pytest tests/integration/ -xvs` — 23 collected and skipped by the existing integration opt-in guards
- `uv run pytest tests/e2e/cloud/test_adf_write.py --cloud-e2e -xvs` — 13 passed
- `uv run pre-commit run --all-files` — passed
