### PR TITLE
fix: normalize position to int before sorting in get_space_page_tree

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -895,8 +895,20 @@ class PagesMixin(ConfluenceClient):
                 page_id = page.get("id")
                 title = page.get("title", "Untitled")
 
-                # Position is auto-included via extensions in the v1 API
-                position = page.get("extensions", {}).get("position")
+                # Position is auto-included via extensions in the v1 API.
+                # Confluence DC/Server can return position as the string
+                # "none" (or other non-numeric strings) instead of int/null.
+                # Normalize to int | None so sorting never mixes types.
+                raw_position = page.get("extensions", {}).get("position")
+                if raw_position is None:
+                    position = None
+                elif isinstance(raw_position, int):
+                    position = raw_position
+                else:
+                    try:
+                        position = int(str(raw_position))
+                    except (TypeError, ValueError):
+                        position = None
 
                 # Determine parent and depth from ancestors
                 ancestors = page.get("ancestors", [])
@@ -917,13 +929,13 @@ class PagesMixin(ConfluenceClient):
                     }
                 )
 
-            # Sort by depth first (breadth-first), then by position
-            # Note: position can be 0 (valid), so check for None explicitly
+            # Sort by depth first (breadth-first), then by position.
+            # Position is now always int | None after normalization above.
             result_pages.sort(
                 key=lambda p: (
                     p["depth"],
                     p["position"] if p["position"] is not None else 999999,
-                    p["title"],
+                    p["title"] or "",
                 )
             )
 

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -2713,6 +2713,57 @@ class TestPageHierarchy:
         assert pages[1]["id"] == "456"  # position 1
         assert pages[2]["id"] == "789"  # position 2
 
+    def test_get_space_page_tree_string_position_none(self, pages_mixin):
+        """Test that string 'none' positions don't cause TypeError.
+
+        Confluence DC/Server returns position as the string "none" for
+        pages without explicit ordering. Mixed with integer positions,
+        this previously caused TypeError in the sort key (gh-1319).
+        """
+        mock_pages = [
+            {
+                "id": "1",
+                "title": "Ordered Page",
+                "ancestors": [],
+                "extensions": {"position": 0},
+            },
+            {
+                "id": "2",
+                "title": "Unordered Page",
+                "ancestors": [],
+                "extensions": {"position": "none"},
+            },
+            {
+                "id": "3",
+                "title": "Another Ordered",
+                "ancestors": [],
+                "extensions": {"position": 1},
+            },
+            {
+                "id": "4",
+                "title": "Numeric String",
+                "ancestors": [],
+                "extensions": {"position": "5"},
+            },
+        ]
+        pages_mixin.confluence.get_all_pages_from_space_raw = MagicMock(
+            return_value=self._raw_response(mock_pages)
+        )
+
+        result = pages_mixin.get_space_page_tree("TEST")
+
+        pages = result["pages"]
+        assert len(pages) == 4
+        # Integer positions are preserved
+        assert pages[0]["id"] == "1"
+        assert pages[0]["position"] == 0
+        # Numeric string is coerced to int
+        p4 = next(p for p in pages if p["id"] == "4")
+        assert p4["position"] == 5
+        # String "none" is normalized to None and sorted last
+        p2 = next(p for p in pages if p["id"] == "2")
+        assert p2["position"] is None
+
     def test_pagination_multiple_batches(self, pages_mixin):
         """Test that pagination fetches across multiple API batches."""
         batch1 = [


### PR DESCRIPTION
## Summary

Fixes #1319 — `get_space_page_tree` raises `TypeError: "<" not supported between instances of "str" and "int"` when a space contains pages whose `extensions.position` is the string `"none"` (common on Confluence DC/Server for pages without explicit ordering).

## Root Cause

The sort key checks for `None` but not string values:

```python
p["position"] if p["position"] is not None else 999999
```

When `position` is `"none"` (str), it passes the `is not None` check and gets compared against integer positions in the sort tuple.

## Fix

Normalize `position` to `int | None` when building the result list:
- `int` values pass through unchanged
- Numeric strings (e.g. `"5"`) are coerced to `int`
- Non-numeric strings (e.g. `"none"`) become `None`
- `None` stays `None`

Also added `or ""` guard on `title` in the sort key.

## Test

Added `test_get_space_page_tree_string_position_none` covering mixed int/string/"none"/None positions.