### PR TITLE
feat(jira): add label management tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ uv run mcp-atlassian -v              # Verbose logging mode
 
 ### Mixin-Based Composition
 Functionality is organized into **focused mixins** that compose together:
-- **Jira**: `JiraFetcher` inherits from 13 feature mixins (ProjectsMixin, IssuesMixin, WorklogMixin, etc.)
+- **Jira**: `JiraFetcher` inherits from 22 feature mixins (ProjectsMixin, IssuesMixin, LabelsMixin, WorklogMixin, etc.)
 - **Confluence**: `ConfluenceFetcher` inherits from 7 feature mixins (SearchMixin, PagesMixin, SpacesMixin, etc.)
 
 Each mixin lives in its own module under `src/mcp_atlassian/jira/` or `src/mcp_atlassian/confluence/`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
             'types-requests',
             'types-setuptools',
             'types-urllib3',
-            'types-cachetools',
+            'types-cachetools==5.5.0.20240820',
             'types-PyYAML',
             'atlassian-python-api',
             'beautifulsoup4',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 | Path | Purpose |
 | --- | --- |
 | `src/mcp_atlassian/` | Library source (Python ≥ 3.10) |
-| `  ├─ jira/` | Jira client + 21 mixins (issues, search, SLA, metrics, …) |
+| `  ├─ jira/` | Jira client + 22 mixins (issues, search, labels, SLA, metrics, …) |
 | `  ├─ confluence/` | Confluence client + 8 mixins (pages, search, analytics, …) |
 | `  ├─ models/` | Pydantic v2 data models (`ApiModel` base) |
 | `  ├─ servers/` | FastMCP server instances (`jira_mcp`, `confluence_mcp`) |
@@ -22,7 +22,7 @@
 
 ## Architecture
 
-- **Mixin composition**: `JiraFetcher` composes 21 mixins, `ConfluenceFetcher` composes 8. Client inheritance is transitive through mixins.
+- **Mixin composition**: `JiraFetcher` composes 22 mixins, `ConfluenceFetcher` composes 8. Client inheritance is transitive through mixins.
 - **FastMCP servers**: `servers/main.py` → lifespan → dependency injection via `get_jira_fetcher(ctx)` / `get_confluence_fetcher(ctx)`.
 - **Tool naming**: `{service}_{action}_{target}` (e.g., `jira_create_issue`, `confluence_get_page`).
 - **Config**: Environment-based `from_env()` factory on `JiraConfig` / `ConfluenceConfig` dataclasses.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,13 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_create_issue` - Create issues | `confluence_create_page` - Create pages |
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
+| `jira_get_issue_labels` - Get issue labels | |
+| `jira_add_issue_labels` - Add labels (preserves existing) | |
+| `jira_remove_issue_labels` - Remove specific labels | |
+| `jira_set_issue_labels` - Replace all labels | |
+| `jira_get_available_labels` - List instance labels | |
 
-**72 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**78 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -20,6 +20,7 @@ from .fields import FieldsMixin
 from .forms_api import FormsApiMixin  # Forms REST API
 from .formatting import FormattingMixin
 from .issues import IssuesMixin
+from .labels import LabelsMixin
 from .links import LinksMixin
 from .metrics import MetricsMixin
 from .projects import ProjectsMixin
@@ -47,6 +48,7 @@ class JiraFetcher(
     IssuesMixin,
     UsersMixin,
     WatchersMixin,
+    LabelsMixin,
     BoardsMixin,
     SprintsMixin,
     QueuesMixin,
@@ -71,6 +73,7 @@ class JiraFetcher(
     - IssuesMixin: Issue operations
     - UsersMixin: User operations
     - WatchersMixin: Watcher operations
+    - LabelsMixin: Label operations
     - BoardsMixin: Board operations
     - SprintsMixin: Sprint operations
     - AttachmentsMixin: Attachment download operations

--- a/src/mcp_atlassian/jira/labels.py
+++ b/src/mcp_atlassian/jira/labels.py
@@ -31,9 +31,7 @@ class LabelsMixin(JiraClient):
         labels: list[str] = result.get("fields", {}).get("labels", [])
         return {"issue_key": issue_key, "labels": labels}
 
-    def add_issue_labels(
-        self, issue_key: str, labels: list[str]
-    ) -> dict[str, Any]:
+    def add_issue_labels(self, issue_key: str, labels: list[str]) -> dict[str, Any]:
         """Add labels to an issue without removing existing ones.
 
         Args:
@@ -52,9 +50,7 @@ class LabelsMixin(JiraClient):
         )
         return {"issue_key": issue_key, "labels": new_labels, "added": added}
 
-    def remove_issue_labels(
-        self, issue_key: str, labels: list[str]
-    ) -> dict[str, Any]:
+    def remove_issue_labels(self, issue_key: str, labels: list[str]) -> dict[str, Any]:
         """Remove specific labels from an issue.
 
         Args:
@@ -83,9 +79,7 @@ class LabelsMixin(JiraClient):
             result["not_found"] = not_found
         return result
 
-    def set_issue_labels(
-        self, issue_key: str, labels: list[str]
-    ) -> dict[str, Any]:
+    def set_issue_labels(self, issue_key: str, labels: list[str]) -> dict[str, Any]:
         """Replace all labels on an issue.
 
         Args:

--- a/src/mcp_atlassian/jira/labels.py
+++ b/src/mcp_atlassian/jira/labels.py
@@ -1,0 +1,150 @@
+"""Module for Jira label operations."""
+
+import logging
+from typing import Any
+
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class LabelsMixin(JiraClient):
+    """Mixin for Jira issue label operations."""
+
+    def get_issue_labels(self, issue_key: str) -> dict[str, Any]:
+        """Get labels for a specific issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+
+        Returns:
+            Dictionary with issue_key and list of label strings.
+        """
+        result = self.jira.get_issue(issue_key, fields="labels")
+        if not isinstance(result, dict):
+            logger.error(
+                "Unexpected response type from get_issue for labels: %s",
+                type(result),
+            )
+            return {"issue_key": issue_key, "labels": []}
+
+        labels: list[str] = result.get("fields", {}).get("labels", [])
+        return {"issue_key": issue_key, "labels": labels}
+
+    def add_issue_labels(
+        self, issue_key: str, labels: list[str]
+    ) -> dict[str, Any]:
+        """Add labels to an issue without removing existing ones.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            labels: List of label strings to add.
+
+        Returns:
+            Dictionary with issue_key, updated labels list, and added labels.
+        """
+        current = self.get_issue_labels(issue_key)
+        existing: set[str] = set(current["labels"])
+        added = sorted(set(labels) - existing)
+        new_labels = sorted(existing | set(labels))
+        self.jira.update_issue(
+            issue_key=issue_key, update={"fields": {"labels": new_labels}}
+        )
+        return {"issue_key": issue_key, "labels": new_labels, "added": added}
+
+    def remove_issue_labels(
+        self, issue_key: str, labels: list[str]
+    ) -> dict[str, Any]:
+        """Remove specific labels from an issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            labels: List of label strings to remove.
+
+        Returns:
+            Dictionary with issue_key, updated labels list, removed labels,
+            and any labels that were not present on the issue.
+        """
+        current = self.get_issue_labels(issue_key)
+        to_remove: set[str] = set(labels)
+        existing: set[str] = set(current["labels"])
+        not_found = sorted(to_remove - existing)
+        removed = sorted(to_remove & existing)
+        new_labels = sorted(existing - to_remove)
+        self.jira.update_issue(
+            issue_key=issue_key, update={"fields": {"labels": new_labels}}
+        )
+        result: dict[str, Any] = {
+            "issue_key": issue_key,
+            "labels": new_labels,
+            "removed": removed,
+        }
+        if not_found:
+            result["not_found"] = not_found
+        return result
+
+    def set_issue_labels(
+        self, issue_key: str, labels: list[str]
+    ) -> dict[str, Any]:
+        """Replace all labels on an issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            labels: New list of label strings (replaces existing labels).
+
+        Returns:
+            Dictionary with issue_key and updated labels list.
+        """
+        self.jira.update_issue(
+            issue_key=issue_key, update={"fields": {"labels": labels}}
+        )
+        return {"issue_key": issue_key, "labels": labels}
+
+    def get_available_labels(
+        self,
+        query: str | None = None,
+        start_at: int = 0,
+        max_results: int = 50,
+    ) -> dict[str, Any]:
+        """Get available labels from the Jira instance.
+
+        Calls GET /rest/api/2/label with optional prefix filtering.
+        Supported on both Jira Cloud and Server/Data Center.
+
+        Args:
+            query: Optional prefix string to filter labels by name.
+            start_at: Index of the first label to return (for pagination).
+            max_results: Maximum number of labels to return.
+
+        Returns:
+            Dictionary with labels list, total count, and pagination info.
+        """
+        params: dict[str, Any] = {
+            "startAt": start_at,
+            "maxResults": max_results,
+        }
+        if query:
+            params["query"] = query
+
+        result = self.jira.get("label", params=params)
+        if not isinstance(result, dict):
+            logger.error(
+                "Unexpected response type from GET label endpoint: %s",
+                type(result),
+            )
+            return {
+                "labels": [],
+                "total": 0,
+                "start_at": start_at,
+                "max_results": max_results,
+                "is_last": True,
+            }
+
+        values: list[str] = result.get("values", [])
+        return {
+            "labels": values,
+            "total": result.get("total", len(values)),
+            "start_at": result.get("startAt", start_at),
+            "max_results": result.get("maxResults", max_results),
+            "is_last": result.get("isLast", True),
+        }

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -292,6 +292,215 @@ async def remove_watcher(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_labels"},
+    annotations={"title": "Get Issue Labels", "readOnlyHint": True},
+)
+async def get_issue_labels(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+) -> str:
+    """Get the labels applied to a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+
+    Returns:
+        JSON string with issue_key and list of label strings.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_issue_labels(issue_key)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_labels"},
+    annotations={"title": "Add Issue Labels", "readOnlyHint": False},
+)
+@check_write_access
+async def add_issue_labels(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    labels: Annotated[
+        str,
+        Field(
+            description=(
+                "Comma-separated list of labels to add (e.g., 'frontend,urgent')."
+                " Existing labels are preserved."
+            ),
+        ),
+    ],
+) -> str:
+    """Add one or more labels to a Jira issue without removing existing labels.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        labels: Comma-separated label strings to add.
+
+    Returns:
+        JSON string with updated labels list and which labels were added.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    label_list = [lbl.strip() for lbl in labels.split(",") if lbl.strip()]
+    if not label_list:
+        raise ValueError("At least one label must be provided")
+    result = jira.add_issue_labels(issue_key, label_list)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_labels"},
+    annotations={"title": "Remove Issue Labels", "readOnlyHint": False},
+)
+@check_write_access
+async def remove_issue_labels(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    labels: Annotated[
+        str,
+        Field(
+            description=(
+                "Comma-separated list of labels to remove (e.g., 'frontend,urgent')."
+                " Labels not present on the issue are reported but not treated as errors."
+            ),
+        ),
+    ],
+) -> str:
+    """Remove one or more labels from a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        labels: Comma-separated label strings to remove.
+
+    Returns:
+        JSON string with updated labels list, removed labels, and any labels
+        that were not present on the issue.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    label_list = [lbl.strip() for lbl in labels.split(",") if lbl.strip()]
+    if not label_list:
+        raise ValueError("At least one label must be provided")
+    result = jira.remove_issue_labels(issue_key, label_list)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_labels"},
+    annotations={"title": "Set Issue Labels", "readOnlyHint": False},
+)
+@check_write_access
+async def set_issue_labels(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    labels: Annotated[
+        str,
+        Field(
+            description=(
+                "Comma-separated list of labels to set (e.g., 'frontend,urgent')."
+                " Replaces ALL existing labels. Pass an empty string to clear all labels."
+            ),
+        ),
+    ],
+) -> str:
+    """Replace all labels on a Jira issue with the provided set.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        labels: Comma-separated label strings (replaces existing labels entirely).
+                Pass an empty string to clear all labels.
+
+    Returns:
+        JSON string with issue_key and the new labels list.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    label_list = [lbl.strip() for lbl in labels.split(",") if lbl.strip()]
+    result = jira.set_issue_labels(issue_key, label_list)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_labels"},
+    annotations={"title": "Get Available Labels", "readOnlyHint": True},
+)
+async def get_available_labels(
+    ctx: Context,
+    query: Annotated[
+        str | None,
+        Field(
+            description="Optional prefix string to filter labels by name.",
+            default=None,
+        ),
+    ] = None,
+    start_at: Annotated[
+        int,
+        Field(description="Index of the first label to return (for pagination).", default=0),
+    ] = 0,
+    max_results: Annotated[
+        int,
+        Field(description="Maximum number of labels to return (default 50).", default=50),
+    ] = 50,
+) -> str:
+    """Get available labels from the Jira instance.
+
+    Args:
+        ctx: The FastMCP context.
+        query: Optional prefix to filter labels.
+        start_at: Pagination offset.
+        max_results: Maximum labels to return.
+
+    Returns:
+        JSON string with labels list, total count, and pagination info.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_available_labels(
+        query=query, start_at=start_at, max_results=max_results
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_issues"},
     annotations={"title": "Get Issue", "readOnlyHint": True},
 )

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -472,11 +472,16 @@ async def get_available_labels(
     ] = None,
     start_at: Annotated[
         int,
-        Field(description="Index of the first label to return (for pagination).", default=0),
+        Field(
+            description="Index of the first label to return (for pagination).",
+            default=0,
+        ),
     ] = 0,
     max_results: Annotated[
         int,
-        Field(description="Maximum number of labels to return (default 50).", default=50),
+        Field(
+            description="Maximum number of labels to return (default 50).", default=50
+        ),
     ] = 50,
 ) -> str:
     """Get available labels from the Jira instance.

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 73 tools into 22 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (15) ---
+# --- Jira toolsets (16) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -100,6 +100,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_labels": ToolsetDefinition(
+        name="jira_labels",
+        description="Issue label management (get, add, remove, set, list available)",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (6) ---
@@ -152,7 +157,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 21 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 22 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -165,8 +170,8 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 21 toolsets (with deprecation warning)
+        TOOLSETS unset -> all 22 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 22 toolsets (with deprecation warning)
         TOOLSETS="all" -> all 21 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
@@ -214,7 +219,8 @@ def get_enabled_toolsets() -> set[str]:
         logger.info(f"TOOLSETS: enabled toolsets: {sorted(result)}")
     else:
         logger.warning(
-            "TOOLSETS: no valid toolset names found — all tools will be blocked (fail-closed)."
+            "TOOLSETS: no valid toolset names found — "
+            "all tools will be blocked (fail-closed)."
         )
 
     return result

--- a/tests/unit/jira/test_labels.py
+++ b/tests/unit/jira/test_labels.py
@@ -81,9 +81,7 @@ class TestAddIssueLabels:
             ["frontend", "backend"]
         )
 
-        result = labels_mixin.add_issue_labels(
-            "TEST-123", ["frontend", "urgent"]
-        )
+        result = labels_mixin.add_issue_labels("TEST-123", ["frontend", "urgent"])
 
         assert result["added"] == ["urgent"]
 
@@ -111,9 +109,7 @@ class TestRemoveIssueLabels:
         assert result["removed"] == ["urgent"]
 
     def test_calls_update_with_remaining_labels(self, labels_mixin):
-        labels_mixin.jira.get_issue.return_value = _issue_with_labels(
-            ["a", "b", "c"]
-        )
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["a", "b", "c"])
 
         labels_mixin.remove_issue_labels("TEST-123", ["b"])
 
@@ -139,9 +135,7 @@ class TestRemoveIssueLabels:
         assert "not_found" not in result
 
     def test_remove_all_labels(self, labels_mixin):
-        labels_mixin.jira.get_issue.return_value = _issue_with_labels(
-            ["a", "b"]
-        )
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["a", "b"])
 
         result = labels_mixin.remove_issue_labels("TEST-123", ["a", "b"])
 

--- a/tests/unit/jira/test_labels.py
+++ b/tests/unit/jira/test_labels.py
@@ -1,0 +1,235 @@
+"""Tests for Jira label operations."""
+
+import pytest
+
+from mcp_atlassian.jira.labels import LabelsMixin
+
+
+@pytest.fixture
+def labels_mixin(jira_client):
+    """Create a LabelsMixin instance with mocked dependencies."""
+    mixin = LabelsMixin(config=jira_client.config)
+    mixin.jira = jira_client.jira
+    return mixin
+
+
+def _issue_with_labels(labels: list[str]) -> dict:
+    return {"fields": {"labels": labels}}
+
+
+class TestGetIssueLabels:
+    """Tests for get_issue_labels method."""
+
+    def test_returns_labels_for_issue(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(
+            ["frontend", "urgent"]
+        )
+
+        result = labels_mixin.get_issue_labels("TEST-123")
+
+        labels_mixin.jira.get_issue.assert_called_once_with("TEST-123", fields="labels")
+        assert result["issue_key"] == "TEST-123"
+        assert result["labels"] == ["frontend", "urgent"]
+
+    def test_returns_empty_list_when_no_labels(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels([])
+
+        result = labels_mixin.get_issue_labels("TEST-123")
+
+        assert result["labels"] == []
+
+    def test_handles_invalid_response_type(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = "unexpected"
+
+        result = labels_mixin.get_issue_labels("TEST-123")
+
+        assert result["issue_key"] == "TEST-123"
+        assert result["labels"] == []
+
+
+class TestAddIssueLabels:
+    """Tests for add_issue_labels method."""
+
+    def test_adds_new_labels_preserving_existing(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["existing"])
+
+        result = labels_mixin.add_issue_labels("TEST-123", ["new"])
+
+        assert "new" in result["labels"]
+        assert "existing" in result["labels"]
+        assert result["added"] == ["new"]
+
+    def test_does_not_duplicate_existing_label(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["frontend"])
+
+        result = labels_mixin.add_issue_labels("TEST-123", ["frontend"])
+
+        assert result["labels"].count("frontend") == 1
+        assert result["added"] == []
+
+    def test_calls_update_with_merged_labels(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["a"])
+
+        labels_mixin.add_issue_labels("TEST-123", ["b"])
+
+        labels_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123", update={"fields": {"labels": ["a", "b"]}}
+        )
+
+    def test_added_shows_only_truly_new_labels(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(
+            ["frontend", "backend"]
+        )
+
+        result = labels_mixin.add_issue_labels(
+            "TEST-123", ["frontend", "urgent"]
+        )
+
+        assert result["added"] == ["urgent"]
+
+    def test_result_labels_are_sorted(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["zebra"])
+
+        result = labels_mixin.add_issue_labels("TEST-123", ["apple"])
+
+        assert result["labels"] == sorted(result["labels"])
+
+
+class TestRemoveIssueLabels:
+    """Tests for remove_issue_labels method."""
+
+    def test_removes_specified_labels(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(
+            ["frontend", "urgent", "backend"]
+        )
+
+        result = labels_mixin.remove_issue_labels("TEST-123", ["urgent"])
+
+        assert "urgent" not in result["labels"]
+        assert "frontend" in result["labels"]
+        assert "backend" in result["labels"]
+        assert result["removed"] == ["urgent"]
+
+    def test_calls_update_with_remaining_labels(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(
+            ["a", "b", "c"]
+        )
+
+        labels_mixin.remove_issue_labels("TEST-123", ["b"])
+
+        labels_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123", update={"fields": {"labels": ["a", "c"]}}
+        )
+
+    def test_reports_not_found_labels(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["frontend"])
+
+        result = labels_mixin.remove_issue_labels(
+            "TEST-123", ["frontend", "nonexistent"]
+        )
+
+        assert result["removed"] == ["frontend"]
+        assert result["not_found"] == ["nonexistent"]
+
+    def test_no_not_found_key_when_all_present(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(["frontend"])
+
+        result = labels_mixin.remove_issue_labels("TEST-123", ["frontend"])
+
+        assert "not_found" not in result
+
+    def test_remove_all_labels(self, labels_mixin):
+        labels_mixin.jira.get_issue.return_value = _issue_with_labels(
+            ["a", "b"]
+        )
+
+        result = labels_mixin.remove_issue_labels("TEST-123", ["a", "b"])
+
+        assert result["labels"] == []
+        assert result["removed"] == ["a", "b"]
+
+
+class TestSetIssueLabels:
+    """Tests for set_issue_labels method."""
+
+    def test_replaces_labels(self, labels_mixin):
+        result = labels_mixin.set_issue_labels("TEST-123", ["new1", "new2"])
+
+        labels_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123",
+            update={"fields": {"labels": ["new1", "new2"]}},
+        )
+        assert result["issue_key"] == "TEST-123"
+        assert result["labels"] == ["new1", "new2"]
+
+    def test_clears_all_labels_with_empty_list(self, labels_mixin):
+        result = labels_mixin.set_issue_labels("TEST-123", [])
+
+        labels_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123",
+            update={"fields": {"labels": []}},
+        )
+        assert result["labels"] == []
+
+
+class TestGetAvailableLabels:
+    """Tests for get_available_labels method."""
+
+    def test_returns_labels_list(self, labels_mixin):
+        labels_mixin.jira.get.return_value = {
+            "values": ["backend", "frontend", "urgent"],
+            "total": 3,
+            "startAt": 0,
+            "maxResults": 50,
+            "isLast": True,
+        }
+
+        result = labels_mixin.get_available_labels()
+
+        labels_mixin.jira.get.assert_called_once_with(
+            "label", params={"startAt": 0, "maxResults": 50}
+        )
+        assert result["labels"] == ["backend", "frontend", "urgent"]
+        assert result["total"] == 3
+        assert result["is_last"] is True
+
+    def test_passes_query_parameter(self, labels_mixin):
+        labels_mixin.jira.get.return_value = {
+            "values": ["frontend"],
+            "total": 1,
+            "startAt": 0,
+            "maxResults": 50,
+            "isLast": True,
+        }
+
+        labels_mixin.get_available_labels(query="front")
+
+        labels_mixin.jira.get.assert_called_once_with(
+            "label", params={"startAt": 0, "maxResults": 50, "query": "front"}
+        )
+
+    def test_passes_pagination_parameters(self, labels_mixin):
+        labels_mixin.jira.get.return_value = {
+            "values": [],
+            "total": 100,
+            "startAt": 50,
+            "maxResults": 25,
+            "isLast": False,
+        }
+
+        result = labels_mixin.get_available_labels(start_at=50, max_results=25)
+
+        labels_mixin.jira.get.assert_called_once_with(
+            "label", params={"startAt": 50, "maxResults": 25}
+        )
+        assert result["start_at"] == 50
+        assert result["is_last"] is False
+
+    def test_handles_invalid_response_type(self, labels_mixin):
+        labels_mixin.jira.get.return_value = "unexpected"
+
+        result = labels_mixin.get_available_labels()
+
+        assert result["labels"] == []
+        assert result["total"] == 0
+        assert result["is_last"] is True

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 22 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 22 entries."""
+        assert len(ALL_TOOLSETS) == 22
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 16
         assert len(confluence_toolsets) == 6
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 54, f"Expected 54 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
Add five MCP tools for managing Jira issue labels:
- jira_get_issue_labels: read labels on an issue
- jira_add_issue_labels: add labels without removing existing ones
- jira_remove_issue_labels: remove specific labels (reports missing gracefully)
- jira_set_issue_labels: replace all labels on an issue
- jira_get_available_labels: list labels in the instance with optional prefix filter and pagination

Implemented as a new LabelsMixin in jira/labels.py and registered in JiraFetcher. Includes 19 unit tests covering all methods and edge cases. Docs updated: README (key tools table, tool count), AGENTS.md, copilot-instructions.md.

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
