### PR TITLE
Include account_id in JiraUser.to_simplified_dict output

### DIFF
--- a/src/mcp_atlassian/models/jira/common.py
+++ b/src/mcp_atlassian/models/jira/common.py
@@ -85,6 +85,8 @@ class JiraUser(ApiModel):
             "email": self.email,
             "avatar_url": self.avatar_url,
         }
+        if self.account_id:
+            result["account_id"] = self.account_id
         if self.user_key:
             result["key"] = self.user_key
         return result


### PR DESCRIPTION
## Summary

`JiraUser.from_api_response()` parses `accountId` from the Jira API into `self.account_id`, but `to_simplified_dict()` never includes it in the output. This means MCP tool consumers cannot see user account IDs, which are needed for formatting @mentions in Jira Cloud comments.

This adds `account_id` to the simplified dict output, consistent with how `user_key` is already handled.

## Test plan

- Verify user profile responses now include `account_id` field
- Verify issue reporter/assignee fields include `account_id`
- Verify comment author fields include `account_id`