### PR TITLE
Preserve MCP tool error details

### DIFF
--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -67,6 +67,16 @@ class SearchMixin(ConfluenceClient):
         # Execute the CQL search query
         results = self.confluence.cql(cql=cql, limit=limit)
 
+        # A well-formed response always carries a "results" field (which may be
+        # an empty list). A response missing it entirely indicates an API,
+        # network, or processing failure that must surface as an error rather
+        # than be silently treated as an empty result set.
+        if not isinstance(results, dict) or "results" not in results:
+            raise ValueError(
+                "Confluence search returned a malformed response "
+                "missing the 'results' field"
+            )
+
         # Convert the response to a search result model
         search_result = ConfluenceSearchResult.from_api_response(
             results,

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -48,13 +48,13 @@ class SearchMixin(ConfluenceClient):
 
     @staticmethod
     def _validate_search_response(response: Any, operation: str) -> dict[str, Any]:
-        """Ensure a search API response carries the required 'results' field.
+        """Ensure a search API response has a list of results.
 
         A well-formed Confluence search response always includes a "results"
-        field (which may legitimately be an empty list). A response missing it
-        entirely indicates an API, network, or processing failure that must
-        surface as an error rather than be silently treated as an empty result
-        set.
+        field containing a list (which may legitimately be empty). A response
+        missing it or containing a different type indicates an API, network, or
+        processing failure that must surface as an error rather than be
+        silently treated as an empty result set.
 
         Args:
             response: The raw response returned by the Confluence API.
@@ -65,13 +65,21 @@ class SearchMixin(ConfluenceClient):
             The validated response dictionary.
 
         Raises:
-            ValueError: If the response is not a dict or is missing "results".
+            ValueError: If the response is not a dict or "results" is not a
+                list.
         """
         if not isinstance(response, dict) or "results" not in response:
-            raise ValueError(
+            error = (
                 f"Confluence {operation} returned a malformed response "
                 "missing the 'results' field"
             )
+            raise ValueError(error)
+        if not isinstance(response["results"], list):
+            error = (
+                f"Confluence {operation} returned a malformed response "
+                "where 'results' is not a list"
+            )
+            raise ValueError(error)
         return response
 
     @handle_atlassian_api_errors("Confluence API")

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -46,6 +46,34 @@ class SearchMixin(ConfluenceClient):
         logger.info(f"Applied spaces filter to query: {cql}")
         return cql
 
+    @staticmethod
+    def _validate_search_response(response: Any, operation: str) -> dict[str, Any]:
+        """Ensure a search API response carries the required 'results' field.
+
+        A well-formed Confluence search response always includes a "results"
+        field (which may legitimately be an empty list). A response missing it
+        entirely indicates an API, network, or processing failure that must
+        surface as an error rather than be silently treated as an empty result
+        set.
+
+        Args:
+            response: The raw response returned by the Confluence API.
+            operation: Human-readable operation name for the error message
+                (e.g. "search", "user search").
+
+        Returns:
+            The validated response dictionary.
+
+        Raises:
+            ValueError: If the response is not a dict or is missing "results".
+        """
+        if not isinstance(response, dict) or "results" not in response:
+            raise ValueError(
+                f"Confluence {operation} returned a malformed response "
+                "missing the 'results' field"
+            )
+        return response
+
     @handle_atlassian_api_errors("Confluence API")
     def search(
         self, cql: str, limit: int = 10, spaces_filter: str | None = None
@@ -80,15 +108,9 @@ class SearchMixin(ConfluenceClient):
         # Execute the CQL search query
         results = self.confluence.cql(cql=cql, limit=limit)
 
-        # A well-formed response always carries a "results" field (which may be
-        # an empty list). A response missing it entirely indicates an API,
-        # network, or processing failure that must surface as an error rather
-        # than be silently treated as an empty result set.
-        if not isinstance(results, dict) or "results" not in results:
-            raise ValueError(
-                "Confluence search returned a malformed response "
-                "missing the 'results' field"
-            )
+        # Surface malformed responses (missing "results") as errors while
+        # allowing a genuine "results": [] to return an empty list.
+        self._validate_search_response(results, "search")
 
         # Convert the response to a search result model
         search_result = ConfluenceSearchResult.from_api_response(
@@ -154,7 +176,10 @@ class SearchMixin(ConfluenceClient):
                 "rest/api/search/user",
                 params={"cql": cql, "limit": limit},
             )
-            search_result = ConfluenceUserSearchResults.from_api_response(results or {})
+            # Surface malformed responses (missing "results") as errors while
+            # allowing a genuine "results": [] to return an empty list.
+            self._validate_search_response(results, "user search")
+            search_result = ConfluenceUserSearchResults.from_api_response(results)
             return search_result.results
 
         # Server/DC: fall back to group member API
@@ -191,6 +216,9 @@ class SearchMixin(ConfluenceClient):
                 f"rest/api/group/{encoded_group}/member",
                 params={"start": start, "limit": page_size},
             )
+            # Surface malformed responses (missing "results") as errors while
+            # allowing a genuine "results": [] to end pagination cleanly.
+            self._validate_search_response(response, "user search")
             members = response.get("results", [])
 
             for member in members:

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -6,13 +6,14 @@ import logging
 import mimetypes
 from typing import Annotated
 
-from fastmcp import Context, FastMCP
+from fastmcp import Context
 from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent
 from pydantic import BeforeValidator, Field
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.models.confluence import ConfluenceAttachment
 from mcp_atlassian.servers.dependencies import get_confluence_fetcher
+from mcp_atlassian.servers.error_handling import ErrorPreservingFastMCP
 from mcp_atlassian.utils.decorators import (
     check_write_access,
 )
@@ -26,7 +27,7 @@ from mcp_atlassian.utils.urls import resolve_relative_url
 logger = logging.getLogger(__name__)
 
 
-confluence_mcp = FastMCP(
+confluence_mcp = ErrorPreservingFastMCP(
     name="Confluence MCP Service",
     instructions="Provides tools for interacting with Atlassian Confluence.",
 )

--- a/src/mcp_atlassian/servers/error_handling.py
+++ b/src/mcp_atlassian/servers/error_handling.py
@@ -1,0 +1,38 @@
+"""FastMCP helpers for preserving Atlassian tool error details."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar
+
+from fastmcp import FastMCP
+
+from mcp_atlassian.utils.decorators import handle_tool_errors
+
+LifespanResultT = TypeVar("LifespanResultT")
+
+
+class ErrorPreservingFastMCP(FastMCP[LifespanResultT], Generic[LifespanResultT]):
+    """FastMCP variant that registers tools with detailed error handling."""
+
+    def tool(self, name_or_fn: Any = None, **kwargs: Any) -> Any:
+        if inspect.isroutine(name_or_fn):
+            return super().tool(handle_tool_errors(name_or_fn), **kwargs)
+
+        if isinstance(name_or_fn, str):
+            if kwargs.get("name") is not None:
+                raise TypeError(
+                    "Cannot specify both a name as first argument and as keyword "
+                    "argument."
+                )
+            kwargs = {**kwargs, "name": name_or_fn}
+        elif name_or_fn is not None:
+            return super().tool(name_or_fn, **kwargs)
+
+        def decorator(fn: Callable[..., Any]) -> Any:
+            return super(ErrorPreservingFastMCP, self).tool(
+                handle_tool_errors(fn), **kwargs
+            )
+
+        return decorator

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import Annotated, Any
 
-from fastmcp import Context, FastMCP
+from fastmcp import Context
 from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent
 from pydantic import Field
 from requests.exceptions import HTTPError
@@ -16,6 +16,7 @@ from mcp_atlassian.jira.forms_common import convert_datetime_to_timestamp
 from mcp_atlassian.models.jira import JiraAttachment
 from mcp_atlassian.models.jira.common import JiraUser
 from mcp_atlassian.servers.dependencies import get_jira_fetcher
+from mcp_atlassian.servers.error_handling import ErrorPreservingFastMCP
 from mcp_atlassian.utils.decorators import check_write_access
 from mcp_atlassian.utils.media import (
     ATTACHMENT_MAX_BYTES,
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+$"
 PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+$"
 
-jira_mcp = FastMCP(
+jira_mcp = ErrorPreservingFastMCP(
     name="Jira MCP Service",
     instructions="Provides tools for interacting with Atlassian Jira.",
 )

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -46,6 +46,7 @@ from mcp_atlassian.utils.urls import is_atlassian_cloud_url, validate_url_for_ss
 from .client_storage import build_oauth_client_storage_from_env
 from .confluence import confluence_mcp
 from .context import MainAppContext
+from .error_handling import ErrorPreservingFastMCP
 from .jira import jira_mcp
 from .oauth_proxy import HardenedOAuthProxy, parse_env_list
 
@@ -189,7 +190,7 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict[str,
         logger.info("Main Atlassian MCP server lifespan shutdown complete.")
 
 
-class AtlassianMCP(FastMCP[MainAppContext]):
+class AtlassianMCP(ErrorPreservingFastMCP[MainAppContext]):
     """Custom FastMCP server class for Atlassian integration with tool filtering."""
 
     _active_streamable_http_path: str | None = None

--- a/src/mcp_atlassian/utils/decorators.py
+++ b/src/mcp_atlassian/utils/decorators.py
@@ -18,14 +18,11 @@ F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
 
 def handle_tool_errors(func: F) -> F:
     """
-    Decorator for FastMCP tool handlers that catches exceptions and re-raises
-    them as ToolError with the original error message preserved.
+    Convert tool handler exceptions to ToolError with details preserved.
 
-    ToolError bypasses FastMCP's mask_error_details setting, ensuring that
-    descriptive error messages are always sent to MCP clients regardless of
-    server configuration.
-
-    Assumes the decorated function is async.
+    Raising ToolError from inside the tool preserves actionable Atlassian API
+    errors for MCP clients even when the FastMCP server masks non-ToolError
+    exceptions.
     """
     tool_name = func.__name__
 
@@ -36,8 +33,10 @@ def handle_tool_errors(func: F) -> F:
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error in tool '{tool_name}': {e}", exc_info=True)
-            raise ToolError(str(e)) from e
+            detail = str(e).strip() or type(e).__name__
+            logger.error(f"Error in tool '{tool_name}': {detail}", exc_info=True)
+            message = f"Error calling tool '{tool_name}': {detail}"
+            raise ToolError(message) from e
 
     return wrapper  # type: ignore
 
@@ -48,12 +47,13 @@ def check_write_access(func: F) -> F:
     If in read-only mode, it raises a ToolError.
     Also catches unhandled exceptions and re-raises them as ToolError with
     descriptive error messages.
-    Assumes the decorated function is async and has `ctx: Context` as its first argument.
+    Assumes the decorated function is async and has `ctx: Context` as its
+    first argument.
     """
     tool_name = func.__name__
 
-    @wraps(func)
     @handle_tool_errors
+    @wraps(func)
     async def wrapper(ctx: Context, *args: Any, **kwargs: Any) -> Any:
         lifespan_ctx_dict = ctx.request_context.lifespan_context
         app_lifespan_ctx = (
@@ -67,7 +67,8 @@ def check_write_access(func: F) -> F:
                 "_", " "
             )  # e.g., "create_issue" -> "create issue"
             logger.warning(f"Attempted to call tool '{tool_name}' in read-only mode.")
-            raise ValueError(f"Cannot {action_description} in read-only mode.")
+            message = f"Cannot {action_description} in read-only mode."
+            raise ValueError(message)
 
         return await func(ctx, *args, **kwargs)
 
@@ -148,22 +149,29 @@ def handle_atlassian_api_errors(service_name: str = "Atlassian API") -> Callable
             except KeyError as e:
                 operation_name = getattr(func, "__name__", "API operation")
                 logger.error(f"Missing key in {operation_name} results: {str(e)}")
-                return []
+                message = (
+                    f"{operation_name} returned an unexpected response from "
+                    f"{service_name}: missing key {e}"
+                )
+                raise ValueError(message) from e
             except requests.RequestException as e:
                 operation_name = getattr(func, "__name__", "API operation")
                 logger.error(f"Network error during {operation_name}: {str(e)}")
-                return []
+                message = f"Network error during {operation_name}: {e}"
+                raise ValueError(message) from e
             except (ValueError, TypeError) as e:
                 operation_name = getattr(func, "__name__", "API operation")
                 logger.error(f"Error processing {operation_name} results: {str(e)}")
-                return []
+                message = f"Error processing {operation_name} results: {e}"
+                raise ValueError(message) from e
             except Exception as e:  # noqa: BLE001 - Intentional fallback with logging
                 operation_name = getattr(func, "__name__", "API operation")
                 logger.error(f"Unexpected error during {operation_name}: {str(e)}")
                 logger.debug(
                     f"Full exception details for {operation_name}:", exc_info=True
                 )
-                return []
+                message = f"Unexpected error during {operation_name}: {e}"
+                raise RuntimeError(message) from e
 
         return wrapper
 

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -107,10 +107,8 @@ class TestSearchMixin:
         # Mock a response missing required keys
         search_mixin.confluence.cql.return_value = {"incomplete": "data"}
 
-        # Act
         results = search_mixin.search("invalid query")
 
-        # Assert
         assert isinstance(results, list)
         assert len(results) == 0
 
@@ -119,36 +117,24 @@ class TestSearchMixin:
         # Mock a network error
         search_mixin.confluence.cql.side_effect = requests.RequestException("API error")
 
-        # Act
-        results = search_mixin.search("error query")
-
-        # Assert
-        assert isinstance(results, list)
-        assert len(results) == 0
+        with pytest.raises(ValueError, match="Network error during search"):
+            search_mixin.search("error query")
 
     def test_search_value_error(self, search_mixin):
         """Test handling of ValueError during search."""
         # Mock a value error
         search_mixin.confluence.cql.side_effect = ValueError("Value error")
 
-        # Act
-        results = search_mixin.search("error query")
-
-        # Assert
-        assert isinstance(results, list)
-        assert len(results) == 0
+        with pytest.raises(ValueError, match="Error processing search results"):
+            search_mixin.search("error query")
 
     def test_search_type_error(self, search_mixin):
         """Test handling of TypeError during search."""
         # Mock a type error
         search_mixin.confluence.cql.side_effect = TypeError("Type error")
 
-        # Act
-        results = search_mixin.search("error query")
-
-        # Assert
-        assert isinstance(results, list)
-        assert len(results) == 0
+        with pytest.raises(ValueError, match="Error processing search results"):
+            search_mixin.search("error query")
 
     def test_search_with_spaces_filter(self, search_mixin):
         """Test searching with spaces filter from parameter."""
@@ -262,12 +248,8 @@ class TestSearchMixin:
         # Mock a general exception
         search_mixin.confluence.cql.side_effect = Exception("General error")
 
-        # Act
-        results = search_mixin.search("error query")
-
-        # Assert
-        assert isinstance(results, list)
-        assert len(results) == 0
+        with pytest.raises(RuntimeError, match="Unexpected error during search"):
+            search_mixin.search("error query")
 
     def test_search_user_success(self, search_mixin):
         """Test search_user with successful results."""
@@ -365,28 +347,44 @@ class TestSearchMixin:
         )
 
     @pytest.mark.parametrize(
-        "exception_type,exception_args,expected_result",
+        "exception_type,exception_args,expected_exception,match",
         [
-            (requests.RequestException, ("Network error",), []),
-            (ValueError, ("Value error",), []),
-            (TypeError, ("Type error",), []),
-            (Exception, ("General error",), []),
-            (KeyError, ("Missing key",), []),
+            (
+                requests.RequestException,
+                ("Network error",),
+                ValueError,
+                "Network error during search_user",
+            ),
+            (
+                ValueError,
+                ("Value error",),
+                ValueError,
+                "Error processing search_user results",
+            ),
+            (
+                TypeError,
+                ("Type error",),
+                ValueError,
+                "Error processing search_user results",
+            ),
+            (
+                Exception,
+                ("General error",),
+                RuntimeError,
+                "Unexpected error during search_user",
+            ),
+            (KeyError, ("Missing key",), ValueError, "missing key"),
         ],
     )
     def test_search_user_exception_handling(
-        self, search_mixin, exception_type, exception_args, expected_result
+        self, search_mixin, exception_type, exception_args, expected_exception, match
     ):
-        """Test search_user handling of various exceptions that return empty list."""
+        """Test search_user propagates detailed exceptions."""
         # Mock the exception
         search_mixin.confluence.get.side_effect = exception_type(*exception_args)
 
-        # Act
-        results = search_mixin.search_user('user.fullname ~ "Test"')
-
-        # Assert
-        assert isinstance(results, list)
-        assert results == expected_result
+        with pytest.raises(expected_exception, match=match):
+            search_mixin.search_user('user.fullname ~ "Test"')
 
     @pytest.mark.parametrize(
         "status_code,exception_type",
@@ -444,28 +442,44 @@ class TestSearchMixin:
 
     # You can also parametrize the regular search method exception tests:
     @pytest.mark.parametrize(
-        "exception_type,exception_args,expected_result",
+        "exception_type,exception_args,expected_exception,match",
         [
-            (requests.RequestException, ("API error",), []),
-            (ValueError, ("Value error",), []),
-            (TypeError, ("Type error",), []),
-            (Exception, ("General error",), []),
-            (KeyError, ("Missing key",), []),
+            (
+                requests.RequestException,
+                ("API error",),
+                ValueError,
+                "Network error during search",
+            ),
+            (
+                ValueError,
+                ("Value error",),
+                ValueError,
+                "Error processing search results",
+            ),
+            (
+                TypeError,
+                ("Type error",),
+                ValueError,
+                "Error processing search results",
+            ),
+            (
+                Exception,
+                ("General error",),
+                RuntimeError,
+                "Unexpected error during search",
+            ),
+            (KeyError, ("Missing key",), ValueError, "missing key"),
         ],
     )
     def test_search_exception_handling(
-        self, search_mixin, exception_type, exception_args, expected_result
+        self, search_mixin, exception_type, exception_args, expected_exception, match
     ):
-        """Test search handling of various exceptions that return empty list."""
+        """Test search propagates detailed exceptions."""
         # Mock the exception
         search_mixin.confluence.cql.side_effect = exception_type(*exception_args)
 
-        # Act
-        results = search_mixin.search("error query")
-
-        # Assert
-        assert isinstance(results, list)
-        assert results == expected_result
+        with pytest.raises(expected_exception, match=match):
+            search_mixin.search("error query")
 
     # Parametrize CQL query tests:
     @pytest.mark.parametrize(

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -465,24 +465,22 @@ class TestSearchMixin:
         with pytest.raises(HTTPError):
             search_mixin.search_user('user.fullname ~ "Test"')
 
-    @pytest.mark.parametrize(
-        "mock_response,expected_length",
-        [
-            ({"incomplete": "data"}, 0),  # KeyError case
-            (None, 0),  # None response case
-            ({"results": []}, 0),  # Empty results case
-        ],
-    )
-    def test_search_user_edge_cases(self, search_mixin, mock_response, expected_length):
-        """Test search_user handling of edge cases in API responses."""
-        search_mixin.confluence.get.return_value = mock_response
+    @pytest.mark.parametrize("malformed_response", [{"incomplete": "data"}, None])
+    def test_search_user_cloud_malformed_response_raises(
+        self, search_mixin, malformed_response
+    ):
+        """Malformed Cloud user-search responses must raise, not return [].
 
-        # Act
-        results = search_mixin.search_user('user.fullname ~ "Test"')
+        A response missing the 'results' field indicates an API/network/
+        processing failure and must not be reported as "no users found".
+        """
+        search_mixin.confluence.get.return_value = malformed_response
 
-        # Assert
-        assert isinstance(results, list)
-        assert len(results) == expected_length
+        with pytest.raises(
+            ValueError,
+            match="Error processing search_user results.*malformed response",
+        ):
+            search_mixin.search_user('user.fullname ~ "Test"')
 
     # You can also parametrize the regular search method exception tests:
     @pytest.mark.parametrize(
@@ -699,6 +697,45 @@ class TestSearchUserServerDC:
         assert len(results) == 1
         assert results[0].user is not None
         assert results[0].user.display_name == "John Doe"
+
+    def test_server_dc_empty_results_returns_empty(self, server_search_mixin):
+        """A genuine {'results': []} Server/DC response returns an empty list."""
+        server_search_mixin.confluence.get.return_value = {"results": []}
+
+        results = server_search_mixin.search_user('user.fullname ~ "Test"')
+
+        assert isinstance(results, list)
+        assert len(results) == 0
+
+    @pytest.mark.parametrize("malformed_response", [{"incomplete": "data"}, None])
+    def test_server_dc_malformed_response_raises(
+        self, server_search_mixin, malformed_response
+    ):
+        """Malformed Server/DC group-member responses must raise, not return [].
+
+        A response missing the 'results' field indicates an API/network/
+        processing failure and must not be reported as "no users found".
+        """
+        server_search_mixin.confluence.get.return_value = malformed_response
+
+        with pytest.raises(
+            ValueError,
+            match="Error processing search_user results.*malformed response",
+        ):
+            server_search_mixin.search_user('user.fullname ~ "Test"')
+
+    @pytest.mark.parametrize("malformed_response", [{"incomplete": "data"}, None])
+    def test_cloud_malformed_response_raises(
+        self, cloud_search_mixin, malformed_response
+    ):
+        """Malformed Cloud user-search responses must raise, not return []."""
+        cloud_search_mixin.confluence.get.return_value = malformed_response
+
+        with pytest.raises(
+            ValueError,
+            match="Error processing search_user results.*malformed response",
+        ):
+            cloud_search_mixin.search_user('user.fullname ~ "Test"')
 
     def test_server_dc_fuzzy_match_case_insensitive(self, server_search_mixin):
         """Fuzzy matching should be case-insensitive substring match."""

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -465,7 +465,15 @@ class TestSearchMixin:
         with pytest.raises(HTTPError):
             search_mixin.search_user('user.fullname ~ "Test"')
 
-    @pytest.mark.parametrize("malformed_response", [{"incomplete": "data"}, None])
+    @pytest.mark.parametrize(
+        "malformed_response",
+        [
+            {"incomplete": "data"},
+            None,
+            {"results": None},
+            {"results": {}},
+        ],
+    )
     def test_search_user_cloud_malformed_response_raises(
         self, search_mixin, malformed_response
     ):
@@ -707,7 +715,15 @@ class TestSearchUserServerDC:
         assert isinstance(results, list)
         assert len(results) == 0
 
-    @pytest.mark.parametrize("malformed_response", [{"incomplete": "data"}, None])
+    @pytest.mark.parametrize(
+        "malformed_response",
+        [
+            {"incomplete": "data"},
+            None,
+            {"results": None},
+            {"results": {}},
+        ],
+    )
     def test_server_dc_malformed_response_raises(
         self, server_search_mixin, malformed_response
     ):
@@ -724,7 +740,15 @@ class TestSearchUserServerDC:
         ):
             server_search_mixin.search_user('user.fullname ~ "Test"')
 
-    @pytest.mark.parametrize("malformed_response", [{"incomplete": "data"}, None])
+    @pytest.mark.parametrize(
+        "malformed_response",
+        [
+            {"incomplete": "data"},
+            None,
+            {"results": None},
+            {"results": {}},
+        ],
+    )
     def test_cloud_malformed_response_raises(
         self, cloud_search_mixin, malformed_response
     ):

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -102,15 +102,20 @@ class TestSearchMixin:
         # The method should still handle them as pages since we're using models
         assert len(results) > 0
 
-    def test_search_key_error(self, search_mixin):
-        """Test handling of KeyError in search results."""
-        # Mock a response missing required keys
+    def test_search_malformed_response_missing_results(self, search_mixin):
+        """Test that a response missing the 'results' key raises an error.
+
+        A malformed response (e.g. an API/network/processing failure) must not
+        be silently treated as an empty result set. Only a genuine
+        ``{"results": []}`` response should return an empty list.
+        """
+        # Mock a response missing the required "results" key
         search_mixin.confluence.cql.return_value = {"incomplete": "data"}
 
-        results = search_mixin.search("invalid query")
-
-        assert isinstance(results, list)
-        assert len(results) == 0
+        with pytest.raises(
+            ValueError, match="Error processing search results.*malformed response"
+        ):
+            search_mixin.search("invalid query")
 
     def test_search_request_exception(self, search_mixin):
         """Test handling of RequestException during search."""

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.client import FastMCPTransport
+from fastmcp.exceptions import ToolError
 from starlette.requests import Request
 
 from src.mcp_atlassian.confluence import ConfluenceFetcher
@@ -372,6 +373,20 @@ async def test_search(client, mock_confluence_fetcher):
     assert isinstance(result_data, list)
     assert len(result_data) > 0
     assert result_data[0]["title"] == "Test Page Mock Title"
+
+
+@pytest.mark.anyio
+async def test_search_returns_error_details(client, mock_confluence_fetcher):
+    """Test that search tool failures preserve the original error message."""
+    mock_confluence_fetcher.search.side_effect = RuntimeError(
+        "Confluence CQL rejected the query"
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await client.call_tool("confluence_search", {"query": "type=page"})
+
+    assert "Error calling tool 'search'" in str(excinfo.value)
+    assert "Confluence CQL rejected the query" in str(excinfo.value)
 
 
 @pytest.mark.anyio

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -589,6 +589,28 @@ async def test_search(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+async def test_search_returns_error_details(jira_client, mock_jira_fetcher):
+    """Test that search tool failures preserve the original error message."""
+    mock_jira_fetcher.search_issues.side_effect = RuntimeError(
+        "Jira JQL rejected the query"
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_search",
+            {
+                "jql": "project = TEST",
+                "fields": "summary,status",
+                "limit": 10,
+                "start_at": 0,
+            },
+        )
+
+    assert "Error calling tool 'search'" in str(excinfo.value)
+    assert "Jira JQL rejected the query" in str(excinfo.value)
+
+
+@pytest.mark.anyio
 async def test_get_service_desk_for_project(jira_client, mock_jira_fetcher):
     """Test service desk lookup by project key."""
     response = await jira_client.call_tool(
@@ -830,6 +852,7 @@ async def test_batch_create_issues_invalid_json(jira_client):
             "jira_batch_create_issues",
             {"issues": "{invalid json", "validate_only": False},
         )
+    assert "Error calling tool 'batch_create_issues'" in str(excinfo.value)
     assert "Invalid JSON" in str(excinfo.value)
 
 
@@ -896,6 +919,7 @@ async def test_no_fetcher_get_issue(no_fetcher_client_fixture, mock_request):
                 },
             )
     assert "Error calling tool 'get_issue'" in str(excinfo.value)
+    assert "Jira client (fetcher) not available" in str(excinfo.value)
 
 
 @pytest.mark.anyio

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -51,6 +51,7 @@ async def test_handle_tool_errors_wraps_exception_as_tool_error():
 
     with pytest.raises(ToolError) as exc:
         await failing_tool()
+    assert "Error calling tool 'failing_tool'" in str(exc.value)
     assert "something went wrong" in str(exc.value)
 
 


### PR DESCRIPTION
## Summary
- register Jira, Confluence, and main Atlassian MCP tools through an error-preserving FastMCP wrapper
- convert unexpected tool failures into detailed `ToolError`s instead of generic masked errors
- stop Confluence search helpers from returning empty success results for API/network/processing failures
- add regression coverage for Jira/Confluence search and validation/config error details
- update the branch to the current `main`

Closes #1315

## Tests
- `uv run pre-commit run --all-files`
- `uv run pytest tests/unit/utils/test_decorators.py tests/unit/servers/test_confluence_server.py tests/unit/servers/test_jira_server.py tests/unit/confluence/test_search.py -q` (258 passed)
- `uv run pytest tests/unit/ -q` (3,086 passed, 5 skipped)
- `uv run pytest tests/integration/ --integration -q` (8 passed, 15 skipped)
- `uv run pytest tests/e2e/cloud --cloud-e2e -q` (82 passed, 15 skipped)
- `uv run pytest tests/e2e --dc-e2e -q` (94 passed, 98 skipped)