### PR TITLE
feat(jira): add update_version tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**78 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**80 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**77 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**78 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 78 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 80 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **78 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **80 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -93,7 +93,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (78 tools)
+# Enable all toolsets (80 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 77 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 78 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **77 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **78 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -65,7 +65,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `jira_fields` | Yes | `jira_search_fields`, `jira_get_field_options` |
 | `jira_comments` | Yes | `jira_add_comment`, `jira_edit_comment` |
 | `jira_transitions` | Yes | `jira_get_transitions`, `jira_transition_issue` |
-| `jira_projects` | No | `jira_get_all_projects`, `jira_get_project_versions`, `jira_get_project_components`, `jira_create_version`, `jira_batch_create_versions` |
+| `jira_projects` | No | `jira_get_all_projects`, `jira_get_project_versions`, `jira_get_project_components`, `jira_create_version`, `jira_batch_create_versions`, `jira_update_version` |
 | `jira_agile` | No | `jira_get_agile_boards`, `jira_get_board_issues`, `jira_get_sprints_from_board`, `jira_get_sprint_issues`, `jira_create_sprint`, `jira_update_sprint`, `jira_add_issues_to_sprint` |
 | `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_create_remote_issue_link`, `jira_remove_issue_link` |
 | `jira_worklog` | No | `jira_get_worklog`, `jira_add_worklog` |
@@ -93,7 +93,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (77 tools)
+# Enable all toolsets (78 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/jira-links-versions.mdx
+++ b/docs/tools/jira-links-versions.mdx
@@ -137,3 +137,23 @@ Batch create multiple versions in a Jira project.
 | `versions` | `string` | Yes | JSON array of version objects. Each object should contain: - name (required): Name of the version - startDate (optional): Start date (YYYY-MM-DD) - releaseDate (optional): Release date (YYYY-MM-DD) - description (optional): Description of the version Example: `[{"name": "v1.0", "startDate": "2025-01-01", "releaseDate": "2025-02-01", "description": "First release"}, {"name": "v2.0"}]` |
 
 ---
+
+### Update Version
+
+Update an existing fix version in a Jira project.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `version_id` | `string` | Yes | Numeric ID of the version to update (e.g., '10001') |
+| `name` | `string` | No | New name for the version |
+| `description` | `string` | No | New description for the version |
+| `start_date` | `string` | No | New start date (YYYY-MM-DD) |
+| `release_date` | `string` | No | New release date (YYYY-MM-DD) |
+| `archived` | `boolean` | No | Set archived flag (true to archive) |
+| `released` | `boolean` | No | Set released flag (true to mark released) |
+
+---

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -387,3 +387,53 @@ class JiraClient:
             error_message = f"Unexpected response from Jira API: {result}"
             raise ValueError(error_message)
         return result
+
+    def update_version(
+        self,
+        version_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        start_date: str | None = None,
+        release_date: str | None = None,
+        archived: bool | None = None,
+        released: bool | None = None,
+    ) -> dict[str, Any]:
+        """
+        Update an existing version in a Jira project.
+
+        Only fields that are not None are sent in the request, so callers can
+        toggle a single attribute (e.g. archived) without touching the others.
+
+        Args:
+            version_id: The numeric ID of the version to update.
+            name: New name for the version (optional).
+            description: New description for the version (optional).
+            start_date: New start date (YYYY-MM-DD, optional).
+            release_date: New release date (YYYY-MM-DD, optional).
+            archived: Archived flag (optional).
+            released: Released flag (optional).
+
+        Returns:
+            The updated version object as returned by Jira.
+        """
+        payload: dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if start_date is not None:
+            payload["startDate"] = start_date
+        if release_date is not None:
+            payload["releaseDate"] = release_date
+        if archived is not None:
+            payload["archived"] = archived
+        if released is not None:
+            payload["released"] = released
+        if not payload:
+            raise ValueError("update_version requires at least one field to update")
+        logger.info(f"Updating Jira version {version_id}: {payload}")
+        result = self.jira.put(f"/rest/api/2/version/{version_id}", data=payload)
+        if not isinstance(result, dict):
+            error_message = f"Unexpected response from Jira API: {result}"
+            raise ValueError(error_message)
+        return result

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -463,3 +463,41 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
             release_date=release_date,
             description=description,
         )
+
+    def update_project_version(
+        self,
+        version_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        start_date: str | None = None,
+        release_date: str | None = None,
+        archived: bool | None = None,
+        released: bool | None = None,
+    ) -> dict[str, Any]:
+        """
+        Update an existing version in a Jira project.
+
+        Only fields that are not None are sent to Jira, so callers can flip a
+        single attribute (e.g. ``archived``) without overwriting the others.
+
+        Args:
+            version_id: The numeric ID of the version to update.
+            name: New name for the version (optional).
+            description: New description for the version (optional).
+            start_date: New start date (YYYY-MM-DD, optional).
+            release_date: New release date (YYYY-MM-DD, optional).
+            archived: Archived flag (optional).
+            released: Released flag (optional).
+
+        Returns:
+            The updated version object as returned by Jira.
+        """
+        return self.update_version(
+            version_id=version_id,
+            name=name,
+            description=description,
+            start_date=start_date,
+            release_date=release_date,
+            archived=archived,
+            released=released,
+        )

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2761,6 +2761,79 @@ async def batch_create_versions(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_projects"},
+    annotations={"title": "Update Version", "destructiveHint": True},
+)
+@check_write_access
+async def update_version(
+    ctx: Context,
+    version_id: Annotated[
+        str,
+        Field(description="Numeric ID of the version to update (e.g. '10001')"),
+    ],
+    name: Annotated[
+        str | None, Field(description="New name for the version", default=None)
+    ] = None,
+    description: Annotated[
+        str | None,
+        Field(description="New description for the version", default=None),
+    ] = None,
+    start_date: Annotated[
+        str | None,
+        Field(description="New start date (YYYY-MM-DD)", default=None),
+    ] = None,
+    release_date: Annotated[
+        str | None,
+        Field(description="New release date (YYYY-MM-DD)", default=None),
+    ] = None,
+    archived: Annotated[
+        bool | None,
+        Field(description="Set archived flag (true to archive)", default=None),
+    ] = None,
+    released: Annotated[
+        bool | None,
+        Field(description="Set released flag (true to mark released)", default=None),
+    ] = None,
+) -> str:
+    """Update an existing fix version in a Jira project.
+
+    Only fields explicitly provided are modified; other attributes of the
+    version are left untouched. Useful for archiving/unarchiving versions,
+    renaming, or shifting release dates without recreating them.
+
+    Args:
+        ctx: The FastMCP context.
+        version_id: Numeric ID of the version to update.
+        name: New name (optional).
+        description: New description (optional).
+        start_date: New start date YYYY-MM-DD (optional).
+        release_date: New release date YYYY-MM-DD (optional).
+        archived: Archived flag (optional).
+        released: Released flag (optional).
+
+    Returns:
+        JSON string of the updated version object.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        version = jira.update_project_version(
+            version_id=version_id,
+            name=name,
+            description=description,
+            start_date=start_date,
+            release_date=release_date,
+            archived=archived,
+            released=released,
+        )
+        return json.dumps(version, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error(f"Error updating version {version_id}: {str(e)}", exc_info=True)
+        return json.dumps(
+            {"success": False, "error": str(e)}, indent=2, ensure_ascii=False
+        )
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_forms"},
     annotations={"title": "Get Issue Forms", "readOnlyHint": True},
 )

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 78 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 80 tools into 21 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 77 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 78 tools into 21 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -77,9 +77,9 @@ class TestJiraCloudEpicOperations:
 
 
 class TestJiraCloudVersionOperations:
-    """Version creation on Cloud."""
+    """Version creation and updates on Cloud."""
 
-    def test_create_project_version(
+    def test_create_and_update_project_version(
         self,
         jira_fetcher: JiraFetcher,
         cloud_instance: CloudInstanceInfo,
@@ -97,6 +97,15 @@ class TestJiraCloudVersionOperations:
 
             assert version["name"] == name
             assert version.get("id")
+
+            updated_name = f"{name}-updated"
+            updated_version = jira_fetcher.update_project_version(
+                version_id=str(version["id"]),
+                name=updated_name,
+            )
+
+            assert updated_version["name"] == updated_name
+            assert str(updated_version["id"]) == str(version["id"])
         finally:
             if version and version.get("id"):
                 requests.delete(

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -78,9 +78,9 @@ class TestJiraDCEpicOperations:
 
 
 class TestJiraDCVersionOperations:
-    """Version creation on DC."""
+    """Version creation and updates on DC."""
 
-    def test_create_project_version(
+    def test_create_and_update_project_version(
         self,
         jira_fetcher: JiraFetcher,
         dc_instance: DCInstanceInfo,
@@ -98,6 +98,15 @@ class TestJiraDCVersionOperations:
 
             assert version["name"] == name
             assert version.get("id")
+
+            updated_name = f"{name}-updated"
+            updated_version = jira_fetcher.update_project_version(
+                version_id=str(version["id"]),
+                name=updated_name,
+            )
+
+            assert updated_version["name"] == updated_name
+            assert str(updated_version["id"]) == str(version["id"])
         finally:
             if version and version.get("id"):
                 requests.post(

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -428,3 +428,65 @@ def test_create_version_uses_correct_api_version(
         mock_jira.return_value.post.assert_called_once_with(
             expected_url, json={"project": "PROJ", "name": "v1.0"}
         )
+
+
+def test_update_version_sends_only_provided_fields() -> None:
+    """Test that update_version sends only fields explicitly provided."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        mock_response = {"id": "10001", "name": "v2.0", "archived": False}
+        mock_jira.return_value.put.return_value = mock_response
+
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="pat",
+            personal_token="test_token",
+        )
+        client = JiraClient(config=config)
+        result = client.update_version("10001", name="v2.0", archived=False)
+
+        assert result == mock_response
+        mock_jira.return_value.put.assert_called_once_with(
+            "/rest/api/2/version/10001",
+            data={"name": "v2.0", "archived": False},
+        )
+
+
+def test_update_version_requires_at_least_one_field() -> None:
+    """Test that update_version rejects empty update payloads."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="pat",
+            personal_token="test_token",
+        )
+        client = JiraClient(config=config)
+
+        with pytest.raises(ValueError, match="requires at least one field"):
+            client.update_version("10001")
+
+        mock_jira.return_value.put.assert_not_called()
+
+
+def test_update_version_rejects_non_dict_response() -> None:
+    """Test that update_version rejects unexpected Jira responses."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        mock_jira.return_value.put.return_value = ["not", "a", "dict"]
+
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="pat",
+            personal_token="test_token",
+        )
+        client = JiraClient(config=config)
+
+        with pytest.raises(ValueError, match="Unexpected response from Jira API"):
+            client.update_version("10001", released=True)

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -766,3 +766,66 @@ def test_create_project_version_error(projects_mixin: ProjectsMixin) -> None:
     ):
         with pytest.raises(Exception):
             projects_mixin.create_project_version("PROJ4", "v6.0")
+
+
+def test_update_project_version_single_field(projects_mixin: ProjectsMixin) -> None:
+    """Test update_project_version forwards a single field change."""
+    mock_response = {"id": "301", "name": "v4.0", "archived": False}
+    with patch.object(
+        projects_mixin, "update_version", return_value=mock_response
+    ) as mock_update_version:
+        result = projects_mixin.update_project_version(version_id="301", archived=False)
+        assert result == mock_response
+        mock_update_version.assert_called_once_with(
+            version_id="301",
+            name=None,
+            description=None,
+            start_date=None,
+            release_date=None,
+            archived=False,
+            released=None,
+        )
+
+
+def test_update_project_version_all_fields(projects_mixin: ProjectsMixin) -> None:
+    """Test update_project_version forwards every field when provided."""
+    mock_response = {
+        "id": "302",
+        "name": "v5.1",
+        "description": "Patched",
+        "startDate": "2025-09-01",
+        "releaseDate": "2025-09-15",
+        "archived": True,
+        "released": True,
+    }
+    with patch.object(
+        projects_mixin, "update_version", return_value=mock_response
+    ) as mock_update_version:
+        result = projects_mixin.update_project_version(
+            version_id="302",
+            name="v5.1",
+            description="Patched",
+            start_date="2025-09-01",
+            release_date="2025-09-15",
+            archived=True,
+            released=True,
+        )
+        assert result == mock_response
+        mock_update_version.assert_called_once_with(
+            version_id="302",
+            name="v5.1",
+            description="Patched",
+            start_date="2025-09-01",
+            release_date="2025-09-15",
+            archived=True,
+            released=True,
+        )
+
+
+def test_update_project_version_error(projects_mixin: ProjectsMixin) -> None:
+    """Test update_project_version propagates errors from the client."""
+    with patch.object(
+        projects_mixin, "update_version", side_effect=Exception("API failure")
+    ):
+        with pytest.raises(Exception):
+            projects_mixin.update_project_version("303", archived=True)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -440,6 +440,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
         transition_issue,
         update_issue,
         update_sprint,
+        update_version,
     )
 
     jira_sub_mcp = FastMCP(name="TestJiraSubMCP")
@@ -483,6 +484,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(update_sprint)
     jira_sub_mcp.add_tool(add_issues_to_sprint)
     jira_sub_mcp.add_tool(batch_create_versions)
+    jira_sub_mcp.add_tool(update_version)
     test_mcp.mount(jira_sub_mcp, prefix="jira")
     return test_mcp
 
@@ -1597,6 +1599,60 @@ async def test_batch_create_versions_empty(jira_client, mock_jira_fetcher):
     )
     content = json.loads(response.content[0].text)
     assert content == []
+
+
+@pytest.mark.anyio
+async def test_update_version_success(jira_client, mock_jira_fetcher):
+    """Test updating a Jira version forwards provided fields."""
+    mock_jira_fetcher.update_project_version.return_value = {
+        "id": "10001",
+        "name": "v1.0-renamed",
+        "archived": False,
+    }
+
+    response = await jira_client.call_tool(
+        "jira_update_version",
+        {
+            "version_id": "10001",
+            "name": "v1.0-renamed",
+            "archived": False,
+        },
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content == {
+        "id": "10001",
+        "name": "v1.0-renamed",
+        "archived": False,
+    }
+    mock_jira_fetcher.update_project_version.assert_called_once_with(
+        version_id="10001",
+        name="v1.0-renamed",
+        description=None,
+        start_date=None,
+        release_date=None,
+        archived=False,
+        released=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_update_version_error(jira_client, mock_jira_fetcher):
+    """Test updating a Jira version returns an error payload on failure."""
+    mock_jira_fetcher.update_project_version.side_effect = ValueError(
+        "update_version requires at least one field to update"
+    )
+
+    response = await jira_client.call_tool(
+        "jira_update_version",
+        {"version_id": "10001"},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content == {
+        "success": False,
+        "error": "update_version requires at least one field to update",
+    }
 
 
 # Regression tests for issue #883: project keys with 4+ characters

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 50, f"Expected 50 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

Adds a `jira_update_version` MCP tool plus the underlying `update_version` client method and `update_project_version` mixin wrapper, backed by `PUT /rest/api/2/version/{id}`.

The tool sends only the fields the caller provides, so a single attribute (e.g. `archived`) can be toggled without overwriting the rest of the version. It mirrors the shape and tags of the existing `create_version` / `batch_create_versions` tools.

## Motivation

The version-related tools today only cover read + create:

- `jira_get_project_versions`
- `jira_create_version`
- `jira_batch_create_versions`

There's no way to update, archive, unarchive, release, rename, or shift the dates on a version — those operations all require falling back to the Jira UI or raw REST. This PR fills that gap with the smallest viable change.

Real-world driver: archiving a large batch of historical build-candidate versions in one project — a task that's trivial via `PUT /rest/api/2/version/{id}` but currently unreachable from the MCP.

## What's in the PR

- **Client (`src/mcp_atlassian/jira/client.py`)**: new `update_version(version_id, name=None, description=None, start_date=None, release_date=None, archived=None, released=None)`. Builds the payload from non-`None` arguments only; raises `ValueError` if no field is supplied.
- **Mixin (`src/mcp_atlassian/jira/projects.py`)**: thin `update_project_version` wrapper mirroring `create_project_version`.
- **Server (`src/mcp_atlassian/servers/jira.py`)**: `@jira_mcp.tool` named `update_version`, tagged `jira / write / toolset:jira_projects`, `destructiveHint=True`, `@check_write_access`.
- **Tests (`tests/unit/jira/test_projects.py`)**: three new tests covering single-field update, all-fields update, and error propagation — same pattern as the existing `create_project_version` tests.
- **Toolset count assertion (`tests/unit/utils/test_toolsets.py`)**: bumped from 49 → 50.

## Endpoint choice: v2 vs v3

This PR uses `/rest/api/2/version/{id}` rather than v3 (which the existing `create_version` uses). Reason, per Atlassian's own documentation:

- **Jira Cloud** publishes both v2 and v3. Neither is deprecated; the only documented difference is rich-text handling (v3 uses ADF for body fields like description/comments). The project-versions endpoint has no rich-text fields, so v2 and v3 payloads are byte-identical for this surface.
- **Jira Server / Data Center** documents v2 only. The DC platform reference states verbatim *"The current API version is `2`"* (https://developer.atlassian.com/server/jira/platform/about-the-jira-server-rest-apis/, https://docs.atlassian.com/software/jira/docs/api/REST/9.17.0/). There is no v3 namespace on DC — not "partial," literally no v3 paths are documented. Atlassian has made no public commitment to bring v3 to DC; the open feature request is [JRASERVER-70688](https://jira.atlassian.com/browse/JRASERVER-70688), in *Gathering Interest* with 105 votes.

Empirically: `PUT /rest/api/3/version/{id}` returns **HTTP 405 Method Not Allowed** on a current DC instance, and `GET /rest/api/3/version/{id}` 302-redirects to v2.

Picking v2 keeps the tool working on both Cloud and DC by Atlassian's documented contract, with no `is_cloud` branch needed. (`create_version`'s use of v3 may have a similar latent issue on DC — out of scope for this PR, but a candidate for a small follow-up.)

## Test plan

- [x] `uv run pytest tests/unit/` — 2569 passed (3 pre-existing Windows-only flakes around `mimetypes`, `stdio_lifecycle`, and a timestamp boundary are deselected; verified red on `main` before this change, so unrelated).
- [x] `pre-commit` Ruff lint clean; `ruff-format` applied.
- [x] `mypy` against the touched files reports zero new errors (same 21 pre-existing errors on `main`, all from missing-stub noise unrelated to this change).
- [x] **End-to-end verified against a real Jira Server / Data Center instance**: archived a version, called `update_version(version_id, archived=false)`, confirmed `archived: false` in the response and on re-listing project versions. Re-archived afterwards to leave state untouched.

## Notes

- This PR is intentionally scoped to update only. Batch-update and delete are useful follow-ups but kept out to keep the diff small and reviewable.