### PR TITLE
fix(jira): don't italicize intraword underscores in markdown_to_jira

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -480,6 +480,34 @@ class JiraPreprocessor(BasePreprocessor):
             flags=re.MULTILINE,
         )
 
+        markdown_url_targets: list[str] = []
+
+        def store_markdown_url_target(target: str) -> str:
+            placeholder = f"\x00MARKDOWNURL{len(markdown_url_targets)}\x00"
+            markdown_url_targets.append(target)
+            return placeholder
+
+        def protect_markdown_link_target(match: re.Match[str]) -> str:
+            return (
+                match.group(1)
+                + store_markdown_url_target(match.group(2))
+                + match.group(3)
+            )
+
+        def protect_markdown_autolink_target(match: re.Match[str]) -> str:
+            return "<" + store_markdown_url_target(match.group(1)) + ">"
+
+        output = re.sub(
+            r"(!?\[[^\]\n]*\]\()([^)]+)(\))",
+            protect_markdown_link_target,
+            output,
+        )
+        output = re.sub(
+            r"<((?:[A-Za-z][A-Za-z0-9+.-]*:[^>\s]+|[^<>\s@]+@[^<>\s@]+))>",
+            protect_markdown_autolink_target,
+            output,
+        )
+
         # Bold and italic - skip lines starting with
         # asterisks+space (Jira list syntax, issue #786)
         def escape_intraword_underscore_runs(match: re.Match[str]) -> str:
@@ -511,6 +539,7 @@ class JiraPreprocessor(BasePreprocessor):
 
         lines = output.split("\n")
         output = "\n".join(convert_bold_italic_line(line) for line in lines)
+        output = _restore_blocks(output, markdown_url_targets, "MARKDOWNURL")
 
         # Multi-level bulleted list
         def bulleted_list_fn(match: re.Match[str]) -> str:

--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -485,6 +485,15 @@ class JiraPreprocessor(BasePreprocessor):
         def convert_bold_italic_line(line: str) -> str:
             if re.match(r"^[*_]+\s", line):
                 return line
+            # CommonMark treats underscores between two word characters as
+            # literal text, not emphasis. The Jira wiki renderer does not:
+            # it italicizes any ``_word_`` span, so identifiers such as
+            # snake_case, customfield_10101 or foo_bar_baz would render with
+            # spurious italics (and adjacent identifiers can pair into a
+            # cross-token italic span). Escape intraword underscores as
+            # ``\_`` so Jira renders them literally; genuine word-boundary
+            # ``_emphasis_`` is left intact for the conversion below.
+            line = re.sub(r"(?<=\w)_(?=\w)", r"\\_", line)
             return re.sub(
                 r"([*_]+)(.*?)\1",
                 lambda m: ("_" if len(m.group(1)) == 1 else "*")

--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -482,18 +482,25 @@ class JiraPreprocessor(BasePreprocessor):
 
         # Bold and italic - skip lines starting with
         # asterisks+space (Jira list syntax, issue #786)
+        def escape_intraword_underscore_runs(match: re.Match[str]) -> str:
+            return r"\_" * len(match.group(0))
+
         def convert_bold_italic_line(line: str) -> str:
-            if re.match(r"^[*_]+\s", line):
-                return line
             # CommonMark treats underscores between two word characters as
             # literal text, not emphasis. The Jira wiki renderer does not:
             # it italicizes any ``_word_`` span, so identifiers such as
             # snake_case, customfield_10101 or foo_bar_baz would render with
             # spurious italics (and adjacent identifiers can pair into a
-            # cross-token italic span). Escape intraword underscores as
+            # cross-token italic span). Escape intraword underscore runs as
             # ``\_`` so Jira renders them literally; genuine word-boundary
-            # ``_emphasis_`` is left intact for the conversion below.
-            line = re.sub(r"(?<=\w)_(?=\w)", r"\\_", line)
+            # ``_emphasis_``/``__strong__`` is left intact for conversion below.
+            line = re.sub(
+                r"(?<=[^\W_])_+(?=[^\W_])",
+                escape_intraword_underscore_runs,
+                line,
+            )
+            if re.match(r"^[*_]+\s", line):
+                return line
             return re.sub(
                 r"([*_]+)(.*?)\1",
                 lambda m: ("_" if len(m.group(1)) == 1 else "*")

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -640,6 +640,55 @@ def test_markdown_to_jira_bold_without_space_still_converts(preprocessor_with_ji
     assert preprocessor_with_jira.markdown_to_jira("*italic text*") == "_italic text_"
 
 
+def test_markdown_to_jira_preserves_intraword_underscores(preprocessor_with_jira):
+    """Intraword underscores are literal per CommonMark, not emphasis.
+
+    The Jira wiki renderer italicizes ``_word_``, so identifiers containing
+    underscores (snake_case, customfield IDs, etc.) must be emitted with the
+    underscores escaped (``\\_``) — otherwise ``foo_bar_baz`` renders with a
+    spurious italic span around ``bar``.
+    """
+    # Single intraword underscore.
+    assert (
+        preprocessor_with_jira.markdown_to_jira("the foo_bar identifier")
+        == "the foo\\_bar identifier"
+    )
+    # Multiple intraword underscores in one token.
+    assert (
+        preprocessor_with_jira.markdown_to_jira("baseline_samples_5m paused")
+        == "baseline\\_samples\\_5m paused"
+    )
+    # Custom field IDs are a common real-world case.
+    assert (
+        preprocessor_with_jira.markdown_to_jira("set customfield_10101 to 5")
+        == "set customfield\\_10101 to 5"
+    )
+    # Two identifiers on one line must not pair into a cross-token italic span.
+    assert (
+        preprocessor_with_jira.markdown_to_jira("netflow_ap and sre_analytics")
+        == "netflow\\_ap and sre\\_analytics"
+    )
+
+
+def test_markdown_to_jira_word_boundary_underscore_still_italicizes(
+    preprocessor_with_jira,
+):
+    """Genuine ``_emphasis_`` at word boundaries must still convert to italic."""
+    assert (
+        preprocessor_with_jira.markdown_to_jira("an _italic phrase_ here")
+        == "an _italic phrase_ here"
+    )
+    assert preprocessor_with_jira.markdown_to_jira("_italic text_") == "_italic text_"
+
+
+def test_markdown_to_jira_underscore_in_inline_code_untouched(preprocessor_with_jira):
+    """Underscores inside inline code spans stay inside monospace, unescaped."""
+    assert (
+        preprocessor_with_jira.markdown_to_jira("call `find_provider_by_url` now")
+        == "call {{find_provider_by_url}} now"
+    )
+
+
 def test_md2conf_elements_from_string_available():
     """Test that elements_from_string is importable with fallback (issue #817)."""
     from mcp_atlassian.preprocessing.confluence import elements_from_string

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -781,6 +781,16 @@ def test_markdown_to_jira_preserves_intraword_underscores(preprocessor_with_jira
         preprocessor_with_jira.markdown_to_jira("netflow_ap and sre_analytics")
         == "netflow\\_ap and sre\\_analytics"
     )
+    # Double underscore runs inside identifiers are also literal in CommonMark.
+    assert (
+        preprocessor_with_jira.markdown_to_jira("the foo__bar__baz identifier")
+        == "the foo\\_\\_bar\\_\\_baz identifier"
+    )
+    # Jira list lines still need escaping inside the item text.
+    assert (
+        preprocessor_with_jira.markdown_to_jira("* customfield_10101 item")
+        == "* customfield\\_10101 item"
+    )
 
 
 def test_markdown_to_jira_word_boundary_underscore_still_italicizes(
@@ -792,6 +802,7 @@ def test_markdown_to_jira_word_boundary_underscore_still_italicizes(
         == "an _italic phrase_ here"
     )
     assert preprocessor_with_jira.markdown_to_jira("_italic text_") == "_italic text_"
+    assert preprocessor_with_jira.markdown_to_jira("__bold text__") == "*bold text*"
 
 
 def test_markdown_to_jira_underscore_in_inline_code_untouched(preprocessor_with_jira):

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -813,6 +813,38 @@ def test_markdown_to_jira_underscore_in_inline_code_untouched(preprocessor_with_
     )
 
 
+def test_markdown_to_jira_preserves_underscores_in_url_targets(
+    preprocessor_with_jira,
+):
+    """URL targets keep literal underscores while visible text is escaped."""
+    assert (
+        preprocessor_with_jira.markdown_to_jira(
+            "[runbook](https://example.com/foo_bar)"
+        )
+        == "[runbook|https://example.com/foo_bar]"
+    )
+    assert (
+        preprocessor_with_jira.markdown_to_jira(
+            "[foo_bar](https://example.com/foo_bar)"
+        )
+        == "[foo\\_bar|https://example.com/foo_bar]"
+    )
+    assert (
+        preprocessor_with_jira.markdown_to_jira(
+            "![diagram](https://example.com/foo_bar.png)"
+        )
+        == "!https://example.com/foo_bar.png|alt=diagram!"
+    )
+    assert (
+        preprocessor_with_jira.markdown_to_jira("![](https://example.com/foo_bar.png)")
+        == "!https://example.com/foo_bar.png!"
+    )
+    assert (
+        preprocessor_with_jira.markdown_to_jira("<https://example.com/foo_bar>")
+        == "[https://example.com/foo_bar]"
+    )
+
+
 def test_md2conf_elements_from_string_available():
     """Test that elements_from_string is importable with fallback (issue #817)."""
     from mcp_atlassian.preprocessing.confluence import elements_from_string


### PR DESCRIPTION
## Problem

`JiraPreprocessor.markdown_to_jira` runs a single emphasis pass that treats `_` exactly like `*`:

```python
re.sub(r"([*_]+)(.*?)\1", ...)   # preprocessing/jira.py
```

This pairs underscores anywhere on a line, which violates CommonMark — **underscores between two word characters are literal, not emphasis** (only `*` does intraword emphasis). Because the Jira wiki renderer italicizes any `_word_` span, the result is that identifiers get corrupted with spurious italics:

| Markdown input | Renders in Jira as |
|---|---|
| `baseline_samples_5m` | baseline*samples*5m (italic "samples") |
| `customfield_10101` | customfield*10101 |
| `netflow_ap and sre_analytics` | netflow*ap and sre*analytics (cross-token italic span) |

This is a frequent foot-gun for technical content (code identifiers, custom-field IDs, table/MV names) posted via `jira_create_issue` / `jira_update_issue` / `jira_add_comment`. It's in the same family as the existing underscore/code-span reports.

## Fix

Escape intraword underscores (`\_`) before the emphasis conversion so the Jira renderer treats them literally:

```python
line = re.sub(r"(?<=\w)_(?=\w)", r"\\_", line)
```

- Genuine word-boundary `_emphasis_` still converts to Jira italic.
- All `*`/`**` handling is unchanged.
- Inline-code spans are already extracted to placeholders before this pass, so `` `find_provider_by_url` `` is untouched.
- Placeholders are `\x00PREFIX<n>\x00` (null-flanked, no `_`), so the rule can't disturb them.

## Tests

Adds three regression tests in `tests/unit/preprocessing/test_preprocessing.py`:

- `test_markdown_to_jira_preserves_intraword_underscores` — snake_case / customfield IDs / cross-token pairing
- `test_markdown_to_jira_word_boundary_underscore_still_italicizes` — genuine `_emphasis_` still works
- `test_markdown_to_jira_underscore_in_inline_code_untouched` — `` `ident_with_underscores` `` stays monospace

Full preprocessing suite: **116 passed** (3 new, 0 regressions).

## Scope / follow-up

This targets the unambiguous **intraword** case (the common identifier breakage). Leading-underscore tokens at a word boundary (`_v2`, `_local`) are genuinely ambiguous in Markdown and best expressed as inline code; a full CommonMark left/right-flanking implementation for `_` would be a larger, separate change.