### PR TITLE
fix(jira): use correct API version for version creation on Server/DC

### DIFF
--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -382,7 +382,9 @@ class JiraClient:
         if description:
             payload["description"] = description
         logger.info(f"Creating Jira version: {payload}")
-        result = self.jira.post("/rest/api/3/version", json=payload)
+        api_version = "3" if self.config.is_cloud else "2"
+        url = self.jira.resource_url("version", api_version=api_version)
+        result = self.jira.post(url, json=payload)
         if not isinstance(result, dict):
             error_message = f"Unexpected response from Jira API: {result}"
             raise ValueError(error_message)

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+import requests
 from requests.exceptions import HTTPError
 
 from mcp_atlassian.jira import JiraFetcher
@@ -59,6 +60,36 @@ class TestJiraCloudEpicOperations:
             raise
         resource_tracker.add_jira_issue(epic.key)
         assert epic.key.startswith(cloud_instance.project_key)
+
+
+class TestJiraCloudVersionOperations:
+    """Version creation on Cloud."""
+
+    def test_create_project_version(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        name = f"cloud-e2e-version-{uid}"
+        version: dict[str, object] | None = None
+
+        try:
+            version = jira_fetcher.create_project_version(
+                project_key=cloud_instance.project_key,
+                name=name,
+                description="Auto-created for Cloud version endpoint testing.",
+            )
+
+            assert version["name"] == name
+            assert version.get("id")
+        finally:
+            if version and version.get("id"):
+                requests.delete(
+                    f"{cloud_instance.jira_url}/rest/api/3/version/{version['id']}",
+                    auth=(cloud_instance.username, cloud_instance.api_token),
+                    timeout=30,
+                ).raise_for_status()
 
 
 class TestJiraCloudSubtask:

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+import requests
 from requests.exceptions import HTTPError
 
 from mcp_atlassian.jira import JiraFetcher
@@ -60,6 +61,38 @@ class TestJiraDCEpicOperations:
             raise
         resource_tracker.add_jira_issue(epic.key)
         assert epic.key.startswith(dc_instance.project_key)
+
+
+class TestJiraDCVersionOperations:
+    """Version creation on DC."""
+
+    def test_create_project_version(
+        self,
+        jira_fetcher: JiraFetcher,
+        dc_instance: DCInstanceInfo,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        name = f"dc-e2e-version-{uid}"
+        version: dict[str, object] | None = None
+
+        try:
+            version = jira_fetcher.create_project_version(
+                project_key=dc_instance.project_key,
+                name=name,
+                description="Auto-created for DC version endpoint testing.",
+            )
+
+            assert version["name"] == name
+            assert version.get("id")
+        finally:
+            if version and version.get("id"):
+                requests.post(
+                    f"{dc_instance.jira_url}/rest/api/2/version/"
+                    f"{version['id']}/removeAndSwap",
+                    auth=(dc_instance.admin_username, dc_instance.admin_password),
+                    json={},
+                    timeout=30,
+                ).raise_for_status()
 
 
 class TestJiraDCSubtask:

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -396,3 +396,33 @@ def test_jira_client_basic_auth_preserves_trust_env():
         JiraClient(config=config)
 
         assert mock_session.trust_env is True
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_api_version"),
+    [
+        ("https://test.atlassian.net", "3"),
+        ("https://jira.example.com", "2"),
+    ],
+    ids=["cloud", "server_dc"],
+)
+def test_create_version_uses_correct_api_version(url: str, expected_api_version: str):
+    """Test that create_version uses API v3 for Cloud and v2 for Server/DC."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        expected_url = f"{url}/rest/api/{expected_api_version}/version"
+        mock_jira.return_value.resource_url.return_value = expected_url
+        mock_jira.return_value.post.return_value = {"id": "100", "name": "v1.0"}
+
+        config = JiraConfig(url=url, auth_type="pat", personal_token="test_token")
+        client = JiraClient(config=config)
+        client.create_version(project="PROJ", name="v1.0")
+
+        mock_jira.return_value.resource_url.assert_called_once_with(
+            "version", api_version=expected_api_version
+        )
+        mock_jira.return_value.post.assert_called_once_with(
+            expected_url, json={"project": "PROJ", "name": "v1.0"}
+        )

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -406,7 +406,9 @@ def test_jira_client_basic_auth_preserves_trust_env():
     ],
     ids=["cloud", "server_dc"],
 )
-def test_create_version_uses_correct_api_version(url: str, expected_api_version: str):
+def test_create_version_uses_correct_api_version(
+    url: str, expected_api_version: str
+) -> None:
     """Test that create_version uses API v3 for Cloud and v2 for Server/DC."""
     with (
         patch("mcp_atlassian.jira.client.Jira") as mock_jira,


### PR DESCRIPTION
## Description

The create_version method hardcoded /rest/api/3/version which only works on Cloud. Server/Data Center requires API v2, the behavior is the same after that. 
This dynamically selects the API version based on config.is_cloud.

Fixes: #1338

## Changes

Use `self.config.is_cloud` to select API v3 (Cloud) or v2 (Server/DC) for version creation
Use `self.jira.resource_url()` to build the endpoint dynamically instead of a hardcoded path
Add parametrized unit test covering both Cloud and Server/DC paths

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `this patch-fix is deployed on our production for a Jira DC`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
