### PR TITLE
feat(jira): add update_version tool

### DIFF
--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -463,3 +463,42 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
             release_date=release_date,
             description=description,
         )
+
+    def update_project_version(
+        self,
+        version_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        is_released: bool | None = None,
+        is_archived: bool | None = None,
+        start_date: str | None = None,
+        release_date: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Update an existing version in a Jira project.
+
+        Any argument left as ``None`` is omitted from the PUT payload, so the
+        corresponding field on the version is left unchanged.
+
+        Args:
+            version_id: The numeric id of the version to update (e.g., '11819').
+            name: New version name (optional).
+            description: New version description (optional).
+            is_released: Mark version as released (True) / un-released (False).
+            is_archived: Mark version as archived (True) / un-archived (False).
+            start_date: New start date (YYYY-MM-DD, optional).
+            release_date: New release date (YYYY-MM-DD, optional).
+
+        Returns:
+            The updated version object as returned by Jira.
+        """
+        result = self.jira.update_version(
+            version=version_id,
+            name=name,
+            description=description,
+            is_archived=is_archived,
+            is_released=is_released,
+            start_date=start_date,
+            release_date=release_date,
+        )
+        return result if isinstance(result, dict) else {}

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2677,6 +2677,93 @@ async def create_version(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_projects"},
+    annotations={"title": "Update Version", "destructiveHint": True},
+)
+@check_write_access
+async def update_version(
+    ctx: Context,
+    version_id: Annotated[
+        str,
+        Field(description="Numeric id of the version to update (e.g., '11819')"),
+    ],
+    name: Annotated[
+        str | None, Field(description="New version name", default=None)
+    ] = None,
+    description: Annotated[
+        str | None, Field(description="New version description", default=None)
+    ] = None,
+    released: Annotated[
+        bool | None,
+        Field(
+            description=(
+                "Mark version as released (True) or un-released (False); "
+                "omit to leave unchanged"
+            ),
+            default=None,
+        ),
+    ] = None,
+    archived: Annotated[
+        bool | None,
+        Field(
+            description=(
+                "Mark version as archived (True) or un-archived (False); "
+                "omit to leave unchanged"
+            ),
+            default=None,
+        ),
+    ] = None,
+    start_date: Annotated[
+        str | None,
+        Field(description="New start date (YYYY-MM-DD)", default=None),
+    ] = None,
+    release_date: Annotated[
+        str | None,
+        Field(description="New release date (YYYY-MM-DD)", default=None),
+    ] = None,
+) -> str:
+    """Update an existing fix version in a Jira project.
+
+    Any field left unset is left unchanged on the server. Common use is to
+    flip ``released`` to ``True`` once a release ships, optionally backfilling
+    the description with the actual deployment summary.
+
+    Args:
+        ctx: The FastMCP context.
+        version_id: Numeric version id (as returned by ``create_version`` or
+            ``get_project_versions``).
+        name: Optional new name.
+        description: Optional new description.
+        released: Optional released flag.
+        archived: Optional archived flag.
+        start_date: Optional new start date.
+        release_date: Optional new release date.
+
+    Returns:
+        JSON string of the updated version object.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        version = jira.update_project_version(
+            version_id=version_id,
+            name=name,
+            description=description,
+            is_released=released,
+            is_archived=archived,
+            start_date=start_date,
+            release_date=release_date,
+        )
+        return json.dumps(version, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.error(
+            f"Error updating version {version_id}: {str(e)}", exc_info=True
+        )
+        return json.dumps(
+            {"success": False, "error": str(e)}, indent=2, ensure_ascii=False
+        )
+
+
+@jira_mcp.tool(
     name="batch_create_versions",
     tags={"jira", "write", "toolset:jira_projects"},
     annotations={"title": "Batch Create Versions", "destructiveHint": True},

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2755,9 +2755,7 @@ async def update_version(
         )
         return json.dumps(version, indent=2, ensure_ascii=False)
     except Exception as e:
-        logger.error(
-            f"Error updating version {version_id}: {str(e)}", exc_info=True
-        )
+        logger.error(f"Error updating version {version_id}: {str(e)}", exc_info=True)
         return json.dumps(
             {"success": False, "error": str(e)}, indent=2, ensure_ascii=False
         )

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -298,6 +298,40 @@ def test_get_project_versions_non_list_response(projects_mixin: ProjectsMixin):
     projects_mixin.jira.get_project_versions.assert_called_once_with(key="PROJ1")
 
 
+def test_update_project_version_marks_released(projects_mixin: ProjectsMixin):
+    """Marking a version released forwards exactly the supplied fields."""
+    updated = {
+        "id": "11819",
+        "name": "v0.99.105",
+        "released": True,
+        "releaseDate": "2026-05-29",
+    }
+    projects_mixin.jira.update_version.return_value = updated
+
+    result = projects_mixin.update_project_version(
+        version_id="11819",
+        is_released=True,
+        release_date="2026-05-29",
+    )
+
+    assert result == updated
+    projects_mixin.jira.update_version.assert_called_once_with(
+        version="11819",
+        name=None,
+        description=None,
+        is_archived=None,
+        is_released=True,
+        start_date=None,
+        release_date="2026-05-29",
+    )
+
+
+def test_update_project_version_non_dict_response(projects_mixin: ProjectsMixin):
+    """Non-dict responses from the underlying client collapse to ``{}``."""
+    projects_mixin.jira.update_version.return_value = "unexpected"
+    assert projects_mixin.update_project_version(version_id="11819") == {}
+
+
 def test_get_project_roles(
     projects_mixin: ProjectsMixin, mock_roles: dict[str, dict[str, str]]
 ):

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 50, f"Expected 50 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

Adds a write-tagged MCP tool that wraps the existing \`update_version\` method on \`atlassian-python-api\`'s JIRA client. Currently the server can \`create_version\` / \`batch_create_versions\` / \`get_project_versions\` but cannot toggle a version's \`released\` / \`archived\` flag or edit its dates/name/description.

## Why

Release-automation flows (e.g. flipping a Fix Version to "Released" the moment a deploy lands, or backfilling the description with the actual deployment summary) currently have to drop out of MCP into the JIRA UI for that one step. With this tool the whole flow stays in MCP.

## Changes

- \`src/mcp_atlassian/jira/projects.py\` — new \`update_project_version\` method on \`ProjectsMixin\`, thin wrapper over the underlying client's \`update_version\`. Any field left as \`None\` is omitted so existing values aren't clobbered.
- \`src/mcp_atlassian/servers/jira.py\` — new \`@jira_mcp.tool\` named \`update_version\`, gated by \`@check_write_access\`, tagged \`{"jira","write","toolset:jira_projects"}\`, mirroring the \`create_version\` registration style.
- \`tests/unit/jira/test_projects.py\` — two unit tests: (a) marking a version released forwards exactly the supplied fields to the underlying client; (b) non-dict client responses collapse to \`{}\`.

## Test Plan

- [x] \`uv run pytest tests/unit/jira/test_projects.py tests/unit/servers/test_jira_server.py\` — 135 passed
- [x] Manually exercised against a real JIRA Cloud instance (ANTELOPE project, version id 11819) — \`released: true\` flip succeeded
- [ ] (Reviewer) Confirm tool surfaces in tool listing under \`toolset:jira_projects\` write filter

## Notes

- Two \`FBT001\` ruff warnings on \`is_released\` / \`is_archived\` match the existing convention in this file (e.g. \`include_archived: bool = False\` at line 22). Happy to convert to keyword-only (\`*\`) if you'd prefer.
- The wrapper deliberately keeps \`None\` semantics ("don't touch") rather than passing through defaults, so it composes naturally with partial updates (e.g. \`update_version(version_id, released=True)\` alone won't blank out an existing description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)