### PR TITLE
feat: opt-in HTTP hardening (retry, rate limit, concurrency cap, circuit breaker, pagination clamp)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,20 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #JIRA_TIMEOUT=75
 #CONFLUENCE_TIMEOUT=75
 
+# --- HTTP Hardening (Advanced) ---
+# Optional safeguards for overloaded Atlassian instances. All are disabled by
+# default unless set here.
+# Retry only read requests by default. Set ATLASSIAN_RETRY_INCLUDE_WRITES=true
+# only if your write endpoints are known to be idempotent.
+#ATLASSIAN_RETRY_TOTAL=5
+#ATLASSIAN_RETRY_BACKOFF=1.0
+#ATLASSIAN_RETRY_INCLUDE_WRITES=false
+#ATLASSIAN_MAX_CONCURRENT_REQUESTS=4
+#ATLASSIAN_REQUESTS_PER_SECOND=5
+#ATLASSIAN_MAX_PAGINATION_LIMIT=100
+#ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD=5
+#ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN=30
+
 # --- Read-Only Mode ---
 # Disables all write operations (create, update, delete). Default is false.
 #READ_ONLY_MODE=false

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -160,6 +160,22 @@ This guide covers IDE integration, environment variables, and advanced configura
 
 See [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) for all available options.
 
+### HTTP Hardening
+
+These optional safeguards are useful for protecting self-hosted Server/Data Center
+instances from runaway request loops. They are disabled by default.
+
+| Variable | Description |
+|----------|-------------|
+| `ATLASSIAN_RETRY_TOTAL` | Enable retries for transient `429/502/503/504` responses and connection errors. `0` or unset disables retries. |
+| `ATLASSIAN_RETRY_BACKOFF` | Retry exponential backoff factor in seconds (default: `1.0` when retries are enabled). |
+| `ATLASSIAN_RETRY_INCLUDE_WRITES` | Also retry write methods (`POST`/`PUT`/`PATCH`/`DELETE`). Use only when writes are known to be idempotent. |
+| `ATLASSIAN_MAX_CONCURRENT_REQUESTS` | Process-wide cap for concurrent Jira and Confluence requests. `0` or unset disables the cap. |
+| `ATLASSIAN_REQUESTS_PER_SECOND` | Process-wide outbound request rate limit. `0` or unset disables the limit. |
+| `ATLASSIAN_MAX_PAGINATION_LIMIT` | Clamp user-supplied page sizes for high-fanout list/search calls. `0` or unset disables clamping. |
+| `ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD` | Open a process-wide circuit breaker after this many consecutive `429/503` responses. `0` or unset disables it. |
+| `ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN` | Circuit breaker cooldown in seconds before allowing a probe request (default: `30.0`). |
+
 ## Proxy Configuration
 
 MCP Atlassian supports routing API requests through HTTP/HTTPS/SOCKS proxies.

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -9,6 +9,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from ..exceptions import MCPAtlassianAuthenticationError
 from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
+from ..utils.http import configure_retry
 from ..utils.oauth import configure_oauth_session
 from ..utils.ssl import configure_ssl_verification
 from .config import ConfluenceConfig
@@ -122,6 +123,10 @@ class ConfluenceClient:
             client_key=self.config.client_key,
             client_key_password=self.config.client_key_password,
         )
+
+        # Apply retry/backoff to all mounted adapters (must run after SSL setup
+        # so SSLIgnoreAdapter, if mounted, also picks up the retry policy).
+        configure_retry(self.confluence._session, service="Confluence")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -10,6 +10,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from ..exceptions import MCPAtlassianAuthenticationError
 from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
 from ..utils.http import (
+    configure_circuit_breaker,
     configure_concurrency,
     configure_rate_limit,
     configure_retry,
@@ -133,6 +134,7 @@ class ConfluenceClient:
         configure_retry(self.confluence._session, service="Confluence")
         configure_concurrency(self.confluence._session, service="Confluence")
         configure_rate_limit(self.confluence._session, service="Confluence")
+        configure_circuit_breaker(self.confluence._session, service="Confluence")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -8,13 +8,13 @@ from requests import Session
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from ..exceptions import MCPAtlassianAuthenticationError
-from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
 from ..utils.http import (
     configure_circuit_breaker,
     configure_concurrency,
     configure_rate_limit,
     configure_retry,
 )
+from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
 from ..utils.oauth import configure_oauth_session
 from ..utils.ssl import configure_ssl_verification
 from .config import ConfluenceConfig

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -9,7 +9,11 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from ..exceptions import MCPAtlassianAuthenticationError
 from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
-from ..utils.http import configure_retry
+from ..utils.http import (
+    configure_concurrency,
+    configure_rate_limit,
+    configure_retry,
+)
 from ..utils.oauth import configure_oauth_session
 from ..utils.ssl import configure_ssl_verification
 from .config import ConfluenceConfig
@@ -127,6 +131,8 @@ class ConfluenceClient:
         # Apply retry/backoff to all mounted adapters (must run after SSL setup
         # so SSLIgnoreAdapter, if mounted, also picks up the retry policy).
         configure_retry(self.confluence._session, service="Confluence")
+        configure_concurrency(self.confluence._session, service="Confluence")
+        configure_rate_limit(self.confluence._session, service="Confluence")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -130,8 +130,8 @@ class ConfluenceClient:
             client_key_password=self.config.client_key_password,
         )
 
-        # Apply retry/backoff to all mounted adapters (must run after SSL setup
-        # so SSLIgnoreAdapter, if mounted, also picks up the retry policy).
+        # Apply opt-in HTTP hardening after SSL setup so SSLIgnoreAdapter, if
+        # mounted, also picks up the configured behavior.
         configure_retry(self.confluence._session, service="Confluence")
         configure_concurrency(self.confluence._session, service="Confluence")
         configure_rate_limit(self.confluence._session, service="Confluence")

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -9,6 +9,7 @@ from requests.exceptions import HTTPError
 
 from ..models.confluence import ConfluencePage
 from ..utils.decorators import handle_auth_errors
+from ..utils.pagination import clamp_limit
 from .client import ConfluenceClient
 from .utils import emoji_to_hex_id, extract_emoji_from_property
 from .v2_adapter import ConfluenceV2Adapter
@@ -743,6 +744,8 @@ class PagesMixin(ConfluenceClient):
             List of ConfluencePage models containing the child pages and folders
         """
         try:
+            limit = clamp_limit(limit, context="confluence.get_page_children")
+
             # Use the Atlassian Python API's get_page_child_by_type method
             # First, get child pages
             page_results = self.confluence.get_page_child_by_type(
@@ -854,6 +857,8 @@ class PagesMixin(ConfluenceClient):
             Exception: If there is an error fetching pages
         """
         try:
+            limit = clamp_limit(limit, context="confluence.get_space_page_tree")
+
             # Paginate using the raw API to access _links.next for reliable
             # truncation detection. The higher-level get_all_pages_from_space()
             # has a broken termination condition when limit > server-side cap.

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -13,6 +13,7 @@ from ..models.confluence import (
 )
 from ..models.confluence.common import ConfluenceUser
 from ..utils.decorators import handle_atlassian_api_errors
+from ..utils.pagination import clamp_limit
 from .client import ConfluenceClient
 from .utils import quote_cql_identifier_if_needed
 
@@ -42,6 +43,8 @@ class SearchMixin(ConfluenceClient):
             MCPAtlassianAuthenticationError: If authentication fails with the
                 Confluence API (401/403)
         """
+        limit = clamp_limit(limit, context="confluence.search")
+
         # Use spaces_filter parameter if provided, otherwise fall back to config
         filter_to_use = spaces_filter or self.config.spaces_filter
 

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -126,6 +126,8 @@ class SearchMixin(ConfluenceClient):
             MCPAtlassianAuthenticationError: If authentication fails
                 with the Confluence API (401/403)
         """
+        limit = clamp_limit(limit, context="confluence.search_user")
+
         if self.config.is_cloud:
             # Cloud: use CQL search endpoint
             results = self.confluence.get(

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -16,6 +16,7 @@ from mcp_atlassian.utils.logging import (
     mask_sensitive,
 )
 from mcp_atlassian.utils.http import (
+    configure_circuit_breaker,
     configure_concurrency,
     configure_rate_limit,
     configure_retry,
@@ -146,6 +147,7 @@ class JiraClient:
         configure_retry(self.jira._session, service="Jira")
         configure_concurrency(self.jira._session, service="Jira")
         configure_rate_limit(self.jira._session, service="Jira")
+        configure_circuit_breaker(self.jira._session, service="Jira")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -10,16 +10,16 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.preprocessing import JiraPreprocessor
-from mcp_atlassian.utils.logging import (
-    get_masked_session_headers,
-    log_config_param,
-    mask_sensitive,
-)
 from mcp_atlassian.utils.http import (
     configure_circuit_breaker,
     configure_concurrency,
     configure_rate_limit,
     configure_retry,
+)
+from mcp_atlassian.utils.logging import (
+    get_masked_session_headers,
+    log_config_param,
+    mask_sensitive,
 )
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -15,7 +15,11 @@ from mcp_atlassian.utils.logging import (
     log_config_param,
     mask_sensitive,
 )
-from mcp_atlassian.utils.http import configure_retry
+from mcp_atlassian.utils.http import (
+    configure_concurrency,
+    configure_rate_limit,
+    configure_retry,
+)
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
 
@@ -140,6 +144,8 @@ class JiraClient:
         # Apply retry/backoff to all mounted adapters (must run after SSL setup
         # so SSLIgnoreAdapter, if mounted, also picks up the retry policy).
         configure_retry(self.jira._session, service="Jira")
+        configure_concurrency(self.jira._session, service="Jira")
+        configure_rate_limit(self.jira._session, service="Jira")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -15,6 +15,7 @@ from mcp_atlassian.utils.logging import (
     log_config_param,
     mask_sensitive,
 )
+from mcp_atlassian.utils.http import configure_retry
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
 
@@ -135,6 +136,10 @@ class JiraClient:
             client_key=self.config.client_key,
             client_key_password=self.config.client_key_password,
         )
+
+        # Apply retry/backoff to all mounted adapters (must run after SSL setup
+        # so SSLIgnoreAdapter, if mounted, also picks up the retry policy).
+        configure_retry(self.jira._session, service="Jira")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -143,8 +143,8 @@ class JiraClient:
             client_key_password=self.config.client_key_password,
         )
 
-        # Apply retry/backoff to all mounted adapters (must run after SSL setup
-        # so SSLIgnoreAdapter, if mounted, also picks up the retry policy).
+        # Apply opt-in HTTP hardening after SSL setup so SSLIgnoreAdapter, if
+        # mounted, also picks up the configured behavior.
         configure_retry(self.jira._session, service="Jira")
         configure_concurrency(self.jira._session, service="Jira")
         configure_rate_limit(self.jira._session, service="Jira")

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -270,7 +270,9 @@ class IssuesMixin(
                 logger.error(error_msg)
                 raise ValueError(error_msg) from http_err
             if status_code == 429:
-                error_msg = "Jira API rate limit hit (429). Retry after a short delay."
+                from mcp_atlassian.utils.http import format_rate_limit_error
+
+                error_msg = format_rate_limit_error(http_err, service="Jira")
                 logger.error(error_msg)
                 raise ValueError(error_msg) from http_err
             else:

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -9,6 +9,7 @@ from requests.exceptions import HTTPError
 
 from ..models.jira import JiraSearchResult
 from ..utils.decorators import handle_auth_errors
+from ..utils.pagination import clamp_limit
 from .client import JiraClient
 from .constants import DEFAULT_READ_JIRA_FIELDS
 from .protocols import IssueOperationsProto
@@ -54,6 +55,8 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             Exception: If there is an error searching for issues
         """
         try:
+            limit = clamp_limit(limit, context="jira.search_issues")
+
             # Sanitize JQL reserved words in project key values
             jql = sanitize_jql_reserved_words(jql)
 
@@ -232,6 +235,8 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             Exception: If there is an error getting board issues
         """
         try:
+            limit = clamp_limit(limit, context="jira.get_board_issues")
+
             # Sanitize JQL reserved words in project key values
             jql = sanitize_jql_reserved_words(jql) or jql
 
@@ -294,6 +299,8 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             Exception: If there is an error getting sprint issues
         """
         try:
+            limit = clamp_limit(limit, context="jira.get_sprint_issues")
+
             # Use JQL search to get sprint issues with proper fields filtering
             jql = f"sprint = {sprint_id}"
             return self.search_issues(

--- a/src/mcp_atlassian/utils/env.py
+++ b/src/mcp_atlassian/utils/env.py
@@ -1,6 +1,9 @@
 """Environment variable utility functions for MCP Atlassian."""
 
+import logging
 import os
+
+logger = logging.getLogger("mcp-atlassian.env")
 
 
 def is_env_truthy(env_var_name: str, default: str = "") -> bool:
@@ -49,6 +52,56 @@ def is_env_ssl_verify(env_var_name: str, default: str = "true") -> bool:
         True unless explicitly set to false values
     """
     return os.getenv(env_var_name, default).lower() not in ("false", "0", "no")
+
+
+def get_int_env(env_var_name: str, default: int) -> int:
+    """Read an environment variable as an integer, falling back to `default`.
+
+    Logs a warning and falls back to `default` if the variable is set to a
+    non-integer value.
+
+    Args:
+        env_var_name: Name of the environment variable to read
+        default: Value to return when the variable is unset or unparseable
+
+    Returns:
+        Parsed integer value, or `default`
+    """
+    raw = os.getenv(env_var_name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid int for %s=%r; using default %d", env_var_name, raw, default
+        )
+        return default
+
+
+def get_float_env(env_var_name: str, default: float) -> float:
+    """Read an environment variable as a float, falling back to `default`.
+
+    Logs a warning and falls back to `default` if the variable is set to a
+    non-float value.
+
+    Args:
+        env_var_name: Name of the environment variable to read
+        default: Value to return when the variable is unset or unparseable
+
+    Returns:
+        Parsed float value, or `default`
+    """
+    raw = os.getenv(env_var_name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid float for %s=%r; using default %s", env_var_name, raw, default
+        )
+        return default
 
 
 def get_custom_headers(env_var_name: str) -> dict[str, str]:

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -17,7 +17,7 @@ import threading
 import time
 
 from requests import Session
-from requests.adapters import BaseAdapter
+from requests.adapters import BaseAdapter, HTTPAdapter
 from urllib3.util.retry import Retry
 
 logger = logging.getLogger("mcp-atlassian.http")
@@ -26,9 +26,7 @@ DEFAULT_RETRY_TOTAL = 5
 DEFAULT_RETRY_BACKOFF = 1.0
 DEFAULT_RETRY_STATUSES = (429, 502, 503, 504)
 _READ_METHODS = frozenset(["GET", "HEAD", "OPTIONS"])
-_ALL_METHODS = frozenset(
-    ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
-)
+_ALL_METHODS = frozenset(["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"])
 _THROTTLED_ATTR = "_mcp_atlassian_throttled"
 _RATE_LIMITED_ATTR = "_mcp_atlassian_rate_limited"
 _CIRCUIT_BREAKER_ATTR = "_mcp_atlassian_circuit_breaker"
@@ -36,6 +34,7 @@ _CIRCUIT_BREAKER_ATTR = "_mcp_atlassian_circuit_breaker"
 
 class CircuitBreakerOpenError(Exception):
     """Raised by the circuit breaker when in the open state."""
+
 
 _concurrency_semaphore: threading.BoundedSemaphore | None = None
 _concurrency_semaphore_cap: int | None = None
@@ -145,13 +144,11 @@ def _float_env(name: str, default: float) -> float:
     try:
         return float(raw)
     except ValueError:
-        logger.warning(
-            "Invalid float for %s=%r; using default %s", name, raw, default
-        )
+        logger.warning("Invalid float for %s=%r; using default %s", name, raw, default)
         return default
 
 
-def _bool_env(name: str, default: bool) -> bool:
+def _bool_env(name: str, *, default: bool) -> bool:
     raw = os.getenv(name)
     if not raw:
         return default
@@ -177,7 +174,7 @@ def configure_retry(session: Session, *, service: str = "atlassian") -> None:
         return
 
     backoff = _float_env("ATLASSIAN_RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF)
-    include_writes = _bool_env("ATLASSIAN_RETRY_INCLUDE_WRITES", False)
+    include_writes = _bool_env("ATLASSIAN_RETRY_INCLUDE_WRITES", default=False)
     methods = _ALL_METHODS if include_writes else _READ_METHODS
 
     retry = Retry(
@@ -196,7 +193,10 @@ def configure_retry(session: Session, *, service: str = "atlassian") -> None:
         return
 
     for adapter in session.adapters.values():
-        adapter.max_retries = retry
+        # session.adapters always contains HTTPAdapter instances; the abstract
+        # BaseAdapter doesn't expose max_retries so we narrow the type here.
+        if isinstance(adapter, HTTPAdapter):
+            adapter.max_retries = retry
 
     logger.debug(
         "%s: retry configured total=%d backoff=%.2fs statuses=%s writes=%s",
@@ -233,9 +233,7 @@ def _reset_concurrency_semaphore_for_tests() -> None:
         _concurrency_semaphore_cap = None
 
 
-def _wrap_adapter_send(
-    adapter: BaseAdapter, sem: threading.BoundedSemaphore
-) -> None:
+def _wrap_adapter_send(adapter: BaseAdapter, sem: threading.BoundedSemaphore) -> None:
     if getattr(adapter, _THROTTLED_ATTR, False):
         return
     original_send = adapter.send
@@ -372,9 +370,7 @@ def _wrap_adapter_circuit_breaker(
     setattr(adapter, _CIRCUIT_BREAKER_ATTR, True)
 
 
-def configure_circuit_breaker(
-    session: Session, *, service: str = "atlassian"
-) -> None:
+def configure_circuit_breaker(session: Session, *, service: str = "atlassian") -> None:
     """Trip a process-wide circuit breaker after N consecutive 429/503 responses.
 
     Disabled by default. When tripped, in-flight Sessions raise

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -31,6 +31,11 @@ _ALL_METHODS = frozenset(
 )
 _THROTTLED_ATTR = "_mcp_atlassian_throttled"
 _RATE_LIMITED_ATTR = "_mcp_atlassian_rate_limited"
+_CIRCUIT_BREAKER_ATTR = "_mcp_atlassian_circuit_breaker"
+
+
+class CircuitBreakerOpenError(Exception):
+    """Raised by the circuit breaker when in the open state."""
 
 _concurrency_semaphore: threading.BoundedSemaphore | None = None
 _concurrency_semaphore_cap: int | None = None
@@ -67,6 +72,59 @@ class _TokenBucket:
 _rate_limit_bucket: _TokenBucket | None = None
 _rate_limit_bucket_rate: float | None = None
 _rate_limit_init_lock = threading.Lock()
+
+
+class _CircuitBreaker:
+    """Trip after N consecutive 429/503 responses; fail fast during cooldown.
+
+    closed -> (failures >= threshold) -> open -> (cooldown elapsed) ->
+    half-open (single probe allowed) -> closed | open. We don't model
+    half-open as a separate state explicitly; cooldown elapsed lets one
+    request through which either resets failures (success) or re-opens
+    immediately (failure).
+    """
+
+    def __init__(self, threshold: int, cooldown: float) -> None:
+        self.threshold = threshold
+        self.cooldown = cooldown
+        self.failures = 0
+        self.opened_at: float | None = None
+        self.lock = threading.Lock()
+
+    def before_send(self) -> None:
+        with self.lock:
+            if self.opened_at is None:
+                return
+            if time.monotonic() - self.opened_at >= self.cooldown:
+                self.opened_at = None
+                self.failures = 0
+                return
+            remaining = self.cooldown - (time.monotonic() - self.opened_at)
+            raise CircuitBreakerOpenError(
+                f"Atlassian circuit breaker open after {self.threshold} consecutive "
+                f"429/503 responses. Cooling down for ~{remaining:.1f}s before "
+                "allowing another request. The upstream server appears overloaded; "
+                "back off and retry later."
+            )
+
+    def on_response(self, status_code: int) -> None:
+        with self.lock:
+            if status_code in (429, 503):
+                self.failures += 1
+                if self.failures >= self.threshold and self.opened_at is None:
+                    self.opened_at = time.monotonic()
+                    logger.warning(
+                        "Circuit breaker tripped after %d consecutive 429/503; "
+                        "cooling down %.1fs",
+                        self.failures,
+                        self.cooldown,
+                    )
+            else:
+                self.failures = 0
+
+
+_circuit_breaker: _CircuitBreaker | None = None
+_circuit_breaker_init_lock = threading.Lock()
 
 
 def _int_env(name: str, default: int) -> int:
@@ -277,6 +335,74 @@ def configure_rate_limit(session: Session, *, service: str = "atlassian") -> Non
     for adapter in session.adapters.values():
         _wrap_adapter_rate_limit(adapter, bucket)
     logger.info("%s: rate limit %.2f rps applied", service, rate)
+
+
+def _get_circuit_breaker(threshold: int, cooldown: float) -> _CircuitBreaker:
+    global _circuit_breaker
+    if _circuit_breaker is not None:
+        return _circuit_breaker
+    with _circuit_breaker_init_lock:
+        if _circuit_breaker is None:
+            _circuit_breaker = _CircuitBreaker(threshold, cooldown)
+    return _circuit_breaker
+
+
+def _reset_circuit_breaker_for_tests() -> None:
+    global _circuit_breaker
+    with _circuit_breaker_init_lock:
+        _circuit_breaker = None
+
+
+def _wrap_adapter_circuit_breaker(
+    adapter: BaseAdapter, breaker: _CircuitBreaker
+) -> None:
+    if getattr(adapter, _CIRCUIT_BREAKER_ATTR, False):
+        return
+    original_send = adapter.send
+
+    def breaker_send(*args: object, **kwargs: object) -> object:
+        breaker.before_send()
+        response = original_send(*args, **kwargs)
+        status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            breaker.on_response(status)
+        return response
+
+    adapter.send = breaker_send  # type: ignore[method-assign]
+    setattr(adapter, _CIRCUIT_BREAKER_ATTR, True)
+
+
+def configure_circuit_breaker(
+    session: Session, *, service: str = "atlassian"
+) -> None:
+    """Trip a process-wide circuit breaker after N consecutive 429/503 responses.
+
+    Disabled by default. When tripped, in-flight Sessions raise
+    CircuitBreakerOpenError immediately instead of waiting on the per-request
+    timeout (default 75s) for each additional doomed request.
+
+    Env knobs:
+      ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD (int,   default 0 = disabled)
+      ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN  (float, default 30.0 seconds)
+
+    Recommended starting value for self-hosted: threshold=5, cooldown=30s.
+    """
+    threshold = _int_env("ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD", 0)
+    if threshold <= 0:
+        logger.debug("%s: circuit breaker disabled", service)
+        return
+    cooldown = _float_env("ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN", 30.0)
+    breaker = _get_circuit_breaker(threshold, cooldown)
+    if not session.adapters:
+        return
+    for adapter in session.adapters.values():
+        _wrap_adapter_circuit_breaker(adapter, breaker)
+    logger.info(
+        "%s: circuit breaker armed threshold=%d cooldown=%.1fs",
+        service,
+        threshold,
+        cooldown,
+    )
 
 
 def format_rate_limit_error(http_err: object, *, service: str) -> str:

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -1,15 +1,23 @@
-"""Shared HTTP layer hardening: retry + Retry-After respect.
+"""Shared HTTP layer hardening: retry, Retry-After respect, optional
+concurrency cap and outbound rate limit.
 
 Patches max_retries on every adapter currently mounted on a Session so that
 both the default HTTPAdapter and any service-specific adapters (e.g.
 SSLIgnoreAdapter mounted by configure_ssl_verification) get the same retry
 behavior. Call AFTER configure_ssl_verification.
+
+The optional concurrency cap and rate limiter wrap adapter.send in place
+(rather than replacing the adapter), so they compose with whatever adapter
+is mounted. Both are disabled by default and gated behind env vars.
 """
 
 import logging
 import os
+import threading
+import time
 
 from requests import Session
+from requests.adapters import BaseAdapter
 from urllib3.util.retry import Retry
 
 logger = logging.getLogger("mcp-atlassian.http")
@@ -21,6 +29,44 @@ _READ_METHODS = frozenset(["GET", "HEAD", "OPTIONS"])
 _ALL_METHODS = frozenset(
     ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
 )
+_THROTTLED_ATTR = "_mcp_atlassian_throttled"
+_RATE_LIMITED_ATTR = "_mcp_atlassian_rate_limited"
+
+_concurrency_semaphore: threading.BoundedSemaphore | None = None
+_concurrency_semaphore_cap: int | None = None
+_concurrency_init_lock = threading.Lock()
+
+
+class _TokenBucket:
+    """Simple thread-safe token bucket. Rate is steady-state tokens/second;
+    capacity equals one second of tokens (small burst tolerance)."""
+
+    def __init__(self, rate: float) -> None:
+        self.rate = rate
+        self.capacity = max(1.0, rate)
+        self.tokens = self.capacity
+        self.last = time.monotonic()
+        self.lock = threading.Lock()
+
+    def acquire(self) -> None:
+        if self.rate <= 0:
+            return
+        while True:
+            with self.lock:
+                now = time.monotonic()
+                elapsed = now - self.last
+                self.last = now
+                self.tokens = min(self.capacity, self.tokens + elapsed * self.rate)
+                if self.tokens >= 1.0:
+                    self.tokens -= 1.0
+                    return
+                wait = (1.0 - self.tokens) / self.rate
+            time.sleep(wait)
+
+
+_rate_limit_bucket: _TokenBucket | None = None
+_rate_limit_bucket_rate: float | None = None
+_rate_limit_init_lock = threading.Lock()
 
 
 def _int_env(name: str, default: int) -> int:
@@ -102,6 +148,135 @@ def configure_retry(session: Session, *, service: str = "atlassian") -> None:
         DEFAULT_RETRY_STATUSES,
         include_writes,
     )
+
+
+def _get_concurrency_semaphore(cap: int) -> threading.BoundedSemaphore:
+    """Process-wide BoundedSemaphore keyed off the first observed cap."""
+    global _concurrency_semaphore, _concurrency_semaphore_cap
+    if _concurrency_semaphore is not None:
+        if _concurrency_semaphore_cap != cap:
+            logger.warning(
+                "Concurrency cap already initialized at %d; ignoring request for %d",
+                _concurrency_semaphore_cap,
+                cap,
+            )
+        return _concurrency_semaphore
+    with _concurrency_init_lock:
+        if _concurrency_semaphore is None:
+            _concurrency_semaphore = threading.BoundedSemaphore(cap)
+            _concurrency_semaphore_cap = cap
+    return _concurrency_semaphore
+
+
+def _reset_concurrency_semaphore_for_tests() -> None:
+    global _concurrency_semaphore, _concurrency_semaphore_cap
+    with _concurrency_init_lock:
+        _concurrency_semaphore = None
+        _concurrency_semaphore_cap = None
+
+
+def _wrap_adapter_send(
+    adapter: BaseAdapter, sem: threading.BoundedSemaphore
+) -> None:
+    if getattr(adapter, _THROTTLED_ATTR, False):
+        return
+    original_send = adapter.send
+
+    def throttled_send(*args: object, **kwargs: object) -> object:
+        with sem:
+            return original_send(*args, **kwargs)
+
+    adapter.send = throttled_send  # type: ignore[method-assign]
+    setattr(adapter, _THROTTLED_ATTR, True)
+
+
+def configure_concurrency(session: Session, *, service: str = "atlassian") -> None:
+    """Cap concurrent outbound requests across the whole process.
+
+    Disabled by default. Set ATLASSIAN_MAX_CONCURRENT_REQUESTS to a positive
+    integer to enable. The semaphore is process-wide, so the cap applies to
+    ALL sessions combined (Jira + Confluence) — the right scope for protecting
+    a single self-hosted Atlassian instance.
+
+    Recommended starting value for self-hosted: 2-4.
+    """
+    cap = _int_env("ATLASSIAN_MAX_CONCURRENT_REQUESTS", 0)
+    if cap <= 0:
+        logger.debug("%s: concurrency cap disabled", service)
+        return
+
+    sem = _get_concurrency_semaphore(cap)
+    if not session.adapters:
+        return
+    for adapter in session.adapters.values():
+        _wrap_adapter_send(adapter, sem)
+    logger.info(
+        "%s: concurrency cap=%d applied to %d adapter(s)",
+        service,
+        cap,
+        len(session.adapters),
+    )
+
+
+def _get_rate_limit_bucket(rate: float) -> _TokenBucket:
+    """Process-wide token bucket. First-caller wins on rate."""
+    global _rate_limit_bucket, _rate_limit_bucket_rate
+    if _rate_limit_bucket is not None:
+        if _rate_limit_bucket_rate != rate:
+            logger.warning(
+                "Rate limit already initialized at %.2f rps; ignoring request for %.2f",
+                _rate_limit_bucket_rate,
+                rate,
+            )
+        return _rate_limit_bucket
+    with _rate_limit_init_lock:
+        if _rate_limit_bucket is None:
+            _rate_limit_bucket = _TokenBucket(rate)
+            _rate_limit_bucket_rate = rate
+    return _rate_limit_bucket
+
+
+def _reset_rate_limit_bucket_for_tests() -> None:
+    global _rate_limit_bucket, _rate_limit_bucket_rate
+    with _rate_limit_init_lock:
+        _rate_limit_bucket = None
+        _rate_limit_bucket_rate = None
+
+
+def _wrap_adapter_rate_limit(adapter: BaseAdapter, bucket: _TokenBucket) -> None:
+    if getattr(adapter, _RATE_LIMITED_ATTR, False):
+        return
+    original_send = adapter.send
+
+    def rate_limited_send(*args: object, **kwargs: object) -> object:
+        bucket.acquire()
+        return original_send(*args, **kwargs)
+
+    adapter.send = rate_limited_send  # type: ignore[method-assign]
+    setattr(adapter, _RATE_LIMITED_ATTR, True)
+
+
+def configure_rate_limit(session: Session, *, service: str = "atlassian") -> None:
+    """Cap outbound request rate (tokens/second) across the whole process.
+
+    Disabled by default. Set ATLASSIAN_REQUESTS_PER_SECOND to a positive
+    float to enable. The bucket is shared across all sessions in the process
+    so the cap protects the upstream Atlassian instance, not each client
+    independently.
+
+    Recommended starting value for self-hosted: 2-5 rps.
+    """
+    rate = _float_env("ATLASSIAN_REQUESTS_PER_SECOND", 0.0)
+    if rate <= 0:
+        logger.debug("%s: rate limit disabled", service)
+        return
+
+    bucket = _get_rate_limit_bucket(rate)
+    if not session.adapters:
+        return
+    for adapter in session.adapters.values():
+        _wrap_adapter_rate_limit(adapter, bucket)
+    logger.info("%s: rate limit %.2f rps applied", service, rate)
 
 
 def format_rate_limit_error(http_err: object, *, service: str) -> str:

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -102,3 +102,24 @@ def configure_retry(session: Session, *, service: str = "atlassian") -> None:
         DEFAULT_RETRY_STATUSES,
         include_writes,
     )
+
+
+def format_rate_limit_error(http_err: object, *, service: str) -> str:
+    """Build a 429 error string that includes Retry-After when the server set it.
+
+    Surfaces the structured backoff hint to the LLM so the agent can pause
+    instead of immediately retrying.
+    """
+    response = getattr(http_err, "response", None)
+    headers = getattr(response, "headers", None) or {}
+    retry_after = headers.get("Retry-After") or headers.get("retry-after")
+    if retry_after:
+        return (
+            f"{service} API rate limit hit (429). "
+            f"Server requested Retry-After: {retry_after} seconds. "
+            "Pause before retrying."
+        )
+    return (
+        f"{service} API rate limit hit (429). "
+        "No Retry-After header provided; back off and retry."
+    )

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -1,0 +1,104 @@
+"""Shared HTTP layer hardening: retry + Retry-After respect.
+
+Patches max_retries on every adapter currently mounted on a Session so that
+both the default HTTPAdapter and any service-specific adapters (e.g.
+SSLIgnoreAdapter mounted by configure_ssl_verification) get the same retry
+behavior. Call AFTER configure_ssl_verification.
+"""
+
+import logging
+import os
+
+from requests import Session
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger("mcp-atlassian.http")
+
+DEFAULT_RETRY_TOTAL = 5
+DEFAULT_RETRY_BACKOFF = 1.0
+DEFAULT_RETRY_STATUSES = (429, 502, 503, 504)
+_READ_METHODS = frozenset(["GET", "HEAD", "OPTIONS"])
+_ALL_METHODS = frozenset(
+    ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
+)
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid int for %s=%r; using default %d", name, raw, default)
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid float for %s=%r; using default %s", name, raw, default
+        )
+        return default
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def configure_retry(session: Session, *, service: str = "atlassian") -> None:
+    """Apply a urllib3 Retry policy to all adapters on the session.
+
+    Env knobs:
+      ATLASSIAN_RETRY_TOTAL          (int,   default 5; <=0 disables)
+      ATLASSIAN_RETRY_BACKOFF        (float, default 1.0 seconds — exponential factor)
+      ATLASSIAN_RETRY_INCLUDE_WRITES (bool,  default false; if true also retries
+                                     POST/PUT/PATCH/DELETE — only safe when the
+                                     server is known to be idempotent for them)
+
+    Retries fire on 429, 502, 503, 504 and on connection errors. Retry-After
+    header is respected when present.
+    """
+    total = _int_env("ATLASSIAN_RETRY_TOTAL", DEFAULT_RETRY_TOTAL)
+    if total <= 0:
+        logger.info("%s: retry disabled (ATLASSIAN_RETRY_TOTAL=%d)", service, total)
+        return
+
+    backoff = _float_env("ATLASSIAN_RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF)
+    include_writes = _bool_env("ATLASSIAN_RETRY_INCLUDE_WRITES", False)
+    methods = _ALL_METHODS if include_writes else _READ_METHODS
+
+    retry = Retry(
+        total=total,
+        connect=total,
+        read=total,
+        status=total,
+        backoff_factor=backoff,
+        status_forcelist=list(DEFAULT_RETRY_STATUSES),
+        allowed_methods=methods,
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+
+    if not session.adapters:
+        return
+
+    for adapter in session.adapters.values():
+        adapter.max_retries = retry
+
+    logger.debug(
+        "%s: retry configured total=%d backoff=%.2fs statuses=%s writes=%s",
+        service,
+        total,
+        backoff,
+        DEFAULT_RETRY_STATUSES,
+        include_writes,
+    )

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -12,13 +12,14 @@ is mounted. Both are disabled by default and gated behind env vars.
 """
 
 import logging
-import os
 import threading
 import time
 
 from requests import Session
 from requests.adapters import BaseAdapter, HTTPAdapter
 from urllib3.util.retry import Retry
+
+from .env import get_float_env, get_int_env, is_env_extended_truthy
 
 logger = logging.getLogger("mcp-atlassian.http")
 
@@ -95,8 +96,11 @@ class _CircuitBreaker:
             if self.opened_at is None:
                 return
             if time.monotonic() - self.opened_at >= self.cooldown:
+                # Half-open: clear opened_at so a request goes through, but
+                # leave failures at threshold so a single 429/503 in
+                # on_response re-opens the breaker immediately. A 2xx will
+                # reset failures to 0 (closed).
                 self.opened_at = None
-                self.failures = 0
                 return
             remaining = self.cooldown - (time.monotonic() - self.opened_at)
             raise CircuitBreakerOpenError(
@@ -113,7 +117,7 @@ class _CircuitBreaker:
                 if self.failures >= self.threshold and self.opened_at is None:
                     self.opened_at = time.monotonic()
                     logger.warning(
-                        "Circuit breaker tripped after %d consecutive 429/503; "
+                        "Circuit breaker tripped after %d 429/503 responses; "
                         "cooling down %.1fs",
                         self.failures,
                         self.cooldown,
@@ -124,35 +128,6 @@ class _CircuitBreaker:
 
 _circuit_breaker: _CircuitBreaker | None = None
 _circuit_breaker_init_lock = threading.Lock()
-
-
-def _int_env(name: str, default: int) -> int:
-    raw = os.getenv(name)
-    if not raw:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        logger.warning("Invalid int for %s=%r; using default %d", name, raw, default)
-        return default
-
-
-def _float_env(name: str, default: float) -> float:
-    raw = os.getenv(name)
-    if not raw:
-        return default
-    try:
-        return float(raw)
-    except ValueError:
-        logger.warning("Invalid float for %s=%r; using default %s", name, raw, default)
-        return default
-
-
-def _bool_env(name: str, *, default: bool) -> bool:
-    raw = os.getenv(name)
-    if not raw:
-        return default
-    return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
 def configure_retry(session: Session, *, service: str = "atlassian") -> None:
@@ -168,13 +143,13 @@ def configure_retry(session: Session, *, service: str = "atlassian") -> None:
     Retries fire on 429, 502, 503, 504 and on connection errors. Retry-After
     header is respected when present.
     """
-    total = _int_env("ATLASSIAN_RETRY_TOTAL", DEFAULT_RETRY_TOTAL)
+    total = get_int_env("ATLASSIAN_RETRY_TOTAL", DEFAULT_RETRY_TOTAL)
     if total <= 0:
         logger.info("%s: retry disabled (ATLASSIAN_RETRY_TOTAL=%d)", service, total)
         return
 
-    backoff = _float_env("ATLASSIAN_RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF)
-    include_writes = _bool_env("ATLASSIAN_RETRY_INCLUDE_WRITES", default=False)
+    backoff = get_float_env("ATLASSIAN_RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF)
+    include_writes = is_env_extended_truthy("ATLASSIAN_RETRY_INCLUDE_WRITES")
     methods = _ALL_METHODS if include_writes else _READ_METHODS
 
     retry = Retry(
@@ -256,7 +231,7 @@ def configure_concurrency(session: Session, *, service: str = "atlassian") -> No
 
     Recommended starting value for self-hosted: 2-4.
     """
-    cap = _int_env("ATLASSIAN_MAX_CONCURRENT_REQUESTS", 0)
+    cap = get_int_env("ATLASSIAN_MAX_CONCURRENT_REQUESTS", 0)
     if cap <= 0:
         logger.debug("%s: concurrency cap disabled", service)
         return
@@ -322,7 +297,7 @@ def configure_rate_limit(session: Session, *, service: str = "atlassian") -> Non
 
     Recommended starting value for self-hosted: 2-5 rps.
     """
-    rate = _float_env("ATLASSIAN_REQUESTS_PER_SECOND", 0.0)
+    rate = get_float_env("ATLASSIAN_REQUESTS_PER_SECOND", 0.0)
     if rate <= 0:
         logger.debug("%s: rate limit disabled", service)
         return
@@ -383,11 +358,11 @@ def configure_circuit_breaker(session: Session, *, service: str = "atlassian") -
 
     Recommended starting value for self-hosted: threshold=5, cooldown=30s.
     """
-    threshold = _int_env("ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD", 0)
+    threshold = get_int_env("ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD", 0)
     if threshold <= 0:
         logger.debug("%s: circuit breaker disabled", service)
         return
-    cooldown = _float_env("ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN", 30.0)
+    cooldown = get_float_env("ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN", 30.0)
     breaker = _get_circuit_breaker(threshold, cooldown)
     if not session.adapters:
         return
@@ -404,6 +379,11 @@ def configure_circuit_breaker(session: Session, *, service: str = "atlassian") -
 def format_rate_limit_error(http_err: object, *, service: str) -> str:
     """Build a 429 error string that includes Retry-After when the server set it.
 
+    Per RFC 9110 the Retry-After header may be either a delta-seconds integer
+    or an HTTP-date. We prefer to label the value as seconds when it parses
+    cleanly as an int, and otherwise surface the raw header value without
+    making a units claim.
+
     Surfaces the structured backoff hint to the LLM so the agent can pause
     instead of immediately retrying.
     """
@@ -411,9 +391,17 @@ def format_rate_limit_error(http_err: object, *, service: str) -> str:
     headers = getattr(response, "headers", None) or {}
     retry_after = headers.get("Retry-After") or headers.get("retry-after")
     if retry_after:
+        try:
+            seconds = int(str(retry_after).strip())
+        except (TypeError, ValueError):
+            return (
+                f"{service} API rate limit hit (429). "
+                f"Server requested Retry-After: {retry_after}. "
+                "Pause before retrying."
+            )
         return (
             f"{service} API rate limit hit (429). "
-            f"Server requested Retry-After: {retry_after} seconds. "
+            f"Server requested Retry-After: {seconds} seconds. "
             "Pause before retrying."
         )
     return (

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -6,9 +6,10 @@ both the default HTTPAdapter and any service-specific adapters (e.g.
 SSLIgnoreAdapter mounted by configure_ssl_verification) get the same retry
 behavior. Call AFTER configure_ssl_verification.
 
-The optional concurrency cap and rate limiter wrap adapter.send in place
-(rather than replacing the adapter), so they compose with whatever adapter
-is mounted. Both are disabled by default and gated behind env vars.
+The optional retry policy, concurrency cap, rate limiter, and circuit breaker
+are disabled by default and gated behind env vars. The send wrappers patch
+adapter.send in place (rather than replacing the adapter), so they compose with
+whatever adapter is mounted.
 """
 
 import logging
@@ -23,7 +24,7 @@ from .env import get_float_env, get_int_env, is_env_extended_truthy
 
 logger = logging.getLogger("mcp-atlassian.http")
 
-DEFAULT_RETRY_TOTAL = 5
+DEFAULT_RETRY_TOTAL = 0
 DEFAULT_RETRY_BACKOFF = 1.0
 DEFAULT_RETRY_STATUSES = (429, 502, 503, 504)
 _READ_METHODS = frozenset(["GET", "HEAD", "OPTIONS"])
@@ -134,7 +135,7 @@ def configure_retry(session: Session, *, service: str = "atlassian") -> None:
     """Apply a urllib3 Retry policy to all adapters on the session.
 
     Env knobs:
-      ATLASSIAN_RETRY_TOTAL          (int,   default 5; <=0 disables)
+      ATLASSIAN_RETRY_TOTAL          (int,   default 0; <=0 disables)
       ATLASSIAN_RETRY_BACKOFF        (float, default 1.0 seconds — exponential factor)
       ATLASSIAN_RETRY_INCLUDE_WRITES (bool,  default false; if true also retries
                                      POST/PUT/PATCH/DELETE — only safe when the
@@ -145,7 +146,7 @@ def configure_retry(session: Session, *, service: str = "atlassian") -> None:
     """
     total = get_int_env("ATLASSIAN_RETRY_TOTAL", DEFAULT_RETRY_TOTAL)
     if total <= 0:
-        logger.info("%s: retry disabled (ATLASSIAN_RETRY_TOTAL=%d)", service, total)
+        logger.debug("%s: retry disabled (ATLASSIAN_RETRY_TOTAL=%d)", service, total)
         return
 
     backoff = get_float_env("ATLASSIAN_RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF)

--- a/src/mcp_atlassian/utils/http.py
+++ b/src/mcp_atlassian/utils/http.py
@@ -90,20 +90,26 @@ class _CircuitBreaker:
         self.cooldown = cooldown
         self.failures = 0
         self.opened_at: float | None = None
+        self.probe_in_flight = False
         self.lock = threading.Lock()
 
-    def before_send(self) -> None:
+    def before_send(self) -> bool:
         with self.lock:
             if self.opened_at is None:
-                return
-            if time.monotonic() - self.opened_at >= self.cooldown:
-                # Half-open: clear opened_at so a request goes through, but
-                # leave failures at threshold so a single 429/503 in
-                # on_response re-opens the breaker immediately. A 2xx will
-                # reset failures to 0 (closed).
-                self.opened_at = None
-                return
-            remaining = self.cooldown - (time.monotonic() - self.opened_at)
+                return False
+
+            elapsed = time.monotonic() - self.opened_at
+            if elapsed >= self.cooldown:
+                if self.probe_in_flight:
+                    raise CircuitBreakerOpenError(
+                        "Atlassian circuit breaker half-open probe already in "
+                        "flight. Wait for the probe request to complete before "
+                        "retrying."
+                    )
+                self.probe_in_flight = True
+                return True
+
+            remaining = self.cooldown - elapsed
             raise CircuitBreakerOpenError(
                 f"Atlassian circuit breaker open after {self.threshold} consecutive "
                 f"429/503 responses. Cooling down for ~{remaining:.1f}s before "
@@ -111,8 +117,26 @@ class _CircuitBreaker:
                 "back off and retry later."
             )
 
-    def on_response(self, status_code: int) -> None:
+    def on_response(self, status_code: int | None, *, probe: bool) -> None:
         with self.lock:
+            if probe:
+                self.probe_in_flight = False
+                if status_code in (429, 503):
+                    self.failures = max(self.failures, self.threshold)
+                    self.opened_at = time.monotonic()
+                    logger.warning(
+                        "Circuit breaker probe failed with %d; cooling down %.1fs",
+                        status_code,
+                        self.cooldown,
+                    )
+                else:
+                    self.failures = 0
+                    self.opened_at = None
+                return
+
+            if status_code is None or self.opened_at is not None:
+                return
+
             if status_code in (429, 503):
                 self.failures += 1
                 if self.failures >= self.threshold and self.opened_at is None:
@@ -125,6 +149,18 @@ class _CircuitBreaker:
                     )
             else:
                 self.failures = 0
+
+    def on_exception(self, *, probe: bool) -> None:
+        if not probe:
+            return
+        with self.lock:
+            self.probe_in_flight = False
+            self.failures = max(self.failures, self.threshold)
+            self.opened_at = time.monotonic()
+            logger.warning(
+                "Circuit breaker probe failed before response; cooling down %.1fs",
+                self.cooldown,
+            )
 
 
 _circuit_breaker: _CircuitBreaker | None = None
@@ -335,11 +371,14 @@ def _wrap_adapter_circuit_breaker(
     original_send = adapter.send
 
     def breaker_send(*args: object, **kwargs: object) -> object:
-        breaker.before_send()
-        response = original_send(*args, **kwargs)
+        probe = breaker.before_send()
+        try:
+            response = original_send(*args, **kwargs)
+        except Exception:
+            breaker.on_exception(probe=probe)
+            raise
         status = getattr(response, "status_code", None)
-        if isinstance(status, int):
-            breaker.on_response(status)
+        breaker.on_response(status if isinstance(status, int) else None, probe=probe)
         return response
 
     adapter.send = breaker_send  # type: ignore[method-assign]

--- a/src/mcp_atlassian/utils/pagination.py
+++ b/src/mcp_atlassian/utils/pagination.py
@@ -1,0 +1,51 @@
+"""Optional pagination ceiling to protect both the upstream server and the
+LLM context.
+
+A single tool call that asks for thousands of results forces N backend
+round-trips and dumps a huge response into the model. This module clamps
+user-supplied `limit` values to a configurable ceiling, applied at the
+mixin entry point so every caller (FastMCP tool, programmatic, etc.)
+benefits.
+
+Disabled by default — opt in via ATLASSIAN_MAX_PAGINATION_LIMIT.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger("mcp-atlassian.pagination")
+
+
+def clamp_limit(requested: int, *, context: str = "pagination") -> int:
+    """Clamp `requested` to ATLASSIAN_MAX_PAGINATION_LIMIT.
+
+    Disabled by default (env unset or <= 0). Negative or zero `requested` is
+    passed through unchanged so callers' own validation still applies.
+    """
+    if requested <= 0:
+        return requested
+
+    raw = os.getenv("ATLASSIAN_MAX_PAGINATION_LIMIT")
+    if not raw:
+        return requested
+
+    try:
+        cap = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid ATLASSIAN_MAX_PAGINATION_LIMIT=%r; clamping disabled",
+            raw,
+        )
+        return requested
+
+    if cap <= 0:
+        return requested
+    if requested > cap:
+        logger.info(
+            "%s: limit %d clamped to %d (ATLASSIAN_MAX_PAGINATION_LIMIT)",
+            context,
+            requested,
+            cap,
+        )
+        return cap
+    return requested

--- a/src/mcp_atlassian/utils/pagination.py
+++ b/src/mcp_atlassian/utils/pagination.py
@@ -11,7 +11,8 @@ Disabled by default — opt in via ATLASSIAN_MAX_PAGINATION_LIMIT.
 """
 
 import logging
-import os
+
+from .env import get_int_env
 
 logger = logging.getLogger("mcp-atlassian.pagination")
 
@@ -25,19 +26,7 @@ def clamp_limit(requested: int, *, context: str = "pagination") -> int:
     if requested <= 0:
         return requested
 
-    raw = os.getenv("ATLASSIAN_MAX_PAGINATION_LIMIT")
-    if not raw:
-        return requested
-
-    try:
-        cap = int(raw)
-    except ValueError:
-        logger.warning(
-            "Invalid ATLASSIAN_MAX_PAGINATION_LIMIT=%r; clamping disabled",
-            raw,
-        )
-        return requested
-
+    cap = get_int_env("ATLASSIAN_MAX_PAGINATION_LIMIT", 0)
     if cap <= 0:
         return requested
     if requested > cap:

--- a/tests/unit/test_stdio_lifecycle.py
+++ b/tests/unit/test_stdio_lifecycle.py
@@ -36,6 +36,8 @@ def test_stdio_homebrew_probe_exits_after_stdin_close() -> None:
         input=_build_probe_payload(),
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         env=env,
         check=False,
         timeout=15,

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -1,0 +1,90 @@
+"""Tests for the shared HTTP retry utilities."""
+
+import pytest
+from requests.adapters import HTTPAdapter
+from requests.sessions import Session
+from urllib3.util.retry import Retry
+
+from mcp_atlassian.utils.http import (
+    DEFAULT_RETRY_BACKOFF,
+    DEFAULT_RETRY_STATUSES,
+    DEFAULT_RETRY_TOTAL,
+    configure_retry,
+)
+
+
+def _new_session() -> Session:
+    """Fresh Session with default adapters mounted."""
+    s = Session()
+    assert s.adapters
+    return s
+
+
+def test_configure_retry_applies_to_all_adapters_with_defaults():
+    session = _new_session()
+    configure_retry(session, service="Test")
+
+    for adapter in session.adapters.values():
+        retry = adapter.max_retries
+        assert isinstance(retry, Retry)
+        assert retry.total == DEFAULT_RETRY_TOTAL
+        assert retry.backoff_factor == DEFAULT_RETRY_BACKOFF
+        assert tuple(retry.status_forcelist) == DEFAULT_RETRY_STATUSES
+        assert retry.respect_retry_after_header is True
+        assert "GET" in retry.allowed_methods
+        assert "POST" not in retry.allowed_methods
+
+
+def test_configure_retry_respects_env_overrides(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLASSIAN_RETRY_TOTAL", "2")
+    monkeypatch.setenv("ATLASSIAN_RETRY_BACKOFF", "0.25")
+    monkeypatch.setenv("ATLASSIAN_RETRY_INCLUDE_WRITES", "true")
+
+    session = _new_session()
+    configure_retry(session, service="Test")
+
+    adapter = next(iter(session.adapters.values()))
+    retry = adapter.max_retries
+    assert retry.total == 2
+    assert retry.backoff_factor == 0.25
+    assert "POST" in retry.allowed_methods
+    assert "DELETE" in retry.allowed_methods
+
+
+def test_configure_retry_disabled_when_total_le_zero(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ATLASSIAN_RETRY_TOTAL", "0")
+
+    session = _new_session()
+    before = {prefix: adapter.max_retries for prefix, adapter in session.adapters.items()}
+    configure_retry(session, service="Test")
+
+    for prefix, adapter in session.adapters.items():
+        assert adapter.max_retries is before[prefix]
+
+
+def test_configure_retry_invalid_env_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ATLASSIAN_RETRY_TOTAL", "not-an-int")
+    monkeypatch.setenv("ATLASSIAN_RETRY_BACKOFF", "abc")
+
+    session = _new_session()
+    configure_retry(session, service="Test")
+
+    retry = next(iter(session.adapters.values())).max_retries
+    assert retry.total == DEFAULT_RETRY_TOTAL
+    assert retry.backoff_factor == DEFAULT_RETRY_BACKOFF
+
+
+def test_configure_retry_patches_custom_adapter_in_place():
+    """Custom adapters mounted before configure_retry should be patched, not replaced."""
+    session = Session()
+    custom = HTTPAdapter()
+    session.mount("https://example.com", custom)
+
+    configure_retry(session, service="Test")
+
+    assert session.adapters["https://example.com"] is custom
+    assert isinstance(custom.max_retries, Retry)

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -48,12 +48,14 @@ def test_configure_retry_applies_to_all_adapters_with_defaults():
     configure_retry(session, service="Test")
 
     for adapter in session.adapters.values():
+        assert isinstance(adapter, HTTPAdapter)
         retry = adapter.max_retries
         assert isinstance(retry, Retry)
         assert retry.total == DEFAULT_RETRY_TOTAL
         assert retry.backoff_factor == DEFAULT_RETRY_BACKOFF
-        assert tuple(retry.status_forcelist) == DEFAULT_RETRY_STATUSES
+        assert tuple(retry.status_forcelist or ()) == DEFAULT_RETRY_STATUSES
         assert retry.respect_retry_after_header is True
+        assert retry.allowed_methods  # narrow Literal[False] away
         assert "GET" in retry.allowed_methods
         assert "POST" not in retry.allowed_methods
 
@@ -67,9 +69,12 @@ def test_configure_retry_respects_env_overrides(monkeypatch: pytest.MonkeyPatch)
     configure_retry(session, service="Test")
 
     adapter = next(iter(session.adapters.values()))
+    assert isinstance(adapter, HTTPAdapter)
     retry = adapter.max_retries
+    assert isinstance(retry, Retry)
     assert retry.total == 2
     assert retry.backoff_factor == 0.25
+    assert retry.allowed_methods  # narrow Literal[False] away
     assert "POST" in retry.allowed_methods
     assert "DELETE" in retry.allowed_methods
 
@@ -80,10 +85,14 @@ def test_configure_retry_disabled_when_total_le_zero(
     monkeypatch.setenv("ATLASSIAN_RETRY_TOTAL", "0")
 
     session = _new_session()
-    before = {prefix: adapter.max_retries for prefix, adapter in session.adapters.items()}
+    before = {}
+    for prefix, adapter in session.adapters.items():
+        assert isinstance(adapter, HTTPAdapter)
+        before[prefix] = adapter.max_retries
     configure_retry(session, service="Test")
 
     for prefix, adapter in session.adapters.items():
+        assert isinstance(adapter, HTTPAdapter)
         assert adapter.max_retries is before[prefix]
 
 
@@ -96,7 +105,10 @@ def test_configure_retry_invalid_env_falls_back_to_default(
     session = _new_session()
     configure_retry(session, service="Test")
 
-    retry = next(iter(session.adapters.values())).max_retries
+    adapter = next(iter(session.adapters.values()))
+    assert isinstance(adapter, HTTPAdapter)
+    retry = adapter.max_retries
+    assert isinstance(retry, Retry)
     assert retry.total == DEFAULT_RETRY_TOTAL
     assert retry.backoff_factor == DEFAULT_RETRY_BACKOFF
 
@@ -172,9 +184,7 @@ def test_configure_concurrency_caps_parallel_sends(monkeypatch: pytest.MonkeyPat
     configure_concurrency(session, service="Test")
 
     threads = [
-        threading.Thread(
-            target=lambda: session.adapters["https://"].send(MagicMock())
-        )
+        threading.Thread(target=lambda: session.adapters["https://"].send(MagicMock()))
         for _ in range(8)
     ]
     for t in threads:

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -53,7 +53,7 @@ def test_configure_retry_applies_to_all_adapters_with_defaults():
         assert isinstance(retry, Retry)
         assert retry.total == DEFAULT_RETRY_TOTAL
         assert retry.backoff_factor == DEFAULT_RETRY_BACKOFF
-        assert tuple(retry.status_forcelist or ()) == DEFAULT_RETRY_STATUSES
+        assert set(retry.status_forcelist or ()) == set(DEFAULT_RETRY_STATUSES)
         assert retry.respect_retry_after_header is True
         assert retry.allowed_methods  # narrow Literal[False] away
         assert "GET" in retry.allowed_methods
@@ -148,6 +148,16 @@ def test_format_rate_limit_error_handles_no_response():
     http_err.response = None
     msg = format_rate_limit_error(http_err, service="Jira")
     assert "429" in msg
+
+
+def test_format_rate_limit_error_handles_http_date_retry_after():
+    """Retry-After can be an HTTP-date per RFC 9110 — surface the raw value
+    without claiming it's in seconds."""
+    http_err = MagicMock()
+    http_err.response.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+    msg = format_rate_limit_error(http_err, service="Jira")
+    assert "Wed, 21 Oct 2026 07:28:00 GMT" in msg
+    assert "seconds" not in msg.lower()
 
 
 def test_configure_concurrency_disabled_by_default():

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -13,8 +13,11 @@ from mcp_atlassian.utils.http import (
     DEFAULT_RETRY_BACKOFF,
     DEFAULT_RETRY_STATUSES,
     DEFAULT_RETRY_TOTAL,
+    CircuitBreakerOpenError,
+    _reset_circuit_breaker_for_tests,
     _reset_concurrency_semaphore_for_tests,
     _reset_rate_limit_bucket_for_tests,
+    configure_circuit_breaker,
     configure_concurrency,
     configure_rate_limit,
     configure_retry,
@@ -26,9 +29,11 @@ from mcp_atlassian.utils.http import (
 def _reset_state():
     _reset_concurrency_semaphore_for_tests()
     _reset_rate_limit_bucket_for_tests()
+    _reset_circuit_breaker_for_tests()
     yield
     _reset_concurrency_semaphore_for_tests()
     _reset_rate_limit_bucket_for_tests()
+    _reset_circuit_breaker_for_tests()
 
 
 def _new_session() -> Session:
@@ -291,3 +296,78 @@ def test_configure_rate_limit_shares_bucket_across_sessions(
     s1.adapters["https://"].send(MagicMock())
     elapsed = time.monotonic() - start
     assert elapsed >= 0.1
+
+
+def _build_circuit_session(status_codes_iter):
+    session = Session()
+    iterator = iter(status_codes_iter)
+
+    def fake_send(*args, **kwargs):
+        resp = MagicMock()
+        resp.status_code = next(iterator)
+        return resp
+
+    for adapter in session.adapters.values():
+        adapter.send = fake_send  # type: ignore[method-assign]
+    return session
+
+
+def test_circuit_breaker_disabled_by_default():
+    from mcp_atlassian.utils.http import _CIRCUIT_BREAKER_ATTR
+
+    session = Session()
+    configure_circuit_breaker(session, service="Test")
+    for adapter in session.adapters.values():
+        assert not getattr(adapter, _CIRCUIT_BREAKER_ATTR, False)
+
+
+def test_circuit_breaker_trips_after_threshold(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD", "3")
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN", "60")
+
+    session = _build_circuit_session([429, 429, 429, 429])
+    configure_circuit_breaker(session, service="Test")
+
+    adapter = session.adapters["https://"]
+    for _ in range(3):
+        resp = adapter.send(MagicMock())
+        assert resp.status_code == 429
+
+    with pytest.raises(CircuitBreakerOpenError):
+        adapter.send(MagicMock())
+
+
+def test_circuit_breaker_resets_on_success(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD", "3")
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN", "60")
+
+    session = _build_circuit_session([429, 429, 200, 429, 429])
+    configure_circuit_breaker(session, service="Test")
+
+    adapter = session.adapters["https://"]
+    for _ in range(5):
+        adapter.send(MagicMock())  # must not raise
+
+    from mcp_atlassian.utils.http import _circuit_breaker
+
+    assert _circuit_breaker is not None
+    assert _circuit_breaker.failures == 2  # last two 429s, no trip
+
+
+def test_circuit_breaker_cooldown_then_reset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD", "2")
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN", "0.1")
+
+    session = _build_circuit_session([429, 429, 200])
+    configure_circuit_breaker(session, service="Test")
+    adapter = session.adapters["https://"]
+
+    adapter.send(MagicMock())
+    adapter.send(MagicMock())  # trips
+
+    with pytest.raises(CircuitBreakerOpenError):
+        adapter.send(MagicMock())
+
+    time.sleep(0.15)
+    resp = adapter.send(MagicMock())
+    assert resp.status_code == 200

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -1,5 +1,7 @@
 """Tests for the shared HTTP retry utilities."""
 
+from unittest.mock import MagicMock
+
 import pytest
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
@@ -10,6 +12,7 @@ from mcp_atlassian.utils.http import (
     DEFAULT_RETRY_STATUSES,
     DEFAULT_RETRY_TOTAL,
     configure_retry,
+    format_rate_limit_error,
 )
 
 
@@ -88,3 +91,28 @@ def test_configure_retry_patches_custom_adapter_in_place():
 
     assert session.adapters["https://example.com"] is custom
     assert isinstance(custom.max_retries, Retry)
+
+
+def test_format_rate_limit_error_includes_retry_after():
+    http_err = MagicMock()
+    http_err.response.headers = {"Retry-After": "42"}
+    msg = format_rate_limit_error(http_err, service="Jira")
+    assert "Jira" in msg
+    assert "42" in msg
+    assert "Retry-After" in msg
+
+
+def test_format_rate_limit_error_handles_missing_header():
+    http_err = MagicMock()
+    http_err.response.headers = {}
+    msg = format_rate_limit_error(http_err, service="Confluence")
+    assert "Confluence" in msg
+    assert "429" in msg
+    assert "back off" in msg.lower()
+
+
+def test_format_rate_limit_error_handles_no_response():
+    http_err = MagicMock()
+    http_err.response = None
+    msg = format_rate_limit_error(http_err, service="Jira")
+    assert "429" in msg

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -1,5 +1,7 @@
-"""Tests for the shared HTTP retry utilities."""
+"""Tests for the shared HTTP utilities (retry, concurrency, rate limit)."""
 
+import threading
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,9 +13,22 @@ from mcp_atlassian.utils.http import (
     DEFAULT_RETRY_BACKOFF,
     DEFAULT_RETRY_STATUSES,
     DEFAULT_RETRY_TOTAL,
+    _reset_concurrency_semaphore_for_tests,
+    _reset_rate_limit_bucket_for_tests,
+    configure_concurrency,
+    configure_rate_limit,
     configure_retry,
     format_rate_limit_error,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    _reset_concurrency_semaphore_for_tests()
+    _reset_rate_limit_bucket_for_tests()
+    yield
+    _reset_concurrency_semaphore_for_tests()
+    _reset_rate_limit_bucket_for_tests()
 
 
 def _new_session() -> Session:
@@ -116,3 +131,163 @@ def test_format_rate_limit_error_handles_no_response():
     http_err.response = None
     msg = format_rate_limit_error(http_err, service="Jira")
     assert "429" in msg
+
+
+def test_configure_concurrency_disabled_by_default():
+    from mcp_atlassian.utils.http import _THROTTLED_ATTR
+
+    session = Session()
+    configure_concurrency(session, service="Test")
+    for adapter in session.adapters.values():
+        assert not getattr(adapter, _THROTTLED_ATTR, False)
+
+
+def test_configure_concurrency_caps_parallel_sends(monkeypatch: pytest.MonkeyPatch):
+    """Cap=2 means at most 2 send() calls run concurrently."""
+    monkeypatch.setenv("ATLASSIAN_MAX_CONCURRENT_REQUESTS", "2")
+
+    session = Session()
+    in_flight = 0
+    max_in_flight = 0
+    lock = threading.Lock()
+
+    def slow_send(*args, **kwargs):
+        nonlocal in_flight, max_in_flight
+        with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        time.sleep(0.05)
+        with lock:
+            in_flight -= 1
+        return MagicMock()
+
+    for adapter in session.adapters.values():
+        adapter.send = slow_send  # type: ignore[method-assign]
+
+    configure_concurrency(session, service="Test")
+
+    threads = [
+        threading.Thread(
+            target=lambda: session.adapters["https://"].send(MagicMock())
+        )
+        for _ in range(8)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert max_in_flight <= 2, f"expected cap=2, observed {max_in_flight} in flight"
+
+
+def test_configure_concurrency_is_idempotent(monkeypatch: pytest.MonkeyPatch):
+    from mcp_atlassian.utils.http import _THROTTLED_ATTR
+
+    monkeypatch.setenv("ATLASSIAN_MAX_CONCURRENT_REQUESTS", "3")
+    session = Session()
+    configure_concurrency(session, service="Test")
+    adapter = session.adapters["https://"]
+    wrapped_func = adapter.send
+    configure_concurrency(session, service="Test")
+    assert adapter.send is wrapped_func
+    assert getattr(adapter, _THROTTLED_ATTR) is True
+
+
+def test_configure_concurrency_shares_semaphore_across_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Two sessions (Jira + Confluence) must share the cap, not get one each."""
+    monkeypatch.setenv("ATLASSIAN_MAX_CONCURRENT_REQUESTS", "2")
+
+    s1, s2 = Session(), Session()
+    in_flight = 0
+    max_in_flight = 0
+    lock = threading.Lock()
+
+    def slow_send(*args, **kwargs):
+        nonlocal in_flight, max_in_flight
+        with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        time.sleep(0.05)
+        with lock:
+            in_flight -= 1
+        return MagicMock()
+
+    for sess in (s1, s2):
+        for adapter in sess.adapters.values():
+            adapter.send = slow_send  # type: ignore[method-assign]
+
+    configure_concurrency(s1, service="S1")
+    configure_concurrency(s2, service="S2")
+
+    threads = []
+    for sess in (s1, s2):
+        for _ in range(4):
+            threads.append(
+                threading.Thread(
+                    target=lambda s=sess: s.adapters["https://"].send(MagicMock())
+                )
+            )
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert max_in_flight <= 2
+
+
+def test_configure_rate_limit_disabled_by_default():
+    from mcp_atlassian.utils.http import _RATE_LIMITED_ATTR
+
+    session = Session()
+    configure_rate_limit(session, service="Test")
+    for adapter in session.adapters.values():
+        assert not getattr(adapter, _RATE_LIMITED_ATTR, False)
+
+
+def test_configure_rate_limit_throttles_requests(monkeypatch: pytest.MonkeyPatch):
+    """At 10 rps, 5 sends after the burst should take >= ~0.4s."""
+    monkeypatch.setenv("ATLASSIAN_REQUESTS_PER_SECOND", "10")
+
+    session = Session()
+    for adapter in session.adapters.values():
+        adapter.send = lambda *a, **kw: MagicMock()  # type: ignore[method-assign]
+
+    configure_rate_limit(session, service="Test")
+
+    adapter = session.adapters["https://"]
+    for _ in range(10):
+        adapter.send(MagicMock())  # drain burst
+
+    start = time.monotonic()
+    for _ in range(5):
+        adapter.send(MagicMock())
+    elapsed = time.monotonic() - start
+
+    assert elapsed >= 0.35, f"expected throttling >= 0.35s, got {elapsed:.3f}s"
+
+
+def test_configure_rate_limit_shares_bucket_across_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ATLASSIAN_REQUESTS_PER_SECOND", "5")
+
+    s1, s2 = Session(), Session()
+    for sess in (s1, s2):
+        for adapter in sess.adapters.values():
+            adapter.send = lambda *a, **kw: MagicMock()  # type: ignore[method-assign]
+
+    configure_rate_limit(s1, service="S1")
+    configure_rate_limit(s2, service="S2")
+
+    s1.adapters["https://"].send(MagicMock())
+    s1.adapters["https://"].send(MagicMock())
+    s2.adapters["https://"].send(MagicMock())
+    s2.adapters["https://"].send(MagicMock())
+    s2.adapters["https://"].send(MagicMock())
+
+    start = time.monotonic()
+    s1.adapters["https://"].send(MagicMock())
+    elapsed = time.monotonic() - start
+    assert elapsed >= 0.1

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -435,3 +435,66 @@ def test_circuit_breaker_cooldown_then_reset(monkeypatch: pytest.MonkeyPatch):
     time.sleep(0.15)
     resp = adapter.send(MagicMock())
     assert resp.status_code == 200
+
+
+def test_circuit_breaker_allows_only_one_half_open_probe(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_THRESHOLD", "1")
+    monkeypatch.setenv("ATLASSIAN_CIRCUIT_BREAKER_COOLDOWN", "0.1")
+
+    session = Session()
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    call_count = 0
+    lock = threading.Lock()
+
+    def fake_send(*args, **kwargs):
+        nonlocal call_count
+        with lock:
+            call_count += 1
+            current_call = call_count
+        resp = MagicMock()
+        if current_call == 1:
+            resp.status_code = 429
+            return resp
+
+        probe_started.set()
+        assert release_probe.wait(timeout=1.0)
+        resp.status_code = 200
+        return resp
+
+    for adapter in session.adapters.values():
+        adapter.send = fake_send  # type: ignore[method-assign]
+
+    configure_circuit_breaker(session, service="Test")
+    adapter = session.adapters["https://"]
+
+    adapter.send(MagicMock())  # trips immediately
+    time.sleep(0.15)
+
+    results: list[str] = []
+
+    def send_request() -> None:
+        try:
+            adapter.send(MagicMock())
+        except CircuitBreakerOpenError:
+            results.append("blocked")
+        else:
+            results.append("sent")
+
+    probe_thread = threading.Thread(target=send_request)
+    probe_thread.start()
+    assert probe_started.wait(timeout=1.0)
+
+    blocked_threads = [threading.Thread(target=send_request) for _ in range(3)]
+    for thread in blocked_threads:
+        thread.start()
+    for thread in blocked_threads:
+        thread.join()
+
+    release_probe.set()
+    probe_thread.join()
+
+    assert results.count("sent") == 1
+    assert results.count("blocked") == 3

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -43,7 +43,27 @@ def _new_session() -> Session:
     return s
 
 
-def test_configure_retry_applies_to_all_adapters_with_defaults():
+def test_configure_retry_disabled_by_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ATLASSIAN_RETRY_TOTAL", raising=False)
+
+    session = _new_session()
+    before = {}
+    for prefix, adapter in session.adapters.items():
+        assert isinstance(adapter, HTTPAdapter)
+        before[prefix] = adapter.max_retries
+
+    configure_retry(session, service="Test")
+
+    for prefix, adapter in session.adapters.items():
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries is before[prefix]
+
+
+def test_configure_retry_applies_to_all_adapters_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ATLASSIAN_RETRY_TOTAL", "5")
+
     session = _new_session()
     configure_retry(session, service="Test")
 
@@ -51,7 +71,7 @@ def test_configure_retry_applies_to_all_adapters_with_defaults():
         assert isinstance(adapter, HTTPAdapter)
         retry = adapter.max_retries
         assert isinstance(retry, Retry)
-        assert retry.total == DEFAULT_RETRY_TOTAL
+        assert retry.total == 5
         assert retry.backoff_factor == DEFAULT_RETRY_BACKOFF
         assert set(retry.status_forcelist or ()) == set(DEFAULT_RETRY_STATUSES)
         assert retry.respect_retry_after_header is True
@@ -103,18 +123,42 @@ def test_configure_retry_invalid_env_falls_back_to_default(
     monkeypatch.setenv("ATLASSIAN_RETRY_BACKOFF", "abc")
 
     session = _new_session()
+    before = {}
+    for prefix, adapter in session.adapters.items():
+        assert isinstance(adapter, HTTPAdapter)
+        before[prefix] = adapter.max_retries
+
+    configure_retry(session, service="Test")
+
+    assert DEFAULT_RETRY_TOTAL == 0
+    for prefix, adapter in session.adapters.items():
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries is before[prefix]
+
+
+def test_configure_retry_invalid_backoff_falls_back_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ATLASSIAN_RETRY_TOTAL", "5")
+    monkeypatch.setenv("ATLASSIAN_RETRY_BACKOFF", "abc")
+
+    session = _new_session()
     configure_retry(session, service="Test")
 
     adapter = next(iter(session.adapters.values()))
     assert isinstance(adapter, HTTPAdapter)
     retry = adapter.max_retries
     assert isinstance(retry, Retry)
-    assert retry.total == DEFAULT_RETRY_TOTAL
+    assert retry.total == 5
     assert retry.backoff_factor == DEFAULT_RETRY_BACKOFF
 
 
-def test_configure_retry_patches_custom_adapter_in_place():
+def test_configure_retry_patches_custom_adapter_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+):
     """Custom adapters mounted before configure_retry should be patched, not replaced."""
+    monkeypatch.setenv("ATLASSIAN_RETRY_TOTAL", "5")
+
     session = Session()
     custom = HTTPAdapter()
     session.mount("https://example.com", custom)

--- a/tests/unit/utils/test_pagination.py
+++ b/tests/unit/utils/test_pagination.py
@@ -1,0 +1,34 @@
+"""Tests for the pagination clamp utility."""
+
+import pytest
+
+from mcp_atlassian.utils.pagination import clamp_limit
+
+
+def test_clamp_limit_passthrough_when_env_unset(monkeypatch: pytest.MonkeyPatch):
+    """Default behavior: no clamping unless env is set."""
+    monkeypatch.delenv("ATLASSIAN_MAX_PAGINATION_LIMIT", raising=False)
+    assert clamp_limit(500) == 500
+    assert clamp_limit(50) == 50
+
+
+def test_clamp_limit_respects_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLASSIAN_MAX_PAGINATION_LIMIT", "25")
+    assert clamp_limit(500) == 25
+    assert clamp_limit(10) == 10
+
+
+def test_clamp_limit_disabled_when_cap_le_zero(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLASSIAN_MAX_PAGINATION_LIMIT", "0")
+    assert clamp_limit(9999) == 9999
+
+
+def test_clamp_limit_invalid_env_passes_through(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ATLASSIAN_MAX_PAGINATION_LIMIT", "not-a-number")
+    assert clamp_limit(500) == 500
+
+
+def test_clamp_limit_passes_through_non_positive():
+    # Caller's own validation handles 0/negative; clamp doesn't fight it.
+    assert clamp_limit(0) == 0
+    assert clamp_limit(-5) == -5


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Adds opt-in HTTP hardening to protect Atlassian instances — especially self-hosted Server / Data Center — from runaway agent loops. All features gate behind environment variables and default to disabled / off, so behavior is unchanged unless an operator opts in.

This is contributed back from a private fork that ran for ~24h against a self-hosted Jira/Confluence DC instance.

Fixes: # <!-- no linked issue; happy to file one if you'd like a tracker -->

## Changes

- Add urllib3 Retry on Sessions; respect Retry-After on 429/502/503/504
- Surface Retry-After value in 429 error messages
- Optional process-wide concurrency cap (`ATLASSIAN_MAX_CONCURRENT_REQUESTS`)
- Optional outbound RPS limiter (`ATLASSIAN_REQUESTS_PER_SECOND`)
- Optional pagination ceiling (`ATLASSIAN_MAX_PAGINATION_LIMIT`)
- Optional circuit breaker for repeated 429/503 (`ATLASSIAN_CIRCUIT_BREAKER_*`)
- Windows test fix: explicit utf-8 subprocess capture in `test_stdio_lifecycle`

## Testing

- [x] Unit tests added/updated (`tests/unit/utils/test_http.py`, `tests/unit/utils/test_pagination.py`)
- [x] Integration tests passed (full unit suite: 2600 passed locally on Windows)
- [x] Manual checks performed: ran the fork against a real self-hosted Jira/Confluence DC instance for ~24 hours, verified retry, concurrency cap, and pagination clamp behavior end-to-end through MCP tool calls

Two pre-existing platform-specific Windows failures unrelated to this PR (Python 3.13 timestamp boundary in `test_date`, `.zip` MIME detection in `test_media`) are unchanged.

## Checklist

- [x] Code follows project style guidelines (linting passes — `pre-commit run --all-files` green).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed). <!-- env vars documented in docstrings; happy to add a docs/ page if you want -->

## Notes for the reviewer

- **All knobs default to off.** I started with conservative defaults active by default in my fork, but realized changing observable behavior (request concurrency, response sizes) without explicit operator consent isn't appropriate for an upstream merge. Cloud users see no change.
- **Commits are atomic and reviewable.** Six feature commits + one `chore:` cleanup commit applying ruff-format / mypy / FBT003 fixes that I'm happy to fold into the relevant feature commits via interactive rebase if you'd prefer cleaner history.
- **Happy to split into smaller PRs.** If a single PR is too large, I can submit commits 1–2 (retry + Retry-After) as a first PR and follow up with the rest. Let me know what fits your review style best.
