### PR TITLE
fix(jira): tolerate default add comment fields

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1785,9 +1785,7 @@ async def add_comment(
     # Some MCP clients send omitted optional booleans as false. Keep normal
     # Jira comments as the default and reserve ServiceDesk routing for true.
     public_value = True if public is True else None
-    result = jira.add_comment(
-        issue_key, body, visibility_dict, public=public_value
-    )
+    result = jira.add_comment(issue_key, body, visibility_dict, public=public_value)
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -55,10 +55,12 @@ def _parse_visibility(
     Raises:
         ValueError: If the input is not valid JSON or not a dict.
     """
-    if visibility is None:
+    if visibility is None or not visibility.strip():
         return None
     try:
         parsed = json.loads(visibility)
+        if parsed is None:
+            return None
         if not isinstance(parsed, dict):
             raise ValueError(
                 f"{field_name} must be a valid JSON object, e.g. "
@@ -1780,7 +1782,12 @@ async def add_comment(
     """
     jira = await get_jira_fetcher(ctx)
     visibility_dict = _parse_visibility(visibility)
-    result = jira.add_comment(issue_key, body, visibility_dict, public=public)
+    # Some MCP clients send omitted optional booleans as false. Keep normal
+    # Jira comments as the default and reserve ServiceDesk routing for true.
+    public_value = True if public is True else None
+    result = jira.add_comment(
+        issue_key, body, visibility_dict, public=public_value
+    )
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1042,8 +1042,8 @@ async def test_get_all_projects_tool(jira_client, mock_jira_fetcher):
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with default parameters (include_archived=False)
@@ -1091,8 +1091,8 @@ async def test_get_all_projects_tool_with_archived(jira_client, mock_jira_fetche
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with include_archived=True
@@ -1145,8 +1145,8 @@ async def test_get_all_projects_tool_with_projects_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up the projects filter in the config
@@ -1199,8 +1199,8 @@ async def test_get_all_projects_tool_no_projects_filter(jira_client, mock_jira_f
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Ensure no projects filter is set
@@ -1260,8 +1260,8 @@ async def test_get_all_projects_tool_case_insensitive_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up projects filter with mixed case and whitespace

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2001,6 +2001,77 @@ async def test_add_comment(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+async def test_add_comment_ignores_empty_optional_fields(
+    jira_client, mock_jira_fetcher
+):
+    """Test add_comment treats client default optional fields as omitted."""
+    response = await jira_client.call_tool(
+        "jira_add_comment",
+        {
+            "issue_key": "TEST-123",
+            "body": "Test comment body",
+            "visibility": "",
+            "public": False,
+        },
+    )
+
+    mock_jira_fetcher.add_comment.assert_called_once_with(
+        "TEST-123", "Test comment body", None, public=None
+    )
+
+    result = json.loads(response.content[0].text)
+    assert result["id"] == "10001"
+    assert result["body"] == "Test comment body"
+
+
+@pytest.mark.anyio
+async def test_add_comment_restricted_visibility_ignores_false_public_default(
+    jira_client, mock_jira_fetcher
+):
+    """Test add_comment can combine visibility with client default public=false."""
+    response = await jira_client.call_tool(
+        "jira_add_comment",
+        {
+            "issue_key": "TEST-123",
+            "body": "Test comment body",
+            "visibility": '{"type":"role","value":"Developer"}',
+            "public": False,
+        },
+    )
+
+    mock_jira_fetcher.add_comment.assert_called_once_with(
+        "TEST-123",
+        "Test comment body",
+        {"type": "role", "value": "Developer"},
+        public=None,
+    )
+
+    result = json.loads(response.content[0].text)
+    assert result["id"] == "10001"
+    assert result["body"] == "Test comment body"
+
+
+@pytest.mark.anyio
+async def test_add_comment_public_true_keeps_servicedesk_routing(
+    jira_client, mock_jira_fetcher
+):
+    """Test add_comment preserves explicit public=true for JSM comments."""
+    await jira_client.call_tool(
+        "jira_add_comment",
+        {
+            "issue_key": "TEST-123",
+            "body": "Test comment body",
+            "visibility": "",
+            "public": True,
+        },
+    )
+
+    mock_jira_fetcher.add_comment.assert_called_once_with(
+        "TEST-123", "Test comment body", None, public=True
+    )
+
+
+@pytest.mark.anyio
 async def test_edit_comment(jira_client, mock_jira_fetcher):
     """Test edit_comment accepts 'body' parameter matching response field name."""
     response = await jira_client.call_tool(


### PR DESCRIPTION
## Summary
- Treat blank or JSON null comment visibility as omitted.
- Keep normal Jira comment routing when MCP clients send optional `public=false` by default.
- Preserve `public=true` routing for Jira Service Management public comments.

## Tests
- `uv run pytest tests/unit/servers/test_jira_server.py -k "add_comment"`
- `uv run pytest tests/unit/jira/test_comments.py`