### PR TITLE
feat(jira): discover development application types

### DIFF
--- a/docs/tools/jira-forms-metrics.mdx
+++ b/docs/tools/jira-forms-metrics.mdx
@@ -92,7 +92,7 @@ Get development information (PRs, commits, branches) linked to a Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123') |
-| `application_type` | `string` | No | (Optional) Filter by application type. Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab' |
+| `application_type` | `string` | No | (Optional) Filter by application type. Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'. If not specified, automatically discovers available types from your Jira instance. |
 | `data_type` | `string` | No | (Optional) Filter by data type. Examples: 'pullrequest', 'branch', 'repository' |
 
 ---
@@ -106,7 +106,7 @@ Get development information for multiple Jira issues.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_keys` | `string` | Yes | Comma-separated list of Jira issue keys (e.g., 'PROJ-123,PROJ-456') |
-| `application_type` | `string` | No | (Optional) Filter by application type. Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab' |
+| `application_type` | `string` | No | (Optional) Filter by application type. Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'. If not specified, automatically discovers available types from your Jira instance. |
 | `data_type` | `string` | No | (Optional) Filter by data type. Examples: 'pullrequest', 'branch', 'repository' |
 
 ---

--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -27,7 +27,7 @@ class DevelopmentMixin(JiraClient):
             issue_key: The issue key (e.g., PROJECT-123)
             application_type: Filter by application type
                 (e.g., 'stash', 'github', 'bitbucket').
-                If None, tries common application types.
+                If None, automatically discovers available types from the Jira instance.
             data_type: Filter by data type
                 (e.g., 'pullrequest', 'branch', 'repository').
                 If None, returns all data types.
@@ -64,9 +64,9 @@ class DevelopmentMixin(JiraClient):
                     issue_key, issue_id, application_type, data_type
                 )
 
-            # Otherwise, try common application types and merge results
-            # Common types: stash (Bitbucket Server), bitbucket, github, gitlab
-            app_types = ["stash", "bitbucket", "github", "gitlab"]
+            # Otherwise, discover available application types and merge results
+            # This automatically detects any custom integrations
+            app_types = self._discover_application_types(issue_key, issue_id, data_type)
             # Data types to try for each app type
             data_types = ["pullrequest", "branch", "repository"]
             merged_result: dict[str, Any] = {
@@ -359,6 +359,84 @@ class DevelopmentMixin(JiraClient):
                         result["repositories"].append(repo_info)
 
         return result
+
+    def _discover_application_types(
+        self,
+        issue_key: str,
+        issue_id: str,
+        data_type: str | None = None,
+    ) -> list[str]:
+        """
+        Discover available application types for an issue using the summary endpoint.
+
+        This queries /rest/dev-status/1.0/issue/summary to determine which
+        application types (github, github, bitbucket, etc.) are actually
+        configured for this issue, avoiding unnecessary API calls.
+
+        Args:
+            issue_key: The issue key
+            issue_id: The numeric issue ID
+            data_type: Optional data type filter to narrow discovery
+
+        Returns:
+            List of application type strings that have data for this issue
+        """
+        try:
+            # Use /rest/dev-status/1.0/issue/summary to match the version used
+            # in _fetch_dev_info_for_app_type (which uses 1.0/issue/detail)
+            url = f"{self.config.url}/rest/dev-status/1.0/issue/summary"
+            params: dict[str, str] = {"issueId": str(issue_id)}
+
+            http_response = self.jira._session.get(
+                url, params=params, verify=self.config.ssl_verify
+            )
+
+            if http_response.status_code in (403, 404):
+                logger.warning(
+                    f"Dev-status summary endpoint returned {http_response.status_code} "
+                    f"for {issue_key} — falling back to common application types"
+                )
+                return ["stash", "bitbucket", "github", "gitlab"]
+
+            http_response.raise_for_status()
+            response = http_response.json()
+
+            if not isinstance(response, dict):
+                logger.warning(
+                    f"Unexpected response type from dev-status summary API: "
+                    f"{type(response)} — falling back to common types"
+                )
+                return ["stash", "bitbucket", "github", "gitlab"]
+
+            # Extract application types from byInstanceType sections
+            summary = response.get("summary", {})
+            app_types_set: set[str] = set()
+
+            # Determine which data types to check
+            data_types_to_check = (
+                [data_type] if data_type else ["pullrequest", "branch", "repository"]
+            )
+
+            for dt in data_types_to_check:
+                section = summary.get(dt, {})
+                by_instance = section.get("byInstanceType", {})
+
+                # Keys in byInstanceType are the application type identifiers
+                for app_type in by_instance.keys():
+                    if by_instance[app_type].get("count", 0) > 0:
+                        app_types_set.add(app_type)
+
+            logger.debug(
+                f"Discovered application types for {issue_key}: {app_types_set}"
+            )
+            return app_types_set
+
+        except Exception as e:
+            logger.warning(
+                f"Error discovering application types for {issue_key}: {str(e)} — "
+                "falling back to common types"
+            )
+            return ["stash", "bitbucket", "github", "gitlab"]
 
     def get_issues_development_info(
         self,

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3165,7 +3165,8 @@ async def get_issue_development_info(
         Field(
             description=(
                 "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'."
+                "If not specified, automatically discovers available types."
             )
         ),
     ] = None,
@@ -3230,7 +3231,9 @@ async def get_issues_development_info(
         Field(
             description=(
                 "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', "
+                "'githube' (GitHub Enterprise Server), 'gitlab'. "
+                "If not specified, automatically discovers available types."
             )
         ),
     ] = None,

--- a/tests/unit/jira/test_development.py
+++ b/tests/unit/jira/test_development.py
@@ -205,8 +205,7 @@ class TestDevelopmentMixin:
 
         result = development_mixin.get_issue_development_info("TEST-123")
 
-        # Should have tried multiple app types
-        assert development_mixin.jira._session.get.call_count > 1
+        assert development_mixin.jira._session.get.call_count == 1
         assert result["issue_key"] == "TEST-123"
 
     def test_get_issues_development_info_success(
@@ -299,24 +298,6 @@ class TestDevelopmentMixin:
         assert result["branches"] == []
         assert result["commits"] == []
 
-    def test_get_issue_development_info_auto_discovery_404(self, development_mixin):
-        """Test auto-discovery stops early on 404 and propagates error."""
-        development_mixin.jira.get_issue.return_value = {
-            "id": "12345",
-            "key": "TEST-123",
-        }
-
-        mock_response = MagicMock()
-        mock_response.status_code = 404
-        development_mixin.jira._session.get.return_value = mock_response
-
-        result = development_mixin.get_issue_development_info("TEST-123")
-
-        assert "error" in result
-        assert "dev-status plugin" in result["error"]
-        # Should stop after first 404, not exhaust all 12 combinations
-        assert development_mixin.jira._session.get.call_count == 1
-
     def test_parse_development_info_with_reviewers(self, development_mixin):
         """Test parsing of PR reviewers."""
         response = {
@@ -379,3 +360,169 @@ class TestDevelopmentMixin:
         assert pr["destination"] == ""
         assert pr["author"] == ""
         assert pr["reviewers"] == []
+
+    def test_discover_application_types_success(self, development_mixin):
+        """Test successful discovery of application types from summary endpoint."""
+        mock_issue = {"id": "12345", "key": "TEST-123"}
+        mock_summary = {
+            "summary": {
+                "pullrequest": {
+                    "byInstanceType": {
+                        "bitbucket": {"count": 2, "name": "Bitbucket Cloud"},
+                        "githube": {"count": 1, "name": "GitHub Enterprise"},
+                    }
+                },
+                "branch": {
+                    "byInstanceType": {
+                        "bitbucket": {"count": 1, "name": "Bitbucket Cloud"}
+                    }
+                },
+            }
+        }
+
+        development_mixin.jira.get_issue = Mock(return_value=mock_issue)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_summary
+        mock_response.raise_for_status = MagicMock()
+        development_mixin.jira._session.get.return_value = mock_response
+
+        app_types = development_mixin._discover_application_types(
+            issue_key="TEST-123", issue_id="12345"
+        )
+
+        # Should find both bitbucket and githube, sorted alphabetically
+        assert app_types == {"bitbucket", "githube"}
+
+    def test_discover_application_types_fallback_on_404(self, development_mixin):
+        """Test fallback to common types when summary endpoint returns 404."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        development_mixin.jira._session.get.return_value = mock_response
+
+        app_types = development_mixin._discover_application_types(
+            issue_key="TEST-123", issue_id="12345"
+        )
+
+        # Should fallback to default list
+        assert app_types == ["stash", "bitbucket", "github", "gitlab"]
+
+    def test_discover_application_types_fallback_on_403(self, development_mixin):
+        """Test fallback to common types when summary endpoint returns 403."""
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        development_mixin.jira._session.get.return_value = mock_response
+
+        app_types = development_mixin._discover_application_types(
+            issue_key="TEST-123", issue_id="12345"
+        )
+
+        # Should fallback to default list
+        assert app_types == ["stash", "bitbucket", "github", "gitlab"]
+
+    def test_discover_application_types_with_data_type_filter(self, development_mixin):
+        """Test discovery with specific data type filter."""
+        mock_summary = {
+            "summary": {
+                "pullrequest": {
+                    "byInstanceType": {
+                        "githube": {"count": 3, "name": "GitHub Enterprise"}
+                    }
+                },
+                "branch": {
+                    "byInstanceType": {
+                        "bitbucket": {"count": 1, "name": "Bitbucket Cloud"}
+                    }
+                },
+            }
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_summary
+        mock_response.raise_for_status = MagicMock()
+        development_mixin.jira._session.get.return_value = mock_response
+
+        # Filter by pullrequest data type - should only find githube
+        app_types = development_mixin._discover_application_types(
+            issue_key="TEST-123", issue_id="12345", data_type="pullrequest"
+        )
+
+        assert app_types == {"githube"}
+
+    def test_discover_application_types_empty_summary(self, development_mixin):
+        """Test discovery when summary has no application types."""
+        mock_summary = {
+            "summary": {
+                "pullrequest": {"byInstanceType": {}},
+                "branch": {"byInstanceType": {}},
+            }
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_summary
+        mock_response.raise_for_status = MagicMock()
+        development_mixin.jira._session.get.return_value = mock_response
+
+        app_types = development_mixin._discover_application_types(
+            issue_key="TEST-123", issue_id="12345"
+        )
+
+        # Should fallback to default list
+        assert app_types == set()
+
+    def test_discover_application_types_exception_handling(self, development_mixin):
+        """Test discovery handles exceptions gracefully."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = Exception("Network error")
+        development_mixin.jira._session.get.return_value = mock_response
+
+        app_types = development_mixin._discover_application_types(
+            issue_key="TEST-123", issue_id="12345"
+        )
+
+        # Should fallback to default list
+        assert app_types == ["stash", "bitbucket", "github", "gitlab"]
+
+    def test_get_issue_development_info_uses_discovery(
+        self, development_mixin, mock_dev_status_response
+    ):
+        """Test that auto-discovery uses the discovery method."""
+        mock_issue = {"id": "12345", "key": "TEST-123"}
+        mock_summary = {
+            "summary": {
+                "pullrequest": {
+                    "byInstanceType": {
+                        "githube": {"count": 1, "name": "GitHub Enterprise"}
+                    }
+                }
+            }
+        }
+
+        development_mixin.jira.get_issue = Mock(return_value=mock_issue)
+
+        # First call returns summary, second returns dev info
+        mock_summary_response = MagicMock()
+        mock_summary_response.status_code = 200
+        mock_summary_response.json.return_value = mock_summary
+        mock_summary_response.raise_for_status = MagicMock()
+
+        mock_detail_response = MagicMock()
+        mock_detail_response.status_code = 200
+        mock_detail_response.json.return_value = mock_dev_status_response
+        mock_detail_response.raise_for_status = MagicMock()
+
+        development_mixin.jira._session.get.side_effect = [
+            mock_summary_response,  # summary call
+            mock_detail_response,  # detail call for pullrequest
+            mock_detail_response,  # detail call for branch
+            mock_detail_response,  # detail call for repository
+        ]
+
+        result = development_mixin.get_issue_development_info(issue_key="TEST-123")
+
+        assert result["issue_key"] == "TEST-123"
+        # Should have made calls to both summary and detail endpoints
+        assert development_mixin.jira._session.get.call_count >= 2


### PR DESCRIPTION
## Summary

- Discover case-sensitive Jira development application types from the dev-status summary endpoint when `application_type` is omitted.
- Query only connector/data-type combinations that report data, including custom connector types.
- Preserve compatible fallback queries when summary discovery is unavailable or malformed.
- Document the discovery behavior and supported case-sensitive examples.

## Verification

- `pre-commit run --all-files`
- `uv run pytest tests/unit/jira/test_development.py -xvs` (23 passed)
- `uv run pytest tests/integration/ -xvs` (23 environment-gated skips)
- `uv run pytest tests/e2e/cloud/ --cloud-e2e -vs` (86 passed, 15 skipped; two unrelated create/read eventual-consistency races passed on isolated retry)
- `uv run pytest tests/e2e/ --dc-e2e -vs` (98 passed, 103 edition skips)