### PR TITLE
fix(jira): use REST v2 for create_version

### DIFF
--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -382,7 +382,7 @@ class JiraClient:
         if description:
             payload["description"] = description
         logger.info(f"Creating Jira version: {payload}")
-        result = self.jira.post("/rest/api/3/version", json=payload)
+        result = self.jira.post("/rest/api/2/version", json=payload)
         if not isinstance(result, dict):
             error_message = f"Unexpected response from Jira API: {result}"
             raise ValueError(error_message)


### PR DESCRIPTION
## Summary

One-line fix: switch `create_version`'s POST endpoint from `/rest/api/3/version` to `/rest/api/2/version`.

## Why

Atlassian's own documentation:

- **Jira Cloud** publishes both `/rest/api/2/` and `/rest/api/3/`. Neither is deprecated. The only documented functional difference is rich-text handling (v3 uses ADF for body fields). The project-versions endpoint has no rich-text fields, so v2 and v3 payloads are byte-identical here.
- **Jira Server / Data Center** documents v2 only. The DC platform reference (https://docs.atlassian.com/software/jira/docs/api/REST/9.17.0/, https://developer.atlassian.com/server/jira/platform/about-the-jira-server-rest-apis/) states verbatim *"The current API version is `2`"*. The v3 namespace does not exist on DC — not "partial," literally no v3 paths are documented. The open feature request [JRASERVER-70688](https://jira.atlassian.com/browse/JRASERVER-70688) sits in *Gathering Interest* with 105 votes and no Atlassian commitment.

So the existing v3 path means `create_version` is implicitly Cloud-only. DC users who happen to hit a working v3 POST are relying on undocumented behavior; that's brittle and not guaranteed across DC versions. Empirically, v3 reads on DC return 302 redirects and v3 PUT on the same path returns 405 — the v3 namespace is at best partially implemented as a redirect shim, not a real surface.

## Impact

- **Cloud users**: no change. v2 returns the same payload as v3 for this endpoint.
- **DC users**: now using the documented, supported path.
- **Risk**: minimal. v2 is the stable, decade-old version surface; no behavior change for the request/response shape.

## Related

Companion to #1349 (which adds `jira_update_version` on v2 for the same reason). That PR's description has a fuller v2 vs v3 writeup if useful context.

## Test plan

- [x] Existing tests pass (no test changes — the project's existing tests don't assert request URLs at the client level, and the v2/v3 payloads are identical).
- [x] Companion PR #1349 was end-to-end verified against a Jira Server / Data Center instance on the same v2 surface.