### PR TITLE
fix(auth): set explicit User-Agent on Jira/Confluence sessions

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -143,7 +143,7 @@ class ConfluenceClient:
             log_config_param(logger, "Confluence", "NO_PROXY", self.config.no_proxy)
 
         # Set an explicit User-Agent so requests aren't blocked by WAFs that
-        # reject the default ``python-requests/X.Y`` header (#TBD). User-supplied
+        # reject the default ``python-requests/X.Y`` header. User-supplied
         # custom headers below can still override this.
         self.confluence._session.headers["User-Agent"] = get_default_user_agent()
 

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -11,6 +11,7 @@ from ..exceptions import MCPAtlassianAuthenticationError
 from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
 from ..utils.oauth import configure_oauth_session
 from ..utils.ssl import configure_ssl_verification
+from ..utils.user_agent import get_default_user_agent
 from .config import ConfluenceConfig
 
 # Configure logging
@@ -140,6 +141,11 @@ class ConfluenceClient:
         if self.config.no_proxy and isinstance(self.config.no_proxy, str):
             os.environ["NO_PROXY"] = self.config.no_proxy
             log_config_param(logger, "Confluence", "NO_PROXY", self.config.no_proxy)
+
+        # Set an explicit User-Agent so requests aren't blocked by WAFs that
+        # reject the default ``python-requests/X.Y`` header (#TBD). User-supplied
+        # custom headers below can still override this.
+        self.confluence._session.headers["User-Agent"] = get_default_user_agent()
 
         # Apply custom headers if configured
         if self.config.custom_headers:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -17,6 +17,7 @@ from mcp_atlassian.utils.logging import (
 )
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
+from mcp_atlassian.utils.user_agent import get_default_user_agent
 
 from ..models.jira.adf import markdown_to_adf
 from .config import JiraConfig
@@ -153,6 +154,11 @@ class JiraClient:
         if self.config.no_proxy and isinstance(self.config.no_proxy, str):
             os.environ["NO_PROXY"] = self.config.no_proxy
             log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
+
+        # Set an explicit User-Agent so requests aren't blocked by WAFs that
+        # reject the default ``python-requests/X.Y`` header (#TBD). User-supplied
+        # custom headers below can still override this.
+        self.jira._session.headers["User-Agent"] = get_default_user_agent()
 
         # Apply custom headers if configured
         if self.config.custom_headers:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -156,7 +156,7 @@ class JiraClient:
             log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
 
         # Set an explicit User-Agent so requests aren't blocked by WAFs that
-        # reject the default ``python-requests/X.Y`` header (#TBD). User-supplied
+        # reject the default ``python-requests/X.Y`` header. User-supplied
         # custom headers below can still override this.
         self.jira._session.headers["User-Agent"] = get_default_user_agent()
 

--- a/src/mcp_atlassian/utils/user_agent.py
+++ b/src/mcp_atlassian/utils/user_agent.py
@@ -1,0 +1,18 @@
+"""User-Agent helpers for HTTP sessions."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+
+def get_default_user_agent() -> str:
+    """Return the default ``User-Agent`` string for outbound requests.
+
+    Some WAFs in front of Jira/Confluence Server/DC instances block requests
+    carrying the default ``python-requests/X.Y`` User-Agent, returning 403 even
+    when the bearer token is valid. Setting an explicit, identifiable
+    ``User-Agent`` avoids that class of false-positive auth errors.
+    """
+    try:
+        pkg_version = version("mcp-atlassian")
+    except PackageNotFoundError:
+        pkg_version = "0.0.0"
+    return f"mcp-atlassian/{pkg_version}"

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -459,3 +459,44 @@ def test_confluence_fetcher_mro_order():
     # Verify that attachment methods are accessible (the real test)
     assert hasattr(ConfluenceFetcher, "upload_attachment")
     assert hasattr(ConfluenceFetcher, "get_content_attachments")
+
+
+def test_confluence_client_sets_default_user_agent():
+    """An explicit User-Agent is set so WAFs don't block the requests default."""
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        headers: dict[str, str] = {}
+        mock_confluence.return_value._session.headers = headers
+
+        config = ConfluenceConfig(
+            url="https://confluence.example.com",
+            auth_type="pat",
+            personal_token="pat",
+        )
+        ConfluenceClient(config=config)
+
+        assert headers["User-Agent"].startswith("mcp-atlassian/")
+
+
+def test_confluence_client_custom_user_agent_overrides_default():
+    """Custom headers must still win over the built-in User-Agent default."""
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        headers: dict[str, str] = {}
+        mock_confluence.return_value._session.headers = headers
+
+        config = ConfluenceConfig(
+            url="https://confluence.example.com",
+            auth_type="pat",
+            personal_token="pat",
+            custom_headers={"User-Agent": "my-app/1.0"},
+        )
+        ConfluenceClient(config=config)
+
+        assert headers["User-Agent"] == "my-app/1.0"

--- a/tests/unit/confluence/test_custom_headers.py
+++ b/tests/unit/confluence/test_custom_headers.py
@@ -109,8 +109,9 @@ class TestConfluenceClientCustomHeaders:
 
         client = ConfluenceClient(config=config)
 
-        # Verify no custom headers were applied
-        assert mock_session.headers == {}
+        # Only the default User-Agent should be present; no custom headers added.
+        assert set(mock_session.headers.keys()) == {"User-Agent"}
+        assert mock_session.headers["User-Agent"].startswith("mcp-atlassian/")
 
     def test_custom_headers_applied_to_session(self, monkeypatch):
         """Test that custom headers are applied to the Confluence session."""

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -396,3 +396,42 @@ def test_jira_client_basic_auth_preserves_trust_env():
         JiraClient(config=config)
 
         assert mock_session.trust_env is True
+
+
+def test_jira_client_sets_default_user_agent():
+    """An explicit User-Agent is set so WAFs don't block the requests default."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        headers: dict[str, str] = {}
+        mock_jira.return_value._session.headers = headers
+
+        config = JiraConfig(
+            url="https://jira.example.com",
+            auth_type="pat",
+            personal_token="pat",
+        )
+        JiraClient(config=config)
+
+        assert headers["User-Agent"].startswith("mcp-atlassian/")
+
+
+def test_jira_client_custom_user_agent_overrides_default():
+    """Custom headers must still win over the built-in User-Agent default."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        headers: dict[str, str] = {}
+        mock_jira.return_value._session.headers = headers
+
+        config = JiraConfig(
+            url="https://jira.example.com",
+            auth_type="pat",
+            personal_token="pat",
+            custom_headers={"User-Agent": "my-app/1.0"},
+        )
+        JiraClient(config=config)
+
+        assert headers["User-Agent"] == "my-app/1.0"

--- a/tests/unit/jira/test_custom_headers.py
+++ b/tests/unit/jira/test_custom_headers.py
@@ -101,8 +101,9 @@ class TestJiraClientCustomHeaders:
 
         client = JiraClient(config=config)
 
-        # Verify no custom headers were applied
-        assert mock_session.headers == {}
+        # Only the default User-Agent should be present; no custom headers added.
+        assert set(mock_session.headers.keys()) == {"User-Agent"}
+        assert mock_session.headers["User-Agent"].startswith("mcp-atlassian/")
 
     def test_custom_headers_applied_to_session(self, monkeypatch):
         """Test that custom headers are applied to the JIRA session."""


### PR DESCRIPTION
## Summary

- Some WAFs in front of Jira/Confluence Server/DC reject the default `python-requests/X.Y` User-Agent and return **403**, even when the bearer token is valid. The error surfaces in mcp-atlassian as a misleading `Authentication failed for Jira API (403). Token may be expired or invalid` — although the same PAT works via `curl`.
- `JiraClient` and `ConfluenceClient` now set `User-Agent: mcp-atlassian/<version>` on the session right after the underlying `atlassian` client is created, **before** `_apply_custom_headers()`, so user-supplied `JIRA_CUSTOM_HEADERS=User-Agent=...` / `CONFLUENCE_CUSTOM_HEADERS=User-Agent=...` still wins.
- Adds `utils/user_agent.py::get_default_user_agent()` (uses `importlib.metadata.version("mcp-atlassian")`, falls back to `0.0.0` when not installed — same pattern as the package `__version__`).

## Reproduction (Jira DC 9.12.4 behind a WAF)

```python
from atlassian import Jira
jira = Jira(url="https://portal.example.com", token=PAT, cloud=False)
jira.get_issue("PROJ-1")
# requests.exceptions.HTTPError: 403 Client Error  (default UA: python-requests/2.x)

# Workaround (now built-in by this PR):
jira._session.headers["User-Agent"] = "mcp-atlassian/0.21.1"
jira.get_issue("PROJ-1")   # 200 OK
```

Direct `curl` with the same URL + Bearer token consistently returns `200`. The WAF blocks only the default `python-requests/X.Y` UA — any identifiable UA (`curl/*`, `Mozilla/*`, `mcp-atlassian/*`, …) is allowed.

## Test plan

- [x] `uv run pytest tests/unit/jira/test_client.py tests/unit/confluence/test_client.py tests/unit/jira/test_custom_headers.py tests/unit/confluence/test_custom_headers.py` — all green
- [x] `pre-commit run` (ruff, ruff-format, mypy) — green
- [x] Pre-existing failures on `main` (`test_stdio_lifecycle`, `test_date::…boundary_max_valid`, `test_media::…[zip]`) verified unrelated to this change
- [x] New unit tests:
  - `test_jira_client_sets_default_user_agent` / `test_confluence_client_sets_default_user_agent` — default UA is set on the session
  - `test_jira_client_custom_user_agent_overrides_default` / equivalent for Confluence — `custom_headers` still wins
- [x] Updated `test_no_custom_headers_applied` (Jira & Confluence) to expect the default UA being present