### PR TITLE
feat(jira): expose required transition fields and worklog support

### DIFF
--- a/docs/_overrides/jira_get_transitions.yaml
+++ b/docs/_overrides/jira_get_transitions.yaml
@@ -1,0 +1,2 @@
+notes: |
+  `required_fields` covers only transition **screen** fields. Jira workflow **validators** (e.g. "Time Spent required") are not exposed through the REST API — a transition may still be rejected even when all `required_fields` are satisfied.

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Jira Issues"
-description: "Create, read, update, move, delete, and transition Jira issues"
+description: "Create, read, update, delete, and transition Jira issues"
 ---
 
 ### Get Issue
 
-Get details of a specific Jira issue including its Epic links and relationship information.
+Get details of a specific Jira issue.
 
 **Parameters:**
 
@@ -17,7 +17,8 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
-| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response. Supported values: `all`, `remote_links`, `transitions`, `watchers`, `changelog`, `comments`, `worklogs`. |
+| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response, avoiding extra tool calls. Supported: all, remote_links, transitions, watchers, changelog, comments, worklogs |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The 'names' expansion is added automatically. Standard fields are unaffected. |
 **Example:**
 
 ```json
@@ -25,14 +26,14 @@ Get details of a specific Jira issue including its Epic links and relationship i
 ```
 
 <Tip>
-Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content. Use `include: "all"` to inline common enrichments that otherwise require separate tool calls.
-</Tip>
+Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content. Use `include: "all"` to inline common enrichments that otherwise require separate tool calls. The response includes `browse_url`, a direct link to the issue in the Jira web UI.
 
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`. If a display name conflicts with another output key, that custom field keeps its raw ID so no value is lost.
+</Tip>
 
 <Warning>
 Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
 </Warning>
-
 
 ---
 
@@ -50,7 +51,7 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 | `summary` | `string` | Yes | Summary/title of the issue |
 | `issue_type` | `string` | Yes | Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). The available types depend on your project configuration. For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields. |
 | `assignee` | `string` | No | (Optional) Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...') |
-| `description` | `string` | No | Issue description in Markdown format |
+| `description` | `string` | No | Issue description in Markdown format. On Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API') |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: `{"priority": {"name": "High"}}` - Add labels: `{"labels": ["frontend", "urgent"]}` - Link to parent (for any issue type): `{"parent": "PROJ-123"}` - Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}` - Set Fix Version/s: `{"fixVersions": [{"id": "10020"}]}` - Custom fields: `{"customfield_10010": "value"}` |
 **Example:**
@@ -60,23 +61,18 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 ```
 
 <Tip>
-Use Markdown in the description - it's automatically converted to ADF (Cloud)
-or wiki markup (Server/DC). On Jira Cloud, mention users with
-`[~accountid:ACCOUNT_ID]` or `@[Display Name](accountid:ACCOUNT_ID)`.
-For epics, provide `epic_name` parameter.
+Use Markdown in the description — it's automatically converted to ADF (Cloud) or wiki markup (Server/DC). On Jira Cloud, mention users with `[~accountid:ACCOUNT_ID]` or `@[Display Name](accountid:ACCOUNT_ID)`. Use `{expand:Title}` and `{expand}` around content to create a collapsible section on Jira Cloud. For epics, provide `epic_name` parameter.
 </Tip>
-
 
 <Warning>
 Cloud uses ADF format internally (auto-converted from Markdown). Server/DC uses wiki markup.
 </Warning>
 
-
 ---
 
 ### Update Issue
 
-Update an existing Jira issue including changing status, adding Epic links, updating fields, etc.
+Update an issue and optionally transition, comment, and log work.
 
 <Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 
@@ -85,20 +81,29 @@ Update an existing Jira issue including changing status, adding Epic links, upda
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format. Example: `'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}'` |
+| `fields` | `string` | No | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format; on Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. Example: '`{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}`' |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}`. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names (e.g., 'Frontend,API') |
 | `attachments` | `string` | No | (Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt'] |
+| `transition` | `string` | No | (Optional) Transition name or ID. Transition names are resolved case-insensitively. |
+| `comment` | `string` | No | (Optional) Comment text in Markdown format. |
+| `comment_visibility` | `string` | No | (Optional) Comment visibility as a JSON string, for example '`{"type":"group","value":"jira-users"}`'. |
+| `worklog` | `string` | No | (Optional) Time spent to log, such as '1h 30m'. |
+| `worklog_started` | `string` | No | (Optional) ISO datetime when the worklog started. |
+| `return_fields` | `string` | No | (Optional) Controls which fields of the updated issue are returned, to reduce response size and token usage. Defaults to '*all' (the complete issue, which can be very large). TOKEN-SAVING TIP: after an update you usually do NOT need the whole issue back. Pass a comma-separated list of just the field(s) you care about (e.g., 'summary,duedate'), or a single light field such as 'status' for a minimal confirmation - this can cut the response by thousands of tokens. The issue 'key' is always returned regardless. If you later need other fields, fetch them on demand with jira_get_issue (which also supports field filtering). Use '*all' only when you genuinely need the full updated issue. |
 **Example:**
 
 ```json
-{"issue_key": "PROJ-123", "summary": "Updated title", "description": "New description", "additional_fields": "{\"priority\": {\"name\": \"High\"}}"}
+{"issue_key": "PROJ-123", "fields": "{\"summary\": \"Updated title\", \"description\": \"New description\"}", "transition": "Done", "comment": "Completed the work", "worklog": "1h"}
 ```
 
 <Tip>
+Save response tokens: after an update you rarely need the whole issue back. Set `return_fields` to only the field(s) you changed (e.g., `return_fields: "duedate"`) — this can cut thousands of tokens. Use `*all` only when you need the full updated issue.
+
+`fields` is optional when you only need to transition, comment, or log work. If `transition` and `comment` are both provided, the issue is transitioned first and the comment is added separately afterward. Use `comment_visibility` to restrict the comment's visibility.
+
 Use `additional_fields` as a JSON string for any field not covered by explicit parameters. Find field IDs with `jira_search_fields`.
 </Tip>
-
 
 ---
 
@@ -116,28 +121,42 @@ Delete an existing Jira issue.
 
 ---
 
-### Move Issue
+### Assign Issue
 
-Move a Jira Cloud issue to a different project.
+Assign a Jira issue to a user using the dedicated assignment endpoint.
 
 <Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 
-<Warning>
-This tool is only available for Jira Cloud. The target project must support the issue's current type. Jira may assign a new issue key in the target project.
-</Warning>
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
+| `assignee` | `string` | No | User identifier (email, display name, account ID, login name, or JIRAUSER key), or a JSON object string from jira_search_assignable_users. Pass null or empty string to unassign. |
+
+---
+
+### Move Issue to Project
+
+Move a Jira issue to a different project (Jira Cloud only).
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key to move (e.g., 'PROJ-123') |
-| `target_project_key` | `string` | Yes | Target project key (e.g., 'OTHERPROJ') |
-
+| `target_project_key` | `string` | Yes | Key of the target project (e.g., 'OTHERPROJ'). The issue will keep its current issue type and may receive a new key in the target project. |
 **Example:**
 
 ```json
 {"issue_key": "PROJ-123", "target_project_key": "OTHERPROJ"}
 ```
+
+<Warning>
+This tool is only available for Jira Cloud. The target project must support the issue's current type. Jira may assign a new issue key in the target project.
+</Warning>
 
 ---
 
@@ -151,7 +170,7 @@ Create multiple Jira issues in a batch.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: `[{"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}, {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}]` |
+| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: [ `{"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}`, `{"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}` ] |
 | `validate_only` | `boolean` | No | If true, only validates the issues without creating them |
 
 ---
@@ -168,19 +187,18 @@ Transition a Jira issue to a new status.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `transition_id` | `string` | Yes | ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31' |
-| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Use `jira_get_transitions` to discover `required_fields`. Example: `{"resolution": {"name": "Fixed"}}` |
-| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. |
+| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '`{"resolution": {"name": "Fixed"}}`' |
+| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be customer-visible on JSM and cannot be forced internal): transition without a comment, then post an internal note with jira_add_comment(public=false). |
 | `update_data` | `string` | No | (Optional) JSON string of Jira update operations to include in the transition. Use this for worklogs and other transition-time operations. Example: `{"worklog": [{"add": {"timeSpent": "1h"}}]}` |
 **Example:**
 
 ```json
-{"issue_key": "PROJ-123", "transition_id": "31", "fields": "{\"resolution\": {\"name\": \"Fixed\"}}", "update_data": "{\"worklog\": [{\"add\": {\"timeSpent\": \"1h\"}}]}"}
+{"issue_key": "PROJ-123", "transition_name": "Done", "comment": "Closing as completed"}
 ```
 
 <Tip>
-Use `jira_get_transitions` first to see available transitions, whether they have a screen, and which fields are required for the current issue state.
+Use `jira_get_transitions` first to see available transitions for the current issue state.
 </Tip>
-
 
 ---
 
@@ -195,6 +213,7 @@ Get available status transitions for a Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
+| `expand_fields` | `boolean` | No | Whether to include required field metadata (allowed values, schema) for each transition. Defaults to false (lightweight). |
 
 ---
 

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -17,7 +17,7 @@ Get details of a specific Jira issue.
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
-| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response, avoiding extra tool calls. Supported: all, remote_links, transitions, watchers, changelog, comments, worklogs |
+| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response, avoiding extra tool calls. Supported: all, remote_links, transitions, watchers, changelog, comments, worklogs. Note: transitions inlined via include are lightweight (no required_fields). Use jira_get_transitions with expand_fields=true for full field metadata. |
 | `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The 'names' expansion is added automatically. Standard fields are unaffected. |
 **Example:**
 
@@ -189,7 +189,7 @@ Transition a Jira issue to a new status.
 | `transition_id` | `string` | Yes | ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31' |
 | `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '`{"resolution": {"name": "Fixed"}}`' |
 | `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be customer-visible on JSM and cannot be forced internal): transition without a comment, then post an internal note with jira_add_comment(public=false). |
-| `update_data` | `string` | No | (Optional) JSON string of Jira update operations to include in the transition. Use this for worklogs and other transition-time operations. Example: `{"worklog": [{"add": {"timeSpent": "1h"}}]}` |
+| `update_data` | `string` | No | (Optional) JSON string of Jira update operations to include in the transition. Use this for worklogs and other transition-time operations. Example: '`{"worklog": [{"add": {"timeSpent": "1h"}}]}`' |
 **Example:**
 
 ```json
@@ -206,14 +206,16 @@ Use `jira_get_transitions` first to see available transitions for the current is
 
 Get available status transitions for a Jira issue.
 
-<Warning>`required_fields` covers only transition screen fields. Jira workflow validators (e.g. "Time Spent required") are not exposed via REST API and may cause a rejection even when all `required_fields` are satisfied.</Warning>
-
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `expand_fields` | `boolean` | No | Whether to include required field metadata (allowed values, schema) for each transition. Defaults to false (lightweight). |
+| `expand_fields` | `boolean` | No | Whether to expand transition field metadata. When true, requests required field details (allowed values, schema) for each transition. Defaults to false (lightweight). |
+
+<Note>
+`required_fields` covers only transition **screen** fields. Jira workflow **validators** (e.g. "Time Spent required") are not exposed through the REST API — a transition may still be rejected even when all `required_fields` are satisfied.
+</Note>
 
 ---
 

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -212,6 +212,11 @@ Get available status transitions for a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `expand_fields` | `boolean` | No | Whether to expand transition field metadata. When true, requests required field details (allowed values, schema) for each transition. Defaults to false (lightweight). |
+
+<Note>
+`required_fields` covers only transition **screen** fields. Jira workflow **validators** (e.g. "Time Spent required") are not exposed through the REST API — a transition may still be rejected even when all `required_fields` are satisfied.
+</Note>
+
 ---
 
 ### Get All Projects

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -212,11 +212,6 @@ Get available status transitions for a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `expand_fields` | `boolean` | No | Whether to expand transition field metadata. When true, requests required field details (allowed values, schema) for each transition. Defaults to false (lightweight). |
-
-<Note>
-`required_fields` covers only transition **screen** fields. Jira workflow **validators** (e.g. "Time Spent required") are not exposed through the REST API — a transition may still be rejected even when all `required_fields` are satisfied.
-</Note>
-
 ---
 
 ### Get All Projects

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Jira Issues"
-description: "Create, read, update, delete, and transition Jira issues"
+description: "Create, read, update, move, delete, and transition Jira issues"
 ---
 
 ### Get Issue
 
-Get details of a specific Jira issue.
+Get details of a specific Jira issue including its Epic links and relationship information.
 
 **Parameters:**
 
@@ -17,8 +17,7 @@ Get details of a specific Jira issue.
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
-| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response, avoiding extra tool calls. Supported: all, remote_links, transitions, watchers, changelog, comments, worklogs |
-| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The 'names' expansion is added automatically. Standard fields are unaffected. |
+| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response. Supported values: `all`, `remote_links`, `transitions`, `watchers`, `changelog`, `comments`, `worklogs`. |
 **Example:**
 
 ```json
@@ -26,14 +25,14 @@ Get details of a specific Jira issue.
 ```
 
 <Tip>
-Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content. Use `include: "all"` to inline common enrichments that otherwise require separate tool calls. The response includes `browse_url`, a direct link to the issue in the Jira web UI.
-
-Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`. If a display name conflicts with another output key, that custom field keeps its raw ID so no value is lost.
+Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content. Use `include: "all"` to inline common enrichments that otherwise require separate tool calls.
 </Tip>
+
 
 <Warning>
 Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
 </Warning>
+
 
 ---
 
@@ -51,7 +50,7 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 | `summary` | `string` | Yes | Summary/title of the issue |
 | `issue_type` | `string` | Yes | Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). The available types depend on your project configuration. For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields. |
 | `assignee` | `string` | No | (Optional) Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...') |
-| `description` | `string` | No | Issue description in Markdown format. On Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. |
+| `description` | `string` | No | Issue description in Markdown format |
 | `components` | `string` | No | (Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API') |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: `{"priority": {"name": "High"}}` - Add labels: `{"labels": ["frontend", "urgent"]}` - Link to parent (for any issue type): `{"parent": "PROJ-123"}` - Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}` - Set Fix Version/s: `{"fixVersions": [{"id": "10020"}]}` - Custom fields: `{"customfield_10010": "value"}` |
 **Example:**
@@ -61,18 +60,23 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 ```
 
 <Tip>
-Use Markdown in the description — it's automatically converted to ADF (Cloud) or wiki markup (Server/DC). On Jira Cloud, mention users with `[~accountid:ACCOUNT_ID]` or `@[Display Name](accountid:ACCOUNT_ID)`. Use `{expand:Title}` and `{expand}` around content to create a collapsible section on Jira Cloud. For epics, provide `epic_name` parameter.
+Use Markdown in the description - it's automatically converted to ADF (Cloud)
+or wiki markup (Server/DC). On Jira Cloud, mention users with
+`[~accountid:ACCOUNT_ID]` or `@[Display Name](accountid:ACCOUNT_ID)`.
+For epics, provide `epic_name` parameter.
 </Tip>
+
 
 <Warning>
 Cloud uses ADF format internally (auto-converted from Markdown). Server/DC uses wiki markup.
 </Warning>
 
+
 ---
 
 ### Update Issue
 
-Update an issue and optionally transition, comment, and log work.
+Update an existing Jira issue including changing status, adding Epic links, updating fields, etc.
 
 <Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 
@@ -81,29 +85,20 @@ Update an issue and optionally transition, comment, and log work.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `fields` | `string` | No | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format; on Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. Example: '`{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}`' |
+| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format. Example: `'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}'` |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}`. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names (e.g., 'Frontend,API') |
 | `attachments` | `string` | No | (Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt'] |
-| `transition` | `string` | No | (Optional) Transition name or ID. Transition names are resolved case-insensitively. |
-| `comment` | `string` | No | (Optional) Comment text in Markdown format. |
-| `comment_visibility` | `string` | No | (Optional) Comment visibility as a JSON string, for example '`{"type":"group","value":"jira-users"}`'. |
-| `worklog` | `string` | No | (Optional) Time spent to log, such as '1h 30m'. |
-| `worklog_started` | `string` | No | (Optional) ISO datetime when the worklog started. |
-| `return_fields` | `string` | No | (Optional) Controls which fields of the updated issue are returned, to reduce response size and token usage. Defaults to '*all' (the complete issue, which can be very large). TOKEN-SAVING TIP: after an update you usually do NOT need the whole issue back. Pass a comma-separated list of just the field(s) you care about (e.g., 'summary,duedate'), or a single light field such as 'status' for a minimal confirmation - this can cut the response by thousands of tokens. The issue 'key' is always returned regardless. If you later need other fields, fetch them on demand with jira_get_issue (which also supports field filtering). Use '*all' only when you genuinely need the full updated issue. |
 **Example:**
 
 ```json
-{"issue_key": "PROJ-123", "fields": "{\"summary\": \"Updated title\", \"description\": \"New description\"}", "transition": "Done", "comment": "Completed the work", "worklog": "1h"}
+{"issue_key": "PROJ-123", "summary": "Updated title", "description": "New description", "additional_fields": "{\"priority\": {\"name\": \"High\"}}"}
 ```
 
 <Tip>
-Save response tokens: after an update you rarely need the whole issue back. Set `return_fields` to only the field(s) you changed (e.g., `return_fields: "duedate"`) — this can cut thousands of tokens. Use `*all` only when you need the full updated issue.
-
-`fields` is optional when you only need to transition, comment, or log work. If `transition` and `comment` are both provided, the issue is transitioned first and the comment is added separately afterward. Use `comment_visibility` to restrict the comment's visibility.
-
 Use `additional_fields` as a JSON string for any field not covered by explicit parameters. Find field IDs with `jira_search_fields`.
 </Tip>
+
 
 ---
 
@@ -121,42 +116,28 @@ Delete an existing Jira issue.
 
 ---
 
-### Assign Issue
+### Move Issue
 
-Assign a Jira issue to a user using the dedicated assignment endpoint.
-
-<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `assignee` | `string` | No | User identifier (email, display name, account ID, login name, or JIRAUSER key), or a JSON object string from jira_search_assignable_users. Pass null or empty string to unassign. |
-
----
-
-### Move Issue to Project
-
-Move a Jira issue to a different project (Jira Cloud only).
+Move a Jira Cloud issue to a different project.
 
 <Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+<Warning>
+This tool is only available for Jira Cloud. The target project must support the issue's current type. Jira may assign a new issue key in the target project.
+</Warning>
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key to move (e.g., 'PROJ-123') |
-| `target_project_key` | `string` | Yes | Key of the target project (e.g., 'OTHERPROJ'). The issue will keep its current issue type and may receive a new key in the target project. |
+| `target_project_key` | `string` | Yes | Target project key (e.g., 'OTHERPROJ') |
+
 **Example:**
 
 ```json
 {"issue_key": "PROJ-123", "target_project_key": "OTHERPROJ"}
 ```
-
-<Warning>
-This tool is only available for Jira Cloud. The target project must support the issue's current type. Jira may assign a new issue key in the target project.
-</Warning>
 
 ---
 
@@ -170,7 +151,7 @@ Create multiple Jira issues in a batch.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: [ `{"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}`, `{"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}` ] |
+| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: `[{"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}, {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}]` |
 | `validate_only` | `boolean` | No | If true, only validates the issues without creating them |
 
 ---
@@ -187,23 +168,27 @@ Transition a Jira issue to a new status.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `transition_id` | `string` | Yes | ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31' |
-| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '`{"resolution": {"name": "Fixed"}}`' |
-| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be customer-visible on JSM and cannot be forced internal): transition without a comment, then post an internal note with jira_add_comment(public=false). |
+| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Use `jira_get_transitions` to discover `required_fields`. Example: `{"resolution": {"name": "Fixed"}}` |
+| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. |
+| `update_data` | `string` | No | (Optional) JSON string of Jira update operations to include in the transition. Use this for worklogs and other transition-time operations. Example: `{"worklog": [{"add": {"timeSpent": "1h"}}]}` |
 **Example:**
 
 ```json
-{"issue_key": "PROJ-123", "transition_name": "Done", "comment": "Closing as completed"}
+{"issue_key": "PROJ-123", "transition_id": "31", "fields": "{\"resolution\": {\"name\": \"Fixed\"}}", "update_data": "{\"worklog\": [{\"add\": {\"timeSpent\": \"1h\"}}]}"}
 ```
 
 <Tip>
-Use `jira_get_transitions` first to see available transitions for the current issue state.
+Use `jira_get_transitions` first to see available transitions, whether they have a screen, and which fields are required for the current issue state.
 </Tip>
+
 
 ---
 
 ### Get Transitions
 
 Get available status transitions for a Jira issue.
+
+<Warning>`required_fields` covers only transition screen fields. Jira workflow validators (e.g. "Time Spent required") are not exposed via REST API and may cause a rejection even when all `required_fields` are satisfied.</Warning>
 
 **Parameters:**
 

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -148,14 +148,38 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             allowed_values = field_data.get("allowedValues")
             if isinstance(allowed_values, list):
                 field_info["allowed_values"] = [
-                    {"id": str(v.get("id", "")), "name": v.get("name", "")}
+                    TransitionsMixin._normalize_allowed_value(v)
                     for v in allowed_values
-                    if isinstance(v, dict)
                 ]
 
             required_fields.append(field_info)
 
         return required_fields
+
+    @staticmethod
+    def _normalize_allowed_value(value: Any) -> dict[str, str]:
+        """
+        Normalize a single allowed value to {id, name, value} dict.
+
+        Jira returns allowed values in multiple shapes:
+        - Scalar (str, int): ``"Fixed"``
+        - ``{id, name}``: ``{"id": "1", "name": "Fixed"}``
+        - ``{id, value}`` (custom field options): ``{"id": "1", "value": "Fixed"}``
+
+        Args:
+            value: A raw allowed value from the Jira API.
+
+        Returns:
+            A dict with ``id``, ``name``, and ``value`` keys.
+        """
+        if not isinstance(value, dict):
+            scalar = str(value)
+            return {"id": scalar, "name": scalar, "value": scalar}
+
+        vid = str(value.get("id", value.get("optionId", "")))
+        vname = str(value.get("name", value.get("value", "")))
+        vvalue = str(value.get("value", value.get("name", vname)))
+        return {"id": vid, "name": vname, "value": vvalue}
 
     def get_transitions(
         self, issue_key: str, expand: str | None = None

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -148,8 +148,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             allowed_values = field_data.get("allowedValues")
             if isinstance(allowed_values, list):
                 field_info["allowed_values"] = [
-                    TransitionsMixin._normalize_allowed_value(v)
-                    for v in allowed_values
+                    TransitionsMixin._normalize_allowed_value(v) for v in allowed_values
                 ]
 
             required_fields.append(field_info)

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -20,7 +20,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
     def get_available_transitions(
         self,
         issue_key: str,
-        expand: str | None = None,
+        expand_fields: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Get the available status transitions for an issue.
@@ -41,10 +41,9 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
 
         Args:
             issue_key: The issue key (e.g. 'PROJ-123')
-            expand: Optional expand parameter. Pass
-                ``"transitions.fields"`` to include required
-                field metadata (allowed values, schema) with
-                each transition. Defaults to None (lightweight).
+            expand_fields: Whether to request required field metadata
+                (allowed values, schema) for each transition. Defaults
+                to False, which keeps the response lightweight.
 
         Returns:
             List of available transitions with id, name,
@@ -56,7 +55,9 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             Exception: If there is an error getting transitions
         """
         try:
-            transitions_data = self.get_transitions(issue_key, expand=expand)
+            transitions_data = self.get_transitions(
+                issue_key, expand_fields=expand_fields
+            )
             result: list[dict[str, Any]] = []
 
             for transition in transitions_data:
@@ -169,9 +170,9 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         return required_fields
 
     @staticmethod
-    def _normalize_allowed_value(value: Any) -> dict[str, Any]:
+    def _normalize_allowed_value(value: Any) -> Any:
         """
-        Normalize a single allowed value to a dict with id, name, value.
+        Preserve an allowed value and fill in its display name when needed.
 
         Jira returns allowed values in multiple shapes:
         - Scalar (str, int): ``"Fixed"``
@@ -182,23 +183,20 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             value: A raw allowed value from the Jira API.
 
         Returns:
-            A dict with ``id``, ``name``, ``value``, and optionally
-            ``description`` keys.
+            The original scalar value, or a shallow copy of the original
+            mapping. Mappings with a ``value`` label get that label copied
+            to ``name`` when Jira omitted ``name``.
         """
         if not isinstance(value, dict):
-            scalar = str(value)
-            return {"id": scalar, "name": scalar, "value": scalar}
+            return value
 
-        vid = str(value.get("id", value.get("optionId", "")))
-        vname = str(value.get("name", value.get("value", "")))
-        vvalue = str(value.get("value", value.get("name", vname)))
-        result: dict[str, Any] = {"id": vid, "name": vname, "value": vvalue}
-        if "description" in value and value["description"]:
-            result["description"] = str(value["description"])
+        result = dict(value)
+        if not result.get("name") and result.get("value") is not None:
+            result["name"] = result["value"]
         return result
 
     def get_transitions(
-        self, issue_key: str, expand: str | None = None
+        self, issue_key: str, expand_fields: bool = False
     ) -> list[dict[str, Any]]:
         """
         Get the raw transitions data for an issue.
@@ -209,13 +207,18 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
 
         Args:
             issue_key: The issue key (e.g. 'PROJ-123')
-            expand: Optional expand parameter (e.g. 'transitions.fields'
-                to include field metadata with required flags and allowed values)
+            expand_fields: Whether to include transition field metadata.
+                Defaults to False, which keeps the response lightweight.
 
         Returns:
             Raw transitions data from the API with full 'to' status objects
         """
-        response = self.jira.get_issue_transitions_full(issue_key, expand=expand)
+        if expand_fields:
+            response = self.jira.get_issue_transitions_full(
+                issue_key, expand="transitions.fields"
+            )
+        else:
+            response = self.jira.get_issue_transitions_full(issue_key)
         if isinstance(response, dict):
             transitions = response.get("transitions", [])
             if isinstance(transitions, list):

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -17,16 +17,38 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
     """Mixin for Jira transition operations."""
 
     @handle_auth_errors("Jira API")
-    def get_available_transitions(self, issue_key: str) -> list[dict[str, Any]]:
+    def get_available_transitions(
+        self,
+        issue_key: str,
+        expand: str | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Get the available status transitions for an issue.
 
+        Includes has_screen flag and required fields metadata
+        (name, schema, allowed values) so callers can see what
+        fields are mandatory before attempting a transition.
+
+        .. note::
+
+           ``required_fields`` only covers transition **screen** fields
+           (resolution, fixVersions, assignee, etc.). Jira workflow
+           **validators** (e.g. "Time Spent required") are not exposed
+           through the REST API. A transition may still be rejected by
+           a validator even when all ``required_fields`` are satisfied.
+           In that case, read the ``errorMessages`` / ``errors``
+           from the transition response to discover the missing data.
+
         Args:
             issue_key: The issue key (e.g. 'PROJ-123')
+            expand: Optional expand parameter. Pass
+                ``"transitions.fields"`` to include required
+                field metadata (allowed values, schema) with
+                each transition. Defaults to None (lightweight).
 
         Returns:
             List of available transitions with id, name,
-            and to status details
+            to_status, has_screen, and required_fields details
 
         Raises:
             MCPAtlassianAuthenticationError: If authentication fails
@@ -34,12 +56,11 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             Exception: If there is an error getting transitions
         """
         try:
-            transitions_data: object = self.jira.get_issue_transitions(issue_key)
-            if not isinstance(transitions_data, list):
-                return []
+            transitions_data = self.get_transitions(issue_key, expand=expand)
             result: list[dict[str, Any]] = []
 
             for transition in transitions_data:
+                # Skip non-dict transitions
                 if not isinstance(transition, dict):
                     continue
 
@@ -61,9 +82,21 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
                 elif "status" in transition:
                     to_status = transition.get("status")
 
-                # Add to_status if found in any format
                 if to_status:
                     transition_info["to_status"] = to_status
+
+                # Include has_screen flag and required fields
+                transition_info["has_screen"] = bool(transition.get("hasScreen"))
+
+                transition_info["is_conditional"] = bool(
+                    transition.get("isConditional")
+                )
+
+                fields = transition.get("fields", {})
+                if isinstance(fields, dict):
+                    required_fields = self._extract_required_fields(fields)
+                    if required_fields:
+                        transition_info["required_fields"] = required_fields
 
                 result.append(transition_info)
 
@@ -73,10 +106,60 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         except Exception as e:
             error_msg = f"Error getting transitions for {issue_key}: {str(e)}"
             logger.error(error_msg)
-            public_error = f"Error getting transitions: {str(e)}"
-            raise Exception(public_error) from e
+            raise Exception(f"Error getting transitions: {str(e)}") from e
 
-    def get_transitions(self, issue_key: str) -> list[dict[str, Any]]:
+    @staticmethod
+    def _extract_required_fields(
+        fields: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """
+        Extract required field metadata from transition fields dict.
+
+        .. note::
+
+           Only covers transition **screen** fields. Jira workflow
+           validators (permission checks, field validators, etc.)
+           are configured at the workflow level and are not
+           discoverable through the REST API.
+
+        Args:
+            fields: The "fields" dict from a transition API response.
+
+        Returns:
+            List of required field info dicts with key, name, schema,
+            and allowed_values (for select-type fields).
+        """
+        required_fields: list[dict[str, Any]] = []
+        for field_key, field_data in fields.items():
+            if not isinstance(field_data, dict):
+                continue
+            if not field_data.get("required"):
+                continue
+
+            field_info: dict[str, Any] = {
+                "key": field_key,
+                "name": field_data.get("name", field_key),
+            }
+
+            schema = field_data.get("schema")
+            if isinstance(schema, dict):
+                field_info["schema"] = schema
+
+            allowed_values = field_data.get("allowedValues")
+            if isinstance(allowed_values, list):
+                field_info["allowed_values"] = [
+                    {"id": str(v.get("id", "")), "name": v.get("name", "")}
+                    for v in allowed_values
+                    if isinstance(v, dict)
+                ]
+
+            required_fields.append(field_info)
+
+        return required_fields
+
+    def get_transitions(
+        self, issue_key: str, expand: str | None = None
+    ) -> list[dict[str, Any]]:
         """
         Get the raw transitions data for an issue.
 
@@ -86,15 +169,17 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
 
         Args:
             issue_key: The issue key (e.g. 'PROJ-123')
+            expand: Optional expand parameter (e.g. 'transitions.fields'
+                to include field metadata with required flags and allowed values)
 
         Returns:
             Raw transitions data from the API with full 'to' status objects
         """
-        response = self.jira.get_issue_transitions_full(issue_key)
+        response = self.jira.get_issue_transitions_full(issue_key, expand=expand)
         if isinstance(response, dict):
             transitions = response.get("transitions", [])
             if isinstance(transitions, list):
-                return [item for item in transitions if isinstance(item, dict)]
+                return transitions
         return []
 
     def get_transitions_models(self, issue_key: str) -> list[JiraTransition]:
@@ -123,6 +208,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         transition_id: str | int,
         fields: dict[str, Any] | None = None,
         comment: str | None = None,
+        update_data: dict[str, Any] | None = None,
     ) -> JiraIssue:
         """
         Transition a Jira issue to a new status.
@@ -133,11 +219,13 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
                 (integer preferred, string accepted)
             fields: Optional fields to set during the transition
             comment: Optional comment to add during the transition.
-                Rejected for projects listed in
-                JIRA_INTERNAL_ONLY_PROJECTS: a transition comment is a
-                standard Jira comment whose customer-visibility on JSM
-                cannot be controlled from this call, so it may not be
-                posted on an internal-only project.
+                Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS
+                (a transition comment may be customer-visible on JSM and
+                cannot be forced internal): transition without a comment,
+                then post an internal note with add_comment(public=False).
+            update_data: Optional update data (e.g., worklog) to send
+                alongside the transition. Example:
+                {"worklog": [{"add": {"timeSpent": "1h", "comment": "Resolved"}}]}
 
         Returns:
             JiraIssue model representing the transitioned issue
@@ -145,20 +233,18 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         Raises:
             MCPAtlassianAuthenticationError: If authentication fails
                 with the Jira API (401/403)
-            ValueError: If there is an error transitioning the issue, or
-                if a comment is provided for a project listed in
-                JIRA_INTERNAL_ONLY_PROJECTS
+            ValueError: If there is an error transitioning the issue
         """
-        if comment:
-            self._enforce_internal_only_transition_comment(issue_key)
-
         try:
+            if comment:
+                self._enforce_internal_only_transition_comment(issue_key)
+
             # Normalize transition_id to int when possible
             normalized_transition_id = self._normalize_transition_id(transition_id)
 
             # Validate that this is a valid transition ID
             valid_transitions = self.get_transitions_models(issue_key)
-            valid_ids: list[str | int] = [t.id for t in valid_transitions]
+            valid_ids = [t.id for t in valid_transitions]
 
             # Convert string IDs to integers for proper comparison
             if isinstance(normalized_transition_id, int):
@@ -182,6 +268,14 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
                 )
                 # Continue anyway as Jira will validate
 
+            # Find the target status name for the transition ID
+            target_status_name = None
+            for transition in valid_transitions:
+                if str(transition.id) == str(normalized_transition_id):
+                    if transition.to_status and transition.to_status.name:
+                        target_status_name = transition.to_status.name
+                        break
+
             # Sanitize fields if provided
             fields_for_api = None
             if fields:
@@ -189,12 +283,13 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
                 if sanitized_fields:
                     fields_for_api = sanitized_fields
 
-            # Prepare update data for comments if provided
-            update_for_api = None
+            # Prepare update data (comment + extra update_data like worklog)
+            temp_transition_data: dict[str, Any] = {}
+            if update_data:
+                temp_transition_data["update"] = dict(update_data)
             if comment:
-                temp_transition_data: dict[str, Any] = {}
                 self._add_comment_to_transition_data(temp_transition_data, comment)
-                update_for_api = temp_transition_data.get("update")
+            update_for_api = temp_transition_data.get("update")
 
             # Log the transition request for debugging
             logger.info(
@@ -203,22 +298,43 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             )
             logger.debug(f"Fields: {fields_for_api}, Update: {update_for_api}")
 
-            payload: dict[str, Any] = {
-                "transition": {"id": str(normalized_transition_id)},
-            }
-            if fields_for_api:
-                payload["fields"] = fields_for_api
-            if update_for_api:
-                payload["update"] = update_for_api
-
-            if self.config.is_cloud:
-                # Cloud comments are ADF and require the REST v3 endpoint.
-                self._post_api3(f"issue/{issue_key}/transitions", payload)
+            # Transition using the appropriate method
+            if target_status_name:
+                logger.info(f"Using status name '{target_status_name}' for transition")
+                self.jira.set_issue_status(
+                    issue_key=issue_key,
+                    status_name=target_status_name,
+                    fields=fields_for_api,
+                    update=update_for_api,
+                )
             else:
-                # Server/DC comments use wiki markup on REST v2.
-                base_url = self.jira.resource_url("issue")
-                url = f"{base_url}/{issue_key}/transitions"
-                self.jira.post(url, data=payload)
+                logger.info(f"Using direct transition ID {normalized_transition_id}")
+                if (
+                    isinstance(normalized_transition_id, str)
+                    and normalized_transition_id.isdigit()
+                ):
+                    normalized_transition_id = int(normalized_transition_id)
+
+                # The transition payload must be sent atomically. Performing the
+                # bare transition first would make a second request with fields or
+                # update operations target an already-transitioned issue.
+                if fields_for_api or update_for_api:
+                    payload: dict[str, Any] = {
+                        "transition": {"id": str(normalized_transition_id)},
+                    }
+                    if fields_for_api:
+                        payload["fields"] = fields_for_api
+                    if update_for_api:
+                        payload["update"] = update_for_api
+
+                    base_url = self.jira.resource_url("issue")
+                    url = f"{base_url}/{issue_key}/transitions"
+                    self.jira.post(url, data=payload)
+                else:
+                    self.jira.set_issue_status_by_transition_id(
+                        issue_key=issue_key,
+                        transition_id=normalized_transition_id,
+                    )
 
             # Return the updated issue
             return self.get_issue(issue_key)
@@ -236,7 +352,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             logger.error(error_msg)
             raise ValueError(error_msg) from e
 
-    def _normalize_transition_id(self, transition_id: object) -> str | int:
+    def _normalize_transition_id(self, transition_id: str | int | dict) -> str | int:
         """
         Normalize the transition ID to a common format.
 
@@ -244,8 +360,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             transition_id: The transition ID, which can be a string, int, or dict
 
         Returns:
-            The normalized transition ID as an integer when possible, or a string
-            otherwise
+            The normalized transition ID as an integer when possible, or string otherwise
         """
         logger.debug(
             f"Normalizing transition_id: {transition_id}, type: {type(transition_id)}"
@@ -253,8 +368,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
 
         # Handle empty or None values
         if transition_id is None:
-            logger.warning("Received None for transition_id, using default 0")
-            return 0
+            raise ValueError("transition_id cannot be None")
 
         # Handle integer directly (preferred by the API)
         if isinstance(transition_id, int):
@@ -314,19 +428,25 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             except (StopIteration, AttributeError):
                 pass
 
-            # Nothing worked, return a default
-            logger.error(f"Could not extract valid transition ID from: {transition_id}")
-            return 0
+            # Nothing worked
+            msg = f"Could not extract valid transition ID from: {transition_id}"
+            logger.error(msg)
+            raise ValueError(msg)
 
         # For any other type, convert to string with warning
         logger.warning(
-            f"Unexpected type for transition_id: {type(transition_id)}, "
-            "trying conversion"
+            f"Unexpected type for transition_id: {type(transition_id)}, trying conversion"
         )
-        str_value = str(transition_id)
-        if str_value.isdigit():
-            return int(str_value)
-        return str_value
+        try:
+            str_value = str(transition_id)
+            if str_value.isdigit():
+                return int(str_value)
+            else:
+                return str_value
+        except Exception as e:
+            msg = f"Failed to convert transition_id: {str(e)}"
+            logger.error(msg)
+            raise ValueError(msg) from e
 
     def _sanitize_transition_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
         """
@@ -415,7 +535,12 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         if hasattr(self, "_markdown_to_jira"):
             jira_formatted_comment = self._markdown_to_jira(comment_str)
 
-        # Add to transition data
-        transition_data["update"] = {
-            "comment": [{"add": {"body": jira_formatted_comment}}]
-        }
+        # Preserve update operations supplied by the caller and append this
+        # comment to any existing comment operations.
+        update = transition_data.setdefault("update", {})
+        existing_comments = update.get("comment")
+        comments = (
+            list(existing_comments) if isinstance(existing_comments, list) else []
+        )
+        comments.append({"add": {"body": jira_formatted_comment}})
+        update["comment"] = comments

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -20,6 +20,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
     def get_available_transitions(
         self,
         issue_key: str,
+        *,
         expand_fields: bool = False,
     ) -> list[dict[str, Any]]:
         """
@@ -106,11 +107,12 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
                     transition.get("isConditional")
                 )
 
-                fields = transition.get("fields", {})
-                if isinstance(fields, dict):
-                    required_fields = self._extract_required_fields(fields)
-                    if required_fields:
-                        transition_info["required_fields"] = required_fields
+                if expand_fields:
+                    fields = transition.get("fields", {})
+                    if isinstance(fields, dict):
+                        required_fields = self._extract_required_fields(fields)
+                        if required_fields:
+                            transition_info["required_fields"] = required_fields
 
                 result.append(transition_info)
 
@@ -196,7 +198,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         return result
 
     def get_transitions(
-        self, issue_key: str, expand_fields: bool = False
+        self, issue_key: str, *, expand_fields: bool = False
     ) -> list[dict[str, Any]]:
         """
         Get the raw transitions data for an issue.

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -156,9 +156,9 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         return required_fields
 
     @staticmethod
-    def _normalize_allowed_value(value: Any) -> dict[str, str]:
+    def _normalize_allowed_value(value: Any) -> dict[str, Any]:
         """
-        Normalize a single allowed value to {id, name, value} dict.
+        Normalize a single allowed value to a dict with id, name, value.
 
         Jira returns allowed values in multiple shapes:
         - Scalar (str, int): ``"Fixed"``
@@ -169,7 +169,8 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             value: A raw allowed value from the Jira API.
 
         Returns:
-            A dict with ``id``, ``name``, and ``value`` keys.
+            A dict with ``id``, ``name``, ``value``, and optionally
+            ``description`` keys.
         """
         if not isinstance(value, dict):
             scalar = str(value)
@@ -178,7 +179,10 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         vid = str(value.get("id", value.get("optionId", "")))
         vname = str(value.get("name", value.get("value", "")))
         vvalue = str(value.get("value", value.get("name", vname)))
-        return {"id": vid, "name": vname, "value": vvalue}
+        result: dict[str, Any] = {"id": vid, "name": vname, "value": vvalue}
+        if "description" in value and value["description"]:
+            result["description"] = str(value["description"])
+        return result
 
     def get_transitions(
         self, issue_key: str, expand: str | None = None

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -70,15 +70,28 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
                     "name": transition.get("name", ""),
                 }
 
-                # Handle "to" field in different formats
+                # Handle "to" field in different formats.
+                # Build a structured "to" object (id, name, statusCategory)
+                # when the raw API returns a full dict; fall back to a
+                # plain string when only a name is available.
                 to_status = None
-                # Option 1: 'to' field with sub-fields
                 if "to" in transition and isinstance(transition["to"], dict):
-                    to_status = transition["to"].get("name")
-                # Option 2: 'to_status' field directly
+                    to_obj = transition["to"]
+                    to_status = to_obj.get("name")
+                    to_info: dict[str, Any] = {
+                        "id": str(to_obj.get("id", "")),
+                        "name": to_obj.get("name", ""),
+                    }
+                    sc = to_obj.get("statusCategory")
+                    if isinstance(sc, dict):
+                        to_info["statusCategory"] = {
+                            "id": str(sc.get("id", "")),
+                            "key": sc.get("key", ""),
+                            "name": sc.get("name", ""),
+                        }
+                    transition_info["to"] = to_info
                 elif "to_status" in transition:
                     to_status = transition.get("to_status")
-                # Option 3: 'status' field directly
                 elif "status" in transition:
                     to_status = transition.get("status")
 

--- a/src/mcp_atlassian/models/jira/workflow.py
+++ b/src/mcp_atlassian/models/jira/workflow.py
@@ -90,4 +90,7 @@ class JiraTransition(ApiModel):
         if self.to_status:
             result["to_status"] = self.to_status.to_simplified_dict()
 
+        result["has_screen"] = self.has_screen
+        result["is_conditional"] = self.is_conditional
+
         return result

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -630,7 +630,11 @@ async def get_issue(
                 "(Optional) Comma-separated sections to inline "
                 "in the response, avoiding extra tool calls. "
                 "Supported: all, remote_links, transitions, "
-                "watchers, changelog, comments, worklogs"
+                "watchers, changelog, comments, worklogs. "
+                "Note: transitions inlined via include are "
+                "lightweight (no required_fields). Use "
+                "jira_get_transitions with expand_fields=true "
+                "for full field metadata."
             ),
             default=None,
         ),

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1138,19 +1138,30 @@ async def get_transitions(
             pattern=ISSUE_KEY_PATTERN,
         ),
     ],
+    expand_fields: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to expand transition field metadata. When true, "
+                "requests required field details (allowed values, schema) "
+                "for each transition. Defaults to false (lightweight)."
+            ),
+        ),
+    ] = False,
 ) -> str:
     """Get available status transitions for a Jira issue.
 
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
+        expand_fields: Whether to include required field metadata.
 
     Returns:
         JSON string representing a list of available transitions.
     """
     jira = await get_jira_fetcher(ctx)
-    # Underlying method returns list[dict] in the desired format
-    transitions = jira.get_available_transitions(issue_key)
+    expand = "transitions.fields" if expand_fields else None
+    transitions = jira.get_available_transitions(issue_key, expand=expand)
     return json.dumps(transitions, indent=2, ensure_ascii=False)
 
 
@@ -2960,6 +2971,17 @@ async def transition_issue(
             ),
         ),
     ] = None,
+    update_data: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) JSON string of Jira update operations to include "
+                "in the transition. Use this for worklogs and other "
+                "transition-time operations. Example: "
+                '\'{"worklog": [{"add": {"timeSpent": "1h"}}]}\''
+            ),
+        ),
+    ] = None,
 ) -> str:
     """Transition a Jira issue to a new status.
 
@@ -2969,6 +2991,8 @@ async def transition_issue(
         transition_id: ID of the transition.
         fields: Optional JSON string of fields to update during transition.
         comment: Optional comment for the transition in Markdown format.
+        update_data: Optional JSON string of Jira update operations
+            (e.g., worklog) for the transition.
 
     Returns:
         JSON string representing the updated issue object.
@@ -2984,12 +3008,15 @@ async def transition_issue(
 
     # Parse fields from JSON string
     update_fields = _parse_additional_fields(fields)
+    # Parse update_data from JSON string
+    update_ops = _parse_additional_fields(update_data) if update_data else None
 
     issue = jira.transition_issue(
         issue_key=issue_key,
         transition_id=transition_id,
         fields=update_fields,
         comment=comment,
+        update_data=update_ops,
     )
 
     result = {

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1164,8 +1164,7 @@ async def get_transitions(
         JSON string representing a list of available transitions.
     """
     jira = await get_jira_fetcher(ctx)
-    expand = "transitions.fields" if expand_fields else None
-    transitions = jira.get_available_transitions(issue_key, expand=expand)
+    transitions = jira.get_available_transitions(issue_key, expand_fields=expand_fields)
     return json.dumps(transitions, indent=2, ensure_ascii=False)
 
 

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -326,7 +326,9 @@ class TestJiraCloudTransitions:
         )
         resource_tracker.add_jira_issue(issue.key)
 
-        transitions = jira_fetcher.get_available_transitions(issue.key)
+        transitions = jira_fetcher.get_available_transitions(
+            issue.key, expand="transitions.fields"
+        )
         assert len(transitions) > 0
         assert all(isinstance(t["has_screen"], bool) for t in transitions)
         for transition in transitions:

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -327,7 +327,7 @@ class TestJiraCloudTransitions:
         resource_tracker.add_jira_issue(issue.key)
 
         transitions = jira_fetcher.get_available_transitions(
-            issue.key, expand="transitions.fields"
+            issue.key, expand_fields=True
         )
         assert len(transitions) > 0
         assert all(isinstance(t["has_screen"], bool) for t in transitions)
@@ -350,8 +350,9 @@ class TestJiraCloudTransitions:
         jira_fetcher.transition_issue(
             issue.key,
             target_id,
-            comment=f"Cloud transition comment {uid}",
-            update_data={"worklog": [{"add": {"timeSpent": "1m"}}]},
+            update_data={
+                "comment": [{"add": {"body": f"Cloud supplemental update {uid}"}}]
+            },
         )
 
         updated = jira_fetcher.get_issue(issue.key)

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -326,8 +326,14 @@ class TestJiraCloudTransitions:
         )
         resource_tracker.add_jira_issue(issue.key)
 
-        transitions = jira_fetcher.get_transitions(issue.key)
+        transitions = jira_fetcher.get_available_transitions(issue.key)
         assert len(transitions) > 0
+        assert all(isinstance(t["has_screen"], bool) for t in transitions)
+        for transition in transitions:
+            assert all(
+                field.get("key") and field.get("name")
+                for field in transition.get("required_fields", [])
+            )
 
         # Find "In Progress" transition or use first available
         target_id = None

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -349,6 +349,7 @@ class TestJiraCloudTransitions:
             issue.key,
             target_id,
             comment=f"Cloud transition comment {uid}",
+            update_data={"worklog": [{"add": {"timeSpent": "1m"}}]},
         )
 
         updated = jira_fetcher.get_issue(issue.key)

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -307,8 +307,14 @@ class TestJiraDCTransitions:
         )
         resource_tracker.add_jira_issue(issue.key)
 
-        transitions = jira_fetcher.get_transitions(issue.key)
+        transitions = jira_fetcher.get_available_transitions(issue.key)
         assert len(transitions) > 0
+        assert all(isinstance(t["has_screen"], bool) for t in transitions)
+        for transition in transitions:
+            assert all(
+                field.get("key") and field.get("name")
+                for field in transition.get("required_fields", [])
+            )
 
         # Find "In Progress" transition or use first available
         target_id = None

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -307,7 +307,9 @@ class TestJiraDCTransitions:
         )
         resource_tracker.add_jira_issue(issue.key)
 
-        transitions = jira_fetcher.get_available_transitions(issue.key)
+        transitions = jira_fetcher.get_available_transitions(
+            issue.key, expand="transitions.fields"
+        )
         assert len(transitions) > 0
         assert all(isinstance(t["has_screen"], bool) for t in transitions)
         for transition in transitions:

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -330,6 +330,7 @@ class TestJiraDCTransitions:
             issue.key,
             target_id,
             comment=f"Data Center transition comment {uid}",
+            update_data={"worklog": [{"add": {"timeSpent": "1m"}}]},
         )
 
         updated = jira_fetcher.get_issue(issue.key)

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -308,7 +308,7 @@ class TestJiraDCTransitions:
         resource_tracker.add_jira_issue(issue.key)
 
         transitions = jira_fetcher.get_available_transitions(
-            issue.key, expand="transitions.fields"
+            issue.key, expand_fields=True
         )
         assert len(transitions) > 0
         assert all(isinstance(t["has_screen"], bool) for t in transitions)
@@ -331,8 +331,9 @@ class TestJiraDCTransitions:
         jira_fetcher.transition_issue(
             issue.key,
             target_id,
-            comment=f"Data Center transition comment {uid}",
-            update_data={"worklog": [{"add": {"timeSpent": "1m"}}]},
+            update_data={
+                "comment": [{"add": {"body": f"Data Center supplemental update {uid}"}}]
+            },
         )
 
         updated = jira_fetcher.get_issue(issue.key)

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -48,7 +48,6 @@ class TestTransitionsMixin:
             )
         ]
         mixin.get_transitions_models = MagicMock(return_value=mock_transitions)
-        mixin._post_api3 = MagicMock()
 
         return mixin
 
@@ -56,12 +55,35 @@ class TestTransitionsMixin:
         self, transitions_mixin: TransitionsMixin
     ):
         """Test get_available_transitions with list format response."""
-        # Setup mock response - list format
-        mock_transitions = [
-            {"id": "10", "name": "In Progress", "to_status": "In Progress"},
-            {"id": "11", "name": "Done", "status": "Done"},
-        ]
-        transitions_mixin.jira.get_issue_transitions.return_value = mock_transitions
+        # Setup mock response - via get_issue_transitions_full
+        mock_response = {
+            "transitions": [
+                {
+                    "id": "10",
+                    "name": "In Progress",
+                    "to": {"name": "In Progress"},
+                    "hasScreen": False,
+                },
+                {
+                    "id": "11",
+                    "name": "Done",
+                    "to": {"name": "Done"},
+                    "hasScreen": True,
+                    "fields": {
+                        "resolution": {
+                            "required": True,
+                            "name": "Resolution",
+                            "schema": {"type": "resolution", "system": "resolution"},
+                            "allowedValues": [
+                                {"id": "1", "name": "Fixed"},
+                                {"id": "2", "name": "Won't Fix"},
+                            ],
+                        }
+                    },
+                },
+            ],
+        }
+        transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
 
         # Call the method
         result = transitions_mixin.get_available_transitions("TEST-123")
@@ -71,16 +93,27 @@ class TestTransitionsMixin:
         assert result[0]["id"] == "10"
         assert result[0]["name"] == "In Progress"
         assert result[0]["to_status"] == "In Progress"
+        assert result[0]["has_screen"] is False
+        assert "required_fields" not in result[0]
+
         assert result[1]["id"] == "11"
         assert result[1]["name"] == "Done"
-        assert result[1]["to_status"] == "Done"
+        assert result[1]["has_screen"] is True
+        required_fields = result[1]["required_fields"]
+        assert len(required_fields) == 1
+        assert required_fields[0]["key"] == "resolution"
+        assert required_fields[0]["name"] == "Resolution"
+        assert required_fields[0]["schema"]["type"] == "resolution"
+        allowed = required_fields[0]["allowed_values"]
+        assert len(allowed) == 2
+        assert allowed[0]["name"] == "Fixed"
 
     def test_get_available_transitions_empty_response(
         self, transitions_mixin: TransitionsMixin
     ):
         """Test get_available_transitions with empty response."""
-        # Setup mock response - empty
-        transitions_mixin.jira.get_issue_transitions.return_value = {}
+        # Setup mock response - empty via get_issue_transitions_full
+        transitions_mixin.jira.get_issue_transitions_full.return_value = {}
 
         # Call the method
         result = transitions_mixin.get_available_transitions("TEST-123")
@@ -94,7 +127,7 @@ class TestTransitionsMixin:
     ):
         """Test get_available_transitions with invalid format response."""
         # Setup mock response - invalid format
-        transitions_mixin.jira.get_issue_transitions.return_value = "invalid"
+        transitions_mixin.jira.get_issue_transitions_full.return_value = "invalid"
 
         # Call the method
         result = transitions_mixin.get_available_transitions("TEST-123")
@@ -103,12 +136,22 @@ class TestTransitionsMixin:
         assert isinstance(result, list)
         assert len(result) == 0
 
+    def test_get_available_transitions_invalid_transitions_value(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test get_available_transitions handles a malformed transitions value."""
+        transitions_mixin.jira.get_issue_transitions_full.return_value = {
+            "transitions": "invalid"
+        }
+
+        assert transitions_mixin.get_available_transitions("TEST-123") == []
+
     def test_get_available_transitions_with_error(
         self, transitions_mixin: TransitionsMixin
     ):
         """Test get_available_transitions error handling."""
         # Setup mock to raise exception
-        transitions_mixin.jira.get_issue_transitions.side_effect = Exception(
+        transitions_mixin.jira.get_issue_transitions_full.side_effect = Exception(
             "Transition fetch error"
         )
 
@@ -123,10 +166,9 @@ class TestTransitionsMixin:
         # Call the method
         result = transitions_mixin.transition_issue("TEST-123", "10")
 
-        # Verify POST to the Cloud v3 endpoint with a minimal payload
-        transitions_mixin._post_api3.assert_called_once_with(
-            "issue/TEST-123/transitions",
-            {"transition": {"id": "10"}},
+        # Verify
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123", status_name="In Progress", fields=None, update=None
         )
         transitions_mixin.get_issue.assert_called_once_with("TEST-123")
         assert isinstance(result, JiraIssue)
@@ -139,10 +181,9 @@ class TestTransitionsMixin:
         # Call the method with int ID
         transitions_mixin.transition_issue("TEST-123", 10)
 
-        # Verify the transition ID is stringified in the payload
-        transitions_mixin._post_api3.assert_called_once_with(
-            "issue/TEST-123/transitions",
-            {"transition": {"id": "10"}},
+        # Verify status name is used instead of ID
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123", status_name="In Progress", fields=None, update=None
         )
 
     def test_transition_issue_with_fields(self, transitions_mixin: TransitionsMixin):
@@ -156,13 +197,12 @@ class TestTransitionsMixin:
         fields = {"summary": "Updated"}
         transitions_mixin.transition_issue("TEST-123", "10", fields=fields)
 
-        # Verify fields are included in the POST payload
-        transitions_mixin._post_api3.assert_called_once_with(
-            "issue/TEST-123/transitions",
-            {
-                "transition": {"id": "10"},
-                "fields": {"summary": "Updated"},
-            },
+        # Verify fields were passed correctly
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123",
+            status_name="In Progress",
+            fields={"summary": "Updated"},
+            update=None,
         )
 
     def test_transition_issue_with_empty_sanitized_fields(
@@ -176,97 +216,57 @@ class TestTransitionsMixin:
         fields = {"invalid": "field"}
         transitions_mixin.transition_issue("TEST-123", "10", fields=fields)
 
-        # Empty sanitized fields should result in no "fields" key in the payload
-        transitions_mixin._post_api3.assert_called_once_with(
-            "issue/TEST-123/transitions",
-            {"transition": {"id": "10"}},
+        # Verify fields were passed as None
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123", status_name="In Progress", fields=None, update=None
         )
 
     def test_transition_issue_with_comment(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue with comment."""
+        # Setup
         comment = "Test comment"
+
+        # Define a side effect to record what's passed to _add_comment_to_transition_data
+        def add_comment_side_effect(transition_data, comment_text):
+            transition_data["update"] = {"comment": [{"add": {"body": comment_text}}]}
+
+        # Mock _add_comment_to_transition_data
+        transitions_mixin._add_comment_to_transition_data = MagicMock(
+            side_effect=add_comment_side_effect
+        )
 
         # Call the method with comment
         transitions_mixin.transition_issue("TEST-123", "10", comment=comment)
 
-        # Cloud sends the converted ADF comment through REST v3.
-        transitions_mixin._post_api3.assert_called_once()
-        resource, payload = transitions_mixin._post_api3.call_args.args
-        assert resource == "issue/TEST-123/transitions"
-        assert payload["transition"] == {"id": "10"}
-        body = payload["update"]["comment"][0]["add"]["body"]
-        assert body["version"] == 1
-        assert body["type"] == "doc"
-        assert body["content"][0]["content"][0]["text"] == comment
+        # Verify _add_comment_to_transition_data was called
+        transitions_mixin._add_comment_to_transition_data.assert_called_once()
 
-    # --- JIRA_INTERNAL_ONLY_PROJECTS guard on transition comments ---
-
-    def test_transition_comment_internal_only_project_rejected(
-        self, transitions_mixin: TransitionsMixin
-    ):
-        """A transition comment on a listed project is rejected before any
-        API call (a transition comment is a standard, potentially
-        customer-visible Jira comment that cannot be forced internal)."""
-        transitions_mixin.config.internal_only_projects = frozenset({"CC"})
-
-        with pytest.raises(ValueError, match="internal-only"):
-            transitions_mixin.transition_issue("CC-1", "10", comment="Client update")
-
-        transitions_mixin._post_api3.assert_not_called()
-
-    def test_transition_comment_internal_only_whitespace_padded_key_rejected(
-        self, transitions_mixin: TransitionsMixin
-    ):
-        """Whitespace-padded issue keys do not bypass the transition guard."""
-        transitions_mixin.config.internal_only_projects = frozenset({"CC"})
-
-        with pytest.raises(ValueError, match="internal-only"):
-            transitions_mixin.transition_issue(" CC-1", "10", comment="Client update")
-
-    def test_transition_comment_unlisted_project_unaffected(
-        self, transitions_mixin: TransitionsMixin
-    ):
-        """A comment on an unlisted project transitions normally even with
-        the guard configured for another project."""
-        transitions_mixin.config.internal_only_projects = frozenset({"CC"})
-
-        transitions_mixin.transition_issue("TEST-123", "10", comment="Test comment")
-
-        transitions_mixin._post_api3.assert_called_once()
-
-    def test_transition_without_comment_internal_only_project_unaffected(
-        self, transitions_mixin: TransitionsMixin
-    ):
-        """A transition WITHOUT a comment on a listed project is allowed —
-        the guard only blocks the comment, not the transition itself."""
-        transitions_mixin.config.internal_only_projects = frozenset({"CC"})
-
-        transitions_mixin.transition_issue("CC-1", "10")
-
-        transitions_mixin._post_api3.assert_called_once_with(
-            "issue/CC-1/transitions",
-            {"transition": {"id": "10"}},
+        # Verify set_issue_status was called with the right parameters
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123",
+            status_name="In Progress",
+            fields=None,
+            update={"comment": [{"add": {"body": comment}}]},
         )
 
     def test_transition_issue_with_error(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue error handling."""
-        # Setup mock to raise exception on the POST
-        transitions_mixin._post_api3.side_effect = Exception("Transition error")
+        # Setup mock to raise exception
+        transitions_mixin.jira.set_issue_status.side_effect = Exception(
+            "Transition error"
+        )
 
         # Call the method and verify exception
         with pytest.raises(
             ValueError,
-            match=(
-                "Error transitioning issue TEST-123 with transition ID 10: "
-                "Transition error"
-            ),
+            match="Error transitioning issue TEST-123 with transition ID 10: Transition error",
         ):
             transitions_mixin.transition_issue("TEST-123", "10")
 
     def test_transition_issue_without_status_name(
         self, transitions_mixin: TransitionsMixin
     ):
-        """Test transition_issue when target status name is not available."""
+        """Test transition_issue when status name is not available."""
         # Setup - create a transition without to_status
         mock_transitions = [
             JiraTransition(
@@ -278,55 +278,24 @@ class TestTransitionsMixin:
         transitions_mixin.get_transitions_models = MagicMock(
             return_value=mock_transitions
         )
+
+        # Add mock for set_issue_status_by_transition_id
+        transitions_mixin.jira.set_issue_status_by_transition_id = MagicMock()
+
         # Call the method
         result = transitions_mixin.transition_issue("TEST-123", "10")
 
-        # Verify the unified POST still happens with the transition id
-        transitions_mixin._post_api3.assert_called_once_with(
-            "issue/TEST-123/transitions",
-            {"transition": {"id": "10"}},
+        # Verify direct transition ID was used
+        transitions_mixin.jira.set_issue_status_by_transition_id.assert_called_once_with(
+            issue_key="TEST-123", transition_id=10
         )
+
+        # Verify standard status call was not made
+        transitions_mixin.jira.set_issue_status.assert_not_called()
 
         # Verify result
         transitions_mixin.get_issue.assert_called_once_with("TEST-123")
         assert isinstance(result, JiraIssue)
-
-    def test_transition_issue_uses_v3_on_cloud(
-        self, transitions_mixin: TransitionsMixin
-    ):
-        """Regression test for issue #1262.
-
-        Cloud transition comments are converted to ADF, so their atomic
-        transition payload must use REST v3.
-        """
-        transitions_mixin.transition_issue("TEST-123", "10", comment="Required")
-
-        transitions_mixin._post_api3.assert_called_once()
-        transitions_mixin.jira.post.assert_not_called()
-
-    def test_transition_issue_uses_v2_on_data_center(
-        self, transitions_mixin: TransitionsMixin
-    ):
-        """Server/DC sends wiki markup through the dependency's REST v2 URL."""
-        transitions_mixin.config.url = "https://jira.example.com"
-        transitions_mixin._markdown_to_jira = MagicMock(return_value="*Required*")
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/2/issue"
-        )
-
-        transitions_mixin.transition_issue("TEST-123", "10", comment="**Required**")
-
-        transitions_mixin.jira.resource_url.assert_called_once_with("issue")
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            data={
-                "transition": {"id": "10"},
-                "update": {
-                    "comment": [{"add": {"body": "*Required*"}}],
-                },
-            },
-        )
-        transitions_mixin._post_api3.assert_not_called()
 
     def test_get_transitions_uses_full_api(self, transitions_mixin: TransitionsMixin):
         """Test that get_transitions uses get_issue_transitions_full for complete data.
@@ -371,7 +340,7 @@ class TestTransitionsMixin:
 
         # Verify get_issue_transitions_full was called (not get_issue_transitions)
         transitions_mixin.jira.get_issue_transitions_full.assert_called_once_with(
-            "TEST-123"
+            "TEST-123", expand=None
         )
 
         # Verify we get the full transitions list with complete 'to' objects
@@ -387,8 +356,8 @@ class TestTransitionsMixin:
     ):
         """Test that get_transitions_models correctly parses full 'to' status objects.
 
-        This verifies that get_issue_transitions_full returns complete 'to'
-        objects and the JiraTransition models are created with proper to_status.
+        This verifies that when get_issue_transitions_full returns complete 'to' objects,
+        the JiraTransition models are created with proper to_status.
         """
         # Setup mock response matching real Jira API format
         mock_response = {
@@ -437,14 +406,11 @@ class TestTransitionsMixin:
     def test_transition_issue_with_resolution_field(
         self, transitions_mixin: TransitionsMixin
     ):
-        """Test transition_issue with resolution field includes it in the payload.
+        """Test transition_issue with resolution field uses correct code path.
 
-        Regression test for issue #602 - the fields parameter (e.g. resolution)
-        must be sent atomically with the transition so the resolution is set
-        as part of the status change rather than dropped.
-
-        After the unification onto a single direct POST path, this is verified
-        directly by inspecting the request payload.
+        This is the end-to-end test for issue #602 - when transitioning with fields
+        like resolution, the to_status should be available (from get_issue_transitions_full)
+        so set_issue_status is used which properly includes fields.
         """
         # Setup mock for get_issue_transitions_full (used by get_transitions)
         mock_response = {
@@ -462,6 +428,7 @@ class TestTransitionsMixin:
         transitions_mixin.jira.get_issue_transitions_full = MagicMock(
             return_value=mock_response
         )
+
         # Don't mock get_transitions_models - let it use real implementation
         # to test the full flow
         transitions_mixin.get_transitions_models = (
@@ -480,14 +447,13 @@ class TestTransitionsMixin:
             fields={"resolution": {"id": "10001"}},
         )
 
-        # Verify the resolution field is present in the POST payload alongside
-        # the transition id, so Jira sets it atomically with the status change
-        transitions_mixin._post_api3.assert_called_once_with(
-            "issue/TEST-123/transitions",
-            {
-                "transition": {"id": "731"},
-                "fields": {"resolution": {"id": "10001"}},
-            },
+        # Verify set_issue_status was called (not set_issue_status_by_transition_id)
+        # because to_status should now be available
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123",
+            status_name="Closed",
+            fields={"resolution": {"id": "10001"}},
+            update=None,
         )
 
     def test_normalize_transition_id(self, transitions_mixin: TransitionsMixin):
@@ -507,8 +473,9 @@ class TestTransitionsMixin:
         # Test with dict containing int id
         assert transitions_mixin._normalize_transition_id({"id": 10}) == 10
 
-        # Test with None
-        assert transitions_mixin._normalize_transition_id(None) == 0
+        # Test with None raises ValueError
+        with pytest.raises(ValueError, match="transition_id cannot be None"):
+            transitions_mixin._normalize_transition_id(None)
 
     def test_sanitize_transition_fields_basic(
         self, transitions_mixin: TransitionsMixin
@@ -538,7 +505,7 @@ class TestTransitionsMixin:
     def test_sanitize_transition_fields_with_assignee_and_get_account_id(
         self, transitions_mixin
     ):
-        """Test assignee sanitization when _get_account_id is available."""
+        """Test _sanitize_transition_fields with assignee when _get_account_id is available."""
         # Setup mock for _get_account_id
         transitions_mixin._get_account_id = MagicMock(return_value="account-123")
 
@@ -630,4 +597,289 @@ class TestTransitionsMixin:
         assert (
             transition_data["update"]["comment"][0]["add"]["body"]
             == "Converted comment"
+        )
+
+    def test_transition_comment_format_cloud_adf(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Transition comment payload carries ADF dict on Cloud."""
+        transitions_mixin._markdown_to_jira = MagicMock(
+            return_value={"version": 1, "type": "doc", "content": []}
+        )
+        transitions_mixin._add_comment_to_transition_data = MagicMock(
+            wraps=TransitionsMixin._add_comment_to_transition_data.__get__(
+                transitions_mixin, type(transitions_mixin)
+            )
+        )
+
+        transitions_mixin.transition_issue("TEST-123", "10", comment="Fixed")
+
+        transitions_mixin.jira.set_issue_status.assert_called_once()
+        call_kwargs = transitions_mixin.jira.set_issue_status.call_args.kwargs
+        update = call_kwargs["update"]
+        body = update["comment"][0]["add"]["body"]
+        assert isinstance(body, dict)
+        assert body["type"] == "doc"
+
+    def test_transition_comment_format_dc_wiki(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Transition comment payload carries wiki markup on Server/DC."""
+        transitions_mixin._markdown_to_jira = MagicMock(return_value="h2. Fixed")
+        transitions_mixin._add_comment_to_transition_data = MagicMock(
+            wraps=TransitionsMixin._add_comment_to_transition_data.__get__(
+                transitions_mixin, type(transitions_mixin)
+            )
+        )
+
+        transitions_mixin.transition_issue("TEST-123", "10", comment="Fixed")
+
+        transitions_mixin.jira.set_issue_status.assert_called_once()
+        call_kwargs = transitions_mixin.jira.set_issue_status.call_args.kwargs
+        update = call_kwargs["update"]
+        body = update["comment"][0]["add"]["body"]
+        assert isinstance(body, str)
+        assert "h2." in body
+
+    def test_extract_required_fields_with_resolution(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test _extract_required_fields with resolution field."""
+        fields = {
+            "resolution": {
+                "required": True,
+                "name": "Resolution",
+                "schema": {"type": "resolution", "system": "resolution"},
+                "allowedValues": [
+                    {"id": "1", "name": "Fixed"},
+                    {"id": "3", "name": "Done"},
+                ],
+            },
+            "summary": {
+                "required": False,
+                "name": "Summary",
+                "schema": {"type": "string", "system": "summary"},
+            },
+        }
+
+        result = TransitionsMixin._extract_required_fields(fields)
+
+        assert len(result) == 1
+        assert result[0]["key"] == "resolution"
+        assert result[0]["name"] == "Resolution"
+        assert result[0]["schema"]["type"] == "resolution"
+        assert len(result[0]["allowed_values"]) == 2
+        assert result[0]["allowed_values"][0]["id"] == "1"
+        assert result[0]["allowed_values"][0]["name"] == "Fixed"
+
+    def test_extract_required_fields_with_timetracking(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test _extract_required_fields with numeric custom field (e.g. Time Spent)."""
+        fields = {
+            "customfield_10000": {
+                "required": True,
+                "name": "Time Spent",
+                "schema": {
+                    "type": "number",
+                    "custom": (
+                        "com.atlassian.jira.plugin.system.customfieldtypes:float"
+                    ),
+                    "customId": 10000,
+                },
+            }
+        }
+
+        result = TransitionsMixin._extract_required_fields(fields)
+
+        assert len(result) == 1
+        assert result[0]["key"] == "customfield_10000"
+        assert result[0]["name"] == "Time Spent"
+        assert result[0]["schema"]["type"] == "number"
+        assert "allowed_values" not in result[0]
+
+    def test_extract_required_fields_empty(self):
+        """Test _extract_required_fields with no required fields."""
+        assert TransitionsMixin._extract_required_fields({}) == []
+
+        fields = {
+            "summary": {"required": False, "name": "Summary"},
+        }
+        assert TransitionsMixin._extract_required_fields(fields) == []
+
+    def test_get_available_transitions_no_expand_by_default(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test get_available_transitions uses lightweight call by default."""
+        mock_response = {"transitions": []}
+        transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
+
+        transitions_mixin.get_available_transitions("TEST-123")
+
+        transitions_mixin.jira.get_issue_transitions_full.assert_called_once_with(
+            "TEST-123", expand=None
+        )
+
+    def test_get_available_transitions_with_expand(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test get_available_transitions passes expand through."""
+        mock_response = {"transitions": []}
+        transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
+
+        transitions_mixin.get_available_transitions(
+            "TEST-123", expand="transitions.fields"
+        )
+
+        transitions_mixin.jira.get_issue_transitions_full.assert_called_once_with(
+            "TEST-123", expand="transitions.fields"
+        )
+
+    def test_get_available_transitions_with_timetracking_field(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test get_available_transitions with Time Spent (timetracking) required."""
+        mock_response = {
+            "transitions": [
+                {
+                    "id": "51",
+                    "name": "Resolve Issue",
+                    "to": {"name": "Resolved", "id": "5"},
+                    "hasScreen": True,
+                    "fields": {
+                        "timetracking": {
+                            "required": True,
+                            "name": "Time Spent",
+                            "schema": {
+                                "type": "timetracking",
+                                "system": "timetracking",
+                            },
+                        },
+                        "resolution": {
+                            "required": True,
+                            "name": "Resolution",
+                            "schema": {"type": "resolution", "system": "resolution"},
+                            "allowedValues": [
+                                {"id": "1", "name": "Fixed"},
+                            ],
+                        },
+                    },
+                }
+            ]
+        }
+        transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
+
+        result = transitions_mixin.get_available_transitions("TEST-123")
+
+        assert len(result) == 1
+        assert result[0]["has_screen"] is True
+        required = result[0]["required_fields"]
+        assert len(required) == 2
+
+        # Verify timetracking field
+        tt = next(r for r in required if r["key"] == "timetracking")
+        assert tt["name"] == "Time Spent"
+        assert tt["schema"]["type"] == "timetracking"
+
+        # Verify resolution field
+        res = next(r for r in required if r["key"] == "resolution")
+        assert res["name"] == "Resolution"
+        assert len(res["allowed_values"]) == 1
+
+    def test_transition_issue_with_update_data(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test transition_issue with update_data (worklog)."""
+        # Call with update_data containing worklog
+        update_data = {"worklog": [{"add": {"timeSpent": "1h", "comment": "Resolved"}}]}
+        transitions_mixin.transition_issue("TEST-123", "10", update_data=update_data)
+
+        # Verify set_issue_status was called with update
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123",
+            status_name="In Progress",
+            fields=None,
+            update={"worklog": [{"add": {"timeSpent": "1h", "comment": "Resolved"}}]},
+        )
+
+    def test_transition_issue_with_comment_and_update_data(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test transition_issue with both comment and update_data."""
+
+        # Setup mock for _add_comment_to_transition_data
+        def add_comment_side_effect(transition_data, comment_text):
+            transition_data.setdefault("update", {}).setdefault("comment", []).append(
+                {"add": {"body": comment_text}}
+            )
+
+        transitions_mixin._add_comment_to_transition_data = MagicMock(
+            side_effect=add_comment_side_effect
+        )
+
+        # Call with both comment and update_data
+        update_data = {"worklog": [{"add": {"timeSpent": "2h"}}]}
+        transitions_mixin.transition_issue(
+            "TEST-123", "10", comment="Done", update_data=update_data
+        )
+
+        # Verify update contains both comment and worklog
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123",
+            status_name="In Progress",
+            fields=None,
+            update={
+                "comment": [{"add": {"body": "Done"}}],
+                "worklog": [{"add": {"timeSpent": "2h"}}],
+            },
+        )
+
+    def test_transition_issue_preserves_update_data_comments(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test comment combines with comment operations in update_data."""
+        transitions_mixin._markdown_to_jira = MagicMock(return_value="New comment")
+        existing_comment = {"add": {"body": "Existing comment"}}
+
+        transitions_mixin.transition_issue(
+            "TEST-123",
+            "10",
+            comment="New comment",
+            update_data={"comment": [existing_comment]},
+        )
+
+        transitions_mixin.jira.set_issue_status.assert_called_once_with(
+            issue_key="TEST-123",
+            status_name="In Progress",
+            fields=None,
+            update={"comment": [existing_comment, {"add": {"body": "New comment"}}]},
+        )
+
+    def test_transition_issue_with_update_data_no_status_name(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test transition_issue with update_data when no status name."""
+        # Setup - transition without to_status
+        mock_transitions = [
+            JiraTransition(id="10", name="Start Progress", to_status=None)
+        ]
+        transitions_mixin.get_transitions_models = MagicMock(
+            return_value=mock_transitions
+        )
+        transitions_mixin.jira.set_issue_status_by_transition_id = MagicMock()
+        transitions_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
+
+        update_data = {"worklog": [{"add": {"timeSpent": "1h"}}]}
+        transitions_mixin.transition_issue("TEST-123", "10", update_data=update_data)
+
+        # Verify a single atomic request includes the transition and update data.
+        transitions_mixin.jira.set_issue_status_by_transition_id.assert_not_called()
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            data={
+                "transition": {"id": "10"},
+                "update": {"worklog": [{"add": {"timeSpent": "1h"}}]},
+            },
         )

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -707,6 +707,112 @@ class TestTransitionsMixin:
         }
         assert TransitionsMixin._extract_required_fields(fields) == []
 
+    def test_normalize_allowed_value_scalar(self):
+        """Test _normalize_allowed_value with scalar (non-dict) value."""
+        result = TransitionsMixin._normalize_allowed_value("Fixed")
+        assert result == {"id": "Fixed", "name": "Fixed", "value": "Fixed"}
+
+    def test_normalize_allowed_value_int_scalar(self):
+        """Test _normalize_allowed_value with integer scalar value."""
+        result = TransitionsMixin._normalize_allowed_value(42)
+        assert result == {"id": "42", "name": "42", "value": "42"}
+
+    def test_normalize_allowed_value_with_id_and_value(self):
+        """Test _normalize_allowed_value with {id, value} dict."""
+        result = TransitionsMixin._normalize_allowed_value(
+            {"id": "1", "value": "Fixed"}
+        )
+        assert result == {"id": "1", "name": "Fixed", "value": "Fixed"}
+
+    def test_normalize_allowed_value_with_id_and_name(self):
+        """Test _normalize_allowed_value with {id, name} dict."""
+        result = TransitionsMixin._normalize_allowed_value(
+            {"id": "2", "name": "Won't Fix"}
+        )
+        assert result == {"id": "2", "name": "Won't Fix", "value": "Won't Fix"}
+
+    def test_normalize_allowed_value_with_option_id(self):
+        """Test _normalize_allowed_value with optionId key."""
+        result = TransitionsMixin._normalize_allowed_value(
+            {"optionId": "100", "value": "Option A"}
+        )
+        assert result == {"id": "100", "name": "Option A", "value": "Option A"}
+
+    def test_normalize_allowed_value_empty_dict(self):
+        """Test _normalize_allowed_value with empty dict returns empty strings."""
+        result = TransitionsMixin._normalize_allowed_value({})
+        assert result == {"id": "", "name": "", "value": ""}
+
+    def test_extract_required_fields_with_scalar_allowed_values(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test _extract_required_fields with scalar allowed values."""
+        fields = {
+            "customfield_10001": {
+                "required": True,
+                "name": "Category",
+                "schema": {"type": "option", "custom": "..."},
+                "allowedValues": ["Fixed", "Won't Fix", 42],
+            }
+        }
+
+        result = TransitionsMixin._extract_required_fields(fields)
+
+        assert len(result) == 1
+        allowed = result[0]["allowed_values"]
+        assert len(allowed) == 3
+        assert allowed[0] == {"id": "Fixed", "name": "Fixed", "value": "Fixed"}
+        assert allowed[2] == {"id": "42", "name": "42", "value": "42"}
+
+    def test_extract_required_fields_with_id_value_allowed_values(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test _extract_required_fields with {id, value} allowed values."""
+        fields = {
+            "versions": {
+                "required": True,
+                "name": "Fix Versions",
+                "schema": {"type": "array", "items": "version"},
+                "allowedValues": [
+                    {"id": "10001", "value": "v1.0"},
+                    {"id": "10002", "value": "v2.0"},
+                ],
+            }
+        }
+
+        result = TransitionsMixin._extract_required_fields(fields)
+
+        assert len(result) == 1
+        allowed = result[0]["allowed_values"]
+        assert len(allowed) == 2
+        assert allowed[0] == {"id": "10001", "name": "v1.0", "value": "v1.0"}
+        assert allowed[1] == {"id": "10002", "name": "v2.0", "value": "v2.0"}
+
+    def test_extract_required_fields_with_mixed_allowed_values(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test _extract_required_fields with mixed shapes."""
+        fields = {
+            "customfield_10002": {
+                "required": True,
+                "name": "Mixed Field",
+                "allowedValues": [
+                    "Scalar",
+                    {"id": "1", "name": "Named"},
+                    {"id": "2", "value": "Valued"},
+                ],
+            }
+        }
+
+        result = TransitionsMixin._extract_required_fields(fields)
+
+        assert len(result) == 1
+        allowed = result[0]["allowed_values"]
+        assert len(allowed) == 3
+        assert allowed[0] == {"id": "Scalar", "name": "Scalar", "value": "Scalar"}
+        assert allowed[1] == {"id": "1", "name": "Named", "value": "Named"}
+        assert allowed[2] == {"id": "2", "name": "Valued", "value": "Valued"}
+
     def test_get_available_transitions_no_expand_by_default(
         self, transitions_mixin: TransitionsMixin
     ):

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -86,7 +86,9 @@ class TestTransitionsMixin:
         transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
 
         # Call the method
-        result = transitions_mixin.get_available_transitions("TEST-123")
+        result = transitions_mixin.get_available_transitions(
+            "TEST-123", expand_fields=True
+        )
 
         # Verify
         assert len(result) == 2
@@ -341,7 +343,7 @@ class TestTransitionsMixin:
 
         # Verify get_issue_transitions_full was called (not get_issue_transitions)
         transitions_mixin.jira.get_issue_transitions_full.assert_called_once_with(
-            "TEST-123", expand=None
+            "TEST-123"
         )
 
         # Verify we get the full transitions list with complete 'to' objects
@@ -709,59 +711,62 @@ class TestTransitionsMixin:
         assert TransitionsMixin._extract_required_fields(fields) == []
 
     def test_normalize_allowed_value_scalar(self):
-        """Test _normalize_allowed_value with scalar (non-dict) value."""
+        """Test _normalize_allowed_value preserves scalar choices."""
         result = TransitionsMixin._normalize_allowed_value("Fixed")
-        assert result == {"id": "Fixed", "name": "Fixed", "value": "Fixed"}
+        assert result == "Fixed"
 
     def test_normalize_allowed_value_int_scalar(self):
-        """Test _normalize_allowed_value with integer scalar value."""
+        """Test _normalize_allowed_value preserves numeric scalar choices."""
         result = TransitionsMixin._normalize_allowed_value(42)
-        assert result == {"id": "42", "name": "42", "value": "42"}
+        assert result == 42
 
     def test_normalize_allowed_value_with_id_and_value(self):
-        """Test _normalize_allowed_value with {id, value} dict."""
+        """Test _normalize_allowed_value exposes a value label as name."""
         result = TransitionsMixin._normalize_allowed_value(
             {"id": "1", "value": "Fixed"}
         )
-        assert result == {"id": "1", "name": "Fixed", "value": "Fixed"}
+        assert result == {"id": "1", "value": "Fixed", "name": "Fixed"}
 
     def test_normalize_allowed_value_with_id_and_name(self):
-        """Test _normalize_allowed_value with {id, name} dict."""
+        """Test _normalize_allowed_value preserves a named option."""
         result = TransitionsMixin._normalize_allowed_value(
             {"id": "2", "name": "Won't Fix"}
         )
-        assert result == {"id": "2", "name": "Won't Fix", "value": "Won't Fix"}
+        assert result == {"id": "2", "name": "Won't Fix"}
 
     def test_normalize_allowed_value_with_option_id(self):
-        """Test _normalize_allowed_value with optionId key."""
+        """Test _normalize_allowed_value preserves optionId-shaped data."""
         result = TransitionsMixin._normalize_allowed_value(
             {"optionId": "100", "value": "Option A"}
         )
-        assert result == {"id": "100", "name": "Option A", "value": "Option A"}
+        assert result == {
+            "optionId": "100",
+            "value": "Option A",
+            "name": "Option A",
+        }
 
     def test_normalize_allowed_value_empty_dict(self):
-        """Test _normalize_allowed_value with empty dict returns empty strings."""
+        """Test _normalize_allowed_value preserves an empty option mapping."""
         result = TransitionsMixin._normalize_allowed_value({})
-        assert result == {"id": "", "name": "", "value": ""}
+        assert result == {}
 
     def test_normalize_allowed_value_with_description(self):
-        """Test _normalize_allowed_value preserves description key."""
+        """Test _normalize_allowed_value preserves extra option metadata."""
         result = TransitionsMixin._normalize_allowed_value(
             {"id": "1", "name": "Fixed", "description": "A fix has been implemented"}
         )
         assert result == {
             "id": "1",
             "name": "Fixed",
-            "value": "Fixed",
             "description": "A fix has been implemented",
         }
 
     def test_normalize_allowed_value_with_empty_description(self):
-        """Test _normalize_allowed_value omits falsy description."""
+        """Test _normalize_allowed_value preserves an empty description."""
         result = TransitionsMixin._normalize_allowed_value(
             {"id": "2", "name": "Done", "description": ""}
         )
-        assert result == {"id": "2", "name": "Done", "value": "Done"}
+        assert result == {"id": "2", "name": "Done", "description": ""}
 
     def test_extract_required_fields_with_scalar_allowed_values(
         self, transitions_mixin: TransitionsMixin
@@ -781,8 +786,8 @@ class TestTransitionsMixin:
         assert len(result) == 1
         allowed = result[0]["allowed_values"]
         assert len(allowed) == 3
-        assert allowed[0] == {"id": "Fixed", "name": "Fixed", "value": "Fixed"}
-        assert allowed[2] == {"id": "42", "name": "42", "value": "42"}
+        assert allowed[0] == "Fixed"
+        assert allowed[2] == 42
 
     def test_extract_required_fields_with_id_value_allowed_values(
         self, transitions_mixin: TransitionsMixin
@@ -805,8 +810,8 @@ class TestTransitionsMixin:
         assert len(result) == 1
         allowed = result[0]["allowed_values"]
         assert len(allowed) == 2
-        assert allowed[0] == {"id": "10001", "name": "v1.0", "value": "v1.0"}
-        assert allowed[1] == {"id": "10002", "name": "v2.0", "value": "v2.0"}
+        assert allowed[0] == {"id": "10001", "value": "v1.0", "name": "v1.0"}
+        assert allowed[1] == {"id": "10002", "value": "v2.0", "name": "v2.0"}
 
     def test_extract_required_fields_with_mixed_allowed_values(
         self, transitions_mixin: TransitionsMixin
@@ -829,9 +834,9 @@ class TestTransitionsMixin:
         assert len(result) == 1
         allowed = result[0]["allowed_values"]
         assert len(allowed) == 3
-        assert allowed[0] == {"id": "Scalar", "name": "Scalar", "value": "Scalar"}
-        assert allowed[1] == {"id": "1", "name": "Named", "value": "Named"}
-        assert allowed[2] == {"id": "2", "name": "Valued", "value": "Valued"}
+        assert allowed[0] == "Scalar"
+        assert allowed[1] == {"id": "1", "name": "Named"}
+        assert allowed[2] == {"id": "2", "value": "Valued", "name": "Valued"}
 
     def test_get_available_transitions_no_expand_by_default(
         self, transitions_mixin: TransitionsMixin
@@ -843,19 +848,17 @@ class TestTransitionsMixin:
         transitions_mixin.get_available_transitions("TEST-123")
 
         transitions_mixin.jira.get_issue_transitions_full.assert_called_once_with(
-            "TEST-123", expand=None
+            "TEST-123"
         )
 
     def test_get_available_transitions_with_expand(
         self, transitions_mixin: TransitionsMixin
     ):
-        """Test get_available_transitions passes expand through."""
+        """Test get_available_transitions opts into field expansion."""
         mock_response = {"transitions": []}
         transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
 
-        transitions_mixin.get_available_transitions(
-            "TEST-123", expand="transitions.fields"
-        )
+        transitions_mixin.get_available_transitions("TEST-123", expand_fields=True)
 
         transitions_mixin.jira.get_issue_transitions_full.assert_called_once_with(
             "TEST-123", expand="transitions.fields"

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -93,6 +93,7 @@ class TestTransitionsMixin:
         assert result[0]["id"] == "10"
         assert result[0]["name"] == "In Progress"
         assert result[0]["to_status"] == "In Progress"
+        assert result[0]["to"]["name"] == "In Progress"
         assert result[0]["has_screen"] is False
         assert "required_fields" not in result[0]
 
@@ -1008,3 +1009,64 @@ class TestTransitionsMixin:
                 "update": {"worklog": [{"add": {"timeSpent": "1h"}}]},
             },
         )
+
+    def test_get_available_transitions_to_object_with_status_category(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """get_available_transitions returns structured 'to' with statusCategory."""
+        mock_response = {
+            "transitions": [
+                {
+                    "id": "41",
+                    "name": "Send to team",
+                    "to": {
+                        "id": "3",
+                        "name": "In Progress",
+                        "statusCategory": {
+                            "id": 4,
+                            "key": "indeterminate",
+                            "name": "In Progress",
+                        },
+                    },
+                    "hasScreen": False,
+                },
+            ],
+        }
+        transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
+
+        result = transitions_mixin.get_available_transitions("TEST-123")
+
+        assert len(result) == 1
+        # Backward-compatible string
+        assert result[0]["to_status"] == "In Progress"
+        # Structured object
+        to_obj = result[0]["to"]
+        assert to_obj["id"] == "3"
+        assert to_obj["name"] == "In Progress"
+        assert to_obj["statusCategory"]["id"] == "4"
+        assert to_obj["statusCategory"]["key"] == "indeterminate"
+        assert to_obj["statusCategory"]["name"] == "In Progress"
+
+    def test_get_available_transitions_to_object_no_status_category(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """'to' object without statusCategory omits the key."""
+        mock_response = {
+            "transitions": [
+                {
+                    "id": "51",
+                    "name": "Resolve",
+                    "to": {"id": "5", "name": "Resolved"},
+                    "hasScreen": True,
+                },
+            ],
+        }
+        transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
+
+        result = transitions_mixin.get_available_transitions("TEST-123")
+
+        assert len(result) == 1
+        assert result[0]["to_status"] == "Resolved"
+        assert result[0]["to"]["id"] == "5"
+        assert result[0]["to"]["name"] == "Resolved"
+        assert "statusCategory" not in result[0]["to"]

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -743,6 +743,25 @@ class TestTransitionsMixin:
         result = TransitionsMixin._normalize_allowed_value({})
         assert result == {"id": "", "name": "", "value": ""}
 
+    def test_normalize_allowed_value_with_description(self):
+        """Test _normalize_allowed_value preserves description key."""
+        result = TransitionsMixin._normalize_allowed_value(
+            {"id": "1", "name": "Fixed", "description": "A fix has been implemented"}
+        )
+        assert result == {
+            "id": "1",
+            "name": "Fixed",
+            "value": "Fixed",
+            "description": "A fix has been implemented",
+        }
+
+    def test_normalize_allowed_value_with_empty_description(self):
+        """Test _normalize_allowed_value omits falsy description."""
+        result = TransitionsMixin._normalize_allowed_value(
+            {"id": "2", "name": "Done", "description": ""}
+        )
+        assert result == {"id": "2", "name": "Done", "value": "Done"}
+
     def test_extract_required_fields_with_scalar_allowed_values(
         self, transitions_mixin: TransitionsMixin
     ):

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -842,14 +842,32 @@ class TestTransitionsMixin:
         self, transitions_mixin: TransitionsMixin
     ):
         """Test get_available_transitions uses lightweight call by default."""
-        mock_response = {"transitions": []}
+        mock_response = {
+            "transitions": [
+                {
+                    "id": "11",
+                    "name": "Done",
+                    "hasScreen": True,
+                    "fields": {
+                        "resolution": {
+                            "required": True,
+                            "name": "Resolution",
+                            "allowedValues": [{"id": "1", "name": "Fixed"}],
+                        }
+                    },
+                }
+            ]
+        }
         transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
 
-        transitions_mixin.get_available_transitions("TEST-123")
+        result = transitions_mixin.get_available_transitions("TEST-123")
 
         transitions_mixin.jira.get_issue_transitions_full.assert_called_once_with(
             "TEST-123"
         )
+        assert result == [
+            {"id": "11", "name": "Done", "has_screen": True, "is_conditional": False}
+        ]
 
     def test_get_available_transitions_with_expand(
         self, transitions_mixin: TransitionsMixin
@@ -898,7 +916,9 @@ class TestTransitionsMixin:
         }
         transitions_mixin.jira.get_issue_transitions_full.return_value = mock_response
 
-        result = transitions_mixin.get_available_transitions("TEST-123")
+        result = transitions_mixin.get_available_transitions(
+            "TEST-123", expand_fields=True
+        )
 
         assert len(result) == 1
         assert result[0]["has_screen"] is True

--- a/tests/unit/models/test_jira_workflow_model.py
+++ b/tests/unit/models/test_jira_workflow_model.py
@@ -81,5 +81,6 @@ class TestJiraTransition:
         assert simplified["name"] == "Start Progress"
         assert simplified["to_status"] is not None
         assert simplified["to_status"]["name"] == "In Progress"
-        assert "has_screen" not in simplified
+        assert simplified["has_screen"] is True
+        assert simplified["is_conditional"] is False
         assert "is_global" not in simplified

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -670,6 +670,35 @@ async def test_get_issue(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+async def test_transition_issue_with_update_data(jira_client, mock_jira_fetcher):
+    """Test transition update data is parsed and forwarded to JiraFetcher."""
+    transitioned_issue = MagicMock()
+    transitioned_issue.to_simplified_dict.return_value = {"key": "TEST-123"}
+    mock_jira_fetcher.transition_issue.return_value = transitioned_issue
+
+    response = await jira_client.call_tool(
+        "jira_transition_issue",
+        {
+            "issue_key": "TEST-123",
+            "transition_id": "31",
+            "fields": '{"resolution": {"name": "Done"}}',
+            "comment": "Completed",
+            "update_data": '{"worklog": [{"add": {"timeSpent": "1h"}}]}',
+        },
+    )
+
+    result = json.loads(response.content[0].text)
+    assert result["message"] == "Issue TEST-123 transitioned successfully"
+    mock_jira_fetcher.transition_issue.assert_called_once_with(
+        issue_key="TEST-123",
+        transition_id="31",
+        fields={"resolution": {"name": "Done"}},
+        comment="Completed",
+        update_data={"worklog": [{"add": {"timeSpent": "1h"}}]},
+    )
+
+
+@pytest.mark.anyio
 async def test_search(jira_client, mock_jira_fetcher):
     """Test the search tool with fixture data."""
     response = await jira_client.call_tool(

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -3845,13 +3845,13 @@ async def test_get_transitions_tool_lightweight_default(jira_client, mock_jira_f
     content = json.loads(response.content[0].text)
     assert content == [{"id": "11", "name": "Done", "to_status": "Done"}]
     mock_jira_fetcher.get_available_transitions.assert_called_once_with(
-        "TEST-123", expand=None
+        "TEST-123", expand_fields=False
     )
 
 
 @pytest.mark.anyio
 async def test_get_transitions_tool_with_expand_fields(jira_client, mock_jira_fetcher):
-    """jira_get_transitions with expand_fields=true passes expand."""
+    """jira_get_transitions with expand_fields=true requests metadata."""
     mock_jira_fetcher.get_available_transitions.return_value = [
         {"id": "11", "name": "Done", "to_status": "Done", "has_screen": True}
     ]
@@ -3865,7 +3865,7 @@ async def test_get_transitions_tool_with_expand_fields(jira_client, mock_jira_fe
         {"id": "11", "name": "Done", "to_status": "Done", "has_screen": True}
     ]
     mock_jira_fetcher.get_available_transitions.assert_called_once_with(
-        "TEST-123", expand="transitions.fields"
+        "TEST-123", expand_fields=True
     )
 
 

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -3832,6 +3832,44 @@ async def test_get_issue_include_transitions_fetches_transitions(
 
 
 @pytest.mark.anyio
+async def test_get_transitions_tool_lightweight_default(jira_client, mock_jira_fetcher):
+    """jira_get_transitions calls get_available_transitions without expand."""
+    mock_jira_fetcher.get_available_transitions.return_value = [
+        {"id": "11", "name": "Done", "to_status": "Done"}
+    ]
+
+    response = await jira_client.call_tool(
+        "jira_get_transitions",
+        {"issue_key": "TEST-123"},
+    )
+    content = json.loads(response.content[0].text)
+    assert content == [{"id": "11", "name": "Done", "to_status": "Done"}]
+    mock_jira_fetcher.get_available_transitions.assert_called_once_with(
+        "TEST-123", expand=None
+    )
+
+
+@pytest.mark.anyio
+async def test_get_transitions_tool_with_expand_fields(jira_client, mock_jira_fetcher):
+    """jira_get_transitions with expand_fields=true passes expand."""
+    mock_jira_fetcher.get_available_transitions.return_value = [
+        {"id": "11", "name": "Done", "to_status": "Done", "has_screen": True}
+    ]
+
+    response = await jira_client.call_tool(
+        "jira_get_transitions",
+        {"issue_key": "TEST-123", "expand_fields": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert content == [
+        {"id": "11", "name": "Done", "to_status": "Done", "has_screen": True}
+    ]
+    mock_jira_fetcher.get_available_transitions.assert_called_once_with(
+        "TEST-123", expand="transitions.fields"
+    )
+
+
+@pytest.mark.anyio
 async def test_get_issue_include_changelog_adds_expand(jira_client, mock_jira_fetcher):
     """get_issue with include=changelog adds to expand."""
     response = await jira_client.call_tool(


### PR DESCRIPTION
## Description

Jira transitions can require values from a transition screen, but agents previously could not discover those requirements or send transition-time update operations such as worklogs.

This PR now:

- requests `expand=transitions.fields` and returns `has_screen` plus compact `required_fields` metadata from `jira_get_transitions`
- adds `update_data` to `jira_transition_issue` and forwards it to the Jira REST `update` object
- combines explicit comments with caller-supplied update operations without dropping either
- sends fields and update operations atomically when falling back to a direct transition ID
- exposes `has_screen` and `is_conditional` from `JiraTransition`
- documents the discovery and transition workflow

Example workflow:

```text
jira_get_transitions
  -> required_fields includes resolution or timetracking
jira_transition_issue(
  fields={"resolution": {"name": "Fixed"}},
  update_data={"worklog": [{"add": {"timeSpent": "1h"}}]}
)
```

Jira still validates that each submitted field or update operation is permitted by the selected transition and its screen configuration.

## Verification

- `uv run pre-commit run --all-files` — passed, including Ruff and strict mypy
- `uv run pytest tests/unit/ -q` — 3072 passed, 5 skipped
- focused transition, model, and server tests — 157 passed
- `uv run pytest tests/integration/ -q` — 23 skipped by environment markers
- `uv run pytest tests/e2e/cloud --cloud-e2e -q` — 82 passed, 15 skipped
- `uv run pytest tests/e2e --dc-e2e -q` — 94 passed, 98 skipped

## Checklist

- [x] Current `main` merged into the contributor branch
- [x] Regression coverage added for discovery, MCP parsing, comment merging, and atomic direct-ID updates
- [x] Cloud and Data Center behavior rechecked against live test instances
- [x] Contributor commits and authorship preserved