### PR TITLE
fix(jira): nest indented list items in markdown_to_adf (#1129)

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -117,6 +117,101 @@ def _make_list_item(text: str) -> dict[str, Any]:
     return {"type": "listItem", "content": [_make_paragraph(text)]}
 
 
+# A list marker is "- ", "* " or "<digits>. " possibly preceded by spaces or tabs.
+# Tabs are normalized to four spaces before the indent is measured.
+_LIST_LINE_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<marker>[-*]|\d+\.)\s+(?P<text>.*)$")
+
+
+def _list_marker(line: str) -> tuple[int, str, str] | None:
+    """Parse a markdown list line into (indent_columns, list_type, item_text).
+
+    Returns None if the line is not a list item. ``indent_columns`` measures
+    leading whitespace with tabs counted as four spaces, matching the
+    CommonMark convention closely enough for nesting decisions.
+    """
+    m = _LIST_LINE_RE.match(line)
+    if m is None:
+        return None
+    indent_text = m.group("indent").replace("\t", "    ")
+    list_type = "orderedList" if m.group("marker").endswith(".") else "bulletList"
+    return len(indent_text), list_type, m.group("text")
+
+
+def _parse_list_block(
+    lines: list[str], start: int, base_indent: int
+) -> tuple[list[dict[str, Any]], str, int]:
+    """Parse one nesting level of list items starting at ``start``.
+
+    Stops as soon as the next non-blank line is not a list item or has a
+    smaller indent than ``base_indent``. A child block whose indent is greater
+    than ``base_indent`` is recursively attached to the most recent item.
+
+    Returns the list items, the list type of this level (``bulletList`` or
+    ``orderedList`` — taken from the first item), and the index of the first
+    line that does not belong to this level.
+    """
+    items: list[dict[str, Any]] = []
+    level_type: str | None = None
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip():
+            # Peek past the blank line(s) — only consume them if a deeper or
+            # same-level list item follows. Otherwise the blank line belongs to
+            # the document, not this list block.
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            if j >= len(lines):
+                break
+            peek = _list_marker(lines[j])
+            if peek is None or peek[0] < base_indent:
+                break
+            i = j
+            continue
+        marker = _list_marker(line)
+        if marker is None or marker[0] < base_indent:
+            break
+        indent, list_type, item_text = marker
+        if indent > base_indent:
+            # Deeper than expected and no parent item to hang off — bail and
+            # let the caller decide what to do.
+            break
+        if level_type is None:
+            level_type = list_type
+        elif list_type != level_type:
+            # A different list type at the same level starts a sibling list,
+            # which the outer loop in ``markdown_to_adf`` will pick up.
+            break
+        i += 1
+        children: list[dict[str, Any]] = []
+        while i < len(lines):
+            next_line = lines[i]
+            if not next_line.strip():
+                j = i + 1
+                while j < len(lines) and not lines[j].strip():
+                    j += 1
+                if j >= len(lines):
+                    break
+                peek = _list_marker(lines[j])
+                if peek is None or peek[0] <= indent:
+                    break
+                i = j
+                continue
+            peek = _list_marker(next_line)
+            if peek is None or peek[0] <= indent:
+                break
+            child_items, child_type, i = _parse_list_block(lines, i, peek[0])
+            children.append({"type": child_type, "content": child_items})
+        items.append(
+            {
+                "type": "listItem",
+                "content": [_make_paragraph(item_text), *children],
+            }
+        )
+    return items, level_type or "bulletList", i
+
+
 def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
     """Convert Markdown text to ADF (Atlassian Document Format) document.
 
@@ -197,24 +292,11 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
             doc["content"].append({"type": "blockquote", "content": bq_content})
             continue
 
-        # --- Unordered list ---
-        if re.match(r"^[-*]\s+", line):
-            items: list[dict[str, Any]] = []
-            while i < len(lines) and re.match(r"^[-*]\s+", lines[i]):
-                item_text = re.sub(r"^[-*]\s+", "", lines[i])
-                items.append(_make_list_item(item_text))
-                i += 1
-            doc["content"].append({"type": "bulletList", "content": items})
-            continue
-
-        # --- Ordered list ---
-        if re.match(r"^\d+\.\s+", line):
-            items_ol: list[dict[str, Any]] = []
-            while i < len(lines) and re.match(r"^\d+\.\s+", lines[i]):
-                item_text = re.sub(r"^\d+\.\s+", "", lines[i])
-                items_ol.append(_make_list_item(item_text))
-                i += 1
-            doc["content"].append({"type": "orderedList", "content": items_ol})
+        # --- List (ordered or unordered, with nesting) ---
+        marker = _list_marker(line)
+        if marker is not None and marker[0] == 0:
+            list_items, list_type, i = _parse_list_block(lines, i, 0)
+            doc["content"].append({"type": list_type, "content": list_items})
             continue
 
         # --- Table ---

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -180,8 +180,10 @@ def _parse_list_block(
         if level_type is None:
             level_type = list_type
         elif list_type != level_type:
-            # A different list type at the same level starts a sibling list,
-            # which the outer loop in ``markdown_to_adf`` will pick up.
+            # A different list type at the same indent starts a sibling
+            # list; return so the caller (``markdown_to_adf`` at the top
+            # level, or the parent ``_parse_list_block`` for nested
+            # levels) opens a new list node for it.
             break
         i += 1
         children: list[dict[str, Any]] = []
@@ -203,12 +205,12 @@ def _parse_list_block(
                 break
             child_items, child_type, i = _parse_list_block(lines, i, peek[0])
             children.append({"type": child_type, "content": child_items})
-        items.append(
-            {
-                "type": "listItem",
-                "content": [_make_paragraph(item_text), *children],
-            }
-        )
+        # Reuse _make_list_item for the paragraph wrapping, then attach any
+        # nested child lists so the same shape used by single-level lists
+        # stays the single source of truth.
+        item = _make_list_item(item_text)
+        item["content"].extend(children)
+        items.append(item)
     return items, level_type or "bulletList", i
 
 

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -478,6 +478,63 @@ class TestMarkdownToAdf:
             assert item["type"] == "listItem"
             assert item["content"][0]["type"] == "paragraph"
 
+    def test_nested_unordered_list(self):
+        """Regression for #1129: indented bullet items nest under the parent.
+
+        Without the fix, '  * Apples' was rendered as a flat paragraph below
+        the 'Fruits' bullet, losing the nesting entirely.
+        """
+        md = "* Fruits\n  * Apples\n  * Bananas"
+        result = markdown_to_adf(md)
+        bl = next(n for n in result["content"] if n["type"] == "bulletList")
+        # Top level has exactly one item: "Fruits" with a nested bulletList.
+        assert len(bl["content"]) == 1
+        fruits = bl["content"][0]
+        assert fruits["content"][0]["content"][0]["text"] == "Fruits"
+        nested = fruits["content"][1]
+        assert nested["type"] == "bulletList"
+        nested_texts = [
+            item["content"][0]["content"][0]["text"] for item in nested["content"]
+        ]
+        assert nested_texts == ["Apples", "Bananas"]
+        # No stray paragraph siblings escaped to the document root.
+        assert all(n["type"] != "paragraph" for n in result["content"])
+
+    def test_nested_mixed_ordered_then_unordered(self):
+        """Ordered parent with nested unordered children is preserved."""
+        md = "1. First\n   * sub one\n   * sub two\n2. Second"
+        result = markdown_to_adf(md)
+        ol = next(n for n in result["content"] if n["type"] == "orderedList")
+        first, second = ol["content"]
+        assert first["content"][0]["content"][0]["text"] == "First"
+        nested = first["content"][1]
+        assert nested["type"] == "bulletList"
+        assert [i["content"][0]["content"][0]["text"] for i in nested["content"]] == [
+            "sub one",
+            "sub two",
+        ]
+        assert second["content"][0]["content"][0]["text"] == "Second"
+        assert len(second["content"]) == 1  # Second has no nested children
+
+    def test_nested_three_levels(self):
+        """Deep nesting (3 levels) is preserved."""
+        md = "- L1\n  - L2\n    - L3"
+        result = markdown_to_adf(md)
+        bl = result["content"][0]
+        l1 = bl["content"][0]
+        l2 = l1["content"][1]["content"][0]
+        l3 = l2["content"][1]["content"][0]
+        assert l1["content"][0]["content"][0]["text"] == "L1"
+        assert l2["content"][0]["content"][0]["text"] == "L2"
+        assert l3["content"][0]["content"][0]["text"] == "L3"
+
+    def test_nested_tab_indented(self):
+        """Tab-indented nested items are recognized (tab = 4 spaces)."""
+        md = "* Fruits\n\t* Apples"
+        result = markdown_to_adf(md)
+        bl = result["content"][0]
+        assert bl["content"][0]["content"][1]["type"] == "bulletList"
+
     # -- Blockquote ---------------------------------------------------------
 
     def test_blockquote(self):


### PR DESCRIPTION
## Summary

`markdown_to_adf` matched list markers with `^[-*]\s+` / `^\d+\.\s+`, so any indented child item fell through to the paragraph fallback. Input like

```markdown
* Fruits
  * Apples
  * Bananas
```

produced a `bulletList` with a single \"Fruits\" item followed by two flat paragraphs that still contained the raw \`* Apples\` / \`* Bananas\` text — the structural nesting was lost.

This PR replaces the two single-level list branches with a small recursive-descent helper (`_parse_list_block`) that builds the proper ADF tree:

- Deeper-indented items become children of the most recent `listItem` (paragraph + nested list, per ADF schema).
- Tabs are treated as four spaces before measuring the indent.
- Bullet and ordered lists nest into each other in either direction.
- Blank lines between a parent item and its nested children are tolerated.

Fixes #1129

## Changes

- `src/mcp_atlassian/models/jira/adf.py` — add `_list_marker` and `_parse_list_block`; replace the existing unordered/ordered branches with a single call into the new helper.
- `tests/unit/models/test_adf.py` — four regression tests covering: indented unordered, mixed ordered→unordered, three levels deep, and tab-indented nesting. Existing flat-list tests still pass unchanged.

## Verification

- `uv run pytest tests/unit/models/test_adf.py -x` — **75 passed** (71 existing + 4 new).
- `uv run pre-commit run --files src/mcp_atlassian/models/jira/adf.py tests/unit/models/test_adf.py` — ruff-format / ruff / mypy all green.

## Notes

The fix is scoped to nesting only — multi-line list item bodies and the loose/tight list distinction are deliberately out of scope. If the maintainer wants a stricter CommonMark-compliant parser, that would be a separate change.