### PR TITLE
fix(jira): prefer sub-task name match before fallback

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -614,7 +614,7 @@ class IssuesMixin(
                 if epic_type_id:
                     actual_issue_id = epic_type_id
                     logger.info(f"Using localized Epic issue type id: {epic_type_id}")
-            elif issue_type.lower() in ["subtask", "sub-task"]:
+            elif self._normalize_issue_type_name(issue_type) == "subtask":
                 # If the user provided "Subtask" but we need to find the localized name
                 subtask_type_id = self._find_subtask_issue_type_id(project_key)
                 if subtask_type_id:
@@ -789,20 +789,43 @@ class IssuesMixin(
             logger.warning(f"Could not get issue types for project {project_key}: {e}")
             return None
 
+    def _normalize_issue_type_name(self, issue_type: str) -> str:
+        """
+        Normalize an issue type name for comparison.
+
+        Args:
+            issue_type: The issue type name to normalize
+
+        Returns:
+            Normalized issue type name
+        """
+        return issue_type.lower().replace("-", "").replace(" ", "")
+
     def _find_subtask_issue_type_id(self, project_key: str) -> str | None:
         """
-        Find the actual Subtask issue type name for a project.
+        Find the best matching subtask issue type id for a project.
 
         Args:
             project_key: The project key
 
         Returns:
-            The Subtask issue type name if found, None otherwise
+            The best matching subtask issue type id if found, None otherwise
         """
         try:
             issue_types = self.get_project_issue_types(project_key)
+
+            # Prefer a server-returned subtask issue type name that
+            # normalizes to "subtask" before falling back.
             for issue_type in issue_types:
-                # Check the subtask field - this is the most reliable way
+                type_name = issue_type.get("name", "")
+                if (
+                    issue_type.get("subtask", False)
+                    and self._normalize_issue_type_name(type_name) == "subtask"
+                ):
+                    return issue_type.get("id")
+
+            # Final fallback: first available subtask-capable issue type.
+            for issue_type in issue_types:
                 if issue_type.get("subtask", False):
                     return issue_type.get("id")
             return None

--- a/tests/unit/jira/test_issue_creation_logic.py
+++ b/tests/unit/jira/test_issue_creation_logic.py
@@ -166,6 +166,16 @@ def test_find_epic_issue_type_id_returns_id(issues_mixin):
     assert epic_id == "10001"
 
 
+def test_find_epic_issue_type_id_returns_none_if_not_found(issues_mixin):
+    """Verify _find_epic_issue_type_id returns None when no Epic type exists."""
+    issues_mixin.get_project_issue_types.return_value = [
+        {"id": "10000", "name": "Story", "subtask": False},
+    ]
+
+    epic_id = issues_mixin._find_epic_issue_type_id("PROJ")
+    assert epic_id is None
+
+
 def test_find_subtask_issue_type_id_returns_id(issues_mixin):
     """Verify _find_subtask_issue_type_id returns the correct ID."""
     issues_mixin.get_project_issue_types.return_value = [
@@ -176,14 +186,26 @@ def test_find_subtask_issue_type_id_returns_id(issues_mixin):
     assert subtask_id == "10002"
 
 
-def test_find_epic_issue_type_id_returns_none_if_not_found(issues_mixin):
-    """Verify _find_epic_issue_type_id returns None when no Epic type exists."""
+def test_find_subtask_issue_type_id_prefers_subtask_name_match(issues_mixin):
+    """Verify Sub-task is preferred over other subtask-capable types."""
     issues_mixin.get_project_issue_types.return_value = [
-        {"id": "10000", "name": "Story", "subtask": False},
+        {"id": "24", "name": "Action Item", "subtask": True},
+        {"id": "5", "name": "Sub-task", "subtask": True},
     ]
 
-    epic_id = issues_mixin._find_epic_issue_type_id("PROJ")
-    assert epic_id is None
+    subtask_id = issues_mixin._find_subtask_issue_type_id("PROJ")
+    assert subtask_id == "5"
+
+
+def test_find_subtask_issue_type_id_falls_back_to_first_subtask(issues_mixin):
+    """Verify the first subtask-capable type is used as a fallback."""
+    issues_mixin.get_project_issue_types.return_value = [
+        {"id": "24", "name": "Action Item", "subtask": True},
+        {"id": "25", "name": "Custom Child", "subtask": True},
+    ]
+
+    subtask_id = issues_mixin._find_subtask_issue_type_id("PROJ")
+    assert subtask_id == "24"
 
 
 def test_find_subtask_issue_type_id_returns_none_if_not_found(issues_mixin):


### PR DESCRIPTION
## Description

Fix child issue creation when multiple project issue types are marked `subtask=true`.

In some Jira Server / Data Center projects, the resolver selected the first subtask-capable issue type returned by project metadata instead of preferring the default Jira `Sub-task` type. This could cause child issue creation requests for `Subtask` / `Sub-task` to create the wrong issue type.

Fixes: #1330

## Changes

- normalize issue type names for comparison during subtask issue type handling
- prefer a server-returned subtask issue type whose name normalizes to `subtask` before falling back
- add regression tests covering preferred `Sub-task` selection and fallback behavior

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: inspected project issue type metadata with multiple `subtask=true` issue types, verified the resolver behavior locally, ran `uv run pytest tests/unit/jira/test_issue_creation_logic.py -q` (`26 passed`), and ran `pre-commit run --all-files` (formatting/lint hooks passed; an unrelated existing mypy failure remained in `src/mcp_atlassian/servers/main.py`)

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
