### PR TITLE
feat(jira): add move_issues_to_backlog tool

### DIFF
--- a/src/mcp_atlassian/jira/sprints.py
+++ b/src/mcp_atlassian/jira/sprints.py
@@ -149,6 +149,24 @@ class SprintsMixin(JiraClient):
         )
         return True
 
+    def move_issues_to_backlog(self, issue_keys: list[str]) -> bool:
+        """Move issues to the backlog (removes them from any sprint).
+
+        Args:
+            issue_keys: List of issue keys to move (e.g., ["PROJ-1", "PROJ-2"]).
+
+        Returns:
+            True if successful.
+
+        Raises:
+            requests.HTTPError: If the API call fails.
+        """
+        self.jira.post(
+            "rest/agile/1.0/backlog/issue",
+            data={"issues": issue_keys},
+        )
+        return True
+
     def create_sprint(
         self,
         board_id: str,

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2374,6 +2374,40 @@ async def add_issues_to_sprint(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_agile"},
+    annotations={"title": "Move Issues to Backlog", "readOnlyHint": False},
+)
+@check_write_access
+async def move_issues_to_backlog(
+    ctx: Context,
+    issue_keys: Annotated[
+        str,
+        Field(description="Comma-separated issue keys (e.g., 'PROJ-1,PROJ-2')"),
+    ],
+) -> str:
+    """Move issues to the backlog, removing them from any sprint.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_keys: Comma-separated issue keys.
+
+    Returns:
+        JSON string with success message.
+
+    Raises:
+        ValueError: If in read-only mode or Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    keys_list = [k.strip() for k in issue_keys.split(",") if k.strip()]
+    jira.move_issues_to_backlog(keys_list)
+    result = {
+        "message": f"Successfully moved {len(keys_list)} issue(s) to backlog",
+        "issue_keys": keys_list,
+    }
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_projects"},
     annotations={"title": "Get Project Versions", "readOnlyHint": True},
 )

--- a/tests/unit/jira/test_sprints.py
+++ b/tests/unit/jira/test_sprints.py
@@ -383,3 +383,54 @@ def test_add_issues_to_sprint_generic_exception(sprints_mixin):
 
     with pytest.raises(Exception, match="Connection error"):
         sprints_mixin.add_issues_to_sprint("100", ["PROJ-1"])
+
+
+# ============================================================================
+# move_issues_to_backlog tests
+# ============================================================================
+
+
+def test_move_issues_to_backlog_single_key(sprints_mixin):
+    """Test move_issues_to_backlog with a single issue key."""
+    sprints_mixin.jira.post.return_value = None
+
+    result = sprints_mixin.move_issues_to_backlog(["PROJ-1"])
+
+    assert result is True
+    sprints_mixin.jira.post.assert_called_once_with(
+        "rest/agile/1.0/backlog/issue",
+        data={"issues": ["PROJ-1"]},
+    )
+
+
+def test_move_issues_to_backlog_multiple_keys(sprints_mixin):
+    """Test move_issues_to_backlog with multiple issue keys."""
+    sprints_mixin.jira.post.return_value = None
+
+    result = sprints_mixin.move_issues_to_backlog(["PROJ-1", "PROJ-2", "PROJ-3"])
+
+    assert result is True
+    sprints_mixin.jira.post.assert_called_once_with(
+        "rest/agile/1.0/backlog/issue",
+        data={"issues": ["PROJ-1", "PROJ-2", "PROJ-3"]},
+    )
+
+
+def test_move_issues_to_backlog_http_error(sprints_mixin):
+    """Test move_issues_to_backlog propagates HTTPError."""
+    sprints_mixin.jira.post.side_effect = requests.HTTPError(
+        response=MagicMock(content="Server error")
+    )
+
+    with pytest.raises(requests.HTTPError):
+        sprints_mixin.move_issues_to_backlog(["PROJ-1"])
+
+    sprints_mixin.jira.post.assert_called_once()
+
+
+def test_move_issues_to_backlog_generic_exception(sprints_mixin):
+    """Test move_issues_to_backlog propagates generic exceptions."""
+    sprints_mixin.jira.post.side_effect = Exception("Connection error")
+
+    with pytest.raises(Exception, match="Connection error"):
+        sprints_mixin.move_issues_to_backlog(["PROJ-1"])

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 50, f"Expected 50 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

Adds a new `move_issues_to_backlog` MCP tool that moves issues to the backlog, removing them from any sprint. This is the inverse of `add_issues_to_sprint`.

- Calls `POST /rest/agile/1.0/backlog/issue` with the provided issue keys
- Accepts comma-separated issue keys (same format as `add_issues_to_sprint`)
- Respects read-only mode via `@check_write_access`
- Tagged with `jira`, `write`, `toolset:jira_agile`

Ref: https://docs.atlassian.com/jira-software/REST/8.9.0/#agile/1.0/backlog-moveIssuesToBacklog

## Changes

- `src/mcp_atlassian/jira/sprints.py`: Added `move_issues_to_backlog()` method to `SprintsMixin`
- `src/mcp_atlassian/servers/jira.py`: Registered the MCP tool
- `tests/unit/jira/test_sprints.py`: Added unit tests (single key, multiple keys, HTTP error, generic exception)

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/jira/test_sprints.py`)
- [x] Integration test against Jira Server instance