### PR TITLE
feat(models): expose account_id in user-profile simplified dict

### DIFF
--- a/src/mcp_atlassian/models/confluence/common.py
+++ b/src/mcp_atlassian/models/confluence/common.py
@@ -73,6 +73,7 @@ class ConfluenceUser(ApiModel):
     def to_simplified_dict(self) -> dict[str, Any]:
         """Convert to simplified dictionary for API response."""
         return {
+            "account_id": self.account_id,
             "display_name": self.display_name,
             "email": self.email,
             "profile_picture": self.profile_picture,

--- a/src/mcp_atlassian/models/jira/common.py
+++ b/src/mcp_atlassian/models/jira/common.py
@@ -80,6 +80,7 @@ class JiraUser(ApiModel):
     def to_simplified_dict(self) -> dict[str, Any]:
         """Convert to simplified dictionary for API response."""
         result: dict[str, Any] = {
+            "account_id": self.account_id,
             "display_name": self.display_name,
             "name": self.username or self.display_name,
             "email": self.email,

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1447,6 +1447,7 @@ class TestIssuesMixin:
                 "changelogs": [
                     {
                         "author": {
+                            "account_id": "user123",
                             "avatar_url": None,
                             "display_name": "Test User 1",
                             "email": None,
@@ -1472,6 +1473,7 @@ class TestIssuesMixin:
                 "changelogs": [
                     {
                         "author": {
+                            "account_id": "user456",
                             "avatar_url": None,
                             "display_name": "Test User 2",
                             "email": None,
@@ -1489,6 +1491,7 @@ class TestIssuesMixin:
                     },
                     {
                         "author": {
+                            "account_id": "user789",
                             "avatar_url": None,
                             "display_name": "Test User 3",
                             "email": None,
@@ -1508,6 +1511,7 @@ class TestIssuesMixin:
                     },
                     {
                         "author": {
+                            "account_id": "user123",
                             "avatar_url": None,
                             "display_name": "Test User 1",
                             "email": None,

--- a/tests/unit/models/test_confluence_common_models.py
+++ b/tests/unit/models/test_confluence_common_models.py
@@ -254,10 +254,10 @@ class TestConfluenceUser:
         simplified = user.to_simplified_dict()
 
         assert isinstance(simplified, dict)
+        assert simplified["account_id"] == "user123"
         assert simplified["display_name"] == "Test User"
         assert simplified["email"] == "test@example.com"
         assert simplified["profile_picture"] == "/wiki/aa-avatar/user123"
-        assert "account_id" not in simplified  # Not included in simplified dict
         assert "locale" not in simplified  # Not included in simplified dict
 
 

--- a/tests/unit/models/test_jira_common_models.py
+++ b/tests/unit/models/test_jira_common_models.py
@@ -79,11 +79,26 @@ class TestJiraUser:
         )
         simplified = user.to_simplified_dict()
         assert isinstance(simplified, dict)
+        assert simplified["account_id"] == "user123"
         assert simplified["display_name"] == "Test User"
         assert simplified["email"] == "test@example.com"
         assert simplified["avatar_url"] == "https://example.com/avatar.png"
-        assert "account_id" not in simplified
         assert "time_zone" not in simplified
+
+    def test_to_simplified_dict_account_id_none(self):
+        """Server/DC users have no account_id; the key should still be present."""
+        user = JiraUser(
+            account_id=None,
+            username="jdoe",
+            display_name="John Doe",
+            email="jdoe@example.com",
+            active=True,
+            avatar_url="https://example.com/avatar.png",
+        )
+        simplified = user.to_simplified_dict()
+        assert "account_id" in simplified
+        assert simplified["account_id"] is None
+        assert simplified["name"] == "jdoe"
 
     def test_from_api_response_server_dc_with_name_and_key(self):
         """Test JiraUser captures username and key from Server/DC API response."""


### PR DESCRIPTION
## Description

  `JiraUser.to_simplified_dict()` and `ConfluenceUser.to_simplified_dict()` capture `account_id` from the Atlassian API response but deliberately omit it from the returned dict. This breaks any consumer that needs to chain
  `jira_get_user_profile` / `confluence_search_user` into a subsequent API call requiring `accountId` — `reporter`, `assignee`, `requestParticipants`, watchers, page authors. In modern Atlassian Cloud, `accountId` is the only accepted user
  reference for these fields, so the omission makes the look-up tools unusable for any flow that ends in a write.

  Concrete flow that's currently impossible end-to-end:

  1. `jira_get_user_profile(email)` resolves the user — but returns no `account_id`
  2. `jira_update_issue(fields={"reporter": {"accountId": "..."}})` has nothing to pass

  Consumers today have to fall back to alternative ID-lookup endpoints or hand-managed account-id strings.

  Fixes: # _(no existing issue)_

  ## Changes

  - Added `account_id` to `JiraUser.to_simplified_dict()` (`src/mcp_atlassian/models/jira/common.py`)
  - Added `account_id` to `ConfluenceUser.to_simplified_dict()` (`src/mcp_atlassian/models/confluence/common.py`)
  - Updated unit tests that previously asserted `account_id` was absent from the dict; added a new test covering the Server/DC case where `account_id` is `None` (key still present, value `None`, response shape stable across Cloud and
  Server/DC)
  - Updated one downstream test (`tests/unit/jira/test_issues.py::test_batch_get_changelogs_cloud`) whose `expected_result` pinned the prior author shape

  ## Testing

  How I tested:

  - Ran the full unit suite: `uv run pytest tests/unit/` → **2579 passed, 5 skipped**
  - Ran `uv run ruff check` and `uv run mypy` on the changed files — zero new findings (all pre-existing warnings on `models/jira/common.py` were verified to exist on `main` untouched by this PR)
  - Verified the change is additive: existing consumers reading `display_name`, `email`, `avatar_url`, `key` from `to_simplified_dict()` see no behavior difference
  - Deployed the patched models into a production environment via ConfigMap overlay and confirmed `jira_get_user_profile` responses now include `account_id` (Atlassian Cloud instance)

  - [x] Unit tests added/updated
  - [x] Integration tests passed _(unit suite includes the relevant scenarios; no real-API integration suite was run against my fork, but the change is a pure response-shape addition with full unit coverage)_
  - [x] Manual checks performed: confirmed the patched response shape includes `account_id` in a live Cloud environment, and that the consumer flow (lookup → set Reporter) succeeds end-to-end

  ## Checklist

  - [x] Code follows existing patterns (additive change to existing `to_simplified_dict()` methods, mirrors the `account_id` field already on the models)
  - [x] Tests updated to reflect the new behavior (and a new test added for the Server/DC `None` case)
  - [x] No new lint or mypy findings introduced
  - [x] Privacy-aware: `email` in responses may still be `None` due to Atlassian Cloud's server-side GDPR redaction of `emailAddress` — that is unchanged and unaffected by this PR
  - [x] Backwards-compatible: existing consumers that read other fields are unaffected; new field is additiv