### PR TITLE
feat: implement external authentication passthrough mode for Jira and…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,34 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # The external system (e.g., MCP Gateway) provides tokens per-request via headers.
 #ATLASSIAN_OAUTH_ENABLE=true
 
+# --- METHOD 7: EXTERNAL SESSION PASSTHROUGH (Advanced — proxy-managed auth) ---
+# Use this method when an upstream authentication proxy (e.g., an API gateway or
+# sidecar) injects session/auth headers into every request before they reach the MCP
+# server.  The MCP server forwards those headers verbatim to Jira/Confluence and adds
+# NO Authorization header of its own.
+#
+# Required environment variables:
+#   ATLASSIAN_EXTERNAL_AUTH_ENABLE=true   — activates the mode
+#   IGNORE_HEADER_AUTH=true               — prevents the MCP from trying to parse
+#                                           Authorization headers as user credentials
+#   JIRA_PASSTHROUGH_HEADERS=<name>       — comma-separated list of header names that
+#   CONFLUENCE_PASSTHROUGH_HEADERS=<name>   the proxy injects (e.g. Cookie, X-Auth-Token)
+#
+# URL configuration (choose one):
+#   a) Set JIRA_URL / CONFLUENCE_URL server-side as usual, OR
+#   b) Let the client supply the URL per-request via the
+#      X-Atlassian-Jira-Url / X-Atlassian-Confluence-Url headers
+#      (useful for multi-tenant / dynamic routing scenarios).
+#
+# Behaviour when no passthrough header is present on a request:
+#   The request is forwarded without an Authorization header; the upstream API
+#   will return 401, which is propagated back to the MCP client.
+#
+#ATLASSIAN_EXTERNAL_AUTH_ENABLE=true
+#IGNORE_HEADER_AUTH=true
+#JIRA_PASSTHROUGH_HEADERS=Cookie
+#CONFLUENCE_PASSTHROUGH_HEADERS=Cookie
+
 # =============================================
 # SERVER/DATA CENTER SPECIFIC SETTINGS
 # =============================================
@@ -149,6 +177,8 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # Set to 'true' to ignore Authorization headers from reverse proxies
 # (e.g., GCP Cloud Run, AWS ALB). When enabled, the server uses only
 # environment-configured credentials, ignoring any proxy-injected headers.
+# Also required when using ATLASSIAN_EXTERNAL_AUTH_ENABLE=true (external session
+# passthrough mode), where the proxy injects auth headers via PASSTHROUGH_HEADERS.
 #IGNORE_HEADER_AUTH=true
 
 # --- Logging Verbosity ---

--- a/.env.example
+++ b/.env.example
@@ -237,5 +237,11 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # Jira-specific custom headers.
 #JIRA_CUSTOM_HEADERS=X-Jira-Service=mcp-integration,X-Custom-Auth=jira-token,X-Forwarded-User=service-account
 
+# Jira-specific incoming MCP request header names to pass through.
+#JIRA_PASSTHROUGH_HEADERS=X-SSO-User,X-Request-ID
+
 # Confluence-specific custom headers.
 #CONFLUENCE_CUSTOM_HEADERS=X-Confluence-Service=mcp-integration,X-Custom-Auth=confluence-token,X-ALB-Token=secret-token
+
+# Confluence-specific incoming MCP request header names to pass through.
+#CONFLUENCE_PASSTHROUGH_HEADERS=X-SSO-User,X-Request-ID

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -182,13 +182,27 @@ Add custom HTTP headers to all API requests. Useful in corporate environments.
 |----------|-------------|
 | `JIRA_CUSTOM_HEADERS` | Custom headers for Jira requests |
 | `CONFLUENCE_CUSTOM_HEADERS` | Custom headers for Confluence requests |
+| `JIRA_PASSTHROUGH_HEADERS` | Incoming MCP request header names to pass through to Jira requests |
+| `CONFLUENCE_PASSTHROUGH_HEADERS` | Incoming MCP request header names to pass through to Confluence requests |
 
-**Format:** Comma-separated `key=value` pairs.
+**Format:** Static custom headers use comma-separated `key=value` pairs.
+Passthrough headers use comma-separated header names.
 
 ```bash
 JIRA_CUSTOM_HEADERS=X-Forwarded-User=service-account,X-Custom-Auth=token
 CONFLUENCE_CUSTOM_HEADERS=X-Service=mcp-integration,X-ALB-Token=secret
+
+# Header names only. Values are read from each incoming MCP HTTP request.
+JIRA_PASSTHROUGH_HEADERS=X-SSO-User,X-Request-ID
+CONFLUENCE_PASSTHROUGH_HEADERS=X-SSO-User,X-Request-ID
 ```
+
+Passthrough headers are request-scoped and only apply to HTTP transports. If a
+passthrough header name conflicts with a static custom header, the incoming
+request header value is used for that request.
+
+Only configure headers that are set by a trusted proxy or gateway. Clients can
+control any passthrough header they are allowed to send to the MCP endpoint.
 
 <Note>
 Header values are masked in debug logs for security.

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -10,12 +10,18 @@ data:
   {{- if .Values.confluence.spacesFilter }}
   confluence-spaces-filter: {{ .Values.confluence.spacesFilter | quote }}
   {{- end }}
+  {{- if .Values.confluence.passthroughHeaders }}
+  confluence-passthrough-headers: {{ .Values.confluence.passthroughHeaders | quote }}
+  {{- end }}
   {{- end }}
 
   {{- if .Values.jira.enabled }}
   jira-url: {{ .Values.jira.url | quote }}
   {{- if .Values.jira.projectsFilter }}
   jira-projects-filter: {{ .Values.jira.projectsFilter | quote }}
+  {{- end }}
+  {{- if .Values.jira.passthroughHeaders }}
+  jira-passthrough-headers: {{ .Values.jira.passthroughHeaders | quote }}
   {{- end }}
   {{- end }}
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -105,6 +105,13 @@ spec:
               name: {{ include "mcp-atlassian.fullname" . }}
               key: confluence-custom-headers
         {{- end }}
+        {{- if .Values.confluence.passthroughHeaders }}
+        - name: CONFLUENCE_PASSTHROUGH_HEADERS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "mcp-atlassian.fullname" . }}
+              key: confluence-passthrough-headers
+        {{- end }}
         {{- end }}
 
         # Jira Configuration
@@ -149,6 +156,13 @@ spec:
             secretKeyRef:
               name: {{ include "mcp-atlassian.fullname" . }}
               key: jira-custom-headers
+        {{- end }}
+        {{- if .Values.jira.passthroughHeaders }}
+        - name: JIRA_PASSTHROUGH_HEADERS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "mcp-atlassian.fullname" . }}
+              key: jira-passthrough-headers
         {{- end }}
         {{- end }}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -131,6 +131,9 @@ confluence:
   # Custom headers (comma-separated key=value pairs)
   customHeaders: ""
 
+  # Incoming MCP request header names to pass through (comma-separated)
+  passthroughHeaders: ""
+
 # Jira Configuration
 jira:
   enabled: true
@@ -153,6 +156,9 @@ jira:
 
   # Custom headers (comma-separated key=value pairs)
   customHeaders: ""
+
+  # Incoming MCP request header names to pass through (comma-separated)
+  passthroughHeaders: ""
 
 # OAuth 2.0 Configuration (Cloud only)
 # Required when authMode: oauth or byot

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -86,6 +86,22 @@ class ConfluenceClient:
                 verify_ssl=self.config.ssl_verify,
                 timeout=self.config.timeout,
             )
+        elif self.config.auth_type == "external":
+            logger.debug(
+                f"Initializing Confluence client in external auth passthrough mode. "
+                f"URL: {self.config.url}"
+            )
+            session = Session()
+            session.trust_env = False
+            self.confluence = Confluence(
+                url=self.config.url,
+                session=session,
+                cloud=self.config.is_cloud,
+                verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
+            )
+            # Ensure no Authorization header is carried over from defaults
+            self.confluence._session.headers.pop("Authorization", None)
         else:  # basic auth
             logger.debug(
                 f"Initializing Confluence client with Basic auth. "
@@ -151,7 +167,7 @@ class ConfluenceClient:
         self.preprocessor = ConfluencePreprocessor(base_url=self.config.url)
 
         # Test authentication during initialization (in debug mode only)
-        if logger.isEnabledFor(logging.DEBUG):
+        if logger.isEnabledFor(logging.DEBUG) and self.config.auth_type != "external":
             try:
                 self._validate_authentication()
             except MCPAtlassianAuthenticationError:

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import get_custom_headers, is_env_ssl_verify
+from ..utils.env import get_custom_headers, get_header_names, is_env_ssl_verify
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -36,6 +36,7 @@ class ConfluenceConfig:
     no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
     socks_proxy: str | None = None  # SOCKS proxy URL (optional)
     custom_headers: dict[str, str] | None = None  # Custom HTTP headers
+    passthrough_headers: list[str] | None = None  # Request headers to pass through
     client_cert: str | None = None  # Client certificate file path (.pem)
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
@@ -173,6 +174,7 @@ class ConfluenceConfig:
 
         # Custom headers - service-specific only
         custom_headers = get_custom_headers("CONFLUENCE_CUSTOM_HEADERS")
+        passthrough_headers = get_header_names("CONFLUENCE_PASSTHROUGH_HEADERS")
 
         # Client certificate settings
         client_cert = os.getenv("CONFLUENCE_CLIENT_CERT")
@@ -201,6 +203,7 @@ class ConfluenceConfig:
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
             custom_headers=custom_headers,
+            passthrough_headers=passthrough_headers,
             client_cert=client_cert,
             client_key=client_key,
             client_key_password=client_key_password,

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -5,7 +5,12 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import get_custom_headers, get_header_names, is_env_ssl_verify
+from ..utils.env import (
+    get_custom_headers,
+    get_header_names,
+    is_env_ssl_verify,
+    is_env_truthy,
+)
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -24,7 +29,7 @@ class ConfluenceConfig:
     """
 
     url: str  # Base URL for Confluence
-    auth_type: Literal["basic", "pat", "oauth"]  # Authentication type
+    auth_type: Literal["basic", "pat", "oauth", "external"]  # Authentication type
     username: str | None = None  # Email or username
     api_token: str | None = None  # API token used as password
     personal_token: str | None = None  # Personal access token (Server/DC)
@@ -91,7 +96,11 @@ class ConfluenceConfig:
             ValueError: If any required environment variable is missing
         """
         url = os.getenv("CONFLUENCE_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        if (
+            not url
+            and not os.getenv("ATLASSIAN_OAUTH_ENABLE")
+            and not is_env_truthy("ATLASSIAN_EXTERNAL_AUTH_ENABLE")
+        ):
             error_msg = (
                 "Missing required CONFLUENCE_URL environment variable. "
                 "Set CONFLUENCE_URL to your Confluence base URL, for example "
@@ -113,7 +122,16 @@ class ConfluenceConfig:
         # Use the shared utility function directly
         is_cloud = is_atlassian_cloud_url(url) if url else False
 
-        if is_cloud:
+        # External auth passthrough mode — no credentials needed
+        if (
+            is_env_truthy("ATLASSIAN_EXTERNAL_AUTH_ENABLE")
+            and not username
+            and not api_token
+            and not personal_token
+            and not oauth_config
+        ):
+            auth_type = "external"
+        elif is_cloud:
             # Cloud: OAuth takes priority, then basic auth
             if oauth_config:
                 auth_type = "oauth"
@@ -263,6 +281,8 @@ class ConfluenceConfig:
             return bool(self.personal_token)
         elif self.auth_type == "basic":
             return bool(self.username and self.api_token)
+        elif self.auth_type == "external":
+            return True
         logger.warning(
             f"Unknown or unsupported auth_type: {self.auth_type} in ConfluenceConfig"
         )

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -100,6 +100,22 @@ class JiraClient:
                 verify_ssl=self.config.ssl_verify,
                 timeout=self.config.timeout,
             )
+        elif self.config.auth_type == "external":
+            logger.debug(
+                f"Initializing Jira client in external auth passthrough mode. "
+                f"URL: {self.config.url}"
+            )
+            session = Session()
+            session.trust_env = False
+            self.jira = Jira(
+                url=self.config.url,
+                session=session,
+                cloud=self.config.is_cloud,
+                verify_ssl=self.config.ssl_verify,
+                timeout=self.config.timeout,
+            )
+            # Ensure no Authorization header is carried over from defaults
+            self.jira._session.headers.pop("Authorization", None)
         else:  # basic auth
             logger.debug(
                 f"Initializing Jira client with Basic auth. "
@@ -167,7 +183,7 @@ class JiraClient:
         self._current_user_account_id = None
 
         # Test authentication during initialization (in debug mode only)
-        if logger.isEnabledFor(logging.DEBUG):
+        if logger.isEnabledFor(logging.DEBUG) and self.config.auth_type != "external":
             try:
                 self._validate_authentication()
             except MCPAtlassianAuthenticationError:

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import get_custom_headers, is_env_ssl_verify
+from ..utils.env import get_custom_headers, get_header_names, is_env_ssl_verify
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -108,6 +108,7 @@ class JiraConfig:
     no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
     socks_proxy: str | None = None  # SOCKS proxy URL (optional)
     custom_headers: dict[str, str] | None = None  # Custom HTTP headers
+    passthrough_headers: list[str] | None = None  # Request headers to pass through
     disable_jira_markup_translation: bool = (
         False  # Disable automatic markup translation between formats
     )
@@ -246,6 +247,7 @@ class JiraConfig:
 
         # Custom headers - service-specific only
         custom_headers = get_custom_headers("JIRA_CUSTOM_HEADERS")
+        passthrough_headers = get_header_names("JIRA_PASSTHROUGH_HEADERS")
 
         # Markup translation setting
         disable_jira_markup_translation = (
@@ -276,6 +278,7 @@ class JiraConfig:
             no_proxy=no_proxy,
             socks_proxy=socks_proxy,
             custom_headers=custom_headers,
+            passthrough_headers=passthrough_headers,
             disable_jira_markup_translation=disable_jira_markup_translation,
             client_cert=client_cert,
             client_key=client_key,

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -5,7 +5,12 @@ import os
 from dataclasses import dataclass
 from typing import Literal
 
-from ..utils.env import get_custom_headers, get_header_names, is_env_ssl_verify
+from ..utils.env import (
+    get_custom_headers,
+    get_header_names,
+    is_env_ssl_verify,
+    is_env_truthy,
+)
 from ..utils.oauth import (
     BYOAccessTokenOAuthConfig,
     OAuthConfig,
@@ -96,7 +101,7 @@ class JiraConfig:
     """
 
     url: str  # Base URL for Jira
-    auth_type: Literal["basic", "pat", "oauth"]  # Authentication type
+    auth_type: Literal["basic", "pat", "oauth", "external"]  # Authentication type
     username: str | None = None  # Email or username (Cloud)
     api_token: str | None = None  # API token (Cloud)
     personal_token: str | None = None  # Personal access token (Server/DC)
@@ -167,7 +172,11 @@ class JiraConfig:
             ValueError: If required environment variables are missing or invalid
         """
         url = os.getenv("JIRA_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        if (
+            not url
+            and not os.getenv("ATLASSIAN_OAUTH_ENABLE")
+            and not is_env_truthy("ATLASSIAN_EXTERNAL_AUTH_ENABLE")
+        ):
             error_msg = (
                 "Missing required JIRA_URL environment variable. "
                 "Set JIRA_URL to your Jira base URL, for example "
@@ -187,7 +196,16 @@ class JiraConfig:
         # Use the shared utility function directly
         is_cloud = is_atlassian_cloud_url(url) if url else False
 
-        if is_cloud:
+        # External auth passthrough mode — no credentials needed
+        if (
+            is_env_truthy("ATLASSIAN_EXTERNAL_AUTH_ENABLE")
+            and not username
+            and not api_token
+            and not personal_token
+            and not oauth_config
+        ):
+            auth_type = "external"
+        elif is_cloud:
             # Cloud: OAuth takes priority, then basic auth
             if oauth_config:
                 auth_type = "oauth"
@@ -339,6 +357,8 @@ class JiraConfig:
             return bool(self.personal_token)
         elif self.auth_type == "basic":
             return bool(self.username and self.api_token)
+        elif self.auth_type == "external":
+            return True
         logger.warning(
             f"Unknown or unsupported auth_type: {self.auth_type} in JiraConfig"
         )

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -566,8 +566,9 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
     """
     fn_name = f"get_{spec.name.lower()}_fetcher"
     logger.debug(f"{fn_name}: ENTERED. Context ID: {id(ctx)}")
+    request: Request | None = None
     try:
-        request: Request = get_http_request()
+        request = get_http_request()
         logger.debug(
             f"{fn_name}: In HTTP request context. "
             f"Request URL: {request.url}. "
@@ -729,6 +730,34 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
             f"{global_config_fallback.auth_type}"
         )
         if request is not None:
+            # Per-request URL override for external auth mode when no URL is
+            # configured server-side (URL is supplied via request header instead).
+            if (
+                global_config_fallback.auth_type == "external"
+                and not global_config_fallback.url
+            ):
+                url_from_header = request.headers.get(spec.url_header)
+                if url_from_header:
+                    ssrf_error = validate_url_for_ssrf(url_from_header)
+                    if ssrf_error:
+                        error_msg = (
+                            f"Forbidden: Invalid {spec.name} URL - {ssrf_error}"
+                        )
+                        raise ValueError(error_msg)
+                    logger.debug(
+                        f"{fn_name}: Using per-request {spec.name} URL "
+                        f"from {spec.url_header} header: {url_from_header}"
+                    )
+                    global_config_fallback = dataclasses.replace(
+                        global_config_fallback, url=url_from_header
+                    )
+                else:
+                    error_msg = (
+                        f"{spec.name} URL is not configured. "
+                        f"Set {spec.url_header} header or configure the "
+                        f"{spec.name.upper()}_URL environment variable."
+                    )
+                    raise ValueError(error_msg)
             global_config_fallback = _with_request_passthrough_headers(
                 request, spec, global_config_fallback
             )

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -17,6 +17,7 @@ from starlette.requests import Request
 from mcp_atlassian.confluence import ConfluenceConfig, ConfluenceFetcher
 from mcp_atlassian.jira import JiraConfig, JiraFetcher
 from mcp_atlassian.servers.context import MainAppContext
+from mcp_atlassian.utils.env import get_header_names
 from mcp_atlassian.utils.oauth import OAuthConfig
 from mcp_atlassian.utils.urls import validate_url_for_ssrf
 
@@ -45,6 +46,7 @@ class _ServiceSpec:
     config_attr: str  # MainAppContext attribute for global config
     url_header: str  # X-Atlassian-{Service}-Url
     token_header: str  # X-Atlassian-{Service}-Personal-Token
+    passthrough_env_var: str  # {SERVICE}_PASSTHROUGH_HEADERS
     filter_kwargs: dict[str, Any]  # e.g. {"projects_filter": None}
     get_session: Callable[[Any], Any]  # fetcher → session
     validate_fn: Callable[[Any], Any]  # fetcher → validation data
@@ -136,6 +138,7 @@ def _jira_spec() -> _ServiceSpec:
         config_attr="full_jira_config",
         url_header="X-Atlassian-Jira-Url",
         token_header="X-Atlassian-Jira-Personal-Token",  # noqa: S106
+        passthrough_env_var="JIRA_PASSTHROUGH_HEADERS",
         filter_kwargs={"projects_filter": None},
         get_session=lambda f: f.jira._session,
         validate_fn=lambda f: f.get_current_user_account_id(),
@@ -157,6 +160,7 @@ def _confluence_spec() -> _ServiceSpec:
         config_attr="full_confluence_config",
         url_header="X-Atlassian-Confluence-Url",
         token_header="X-Atlassian-Confluence-Personal-Token",  # noqa: S106
+        passthrough_env_var="CONFLUENCE_PASSTHROUGH_HEADERS",
         filter_kwargs={"spaces_filter": None},
         get_session=lambda f: f.confluence._session,
         validate_fn=lambda f: f.get_current_user_info(),
@@ -197,6 +201,61 @@ def _get_global_config(
     return config
 
 
+def _get_passthrough_header_names(config: Any, spec: _ServiceSpec) -> list[str]:
+    configured_names = getattr(config, "passthrough_headers", None)
+    if configured_names is not None:
+        return configured_names
+    return get_header_names(spec.passthrough_env_var)
+
+
+def _get_request_passthrough_headers(
+    request: Request, spec: _ServiceSpec, config: Any
+) -> dict[str, str]:
+    request_headers = getattr(request, "headers", None)
+    if request_headers is None:
+        return {}
+
+    passthrough_headers: dict[str, str] = {}
+    for header_name in _get_passthrough_header_names(config, spec):
+        header_value = request_headers.get(header_name)
+        if header_value is not None:
+            passthrough_headers[header_name] = header_value
+
+    if passthrough_headers:
+        logger.debug(
+            "Forwarding %d passthrough headers to %s: %s",
+            len(passthrough_headers),
+            spec.name,
+            list(passthrough_headers.keys()),
+        )
+    return passthrough_headers
+
+
+def _merge_passthrough_headers(
+    custom_headers: dict[str, str] | None, passthrough_headers: dict[str, str]
+) -> dict[str, str]:
+    merged_headers = dict(custom_headers or {})
+    passthrough_names = {name.lower() for name in passthrough_headers}
+    for header_name in list(merged_headers):
+        if header_name.lower() in passthrough_names:
+            del merged_headers[header_name]
+    merged_headers.update(passthrough_headers)
+    return merged_headers
+
+
+def _with_request_passthrough_headers(
+    request: Request, spec: _ServiceSpec, config: Any
+) -> Any:
+    passthrough_headers = _get_request_passthrough_headers(request, spec, config)
+    if not passthrough_headers:
+        return config
+
+    custom_headers = _merge_passthrough_headers(
+        getattr(config, "custom_headers", None), passthrough_headers
+    )
+    return dataclasses.replace(config, custom_headers=custom_headers)
+
+
 def _create_and_validate(
     request: Request,
     spec: _ServiceSpec,
@@ -225,6 +284,7 @@ def _create_and_validate(
     fn_name = f"get_{spec.name.lower()}_fetcher"
     auth_desc = "header-based" if auth_branch == "header_pat" else "user"
     try:
+        config = _with_request_passthrough_headers(request, spec, config)
         fetcher = spec.fetcher_class(config=config)
         if attach_ssrf_hook:
             session = spec.get_session(fetcher)
@@ -551,6 +611,7 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
                 no_proxy=None,
                 socks_proxy=None,
                 custom_headers=None,
+                passthrough_headers=get_header_names(spec.passthrough_env_var),
                 **spec.filter_kwargs,
             )
             return _create_and_validate(
@@ -667,6 +728,10 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
             f"Global config auth_type: "
             f"{global_config_fallback.auth_type}"
         )
+        if request is not None:
+            global_config_fallback = _with_request_passthrough_headers(
+                request, spec, global_config_fallback
+            )
         return spec.fetcher_class(config=global_config_fallback)
 
     logger.error(f"{spec.name} configuration could not be resolved.")

--- a/src/mcp_atlassian/utils/env.py
+++ b/src/mcp_atlassian/utils/env.py
@@ -91,3 +91,33 @@ def get_custom_headers(env_var_name: str) -> dict[str, str]:
             headers[key] = value
 
     return headers
+
+
+def get_header_names(env_var_name: str) -> list[str]:
+    """Parse comma-separated HTTP header names from an environment variable.
+
+    Args:
+        env_var_name: Name of the environment variable to read.
+
+    Returns:
+        List of parsed header names, preserving the first configured casing.
+    """
+    header_string = os.getenv(env_var_name)
+    if not header_string or not header_string.strip():
+        return []
+
+    header_names: list[str] = []
+    seen_names: set[str] = set()
+    for raw_name in header_string.split(","):
+        header_name = raw_name.strip()
+        if not header_name:
+            continue
+
+        normalized_name = header_name.lower()
+        if normalized_name in seen_names:
+            continue
+
+        seen_names.add(normalized_name)
+        header_names.append(header_name)
+
+    return header_names

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -3,6 +3,7 @@
 import logging
 import os
 
+from .env import is_env_truthy
 from .urls import is_atlassian_cloud_url
 
 logger = logging.getLogger("mcp-atlassian.utils.environment")
@@ -120,6 +121,13 @@ def get_available_services(
             "- expecting user-provided tokens via headers"
         )
 
+    if not confluence_is_setup and is_env_truthy("ATLASSIAN_EXTERNAL_AUTH_ENABLE"):
+        confluence_is_setup = True
+        logger.info(
+            "Using Confluence external auth passthrough mode "
+            "- auth headers injected by upstream proxy"
+        )
+
     if not confluence_is_setup:
         confluence_token = headers.get("X-Atlassian-Confluence-Personal-Token")
         confluence_url_header = headers.get("X-Atlassian-Confluence-Url")
@@ -157,6 +165,13 @@ def get_available_services(
         logger.info(
             "Using Jira minimal OAuth configuration "
             "- expecting user-provided tokens via headers"
+        )
+
+    if not jira_is_setup and is_env_truthy("ATLASSIAN_EXTERNAL_AUTH_ENABLE"):
+        jira_is_setup = True
+        logger.info(
+            "Using Jira external auth passthrough mode "
+            "- auth headers injected by upstream proxy"
         )
 
     if not jira_is_setup:

--- a/tests/unit/confluence/test_custom_headers.py
+++ b/tests/unit/confluence/test_custom_headers.py
@@ -74,6 +74,21 @@ class TestConfluenceConfigCustomHeaders:
             config = ConfluenceConfig.from_env()
             assert config.custom_headers == {}
 
+    def test_passthrough_headers(self):
+        """Test ConfluenceConfig parsing of passthrough header names."""
+        with patch.dict(
+            os.environ,
+            {
+                "CONFLUENCE_URL": "https://test.atlassian.net/wiki",
+                "CONFLUENCE_USERNAME": "test_user",
+                "CONFLUENCE_API_TOKEN": "test_token",
+                "CONFLUENCE_PASSTHROUGH_HEADERS": "X-SSO-User, X-Request-ID,x-sso-user",
+            },
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            assert config.passthrough_headers == ["X-SSO-User", "X-Request-ID"]
+
 
 class TestConfluenceClientCustomHeaders:
     """Test ConfluenceClient custom headers application."""

--- a/tests/unit/jira/test_custom_headers.py
+++ b/tests/unit/jira/test_custom_headers.py
@@ -71,6 +71,21 @@ class TestJiraConfigCustomHeaders:
             config = JiraConfig.from_env()
             assert config.custom_headers == {}
 
+    def test_passthrough_headers(self):
+        """Test JiraConfig parsing of passthrough header names."""
+        with patch.dict(
+            os.environ,
+            {
+                "JIRA_URL": "https://test.atlassian.net",
+                "JIRA_USERNAME": "test_user",
+                "JIRA_API_TOKEN": "test_token",
+                "JIRA_PASSTHROUGH_HEADERS": "X-SSO-User, X-Request-ID,x-sso-user",
+            },
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            assert config.passthrough_headers == ["X-SSO-User", "X-Request-ID"]
+
 
 class TestJiraClientCustomHeaders:
     """Test JiraClient custom headers application."""

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from starlette.datastructures import Headers
 
 from mcp_atlassian.confluence import ConfluenceConfig, ConfluenceFetcher
 from mcp_atlassian.jira import JiraConfig, JiraFetcher
@@ -586,6 +587,49 @@ class TestGetJiraFetcher:
         elif scenario["auth_type"] == "pat":
             assert called_config.personal_token == scenario["token"]
 
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
+    async def test_user_specific_jira_passthrough_headers_override_static_headers(
+        self,
+        mock_jira_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+        auth_scenarios,
+    ):
+        """Passthrough headers are merged into user-specific Jira configs."""
+        scenario = auth_scenarios["pat"]
+        _setup_mock_request_state(mock_request, scenario)
+        mock_request.headers = Headers(
+            {
+                "x-sso-user": "incoming-user",
+                "x-request-id": "request-123",
+            }
+        )
+        mock_get_http_request.return_value = mock_request
+
+        jira_config = config_factory.create_jira_config(
+            auth_type="pat",
+            custom_headers={"X-SSO-User": "static-user", "X-Static": "keep"},
+            passthrough_headers=["X-SSO-User", "X-Request-ID", "X-Missing"],
+        )
+        app_context = config_factory.create_app_context(jira_config=jira_config)
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(JiraFetcher)
+        mock_jira_fetcher_class.return_value = mock_fetcher
+
+        result = await get_jira_fetcher(mock_context)
+
+        assert result == mock_fetcher
+        called_config = mock_jira_fetcher_class.call_args[1]["config"]
+        assert called_config.custom_headers == {
+            "X-Static": "keep",
+            "X-SSO-User": "incoming-user",
+            "X-Request-ID": "request-123",
+        }
+
     @patch("mcp_atlassian.servers.dependencies.get_access_token")
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
@@ -734,6 +778,40 @@ class TestGetJiraFetcher:
             mock_jira_fetcher_class.reset_mock()
             mock_get_http_request.reset_mock()
 
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
+    async def test_global_jira_passthrough_headers(
+        self,
+        mock_jira_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ):
+        """Global Jira fallback applies passthrough headers in HTTP requests."""
+        _setup_mock_request_state(mock_request)
+        mock_request.headers = Headers({"x-sso-user": "global-user"})
+        mock_get_http_request.return_value = mock_request
+
+        jira_config = config_factory.create_jira_config(
+            custom_headers={"X-Static": "keep"},
+            passthrough_headers=["X-SSO-User"],
+        )
+        app_context = config_factory.create_app_context(jira_config=jira_config)
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(JiraFetcher)
+        mock_jira_fetcher_class.return_value = mock_fetcher
+
+        result = await get_jira_fetcher(mock_context)
+
+        assert result == mock_fetcher
+        called_config = mock_jira_fetcher_class.call_args[1]["config"]
+        assert called_config.custom_headers == {
+            "X-Static": "keep",
+            "X-SSO-User": "global-user",
+        }
+
     @pytest.mark.parametrize(
         "error_scenario,expected_error_match",
         [
@@ -867,6 +945,51 @@ class TestGetConfluenceFetcher:
         assert called_config.auth_type == "pat"
         assert called_config.url == "https://test.atlassian.net"
         assert called_config.personal_token == "test-confluence-pat-token"
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_header_based_confluence_passthrough_headers_without_global_config(
+        self,
+        mock_confluence_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        monkeypatch,
+    ):
+        """Header-based Confluence auth can use passthrough without global config."""
+        monkeypatch.setenv("CONFLUENCE_PASSTHROUGH_HEADERS", "X-SSO-User, X-Request-ID")
+        service_headers = {
+            "X-Atlassian-Confluence-Url": "https://test.atlassian.net",
+            "X-Atlassian-Confluence-Personal-Token": "test-confluence-pat-token",
+        }
+
+        class MockState:
+            def __init__(self):
+                self.confluence_fetcher = None
+                self.user_atlassian_auth_type = "pat"
+                self.user_atlassian_email = None
+                self.atlassian_service_headers = service_headers
+
+            def __getattr__(self, name):
+                if name == "user_atlassian_token":
+                    raise AttributeError(
+                        f"'{type(self).__name__}' object has no attribute '{name}'"
+                    )
+                return None
+
+        mock_request.state = MockState()
+        mock_request.headers = Headers({"x-sso-user": "header-user"})
+        mock_get_http_request.return_value = mock_request
+        mock_context.request_context.lifespan_context = {}
+
+        mock_fetcher = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.return_value = mock_fetcher
+
+        result = await get_confluence_fetcher(mock_context)
+
+        assert result == mock_fetcher
+        called_config = mock_confluence_fetcher_class.call_args[1]["config"]
+        assert called_config.custom_headers == {"X-SSO-User": "header-user"}
 
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")

--- a/tests/unit/test_external_auth.py
+++ b/tests/unit/test_external_auth.py
@@ -1,0 +1,480 @@
+"""Tests for external auth passthrough mode (ATLASSIAN_EXTERNAL_AUTH_ENABLE)."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.datastructures import Headers
+
+from mcp_atlassian.confluence.client import ConfluenceClient
+from mcp_atlassian.confluence.config import ConfluenceConfig
+from mcp_atlassian.jira.client import JiraClient
+from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.utils.environment import get_available_services
+
+pytestmark = pytest.mark.anyio
+
+# ---------------------------------------------------------------------------
+# Config tests — JiraConfig
+# ---------------------------------------------------------------------------
+
+
+class TestJiraConfigExternalAuth:
+    def test_from_env_with_url_creates_external_auth_type(self):
+        """from_env() produces auth_type='external' when flag is set and no creds."""
+        with patch.dict(
+            os.environ,
+            {
+                "ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true",
+                "JIRA_URL": "https://jira.example.com",
+            },
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            assert config.auth_type == "external"
+            assert config.url == "https://jira.example.com"
+            assert config.username is None
+            assert config.api_token is None
+            assert config.personal_token is None
+            assert config.oauth_config is None
+
+    def test_from_env_without_url_creates_external_auth_type(self):
+        """from_env() allows missing JIRA_URL when ATLASSIAN_EXTERNAL_AUTH_ENABLE=true."""
+        with patch.dict(
+            os.environ,
+            {"ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true"},
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            assert config.auth_type == "external"
+            assert config.url == ""
+
+    def test_is_auth_configured_returns_true_for_external(self):
+        """is_auth_configured() returns True for external auth type."""
+        config = JiraConfig(url="https://jira.example.com", auth_type="external")
+        assert config.is_auth_configured() is True
+
+    def test_external_auth_ignored_when_credentials_present(self):
+        """Explicit credentials take precedence over ATLASSIAN_EXTERNAL_AUTH_ENABLE."""
+        with patch.dict(
+            os.environ,
+            {
+                "ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true",
+                "JIRA_URL": "https://jira.example.com",
+                "JIRA_PERSONAL_TOKEN": "mytoken",
+            },
+            clear=True,
+        ):
+            config = JiraConfig.from_env()
+            # PAT is present → should use PAT, not external
+            assert config.auth_type == "pat"
+            assert config.personal_token == "mytoken"
+
+    def test_is_cloud_with_external_auth_and_cloud_url(self):
+        """is_cloud is True when URL is a cloud URL, even with external auth."""
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="external",
+        )
+        assert config.is_cloud is True
+
+    def test_is_cloud_with_external_auth_and_server_url(self):
+        """is_cloud is False when URL is a server URL with external auth."""
+        config = JiraConfig(
+            url="https://jira.example.com",
+            auth_type="external",
+        )
+        assert config.is_cloud is False
+
+    def test_is_cloud_with_external_auth_and_no_url(self):
+        """is_cloud defaults to False when URL is empty with external auth."""
+        config = JiraConfig(url="", auth_type="external")
+        assert config.is_cloud is False
+
+
+# ---------------------------------------------------------------------------
+# Config tests — ConfluenceConfig
+# ---------------------------------------------------------------------------
+
+
+class TestConfluenceConfigExternalAuth:
+    def test_from_env_with_url_creates_external_auth_type(self):
+        """from_env() produces auth_type='external' when flag is set and no creds."""
+        with patch.dict(
+            os.environ,
+            {
+                "ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true",
+                "CONFLUENCE_URL": "https://confluence.example.com",
+            },
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            assert config.auth_type == "external"
+            assert config.url == "https://confluence.example.com"
+            assert config.username is None
+            assert config.api_token is None
+            assert config.personal_token is None
+            assert config.oauth_config is None
+
+    def test_from_env_without_url_creates_external_auth_type(self):
+        """from_env() allows missing CONFLUENCE_URL when external auth is enabled."""
+        with patch.dict(
+            os.environ,
+            {"ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true"},
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            assert config.auth_type == "external"
+            assert config.url == ""
+
+    def test_is_auth_configured_returns_true_for_external(self):
+        """is_auth_configured() returns True for external auth type."""
+        config = ConfluenceConfig(
+            url="https://confluence.example.com", auth_type="external"
+        )
+        assert config.is_auth_configured() is True
+
+    def test_external_auth_ignored_when_credentials_present(self):
+        """Explicit credentials take precedence over ATLASSIAN_EXTERNAL_AUTH_ENABLE."""
+        with patch.dict(
+            os.environ,
+            {
+                "ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true",
+                "CONFLUENCE_URL": "https://confluence.example.com",
+                "CONFLUENCE_PERSONAL_TOKEN": "mytoken",
+            },
+            clear=True,
+        ):
+            config = ConfluenceConfig.from_env()
+            assert config.auth_type == "pat"
+            assert config.personal_token == "mytoken"
+
+
+# ---------------------------------------------------------------------------
+# Client tests — JiraClient
+# ---------------------------------------------------------------------------
+
+
+class TestJiraClientExternalAuth:
+    def test_init_external_auth_no_authorization_header(self):
+        """JiraClient with external auth does not set an Authorization header."""
+        with (
+            patch("mcp_atlassian.jira.client.Jira") as mock_jira_cls,
+            patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+        ):
+            mock_session = MagicMock()
+            mock_session.headers = {}
+            mock_jira_instance = MagicMock()
+            mock_jira_instance._session = mock_session
+            mock_jira_cls.return_value = mock_jira_instance
+
+            config = JiraConfig(
+                url="https://jira.example.com",
+                auth_type="external",
+            )
+            JiraClient(config=config)
+
+            # Jira should be instantiated with a session but no credential kwargs
+            call_kwargs = mock_jira_cls.call_args.kwargs
+            assert "username" not in call_kwargs
+            assert "password" not in call_kwargs
+            assert "token" not in call_kwargs
+            # Authorization header should be removed
+            assert "Authorization" not in mock_session.headers
+
+    def test_init_external_auth_skips_validation(self):
+        """JiraClient with external auth skips _validate_authentication."""
+        with (
+            patch("mcp_atlassian.jira.client.Jira") as mock_jira_cls,
+            patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+            patch("logging.Logger.isEnabledFor", return_value=True),
+        ):
+            mock_session = MagicMock()
+            mock_session.headers = {}
+            mock_jira_instance = MagicMock()
+            mock_jira_instance._session = mock_session
+            mock_jira_cls.return_value = mock_jira_instance
+
+            config = JiraConfig(
+                url="https://jira.example.com",
+                auth_type="external",
+            )
+            with patch.object(
+                JiraClient, "_validate_authentication"
+            ) as mock_validate:
+                JiraClient(config=config)
+                mock_validate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Client tests — ConfluenceClient
+# ---------------------------------------------------------------------------
+
+
+class TestConfluenceClientExternalAuth:
+    def test_init_external_auth_no_authorization_header(self):
+        """ConfluenceClient with external auth does not set an Authorization header."""
+        with (
+            patch("mcp_atlassian.confluence.client.Confluence") as mock_conf_cls,
+            patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+        ):
+            mock_session = MagicMock()
+            mock_session.headers = {}
+            mock_conf_instance = MagicMock()
+            mock_conf_instance._session = mock_session
+            mock_conf_cls.return_value = mock_conf_instance
+
+            config = ConfluenceConfig(
+                url="https://confluence.example.com",
+                auth_type="external",
+            )
+            ConfluenceClient(config=config)
+
+            call_kwargs = mock_conf_cls.call_args.kwargs
+            assert "username" not in call_kwargs
+            assert "password" not in call_kwargs
+            assert "token" not in call_kwargs
+            assert "Authorization" not in mock_session.headers
+
+    def test_init_external_auth_skips_validation(self):
+        """ConfluenceClient with external auth skips _validate_authentication."""
+        with (
+            patch("mcp_atlassian.confluence.client.Confluence") as mock_conf_cls,
+            patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+            patch("logging.Logger.isEnabledFor", return_value=True),
+        ):
+            mock_session = MagicMock()
+            mock_session.headers = {}
+            mock_conf_instance = MagicMock()
+            mock_conf_instance._session = mock_session
+            mock_conf_cls.return_value = mock_conf_instance
+
+            config = ConfluenceConfig(
+                url="https://confluence.example.com",
+                auth_type="external",
+            )
+            with patch.object(
+                ConfluenceClient, "_validate_authentication"
+            ) as mock_validate:
+                ConfluenceClient(config=config)
+                mock_validate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_available_services
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableServicesExternalAuth:
+    def test_both_services_available_with_only_flag(self):
+        """Both services are available when ATLASSIAN_EXTERNAL_AUTH_ENABLE=true."""
+        with patch.dict(
+            os.environ,
+            {"ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true"},
+            clear=True,
+        ):
+            result = get_available_services()
+            assert result["jira"] is True
+            assert result["confluence"] is True
+
+    def test_flag_with_urls_marks_services_available(self):
+        """Services with URLs and external-auth flag are reported as available."""
+        with patch.dict(
+            os.environ,
+            {
+                "ATLASSIAN_EXTERNAL_AUTH_ENABLE": "true",
+                "JIRA_URL": "https://jira.example.com",
+                "CONFLUENCE_URL": "https://confluence.example.com",
+            },
+            clear=True,
+        ):
+            result = get_available_services()
+            assert result["jira"] is True
+            assert result["confluence"] is True
+
+    def test_flag_absent_services_not_available(self):
+        """Without the flag and without credentials, services are not available."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = get_available_services()
+            assert result["jira"] is False
+            assert result["confluence"] is False
+
+
+# ---------------------------------------------------------------------------
+# _get_fetcher — global fallback with external auth
+# ---------------------------------------------------------------------------
+
+
+class TestGetFetcherExternalAuth:
+    """Tests for the global-fallback path in _get_fetcher with external auth."""
+
+    def _make_request(
+        self,
+        headers: dict[str, str] | None = None,
+        state_overrides: dict[str, Any] | None = None,
+    ) -> MagicMock:
+        """Build a minimal mock Starlette request."""
+        request = MagicMock()
+        raw_headers = {k.lower(): v for k, v in (headers or {}).items()}
+        # Starlette Headers are case-insensitive; mimic with a dict subclass
+        request.headers = Headers(raw=[(k.encode(), v.encode()) for k, v in raw_headers.items()])
+        # Use SimpleNamespace so unset attributes raise AttributeError,
+        # making getattr(..., None) return None instead of a truthy MagicMock.
+        state = SimpleNamespace(
+            user_atlassian_auth_type=None,
+            atlassian_service_headers={},
+            user_atlassian_email=None,
+            user_atlassian_cloud_id=None,
+            auth_validation_error=None,
+        )
+        for key, val in (state_overrides or {}).items():
+            setattr(state, key, val)
+        request.state = state
+        return request
+
+    def _make_context(self, jira_config: JiraConfig) -> MagicMock:
+        """Build a minimal mock FastMCP context with a MainAppContext."""
+        from mcp_atlassian.servers.context import MainAppContext
+
+        app_ctx = MainAppContext(
+            full_jira_config=jira_config,
+            full_confluence_config=None,
+            read_only=False,
+            enabled_tools=None,
+            enabled_toolsets=set(),
+        )
+        ctx = MagicMock()
+        ctx.request_context.lifespan_context = {"app_lifespan_context": app_ctx}
+        return ctx
+
+    async def test_url_from_header_used_when_config_url_empty(self):
+        """Per-request Jira URL header is applied when config.url is empty."""
+        from mcp_atlassian.servers.dependencies import get_jira_fetcher
+
+        base_config = JiraConfig(url="", auth_type="external")
+        ctx = self._make_context(base_config)
+        request = self._make_request(
+            headers={"X-Atlassian-Jira-Url": "https://jira.example.com"}
+        )
+
+        with (
+            patch(
+                "mcp_atlassian.servers.dependencies.get_http_request",
+                return_value=request,
+            ),
+            patch(
+                "mcp_atlassian.servers.dependencies.validate_url_for_ssrf",
+                return_value=None,  # no SSRF issue
+            ),
+            patch(
+                "mcp_atlassian.servers.dependencies.JiraFetcher"
+            ) as mock_fetcher_cls,
+        ):
+            mock_fetcher_cls.return_value = MagicMock()
+            await get_jira_fetcher(ctx)
+
+            called_config = mock_fetcher_cls.call_args.kwargs["config"]
+            assert called_config.url == "https://jira.example.com"
+            assert called_config.auth_type == "external"
+
+    async def test_url_from_env_used_when_config_url_set(self):
+        """When config URL is already set, no header override occurs."""
+        from mcp_atlassian.servers.dependencies import get_jira_fetcher
+
+        base_config = JiraConfig(url="https://jira.company.com", auth_type="external")
+        ctx = self._make_context(base_config)
+        request = self._make_request(
+            # Header present but should NOT override env-configured URL
+            headers={"X-Atlassian-Jira-Url": "https://other.example.com"}
+        )
+
+        with (
+            patch(
+                "mcp_atlassian.servers.dependencies.get_http_request",
+                return_value=request,
+            ),
+            patch(
+                "mcp_atlassian.servers.dependencies.validate_url_for_ssrf",
+                return_value=None,
+            ),
+            patch(
+                "mcp_atlassian.servers.dependencies.JiraFetcher"
+            ) as mock_fetcher_cls,
+        ):
+            mock_fetcher_cls.return_value = MagicMock()
+            await get_jira_fetcher(ctx)
+
+            called_config = mock_fetcher_cls.call_args.kwargs["config"]
+            assert called_config.url == "https://jira.company.com"
+
+    async def test_missing_url_header_raises_value_error(self):
+        """ValueError raised when external auth has no URL from env or header."""
+        from mcp_atlassian.servers.dependencies import get_jira_fetcher
+
+        base_config = JiraConfig(url="", auth_type="external")
+        ctx = self._make_context(base_config)
+        request = self._make_request()  # no URL header
+
+        with (
+            patch(
+                "mcp_atlassian.servers.dependencies.get_http_request",
+                return_value=request,
+            ),
+        ):
+            with pytest.raises(ValueError, match="Jira URL is not configured"):
+                await get_jira_fetcher(ctx)
+
+    async def test_passthrough_header_forwarded_to_fetcher(self):
+        """Passthrough headers are merged into the config for external auth."""
+        from mcp_atlassian.servers.dependencies import get_jira_fetcher
+
+        base_config = JiraConfig(
+            url="https://jira.example.com",
+            auth_type="external",
+            passthrough_headers=["Cookie"],
+        )
+        ctx = self._make_context(base_config)
+        request = self._make_request(headers={"Cookie": "session=abc123"})
+
+        with (
+            patch(
+                "mcp_atlassian.servers.dependencies.get_http_request",
+                return_value=request,
+            ),
+            patch(
+                "mcp_atlassian.servers.dependencies.validate_url_for_ssrf",
+                return_value=None,
+            ),
+            patch(
+                "mcp_atlassian.servers.dependencies.JiraFetcher"
+            ) as mock_fetcher_cls,
+        ):
+            mock_fetcher_cls.return_value = MagicMock()
+            await get_jira_fetcher(ctx)
+
+            called_config = mock_fetcher_cls.call_args.kwargs["config"]
+            assert called_config.custom_headers is not None
+            assert called_config.custom_headers.get("Cookie") == "session=abc123"
+
+    async def test_ssrf_blocked_url_raises_value_error(self):
+        """A private/SSRF URL supplied via header is rejected."""
+        from mcp_atlassian.servers.dependencies import get_jira_fetcher
+
+        base_config = JiraConfig(url="", auth_type="external")
+        ctx = self._make_context(base_config)
+        request = self._make_request(
+            headers={"X-Atlassian-Jira-Url": "http://169.254.169.254/latest/meta-data"}
+        )
+
+        with (
+            patch(
+                "mcp_atlassian.servers.dependencies.get_http_request",
+                return_value=request,
+            ),
+        ):
+            with pytest.raises(ValueError, match="Forbidden"):
+                await get_jira_fetcher(ctx)

--- a/tests/unit/utils/test_custom_headers.py
+++ b/tests/unit/utils/test_custom_headers.py
@@ -1,6 +1,6 @@
 """Tests for custom headers parsing functionality."""
 
-from mcp_atlassian.utils.env import get_custom_headers
+from mcp_atlassian.utils.env import get_custom_headers, get_header_names
 
 
 class TestParseCustomHeaders:
@@ -173,3 +173,52 @@ class TestParseCustomHeaders:
         result = get_custom_headers("TEST_HEADERS")
         expected = {"X-Multi": "line1\nline2", "X-Tab": "value\twith\ttabs"}
         assert result == expected
+
+
+class TestParseHeaderNames:
+    """Test the get_header_names function."""
+
+    def test_empty_input(self, monkeypatch):
+        """Test header name parsing with empty inputs."""
+        monkeypatch.delenv("TEST_HEADER_NAMES", raising=False)
+        assert get_header_names("TEST_HEADER_NAMES") == []
+
+        monkeypatch.setenv("TEST_HEADER_NAMES", "")
+        assert get_header_names("TEST_HEADER_NAMES") == []
+
+        monkeypatch.setenv("TEST_HEADER_NAMES", "   ")
+        assert get_header_names("TEST_HEADER_NAMES") == []
+
+    def test_single_header_name(self, monkeypatch):
+        """Test parsing a single header name."""
+        monkeypatch.setenv("TEST_HEADER_NAMES", "X-SSO-User")
+        assert get_header_names("TEST_HEADER_NAMES") == ["X-SSO-User"]
+
+    def test_multiple_header_names(self, monkeypatch):
+        """Test parsing comma-separated header names."""
+        monkeypatch.setenv("TEST_HEADER_NAMES", "X-SSO-User,X-Request-ID")
+        assert get_header_names("TEST_HEADER_NAMES") == [
+            "X-SSO-User",
+            "X-Request-ID",
+        ]
+
+    def test_header_names_with_spaces(self, monkeypatch):
+        """Test parsing comma-separated header names with whitespace."""
+        monkeypatch.setenv("TEST_HEADER_NAMES", " X-SSO-User, X-Request-ID ")
+        assert get_header_names("TEST_HEADER_NAMES") == [
+            "X-SSO-User",
+            "X-Request-ID",
+        ]
+
+    def test_empty_entries_are_skipped(self, monkeypatch):
+        """Test that empty entries are ignored."""
+        monkeypatch.setenv("TEST_HEADER_NAMES", "X-First,, X-Second, ")
+        assert get_header_names("TEST_HEADER_NAMES") == ["X-First", "X-Second"]
+
+    def test_duplicate_names_are_deduplicated_case_insensitively(self, monkeypatch):
+        """Test duplicate header names preserve first configured casing."""
+        monkeypatch.setenv("TEST_HEADER_NAMES", "X-SSO-User,x-sso-user,X-Trace")
+        assert get_header_names("TEST_HEADER_NAMES") == [
+            "X-SSO-User",
+            "X-Trace",
+        ]


### PR DESCRIPTION
## Description

This PR adds proxy-managed Atlassian authentication support for Jira and Confluence. It allows trusted upstream gateways to inject session/auth headers that the MCP server forwards per request, and adds an external auth mode so the server can operate without storing Atlassian credentials.

Fixes: #

## Changes

- add `JIRA_PASSTHROUGH_HEADERS` and `CONFLUENCE_PASSTHROUGH_HEADERS` support so selected incoming MCP request headers are forwarded to outgoing Jira and Confluence API calls
- add external session passthrough auth mode behind `ATLASSIAN_EXTERNAL_AUTH_ENABLE`, including no local Authorization header injection, no credential requirement, and per-request service URL support for proxy-managed deployments
- add unit coverage for passthrough header parsing and external auth behavior, and update operator-facing configuration/examples for the new auth flow

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `deployed and tested on our infrastructure`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).