### PR TITLE
fix(server): per-user PAT service headers outrank gateway Authorization (#1162)

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -578,21 +578,29 @@ class UserTokenMiddleware:
                     f"UserTokenMiddleware: Extracted cloudId: {cloud_id_str.strip()}"
                 )
 
-            # Process Authorization header
-            if auth_header_str:
+            # If per-user PAT + URL service headers are present, they take
+            # precedence over any Authorization header. Gateways (AWS AgentCore,
+            # OAuth proxies) frequently inject their own outbound Authorization
+            # bearer; treating that as the Atlassian credential breaks
+            # multi-tenant PAT injection (#1162).
+            has_service_pat = bool(
+                service_headers
+                and (
+                    (jira_token_str and jira_url_str)
+                    or (confluence_token_str and confluence_url_str)
+                )
+            )
+            if has_service_pat:
+                scope["state"]["user_atlassian_auth_type"] = "pat"
+                scope["state"]["user_atlassian_email"] = None
+                logger.debug(
+                    "UserTokenMiddleware: Header-based PAT detected; ignoring "
+                    "Authorization header for Atlassian credential resolution."
+                )
+            elif auth_header_str:
                 self._parse_auth_header(auth_header_str, scope)
             else:
                 logger.debug("UserTokenMiddleware: No Authorization header provided")
-                # If service headers are present without Authorization header, set PAT auth type
-                if service_headers and (
-                    (jira_token_str and jira_url_str)
-                    or (confluence_token_str and confluence_url_str)
-                ):
-                    scope["state"]["user_atlassian_auth_type"] = "pat"
-                    scope["state"]["user_atlassian_email"] = None
-                    logger.debug(
-                        "UserTokenMiddleware: Header-based authentication detected. Setting PAT auth type."
-                    )
 
         except Exception as e:
             logger.error(f"Error processing authentication headers: {e}", exc_info=True)

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -407,6 +407,57 @@ class TestUserTokenMiddleware:
         assert passed_scope["state"]["user_atlassian_auth_type"] == "pat"
 
     @pytest.mark.anyio
+    async def test_service_headers_take_precedence_over_gateway_authorization(
+        self, middleware, mock_scope, mock_receive, mock_send
+    ):
+        """Regression for #1162: gateway-injected Authorization must not be
+        used as the Atlassian credential when per-user PAT service headers
+        are present (multi-tenant deployment behind AWS AgentCore-style
+        gateway).
+        """
+        mock_scope["headers"] = [
+            (b"authorization", b"Bearer gateway-outbound-token"),
+            (b"x-atlassian-jira-personal-token", b"user-jira-pat"),
+            (b"x-atlassian-jira-url", b"https://jira.example.com"),
+        ]
+
+        with patch(
+            "mcp_atlassian.servers.main.validate_url_for_ssrf", return_value=None
+        ):
+            await middleware(mock_scope, mock_receive, mock_send)
+
+        middleware.app.assert_called_once()
+        passed_scope = middleware.app.call_args[0][0]
+        assert passed_scope["state"]["user_atlassian_auth_type"] == "pat"
+        # The gateway bearer must NOT have been stored as the Atlassian token.
+        assert (
+            passed_scope["state"].get("user_atlassian_token")
+            != "gateway-outbound-token"
+        )
+        # The service headers are still forwarded for downstream fetchers.
+        assert (
+            passed_scope["state"]["atlassian_service_headers"][
+                "X-Atlassian-Jira-Personal-Token"
+            ]
+            == "user-jira-pat"
+        )
+
+    @pytest.mark.anyio
+    async def test_authorization_used_when_no_service_pat_headers(
+        self, middleware, mock_scope, mock_receive, mock_send
+    ):
+        """Authorization header still works on its own (no service PAT present)."""
+        mock_scope["headers"] = [
+            (b"authorization", b"Bearer real-bearer-token"),
+        ]
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        passed_scope = middleware.app.call_args[0][0]
+        assert passed_scope["state"]["user_atlassian_auth_type"] == "oauth"
+        assert passed_scope["state"]["user_atlassian_token"] == "real-bearer-token"
+
+    @pytest.mark.anyio
     async def test_basic_auth_header_extraction_success(
         self, middleware, mock_scope, mock_receive, mock_send
     ):


### PR DESCRIPTION
## Summary

In multi-tenant deployments behind an authenticating gateway (AWS AgentCore Runtime, OAuth proxies, etc.) the gateway adds its own outbound \`Authorization: Bearer <gateway-token>\` header. \`UserTokenMiddleware._process_authentication_headers\` processed the \`Authorization\` header first, stored the gateway token as \`user_atlassian_token\`, and set \`auth_type=oauth\` — so the \`X-Atlassian-*-Personal-Token\` + \`X-Atlassian-*-Url\` headers carrying the actual per-user PAT were silently overridden, causing 401s on every downstream tool call.

This PR re-orders the resolution: when the service-header PAT shape (a token + URL pair for Jira or Confluence) is present, those headers are treated as authoritative and the Authorization bearer is intentionally ignored for Atlassian credential resolution. When no PAT service headers are sent, \`Authorization\` is parsed as before. The existing \`IGNORE_HEADER_AUTH\` env knob is unaffected.

Fixes #1162

## Changes

- \`src/mcp_atlassian/servers/main.py\` — swap the \`if auth_header_str / else\` block for a precedence check: PAT service headers → set \`auth_type=pat\`; otherwise parse Authorization; otherwise no-op. Behavior with only Authorization, only service headers, or neither is unchanged.
- \`tests/unit/servers/test_main_server.py\` — two regression tests: the issue reporter's test_service_headers_take_precedence_over_gateway_authorization, plus a sanity check that bare \`Authorization\` still flows through as OAuth.

## Verification

- \`uv run pytest tests/unit/servers/test_main_server.py -x -k TestUserTokenMiddleware\` — **32 passed**.
- \`uv run pre-commit run --files src/mcp_atlassian/servers/main.py tests/unit/servers/test_main_server.py\` — ruff-format / ruff pass. mypy reports a pre-existing \`TTLCache\` type-args error on line 363 that's present on \`main\` and unrelated to these changes.

## Notes

The precedence is intentional and one-way (service headers win). The opposite preference (Authorization wins, ignore service headers) doesn't seem to map to a real deployment shape — happy to revisit if the maintainer wants a toggle.