### PR TITLE
fix(jira): route transition comments through the correct API version

### DIFF
--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -34,11 +34,12 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             Exception: If there is an error getting transitions
         """
         try:
-            transitions_data = self.jira.get_issue_transitions(issue_key)
+            transitions_data: object = self.jira.get_issue_transitions(issue_key)
+            if not isinstance(transitions_data, list):
+                return []
             result: list[dict[str, Any]] = []
 
             for transition in transitions_data:
-                # Skip non-dict transitions
                 if not isinstance(transition, dict):
                     continue
 
@@ -72,7 +73,8 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         except Exception as e:
             error_msg = f"Error getting transitions for {issue_key}: {str(e)}"
             logger.error(error_msg)
-            raise Exception(f"Error getting transitions: {str(e)}") from e
+            public_error = f"Error getting transitions: {str(e)}"
+            raise Exception(public_error) from e
 
     def get_transitions(self, issue_key: str) -> list[dict[str, Any]]:
         """
@@ -90,7 +92,9 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         """
         response = self.jira.get_issue_transitions_full(issue_key)
         if isinstance(response, dict):
-            return response.get("transitions", [])
+            transitions = response.get("transitions", [])
+            if isinstance(transitions, list):
+                return [item for item in transitions if isinstance(item, dict)]
         return []
 
     def get_transitions_models(self, issue_key: str) -> list[JiraTransition]:
@@ -144,7 +148,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
 
             # Validate that this is a valid transition ID
             valid_transitions = self.get_transitions_models(issue_key)
-            valid_ids = [t.id for t in valid_transitions]
+            valid_ids: list[str | int] = [t.id for t in valid_transitions]
 
             # Convert string IDs to integers for proper comparison
             if isinstance(normalized_transition_id, int):
@@ -168,14 +172,6 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
                 )
                 # Continue anyway as Jira will validate
 
-            # Find the target status name for the transition ID
-            target_status_name = None
-            for transition in valid_transitions:
-                if str(transition.id) == str(normalized_transition_id):
-                    if transition.to_status and transition.to_status.name:
-                        target_status_name = transition.to_status.name
-                        break
-
             # Sanitize fields if provided
             fields_for_api = None
             if fields:
@@ -197,19 +193,6 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             )
             logger.debug(f"Fields: {fields_for_api}, Update: {update_for_api}")
 
-            # POST directly to the v2 transitions endpoint. atlassian-python-api
-            # defaults to v3 on Jira Cloud, but v3 requires update.comment[].add.body
-            # to be an Atlassian Document (ADF). _markdown_to_jira produces a
-            # wiki-markup string, which v2 accepts. Forcing v2 here avoids a
-            # markdown->ADF conversion path on the transitions endpoint
-            # specifically; other endpoints retain whatever version the client
-            # is configured for. See upstream issue #1262.
-            if (
-                isinstance(normalized_transition_id, str)
-                and normalized_transition_id.isdigit()
-            ):
-                normalized_transition_id = int(normalized_transition_id)
-
             payload: dict[str, Any] = {
                 "transition": {"id": str(normalized_transition_id)},
             }
@@ -218,9 +201,14 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             if update_for_api:
                 payload["update"] = update_for_api
 
-            base_url = self.jira.resource_url("issue").replace("/api/3/", "/api/2/")
-            url = f"{base_url}/{issue_key}/transitions"
-            self.jira.post(url, json=payload)
+            if self.config.is_cloud:
+                # Cloud comments are ADF and require the REST v3 endpoint.
+                self._post_api3(f"issue/{issue_key}/transitions", payload)
+            else:
+                # Server/DC comments use wiki markup on REST v2.
+                base_url = self.jira.resource_url("issue")
+                url = f"{base_url}/{issue_key}/transitions"
+                self.jira.post(url, data=payload)
 
             # Return the updated issue
             return self.get_issue(issue_key)
@@ -238,7 +226,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             logger.error(error_msg)
             raise ValueError(error_msg) from e
 
-    def _normalize_transition_id(self, transition_id: str | int | dict) -> str | int:
+    def _normalize_transition_id(self, transition_id: object) -> str | int:
         """
         Normalize the transition ID to a common format.
 
@@ -246,7 +234,8 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             transition_id: The transition ID, which can be a string, int, or dict
 
         Returns:
-            The normalized transition ID as an integer when possible, or string otherwise
+            The normalized transition ID as an integer when possible, or a string
+            otherwise
         """
         logger.debug(
             f"Normalizing transition_id: {transition_id}, type: {type(transition_id)}"
@@ -321,17 +310,13 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
 
         # For any other type, convert to string with warning
         logger.warning(
-            f"Unexpected type for transition_id: {type(transition_id)}, trying conversion"
+            f"Unexpected type for transition_id: {type(transition_id)}, "
+            "trying conversion"
         )
-        try:
-            str_value = str(transition_id)
-            if str_value.isdigit():
-                return int(str_value)
-            else:
-                return str_value
-        except Exception as e:
-            logger.error(f"Failed to convert transition_id: {str(e)}")
-            return 0
+        str_value = str(transition_id)
+        if str_value.isdigit():
+            return int(str_value)
+        return str_value
 
     def _sanitize_transition_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
         """
@@ -385,7 +370,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             comment_str = comment
 
         # Convert markdown to Jira format if _markdown_to_jira is available
-        jira_formatted_comment = comment_str
+        jira_formatted_comment: str | dict[str, Any] = comment_str
         if hasattr(self, "_markdown_to_jira"):
             jira_formatted_comment = self._markdown_to_jira(comment_str)
 

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -218,9 +218,7 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             if update_for_api:
                 payload["update"] = update_for_api
 
-            base_url = self.jira.resource_url("issue").replace(
-                "/api/3/", "/api/2/"
-            )
+            base_url = self.jira.resource_url("issue").replace("/api/3/", "/api/2/")
             url = f"{base_url}/{issue_key}/transitions"
             self.jira.post(url, json=payload)
 

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -197,42 +197,32 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
             )
             logger.debug(f"Fields: {fields_for_api}, Update: {update_for_api}")
 
-            # Transition using the appropriate method
-            if target_status_name:
-                logger.info(f"Using status name '{target_status_name}' for transition")
-                self.jira.set_issue_status(
-                    issue_key=issue_key,
-                    status_name=target_status_name,
-                    fields=fields_for_api,
-                    update=update_for_api,
-                )
-            else:
-                logger.info(f"Using direct transition ID {normalized_transition_id}")
-                if (
-                    isinstance(normalized_transition_id, str)
-                    and normalized_transition_id.isdigit()
-                ):
-                    normalized_transition_id = int(normalized_transition_id)
+            # POST directly to the v2 transitions endpoint. atlassian-python-api
+            # defaults to v3 on Jira Cloud, but v3 requires update.comment[].add.body
+            # to be an Atlassian Document (ADF). _markdown_to_jira produces a
+            # wiki-markup string, which v2 accepts. Forcing v2 here avoids a
+            # markdown->ADF conversion path on the transitions endpoint
+            # specifically; other endpoints retain whatever version the client
+            # is configured for. See upstream issue #1262.
+            if (
+                isinstance(normalized_transition_id, str)
+                and normalized_transition_id.isdigit()
+            ):
+                normalized_transition_id = int(normalized_transition_id)
 
-                self.jira.set_issue_status_by_transition_id(
-                    issue_key=issue_key,
-                    transition_id=normalized_transition_id,
-                )
+            payload: dict[str, Any] = {
+                "transition": {"id": str(normalized_transition_id)},
+            }
+            if fields_for_api:
+                payload["fields"] = fields_for_api
+            if update_for_api:
+                payload["update"] = update_for_api
 
-                # Apply fields and comments separately
-                if fields_for_api or update_for_api:
-                    payload: dict[str, Any] = {
-                        "transition": {"id": str(normalized_transition_id)},
-                    }
-                    if fields_for_api:
-                        payload["fields"] = fields_for_api
-                    if update_for_api:
-                        payload["update"] = update_for_api
-
-                    if payload:
-                        base_url = self.jira.resource_url("issue")
-                        url = f"{base_url}/{issue_key}/transitions"
-                        self.jira.post(url, json=payload)
+            base_url = self.jira.resource_url("issue").replace(
+                "/api/3/", "/api/2/"
+            )
+            url = f"{base_url}/{issue_key}/transitions"
+            self.jira.post(url, json=payload)
 
             # Return the updated issue
             return self.get_issue(issue_key)

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -290,7 +290,11 @@ class TestJiraCloudTransitions:
         if target_id is None:
             target_id = transitions[0]["id"]
 
-        jira_fetcher.transition_issue(issue.key, target_id)
+        jira_fetcher.transition_issue(
+            issue.key,
+            target_id,
+            comment=f"Cloud transition comment {uid}",
+        )
 
         updated = jira_fetcher.get_issue(issue.key)
         assert updated.status is not None

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -271,7 +271,11 @@ class TestJiraDCTransitions:
         if target_id is None:
             target_id = transitions[0]["id"]
 
-        jira_fetcher.transition_issue(issue.key, target_id)
+        jira_fetcher.transition_issue(
+            issue.key,
+            target_id,
+            comment=f"Data Center transition comment {uid}",
+        )
 
         updated = jira_fetcher.get_issue(issue.key)
         assert updated.status is not None

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -119,12 +119,18 @@ class TestTransitionsMixin:
 
     def test_transition_issue_basic(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue with basic parameters."""
+        # Client configured for v3 (Jira Cloud default)
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
+        )
+
         # Call the method
         result = transitions_mixin.transition_issue("TEST-123", "10")
 
-        # Verify
-        transitions_mixin.jira.set_issue_status.assert_called_once_with(
-            issue_key="TEST-123", status_name="In Progress", fields=None, update=None
+        # Verify POST to the v2 transitions endpoint with a minimal payload
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={"transition": {"id": "10"}},
         )
         transitions_mixin.get_issue.assert_called_once_with("TEST-123")
         assert isinstance(result, JiraIssue)
@@ -134,12 +140,17 @@ class TestTransitionsMixin:
 
     def test_transition_issue_with_int_id(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue with int transition ID."""
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
+        )
+
         # Call the method with int ID
         transitions_mixin.transition_issue("TEST-123", 10)
 
-        # Verify status name is used instead of ID
-        transitions_mixin.jira.set_issue_status.assert_called_once_with(
-            issue_key="TEST-123", status_name="In Progress", fields=None, update=None
+        # Verify the transition ID is stringified in the payload
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={"transition": {"id": "10"}},
         )
 
     def test_transition_issue_with_fields(self, transitions_mixin: TransitionsMixin):
@@ -148,17 +159,21 @@ class TestTransitionsMixin:
         transitions_mixin._sanitize_transition_fields = MagicMock(
             return_value={"summary": "Updated"}
         )
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
+        )
 
         # Call the method with fields
         fields = {"summary": "Updated"}
         transitions_mixin.transition_issue("TEST-123", "10", fields=fields)
 
-        # Verify fields were passed correctly
-        transitions_mixin.jira.set_issue_status.assert_called_once_with(
-            issue_key="TEST-123",
-            status_name="In Progress",
-            fields={"summary": "Updated"},
-            update=None,
+        # Verify fields are included in the POST payload
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={
+                "transition": {"id": "10"},
+                "fields": {"summary": "Updated"},
+            },
         )
 
     def test_transition_issue_with_empty_sanitized_fields(
@@ -167,14 +182,18 @@ class TestTransitionsMixin:
         """Test transition_issue with empty sanitized fields."""
         # Mock _sanitize_transition_fields to return empty dict
         transitions_mixin._sanitize_transition_fields = MagicMock(return_value={})
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
+        )
 
         # Call the method with fields that will be sanitized to empty
         fields = {"invalid": "field"}
         transitions_mixin.transition_issue("TEST-123", "10", fields=fields)
 
-        # Verify fields were passed as None
-        transitions_mixin.jira.set_issue_status.assert_called_once_with(
-            issue_key="TEST-123", status_name="In Progress", fields=None, update=None
+        # Empty sanitized fields should result in no "fields" key in the payload
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={"transition": {"id": "10"}},
         )
 
     def test_transition_issue_with_comment(self, transitions_mixin: TransitionsMixin):
@@ -190,6 +209,9 @@ class TestTransitionsMixin:
         transitions_mixin._add_comment_to_transition_data = MagicMock(
             side_effect=add_comment_side_effect
         )
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
+        )
 
         # Call the method with comment
         transitions_mixin.transition_issue("TEST-123", "10", comment=comment)
@@ -197,20 +219,22 @@ class TestTransitionsMixin:
         # Verify _add_comment_to_transition_data was called
         transitions_mixin._add_comment_to_transition_data.assert_called_once()
 
-        # Verify set_issue_status was called with the right parameters
-        transitions_mixin.jira.set_issue_status.assert_called_once_with(
-            issue_key="TEST-123",
-            status_name="In Progress",
-            fields=None,
-            update={"comment": [{"add": {"body": comment}}]},
+        # Verify the comment update is included in the POST payload, sent to v2
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={
+                "transition": {"id": "10"},
+                "update": {"comment": [{"add": {"body": comment}}]},
+            },
         )
 
     def test_transition_issue_with_error(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue error handling."""
-        # Setup mock to raise exception
-        transitions_mixin.jira.set_issue_status.side_effect = Exception(
-            "Transition error"
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
         )
+        # Setup mock to raise exception on the POST
+        transitions_mixin.jira.post.side_effect = Exception("Transition error")
 
         # Call the method and verify exception
         with pytest.raises(
@@ -222,7 +246,12 @@ class TestTransitionsMixin:
     def test_transition_issue_without_status_name(
         self, transitions_mixin: TransitionsMixin
     ):
-        """Test transition_issue when status name is not available."""
+        """Test transition_issue when target status name is not available.
+
+        After the unification onto a single v2 POST path, the absence of a
+        resolvable target status name no longer affects behavior -- the
+        transition still succeeds using the transition_id alone.
+        """
         # Setup - create a transition without to_status
         mock_transitions = [
             JiraTransition(
@@ -234,24 +263,65 @@ class TestTransitionsMixin:
         transitions_mixin.get_transitions_models = MagicMock(
             return_value=mock_transitions
         )
-
-        # Add mock for set_issue_status_by_transition_id
-        transitions_mixin.jira.set_issue_status_by_transition_id = MagicMock()
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
+        )
 
         # Call the method
         result = transitions_mixin.transition_issue("TEST-123", "10")
 
-        # Verify direct transition ID was used
-        transitions_mixin.jira.set_issue_status_by_transition_id.assert_called_once_with(
-            issue_key="TEST-123", transition_id=10
+        # Verify the unified POST still happens with the transition id
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={"transition": {"id": "10"}},
         )
-
-        # Verify standard status call was not made
-        transitions_mixin.jira.set_issue_status.assert_not_called()
 
         # Verify result
         transitions_mixin.get_issue.assert_called_once_with("TEST-123")
         assert isinstance(result, JiraIssue)
+
+    def test_transition_issue_forces_v2_on_cloud(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Regression test for issue #1262.
+
+        The v3 transitions endpoint rejects update.comment[].add.body when it
+        is a wiki-markup string (it expects ADF). _markdown_to_jira produces
+        wiki-markup. Forcing v2 here avoids the impedance mismatch without
+        needing a markdown->ADF conversion path.
+        """
+        # Client configured for v3 (Jira Cloud default)
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
+        )
+
+        transitions_mixin.transition_issue("TEST-123", "10")
+
+        # The URL must have been rewritten to /api/2/
+        call_args = transitions_mixin.jira.post.call_args
+        url = call_args.args[0]
+        assert "/rest/api/2/issue/TEST-123/transitions" in url
+        assert "/api/3/" not in url
+
+    def test_transition_issue_v2_url_passthrough(
+        self, transitions_mixin: TransitionsMixin
+    ):
+        """Test that a v2 URL from the client is passed through unchanged.
+
+        This is the Server / Data Center case, where the client is already
+        configured for v2. The string-replace from /api/3/ to /api/2/ is a
+        no-op when /api/3/ is not present.
+        """
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/2/issue"
+        )
+
+        transitions_mixin.transition_issue("TEST-123", "10")
+
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={"transition": {"id": "10"}},
+        )
 
     def test_get_transitions_uses_full_api(self, transitions_mixin: TransitionsMixin):
         """Test that get_transitions uses get_issue_transitions_full for complete data.
@@ -362,11 +432,14 @@ class TestTransitionsMixin:
     def test_transition_issue_with_resolution_field(
         self, transitions_mixin: TransitionsMixin
     ):
-        """Test transition_issue with resolution field uses correct code path.
+        """Test transition_issue with resolution field includes it in the payload.
 
-        This is the end-to-end test for issue #602 - when transitioning with fields
-        like resolution, the to_status should be available (from get_issue_transitions_full)
-        so set_issue_status is used which properly includes fields.
+        Regression test for issue #602 - the fields parameter (e.g. resolution)
+        must be sent atomically with the transition so the resolution is set
+        as part of the status change rather than dropped.
+
+        After the unification onto a single v2 POST path, this is verified
+        directly by inspecting the request payload.
         """
         # Setup mock for get_issue_transitions_full (used by get_transitions)
         mock_response = {
@@ -383,6 +456,9 @@ class TestTransitionsMixin:
         }
         transitions_mixin.jira.get_issue_transitions_full = MagicMock(
             return_value=mock_response
+        )
+        transitions_mixin.jira.resource_url = MagicMock(
+            return_value="https://jira.example.com/rest/api/3/issue"
         )
 
         # Don't mock get_transitions_models - let it use real implementation
@@ -403,13 +479,14 @@ class TestTransitionsMixin:
             fields={"resolution": {"id": "10001"}},
         )
 
-        # Verify set_issue_status was called (not set_issue_status_by_transition_id)
-        # because to_status should now be available
-        transitions_mixin.jira.set_issue_status.assert_called_once_with(
-            issue_key="TEST-123",
-            status_name="Closed",
-            fields={"resolution": {"id": "10001"}},
-            update=None,
+        # Verify the resolution field is present in the POST payload alongside
+        # the transition id, so Jira sets it atomically with the status change
+        transitions_mixin.jira.post.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
+            json={
+                "transition": {"id": "731"},
+                "fields": {"resolution": {"id": "10001"}},
+            },
         )
 
     def test_normalize_transition_id(self, transitions_mixin: TransitionsMixin):

--- a/tests/unit/jira/test_transitions.py
+++ b/tests/unit/jira/test_transitions.py
@@ -48,6 +48,7 @@ class TestTransitionsMixin:
             )
         ]
         mixin.get_transitions_models = MagicMock(return_value=mock_transitions)
+        mixin._post_api3 = MagicMock()
 
         return mixin
 
@@ -119,18 +120,13 @@ class TestTransitionsMixin:
 
     def test_transition_issue_basic(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue with basic parameters."""
-        # Client configured for v3 (Jira Cloud default)
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
-
         # Call the method
         result = transitions_mixin.transition_issue("TEST-123", "10")
 
-        # Verify POST to the v2 transitions endpoint with a minimal payload
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={"transition": {"id": "10"}},
+        # Verify POST to the Cloud v3 endpoint with a minimal payload
+        transitions_mixin._post_api3.assert_called_once_with(
+            "issue/TEST-123/transitions",
+            {"transition": {"id": "10"}},
         )
         transitions_mixin.get_issue.assert_called_once_with("TEST-123")
         assert isinstance(result, JiraIssue)
@@ -140,17 +136,13 @@ class TestTransitionsMixin:
 
     def test_transition_issue_with_int_id(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue with int transition ID."""
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
-
         # Call the method with int ID
         transitions_mixin.transition_issue("TEST-123", 10)
 
         # Verify the transition ID is stringified in the payload
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={"transition": {"id": "10"}},
+        transitions_mixin._post_api3.assert_called_once_with(
+            "issue/TEST-123/transitions",
+            {"transition": {"id": "10"}},
         )
 
     def test_transition_issue_with_fields(self, transitions_mixin: TransitionsMixin):
@@ -159,18 +151,15 @@ class TestTransitionsMixin:
         transitions_mixin._sanitize_transition_fields = MagicMock(
             return_value={"summary": "Updated"}
         )
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
 
         # Call the method with fields
         fields = {"summary": "Updated"}
         transitions_mixin.transition_issue("TEST-123", "10", fields=fields)
 
         # Verify fields are included in the POST payload
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={
+        transitions_mixin._post_api3.assert_called_once_with(
+            "issue/TEST-123/transitions",
+            {
                 "transition": {"id": "10"},
                 "fields": {"summary": "Updated"},
             },
@@ -182,76 +171,53 @@ class TestTransitionsMixin:
         """Test transition_issue with empty sanitized fields."""
         # Mock _sanitize_transition_fields to return empty dict
         transitions_mixin._sanitize_transition_fields = MagicMock(return_value={})
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
 
         # Call the method with fields that will be sanitized to empty
         fields = {"invalid": "field"}
         transitions_mixin.transition_issue("TEST-123", "10", fields=fields)
 
         # Empty sanitized fields should result in no "fields" key in the payload
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={"transition": {"id": "10"}},
+        transitions_mixin._post_api3.assert_called_once_with(
+            "issue/TEST-123/transitions",
+            {"transition": {"id": "10"}},
         )
 
     def test_transition_issue_with_comment(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue with comment."""
-        # Setup
         comment = "Test comment"
-
-        # Define a side effect to record what's passed to _add_comment_to_transition_data
-        def add_comment_side_effect(transition_data, comment_text):
-            transition_data["update"] = {"comment": [{"add": {"body": comment_text}}]}
-
-        # Mock _add_comment_to_transition_data
-        transitions_mixin._add_comment_to_transition_data = MagicMock(
-            side_effect=add_comment_side_effect
-        )
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
 
         # Call the method with comment
         transitions_mixin.transition_issue("TEST-123", "10", comment=comment)
 
-        # Verify _add_comment_to_transition_data was called
-        transitions_mixin._add_comment_to_transition_data.assert_called_once()
-
-        # Verify the comment update is included in the POST payload, sent to v2
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={
-                "transition": {"id": "10"},
-                "update": {"comment": [{"add": {"body": comment}}]},
-            },
-        )
+        # Cloud sends the converted ADF comment through REST v3.
+        transitions_mixin._post_api3.assert_called_once()
+        resource, payload = transitions_mixin._post_api3.call_args.args
+        assert resource == "issue/TEST-123/transitions"
+        assert payload["transition"] == {"id": "10"}
+        body = payload["update"]["comment"][0]["add"]["body"]
+        assert body["version"] == 1
+        assert body["type"] == "doc"
+        assert body["content"][0]["content"][0]["text"] == comment
 
     def test_transition_issue_with_error(self, transitions_mixin: TransitionsMixin):
         """Test transition_issue error handling."""
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
         # Setup mock to raise exception on the POST
-        transitions_mixin.jira.post.side_effect = Exception("Transition error")
+        transitions_mixin._post_api3.side_effect = Exception("Transition error")
 
         # Call the method and verify exception
         with pytest.raises(
             ValueError,
-            match="Error transitioning issue TEST-123 with transition ID 10: Transition error",
+            match=(
+                "Error transitioning issue TEST-123 with transition ID 10: "
+                "Transition error"
+            ),
         ):
             transitions_mixin.transition_issue("TEST-123", "10")
 
     def test_transition_issue_without_status_name(
         self, transitions_mixin: TransitionsMixin
     ):
-        """Test transition_issue when target status name is not available.
-
-        After the unification onto a single v2 POST path, the absence of a
-        resolvable target status name no longer affects behavior -- the
-        transition still succeeds using the transition_id alone.
-        """
+        """Test transition_issue when target status name is not available."""
         # Setup - create a transition without to_status
         mock_transitions = [
             JiraTransition(
@@ -263,65 +229,55 @@ class TestTransitionsMixin:
         transitions_mixin.get_transitions_models = MagicMock(
             return_value=mock_transitions
         )
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
-
         # Call the method
         result = transitions_mixin.transition_issue("TEST-123", "10")
 
         # Verify the unified POST still happens with the transition id
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={"transition": {"id": "10"}},
+        transitions_mixin._post_api3.assert_called_once_with(
+            "issue/TEST-123/transitions",
+            {"transition": {"id": "10"}},
         )
 
         # Verify result
         transitions_mixin.get_issue.assert_called_once_with("TEST-123")
         assert isinstance(result, JiraIssue)
 
-    def test_transition_issue_forces_v2_on_cloud(
+    def test_transition_issue_uses_v3_on_cloud(
         self, transitions_mixin: TransitionsMixin
     ):
         """Regression test for issue #1262.
 
-        The v3 transitions endpoint rejects update.comment[].add.body when it
-        is a wiki-markup string (it expects ADF). _markdown_to_jira produces
-        wiki-markup. Forcing v2 here avoids the impedance mismatch without
-        needing a markdown->ADF conversion path.
+        Cloud transition comments are converted to ADF, so their atomic
+        transition payload must use REST v3.
         """
-        # Client configured for v3 (Jira Cloud default)
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
+        transitions_mixin.transition_issue("TEST-123", "10", comment="Required")
 
-        transitions_mixin.transition_issue("TEST-123", "10")
+        transitions_mixin._post_api3.assert_called_once()
+        transitions_mixin.jira.post.assert_not_called()
 
-        # The URL must have been rewritten to /api/2/
-        call_args = transitions_mixin.jira.post.call_args
-        url = call_args.args[0]
-        assert "/rest/api/2/issue/TEST-123/transitions" in url
-        assert "/api/3/" not in url
-
-    def test_transition_issue_v2_url_passthrough(
+    def test_transition_issue_uses_v2_on_data_center(
         self, transitions_mixin: TransitionsMixin
     ):
-        """Test that a v2 URL from the client is passed through unchanged.
-
-        This is the Server / Data Center case, where the client is already
-        configured for v2. The string-replace from /api/3/ to /api/2/ is a
-        no-op when /api/3/ is not present.
-        """
+        """Server/DC sends wiki markup through the dependency's REST v2 URL."""
+        transitions_mixin.config.url = "https://jira.example.com"
+        transitions_mixin._markdown_to_jira = MagicMock(return_value="*Required*")
         transitions_mixin.jira.resource_url = MagicMock(
             return_value="https://jira.example.com/rest/api/2/issue"
         )
 
-        transitions_mixin.transition_issue("TEST-123", "10")
+        transitions_mixin.transition_issue("TEST-123", "10", comment="**Required**")
 
+        transitions_mixin.jira.resource_url.assert_called_once_with("issue")
         transitions_mixin.jira.post.assert_called_once_with(
             "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={"transition": {"id": "10"}},
+            data={
+                "transition": {"id": "10"},
+                "update": {
+                    "comment": [{"add": {"body": "*Required*"}}],
+                },
+            },
         )
+        transitions_mixin._post_api3.assert_not_called()
 
     def test_get_transitions_uses_full_api(self, transitions_mixin: TransitionsMixin):
         """Test that get_transitions uses get_issue_transitions_full for complete data.
@@ -382,8 +338,8 @@ class TestTransitionsMixin:
     ):
         """Test that get_transitions_models correctly parses full 'to' status objects.
 
-        This verifies that when get_issue_transitions_full returns complete 'to' objects,
-        the JiraTransition models are created with proper to_status.
+        This verifies that get_issue_transitions_full returns complete 'to'
+        objects and the JiraTransition models are created with proper to_status.
         """
         # Setup mock response matching real Jira API format
         mock_response = {
@@ -438,7 +394,7 @@ class TestTransitionsMixin:
         must be sent atomically with the transition so the resolution is set
         as part of the status change rather than dropped.
 
-        After the unification onto a single v2 POST path, this is verified
+        After the unification onto a single direct POST path, this is verified
         directly by inspecting the request payload.
         """
         # Setup mock for get_issue_transitions_full (used by get_transitions)
@@ -457,10 +413,6 @@ class TestTransitionsMixin:
         transitions_mixin.jira.get_issue_transitions_full = MagicMock(
             return_value=mock_response
         )
-        transitions_mixin.jira.resource_url = MagicMock(
-            return_value="https://jira.example.com/rest/api/3/issue"
-        )
-
         # Don't mock get_transitions_models - let it use real implementation
         # to test the full flow
         transitions_mixin.get_transitions_models = (
@@ -481,9 +433,9 @@ class TestTransitionsMixin:
 
         # Verify the resolution field is present in the POST payload alongside
         # the transition id, so Jira sets it atomically with the status change
-        transitions_mixin.jira.post.assert_called_once_with(
-            "https://jira.example.com/rest/api/2/issue/TEST-123/transitions",
-            json={
+        transitions_mixin._post_api3.assert_called_once_with(
+            "issue/TEST-123/transitions",
+            {
                 "transition": {"id": "731"},
                 "fields": {"resolution": {"id": "10001"}},
             },
@@ -537,7 +489,7 @@ class TestTransitionsMixin:
     def test_sanitize_transition_fields_with_assignee_and_get_account_id(
         self, transitions_mixin
     ):
-        """Test _sanitize_transition_fields with assignee when _get_account_id is available."""
+        """Test assignee sanitization when _get_account_id is available."""
         # Setup mock for _get_account_id
         transitions_mixin._get_account_id = MagicMock(return_value="account-123")
 


### PR DESCRIPTION
## Summary

Closes #1262.

Fixes `jira_transition_issue` on Jira Cloud when a transition includes a comment, including workflows whose transition screen requires Comment. Jira Cloud comments are converted to Atlassian Document Format (ADF), so the atomic transition request now uses REST API v3. Jira Server and Data Center continue to send wiki-markup comments through REST API v2.

## Changes

- Send the transition ID, fields, and update operations in one atomic request.
- Route Cloud transition payloads through the existing REST v3 helper so ADF comments are accepted.
- Keep Server/Data Center transition payloads on the dependency-provided REST v2 URL.
- Add unit regressions for Cloud ADF and Server/Data Center wiki-markup payloads.
- Exercise comment-bearing transitions in both Cloud and Data Center E2E suites.
- Retain defensive transition-response handling and make the touched module clean under strict mypy and Ruff checks.

## Why the endpoint differs by deployment

The original proposal forced REST v2 everywhere. That is no longer correct because the current Cloud formatter produces ADF, which REST v2 rejects. Cloud must use v3 for the ADF body, while Server/Data Center must retain v2 for wiki markup.

## Verification

- `uv run pre-commit run --all-files` — passed
- `uv run pytest tests/unit/jira/ -q` — 883 passed
- `uv run pytest tests/integration/ -q` — 23 skipped by environment markers
- `uv run pytest tests/e2e/cloud/test_adf_write.py tests/e2e/cloud/test_jira_*.py --cloud-e2e -q` — 41 passed, 8 skipped
- `uv run pytest tests/e2e --dc-e2e -q` — 98 passed, 103 skipped
- Full Cloud suite — the Jira transition regression passed; 86 passed and 15 skipped overall, with one unrelated existing Confluence search normalization failure

## Contributor credit

The contributor commits remain in the branch unchanged. The maintainer follow-up updates the endpoint selection for the current ADF behavior and adds live cross-edition coverage.
