### PR TITLE
Feat/jira filter dashboard tools

### DIFF
--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -32,6 +32,8 @@ from .users import UsersMixin
 from .velocity import VelocityMixin
 from .watchers import WatchersMixin
 from .worklog import WorklogMixin
+from .filters import FilterMixin
+from .dashboards import DashboardMixin
 
 
 class JiraFetcher(
@@ -57,6 +59,8 @@ class JiraFetcher(
     SLAMixin,
     DevelopmentMixin,
     VelocityMixin,
+    FilterMixin,
+    DashboardMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -80,6 +84,8 @@ class JiraFetcher(
     - MetricsMixin: Issue metrics and date operations
     - QueuesMixin: Service Desk queue read operations (Server/DC)
     - SLAMixin: SLA calculations
+    - FilterMixin: Saved filter read operations
+    - DashboardMixin: Dashboard metadata and gadget read operations
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.
@@ -96,4 +102,6 @@ __all__ = [
     "MetricsMixin",
     "SLAMixin",
     "VelocityMixin",
+    "FilterMixin",
+    "DashboardMixin",
 ]

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -29,6 +29,7 @@ from .search import SearchMixin
 from .sprints import SprintsMixin
 from .transitions import TransitionsMixin
 from .users import UsersMixin
+from .velocity import VelocityMixin
 from .watchers import WatchersMixin
 from .worklog import WorklogMixin
 
@@ -55,6 +56,7 @@ class JiraFetcher(
     MetricsMixin,
     SLAMixin,
     DevelopmentMixin,
+    VelocityMixin,
 ):
     """
     The main Jira client class providing access to all Jira operations.
@@ -93,4 +95,5 @@ __all__ = [
     "Jira",
     "MetricsMixin",
     "SLAMixin",
+    "VelocityMixin",
 ]

--- a/src/mcp_atlassian/jira/dashboards.py
+++ b/src/mcp_atlassian/jira/dashboards.py
@@ -1,0 +1,185 @@
+"""Module for Jira dashboard read operations."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+_GADGET_HINT = (
+    "Gadget enumeration is not supported on this Jira instance. Open the "
+    "dashboard in your browser, click each gadget's title, and share the "
+    "filter IDs from the resulting URLs (?filter=NNNNN) so the assistant "
+    "can proceed."
+)
+
+
+class DashboardMixin(JiraClient):
+    """Mixin for reading Jira dashboard metadata and gadget configuration.
+
+    Gadget filter resolution is best-effort on Data Center. Some gadgets store
+    JQL inline rather than via a saved filterId; those cannot be resolved through
+    the properties/config endpoint. Unresolvable gadgets are listed in
+    gadget_resolution_warnings without raising an error.
+    """
+
+    def get_dashboard(
+        self,
+        dashboard_id: str,
+        resolve_filters: bool = True,
+    ) -> dict[str, Any]:
+        """Fetch dashboard metadata and resolve gadget filter details.
+
+        Args:
+            dashboard_id: The numeric ID of the Jira dashboard.
+            resolve_filters: When True, attempt to resolve filter name and JQL
+                for each gadget that exposes a filterId via its config property.
+
+        Returns:
+            A dict with keys id, name, description, owner, view_url, gadgets,
+            gadget_resolution_warnings, gadgets_supported, and next_step_hint.
+            Returns an error dict on 404.
+
+            gadgets_supported is False when the Jira instance does not expose
+            gadget data (common on Data Center). In that case next_step_hint
+            contains a human-readable instruction for the user.
+
+            On Jira Data Center, gadget enumeration may not be supported.
+            In that case, gadgets will be empty and gadgets_supported will
+            be False. The caller should prompt the user for filter IDs and
+            resolve them via jira_get_filter.
+        """
+        try:
+            dashboard = self.jira.get(path=f"rest/api/2/dashboard/{dashboard_id}")
+        except HTTPError as error:
+            if error.response is not None and error.response.status_code == 404:
+                return {"error": f"Dashboard {dashboard_id} not found"}
+            logger.error("Error fetching dashboard %s: %s", dashboard_id, error)
+            raise
+
+        if not isinstance(dashboard, dict):
+            return {"error": f"Dashboard {dashboard_id} not found"}
+
+        # Distinguish supported (key present, even if []) from unsupported (key absent).
+        gadgets_raw_value = dashboard.get("gadgets")
+        gadgets_supported = gadgets_raw_value is not None
+        gadgets_raw: list[Any] = gadgets_raw_value if isinstance(gadgets_raw_value, list) else []
+
+        gadgets: list[dict[str, Any]] = []
+        warnings: list[str] = []
+
+        for gadget in gadgets_raw:
+            if not isinstance(gadget, dict):
+                continue
+            processed = self._process_gadget(
+                dashboard_id=dashboard_id,
+                gadget=gadget,
+                resolve_filters=resolve_filters,
+                warnings=warnings,
+            )
+            gadgets.append(processed)
+
+        owner_raw = dashboard.get("owner") or {}
+        if isinstance(owner_raw, dict):
+            owner = owner_raw.get("displayName") or owner_raw.get("name")
+        else:
+            owner = str(owner_raw) if owner_raw else None
+
+        return {
+            "id": str(dashboard.get("id", dashboard_id)),
+            "name": str(dashboard.get("name", "")),
+            "description": dashboard.get("description"),
+            "owner": owner,
+            "view_url": str(dashboard.get("view", "")),
+            "gadgets": gadgets,
+            "gadget_resolution_warnings": warnings,
+            "gadgets_supported": gadgets_supported,
+            "next_step_hint": None if gadgets_supported else _GADGET_HINT,
+        }
+
+    def _process_gadget(
+        self,
+        dashboard_id: str,
+        gadget: dict[str, Any],
+        resolve_filters: bool,
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        """Build a processed gadget dict, attempting filter resolution."""
+        gadget_id = str(gadget.get("id", ""))
+        position = gadget.get("position") or {}
+
+        result: dict[str, Any] = {
+            "id": gadget_id,
+            "title": str(gadget.get("title", "")),
+            "color": gadget.get("color"),
+            "position": {
+                "row": int(position.get("row", 0)) if isinstance(position, dict) else 0,
+                "column": int(position.get("column", 0)) if isinstance(position, dict) else 0,
+            },
+            "filter_id": None,
+            "filter_name": None,
+            "jql": None,
+        }
+
+        config = self._fetch_gadget_config(
+            dashboard_id=dashboard_id,
+            gadget_id=gadget_id,
+            warnings=warnings,
+        )
+        if config is None:
+            return result
+
+        filter_id = _extract_filter_id_from_config(config)
+        result["filter_id"] = filter_id
+
+        if filter_id and resolve_filters:
+            filter_data = self.get_filter(filter_id)  # type: ignore[attr-defined]
+            if isinstance(filter_data, dict) and "error" not in filter_data:
+                result["filter_name"] = filter_data.get("name")
+                result["jql"] = filter_data.get("jql")
+
+        return result
+
+    def _fetch_gadget_config(
+        self,
+        dashboard_id: str,
+        gadget_id: str,
+        warnings: list[str],
+    ) -> dict[str, Any] | None:
+        """Fetch gadget config property; returns None and appends to warnings on failure."""
+        if not gadget_id:
+            return None
+        try:
+            response = self.jira.get(
+                path=(
+                    f"rest/api/2/dashboard/{dashboard_id}"
+                    f"/items/{gadget_id}/properties/config"
+                )
+            )
+            if isinstance(response, dict):
+                return response.get("value") if "value" in response else response
+            return None
+        except HTTPError as error:
+            if error.response is not None and error.response.status_code == 404:
+                warnings.append(gadget_id)
+                return None
+            logger.warning(
+                "Unexpected error fetching config for gadget %s on dashboard %s: %s",
+                gadget_id,
+                dashboard_id,
+                error,
+            )
+            warnings.append(gadget_id)
+            return None
+
+
+def _extract_filter_id_from_config(config: dict[str, Any]) -> str | None:
+    """Extract a filter ID string from a gadget config dict."""
+    for key in ("filterId", "filter_id", "filterid"):
+        value = config.get(key)
+        if value is not None:
+            return str(value)
+    return None

--- a/src/mcp_atlassian/jira/filters.py
+++ b/src/mcp_atlassian/jira/filters.py
@@ -1,0 +1,144 @@
+"""Module for Jira saved filter read operations."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class FilterMixin(JiraClient):
+    """Mixin for reading Jira saved filters."""
+
+    def get_filter(self, filter_id: str) -> dict[str, Any]:
+        """Fetch a single saved filter by ID.
+
+        Args:
+            filter_id: The numeric ID of the Jira filter.
+
+        Returns:
+            A dict with keys id, name, jql, owner, description, favourite,
+            shared_with, or an error dict if the filter is not found.
+        """
+        try:
+            response = self.jira.get(path=f"rest/api/2/filter/{filter_id}")
+        except HTTPError as error:
+            if error.response is not None and error.response.status_code == 404:
+                return {"error": f"Filter {filter_id} not found"}
+            logger.error("Error fetching filter %s: %s", filter_id, error)
+            raise
+
+        if not isinstance(response, dict):
+            return {"error": f"Filter {filter_id} not found"}
+
+        owner = response.get("owner") or {}
+        share_permissions = response.get("sharePermissions") or []
+        shared_with = [
+            {
+                "type": perm.get("type"),
+                "project": (perm.get("project") or {}).get("name"),
+                "role": (perm.get("role") or {}).get("name"),
+                "group": (perm.get("group") or {}).get("name"),
+            }
+            for perm in share_permissions
+            if isinstance(perm, dict)
+        ]
+
+        return {
+            "id": str(response.get("id", filter_id)),
+            "name": str(response.get("name", "")),
+            "jql": str(response.get("jql", "")),
+            "description": response.get("description"),
+            "favourite": bool(response.get("favourite", False)),
+            "owner": {
+                "name": owner.get("name"),
+                "displayName": owner.get("displayName"),
+                "emailAddress": owner.get("emailAddress"),
+            },
+            "shared_with": shared_with,
+        }
+
+    def search_filters(
+        self,
+        query: str | None = None,
+        limit: int = 25,
+    ) -> list[dict[str, Any]]:
+        """Search for saved filters accessible to the current user.
+
+        Args:
+            query: Optional substring to match against filter names.
+                If omitted, returns the user's accessible filters.
+            limit: Maximum number of results to return (1–50).
+
+        Returns:
+            A list of dicts with keys id, name, jql, owner_display_name.
+        """
+        limit = max(1, min(50, limit))
+
+        params: dict[str, Any] = {"maxResults": limit}
+        if query:
+            params["filterName"] = query
+
+        try:
+            response = self.jira.get(
+                path="rest/api/2/filter/search",
+                params=params,
+            )
+            filters = _extract_filter_list(response)
+        except HTTPError as error:
+            if error.response is not None and error.response.status_code == 404:
+                logger.debug(
+                    "GET /rest/api/2/filter/search returned 404 — "
+                    "falling back to GET /rest/api/2/filter"
+                )
+                filters = self._search_filters_fallback(query=query, limit=limit)
+            else:
+                logger.error("Error searching filters: %s", error)
+                raise
+
+        return [_simplify_filter(f) for f in filters]
+
+    def _search_filters_fallback(
+        self,
+        query: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Fallback for older DC instances that lack /filter/search."""
+        response = self.jira.get(path="rest/api/2/filter")
+        all_filters = _extract_filter_list(response)
+
+        if query:
+            q = query.lower()
+            all_filters = [
+                f
+                for f in all_filters
+                if isinstance(f, dict) and q in str(f.get("name", "")).lower()
+            ]
+
+        return all_filters[:limit]
+
+
+def _extract_filter_list(response: Any) -> list[dict[str, Any]]:
+    """Extract a list of filter dicts from a /filter/search or /filter response."""
+    if isinstance(response, list):
+        return [f for f in response if isinstance(f, dict)]
+    if isinstance(response, dict):
+        values = response.get("values") or response.get("filters") or []
+        return [f for f in values if isinstance(f, dict)]
+    return []
+
+
+def _simplify_filter(f: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact filter summary dict."""
+    owner = f.get("owner") or {}
+    return {
+        "id": str(f.get("id", "")),
+        "name": str(f.get("name", "")),
+        "jql": str(f.get("jql", "")),
+        "owner_display_name": str(
+            owner.get("displayName") or owner.get("name") or ""
+        ),
+    }

--- a/src/mcp_atlassian/jira/velocity.py
+++ b/src/mcp_atlassian/jira/velocity.py
@@ -1,0 +1,362 @@
+"""Module for Jira sprint velocity and team performance analytics."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from .client import JiraClient
+
+logger = logging.getLogger("mcp-jira")
+
+
+class VelocityMixin(JiraClient):
+    """Mixin for Jira sprint velocity and team performance analytics."""
+
+    def _get_story_points_field_id(self, board_id: str) -> str | None:
+        """Get the story points custom field id configured for a board."""
+        try:
+            response = self.jira.get(
+                path=f"rest/agile/1.0/board/{board_id}/configuration"
+            )
+            if not isinstance(response, dict):
+                return None
+
+            estimation = response.get("estimation")
+            if not isinstance(estimation, dict):
+                return None
+
+            field = estimation.get("field")
+            if not isinstance(field, dict):
+                return None
+
+            field_id = field.get("fieldId") or field.get("id")
+            if not isinstance(field_id, str):
+                return None
+
+            if not field_id.startswith("customfield_"):
+                return None
+
+            return field_id
+        except (HTTPError, ValueError, TypeError, KeyError) as error:
+            logger.error(
+                "Error retrieving board estimation field for board %s: %s",
+                board_id,
+                error,
+            )
+            return None
+
+    def _get_sprint_details(self, sprint_id: str) -> dict[str, Any]:
+        """Get sprint details by sprint id."""
+        response = self.jira.get(path=f"rest/agile/1.0/sprint/{sprint_id}")
+        if not isinstance(response, dict):
+            return {}
+        return response
+
+    def _get_sprint_issues_raw(
+        self,
+        sprint_id: str,
+        fields: list[str],
+        page_size: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Fetch all issues for a sprint using Agile API pagination."""
+        all_issues: list[dict[str, Any]] = []
+        start_at = 0
+
+        while True:
+            response = self.jira.get(
+                path=f"rest/agile/1.0/sprint/{sprint_id}/issue",
+                params={
+                    "startAt": start_at,
+                    "maxResults": page_size,
+                    "fields": ",".join(fields),
+                },
+            )
+            if not isinstance(response, dict):
+                break
+
+            issues = response.get("issues", [])
+            if not isinstance(issues, list):
+                break
+
+            valid_issues = [issue for issue in issues if isinstance(issue, dict)]
+            all_issues.extend(valid_issues)
+
+            if not issues:
+                break
+
+            is_last = response.get("isLast")
+            total = response.get("total")
+            start_at += len(issues)
+
+            if is_last is True:
+                break
+
+            if isinstance(total, int) and start_at >= total:
+                break
+
+        return all_issues
+
+    def _extract_story_points(self, issue: dict[str, Any], field_id: str) -> float:
+        """Extract numeric story points from a Jira issue."""
+        fields = issue.get("fields", {})
+        if not isinstance(fields, dict):
+            return 0.0
+
+        raw_points = fields.get(field_id)
+        if isinstance(raw_points, int | float):
+            return float(raw_points)
+
+        if isinstance(raw_points, str):
+            try:
+                return float(raw_points)
+            except ValueError:
+                return 0.0
+
+        return 0.0
+
+    def _is_completed_issue(self, issue: dict[str, Any]) -> bool:
+        """Determine whether an issue is in a done status category."""
+        fields = issue.get("fields", {})
+        if not isinstance(fields, dict):
+            return False
+
+        status = fields.get("status")
+        if not isinstance(status, dict):
+            return False
+
+        status_category = status.get("statusCategory")
+        if not isinstance(status_category, dict):
+            return False
+
+        key = str(status_category.get("key", "")).lower()
+        name = str(status_category.get("name", "")).lower()
+        return key == "done" or name == "done"
+
+    def get_sprint_velocity(self, board_id: str, sprint_id: str) -> dict[str, Any]:
+        """Calculate committed vs completed story points for a sprint."""
+        story_points_field = self._get_story_points_field_id(board_id)
+        if not story_points_field:
+            raise ValueError(
+                "Could not determine Story Points field from board configuration."
+            )
+
+        sprint = self._get_sprint_details(sprint_id)
+        issues = self._get_sprint_issues_raw(
+            sprint_id=sprint_id,
+            fields=["summary", "status", "assignee", story_points_field],
+        )
+
+        committed_points = 0.0
+        completed_points = 0.0
+        assignee_stats: dict[str, dict[str, float | int]] = {}
+
+        for issue in issues:
+            points = self._extract_story_points(issue, story_points_field)
+            committed_points += points
+
+            fields = issue.get("fields", {})
+            if not isinstance(fields, dict):
+                fields = {}
+
+            assignee = fields.get("assignee")
+            assignee_name = "Unassigned"
+            if isinstance(assignee, dict):
+                assignee_name = str(
+                    assignee.get("displayName")
+                    or assignee.get("name")
+                    or "Unassigned"
+                )
+
+            if assignee_name not in assignee_stats:
+                assignee_stats[assignee_name] = {
+                    "issue_count": 0,
+                    "committed_points": 0.0,
+                    "completed_points": 0.0,
+                }
+
+            assignee_stats[assignee_name]["issue_count"] += 1
+            assignee_stats[assignee_name]["committed_points"] += points
+
+            if self._is_completed_issue(issue):
+                completed_points += points
+                assignee_stats[assignee_name]["completed_points"] += points
+
+        completion_rate = (
+            round((completed_points / committed_points) * 100, 2)
+            if committed_points > 0
+            else 0.0
+        )
+
+        per_assignee = [
+            {
+                "assignee": name,
+                "issue_count": stats["issue_count"],
+                "committed_points": round(float(stats["committed_points"]), 2),
+                "completed_points": round(float(stats["completed_points"]), 2),
+            }
+            for name, stats in sorted(assignee_stats.items())
+        ]
+
+        return {
+            "board_id": board_id,
+            "sprint_id": sprint_id,
+            "sprint_name": str(sprint.get("name", "")),
+            "sprint_state": str(sprint.get("state", "")),
+            "start_date": sprint.get("startDate"),
+            "end_date": sprint.get("endDate"),
+            "story_points_field": story_points_field,
+            "issue_count": len(issues),
+            "committed_points": round(committed_points, 2),
+            "completed_points": round(completed_points, 2),
+            "completion_rate": completion_rate,
+            "per_assignee": per_assignee,
+        }
+
+    def _calculate_velocity_trend(
+        self, sprint_data: list[dict[str, Any]]
+    ) -> str:
+        """Calculate high-level velocity trend from first to last sprint."""
+        if len(sprint_data) < 2:
+            return "insufficient_data"
+
+        first = float(sprint_data[0].get("completed_points", 0.0))
+        last = float(sprint_data[-1].get("completed_points", 0.0))
+
+        if first == 0 and last == 0:
+            return "stable"
+        if first == 0 and last > 0:
+            return "increasing"
+
+        delta_pct = ((last - first) / first) * 100
+        if delta_pct > 5:
+            return "increasing"
+        if delta_pct < -5:
+            return "decreasing"
+        return "stable"
+
+    def get_velocity_report(
+        self,
+        board_id: str,
+        num_sprints: int = 3,
+    ) -> dict[str, Any]:
+        """Get velocity report for the latest closed sprints on a board."""
+        if num_sprints < 1:
+            raise ValueError("num_sprints must be at least 1")
+
+        raw_sprints = self.get_all_sprints_from_board(
+            board_id=board_id,
+            state="closed",
+            start=0,
+            limit=max(50, num_sprints),
+        )
+
+        sorted_sprints = sorted(
+            raw_sprints,
+            key=lambda sprint: (
+                str(sprint.get("completeDate", "")),
+                str(sprint.get("endDate", "")),
+                str(sprint.get("startDate", "")),
+            ),
+            reverse=True,
+        )
+        selected_sprints = list(reversed(sorted_sprints[:num_sprints]))
+
+        report_rows = [
+            self.get_sprint_velocity(board_id=board_id, sprint_id=str(sprint["id"]))
+            for sprint in selected_sprints
+            if isinstance(sprint, dict) and sprint.get("id") is not None
+        ]
+
+        if report_rows:
+            avg_completed = round(
+                sum(float(row.get("completed_points", 0.0)) for row in report_rows)
+                / len(report_rows),
+                2,
+            )
+            avg_completion_rate = round(
+                sum(float(row.get("completion_rate", 0.0)) for row in report_rows)
+                / len(report_rows),
+                2,
+            )
+        else:
+            avg_completed = 0.0
+            avg_completion_rate = 0.0
+
+        trend = self._calculate_velocity_trend(report_rows)
+
+        return {
+            "board_id": board_id,
+            "num_sprints_requested": num_sprints,
+            "num_sprints_analyzed": len(report_rows),
+            "average_completed_points": avg_completed,
+            "average_completion_rate": avg_completion_rate,
+            "velocity_trend": trend,
+            "sprints": report_rows,
+        }
+
+    def get_team_sprint_summary(
+        self,
+        board_id: str,
+        num_sprints: int = 3,
+    ) -> dict[str, Any]:
+        """Get aggregated team performance summary for the latest sprints."""
+        velocity_report = self.get_velocity_report(
+            board_id=board_id,
+            num_sprints=num_sprints,
+        )
+
+        assignee_totals: dict[str, dict[str, float | int]] = {}
+        for sprint in velocity_report.get("sprints", []):
+            assignees = sprint.get("per_assignee", [])
+            if not isinstance(assignees, list):
+                continue
+
+            for assignee_data in assignees:
+                if not isinstance(assignee_data, dict):
+                    continue
+
+                assignee = str(assignee_data.get("assignee", "Unassigned"))
+                if assignee not in assignee_totals:
+                    assignee_totals[assignee] = {
+                        "issue_count": 0,
+                        "committed_points": 0.0,
+                        "completed_points": 0.0,
+                    }
+
+                assignee_totals[assignee]["issue_count"] += int(
+                    assignee_data.get("issue_count", 0)
+                )
+                assignee_totals[assignee]["committed_points"] += float(
+                    assignee_data.get("committed_points", 0.0)
+                )
+                assignee_totals[assignee]["completed_points"] += float(
+                    assignee_data.get("completed_points", 0.0)
+                )
+
+        per_assignee = [
+            {
+                "assignee": name,
+                "issue_count": int(values["issue_count"]),
+                "committed_points": round(float(values["committed_points"]), 2),
+                "completed_points": round(float(values["completed_points"]), 2),
+            }
+            for name, values in assignee_totals.items()
+        ]
+        per_assignee.sort(key=lambda value: value["completed_points"], reverse=True)
+
+        return {
+            "board_id": board_id,
+            "num_sprints": velocity_report.get("num_sprints_analyzed", 0),
+            "velocity": {
+                "average_completed_points": velocity_report.get(
+                    "average_completed_points", 0.0
+                ),
+                "average_completion_rate": velocity_report.get(
+                    "average_completion_rate", 0.0
+                ),
+                "trend": velocity_report.get("velocity_trend", "insufficient_data"),
+            },
+            "per_assignee": per_assignee,
+            "sprints": velocity_report.get("sprints", []),
+        }

--- a/src/mcp_atlassian/jira/velocity.py
+++ b/src/mcp_atlassian/jira/velocity.py
@@ -163,9 +163,7 @@ class VelocityMixin(JiraClient):
             assignee_name = "Unassigned"
             if isinstance(assignee, dict):
                 assignee_name = str(
-                    assignee.get("displayName")
-                    or assignee.get("name")
-                    or "Unassigned"
+                    assignee.get("displayName") or assignee.get("name") or "Unassigned"
                 )
 
             if assignee_name not in assignee_stats:
@@ -213,9 +211,7 @@ class VelocityMixin(JiraClient):
             "per_assignee": per_assignee,
         }
 
-    def _calculate_velocity_trend(
-        self, sprint_data: list[dict[str, Any]]
-    ) -> str:
+    def _calculate_velocity_trend(self, sprint_data: list[dict[str, Any]]) -> str:
         """Calculate high-level velocity trend from first to last sprint."""
         if len(sprint_data) < 2:
             return "insufficient_data"

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1266,6 +1266,96 @@ async def get_sprint_issues(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read"},
+    annotations={"title": "Get Sprint Velocity", "readOnlyHint": True},
+)
+async def get_sprint_velocity(
+    ctx: Context,
+    board_id: Annotated[
+        str,
+        Field(description="The id of board (e.g., '1000')"),
+    ],
+    sprint_id: Annotated[
+        str,
+        Field(description="The id of sprint (e.g., '10001')"),
+    ],
+) -> str:
+    """Calculate sprint velocity metrics for a specific sprint.
+
+    Args:
+        ctx: The FastMCP context.
+        board_id: The ID of the board.
+        sprint_id: The ID of the sprint.
+
+    Returns:
+        JSON string representing committed/completed points and completion rate.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_sprint_velocity(board_id=board_id, sprint_id=sprint_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read"},
+    annotations={"title": "Get Velocity Report", "readOnlyHint": True},
+)
+async def get_velocity_report(
+    ctx: Context,
+    board_id: Annotated[
+        str,
+        Field(description="The id of board (e.g., '1000')"),
+    ],
+    num_sprints: Annotated[
+        int,
+        Field(description="Number of latest closed sprints", default=3, ge=1, le=20),
+    ] = 3,
+) -> str:
+    """Get sprint velocity trend for the latest closed sprints.
+
+    Args:
+        ctx: The FastMCP context.
+        board_id: The ID of the board.
+        num_sprints: Number of recent closed sprints to analyze.
+
+    Returns:
+        JSON string representing sprint-by-sprint velocity metrics and trend.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_velocity_report(board_id=board_id, num_sprints=num_sprints)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read"},
+    annotations={"title": "Get Team Sprint Summary", "readOnlyHint": True},
+)
+async def get_team_sprint_summary(
+    ctx: Context,
+    board_id: Annotated[
+        str,
+        Field(description="The id of board (e.g., '1000')"),
+    ],
+    num_sprints: Annotated[
+        int,
+        Field(description="Number of latest closed sprints", default=3, ge=1, le=20),
+    ] = 3,
+) -> str:
+    """Get aggregated team performance summary for recent sprints.
+
+    Args:
+        ctx: The FastMCP context.
+        board_id: The ID of the board.
+        num_sprints: Number of recent closed sprints to analyze.
+
+    Returns:
+        JSON string representing team-level velocity and assignee breakdown.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_team_sprint_summary(board_id=board_id, num_sprints=num_sprints)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_links"},
     annotations={"title": "Get Link Types", "readOnlyHint": True},
 )

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1266,7 +1266,7 @@ async def get_sprint_issues(
 
 
 @jira_mcp.tool(
-    tags={"jira", "read"},
+    tags={"jira", "read", "toolset:jira_agile"},
     annotations={"title": "Get Sprint Velocity", "readOnlyHint": True},
 )
 async def get_sprint_velocity(
@@ -1296,7 +1296,7 @@ async def get_sprint_velocity(
 
 
 @jira_mcp.tool(
-    tags={"jira", "read"},
+    tags={"jira", "read", "toolset:jira_agile"},
     annotations={"title": "Get Velocity Report", "readOnlyHint": True},
 )
 async def get_velocity_report(
@@ -1326,7 +1326,7 @@ async def get_velocity_report(
 
 
 @jira_mcp.tool(
-    tags={"jira", "read"},
+    tags={"jira", "read", "toolset:jira_agile"},
     annotations={"title": "Get Team Sprint Summary", "readOnlyHint": True},
 )
 async def get_team_sprint_summary(
@@ -3363,3 +3363,122 @@ async def get_issues_development_info(
         logger.error(f"Error getting development info for issues: {str(e)}")
         error_result = {"success": False, "error": str(e)}
         return json.dumps(error_result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Get Jira Filter", "readOnlyHint": True},
+)
+async def get_filter(
+    ctx: Context,
+    filter_id: Annotated[
+        str,
+        Field(description="The numeric ID of the Jira saved filter (e.g., '12345')"),
+    ],
+) -> str:
+    """Get a saved Jira filter by ID, returning its JQL and metadata.
+
+    Args:
+        ctx: The FastMCP context.
+        filter_id: The ID of the saved filter.
+
+    Returns:
+        JSON string with id, name, jql, owner, description, favourite,
+        shared_with fields, or an error object if not found.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_filter(filter_id=filter_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_filters"},
+    annotations={"title": "Search Jira Filters", "readOnlyHint": True},
+)
+async def search_filters(
+    ctx: Context,
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional substring to match against filter names. "
+                "If omitted, returns the current user's accessible filters."
+            ),
+            default="",
+        ),
+    ] = "",
+    limit: Annotated[
+        int,
+        Field(
+            description="Maximum number of filters to return (1–50)",
+            default=25,
+            ge=1,
+            le=50,
+        ),
+    ] = 25,
+) -> str:
+    """Search for saved Jira filters accessible to the current user.
+
+    Args:
+        ctx: The FastMCP context.
+        query: Optional filter name substring. Omit to list all accessible filters.
+        limit: Maximum results (1–50).
+
+    Returns:
+        JSON array of objects with id, name, jql, owner_display_name.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.search_filters(
+        query=query if query else None,
+        limit=limit,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_dashboards"},
+    annotations={"title": "Get Jira Dashboard", "readOnlyHint": True},
+)
+async def get_dashboard(
+    ctx: Context,
+    dashboard_id: Annotated[
+        str,
+        Field(description="The numeric ID of the Jira dashboard (e.g., '14207')"),
+    ],
+    resolve_filters: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True (default), attempt to resolve the filter name and JQL "
+                "for each gadget that references a saved filter. Best-effort on "
+                "Data Center — gadgets without a filterId are skipped gracefully."
+            ),
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Get Jira dashboard metadata including gadgets and their filter details.
+
+    On Jira Data Center, gadget enumeration may not be supported.
+    In that case, gadgets will be empty and gadgets_supported will be False.
+    When gadgets_supported is False, surface next_step_hint to the user and
+    wait for filter IDs before continuing. Resolve via jira_get_filter or
+    jira_search_filters.
+
+    Args:
+        ctx: The FastMCP context.
+        dashboard_id: The ID of the dashboard.
+        resolve_filters: Whether to resolve filter name/JQL per gadget.
+
+    Returns:
+        JSON with id, name, description, owner, view_url, gadgets list
+        (each with filter_id, filter_name, jql when resolvable),
+        gadget_resolution_warnings, gadgets_supported bool, and
+        next_step_hint (set when gadgets_supported is False).
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_dashboard(
+        dashboard_id=dashboard_id,
+        resolve_filters=resolve_filters,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 71 tools into 23 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -22,7 +22,7 @@ class ToolsetDefinition:
     default: bool
 
 
-# --- Jira toolsets (15) ---
+# --- Jira toolsets (17) ---
 
 JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     "jira_issues": ToolsetDefinition(
@@ -100,6 +100,16 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Development info (branches, PRs, commits)",
         default=False,
     ),
+    "jira_filters": ToolsetDefinition(
+        name="jira_filters",
+        description="Saved filter read operations",
+        default=False,
+    ),
+    "jira_dashboards": ToolsetDefinition(
+        name="jira_dashboards",
+        description="Dashboard metadata and gadget read operations",
+        default=False,
+    ),
 }
 
 # --- Confluence toolsets (6) ---
@@ -152,7 +162,7 @@ DEFAULT_TOOLSETS: set[str] = {
 def get_enabled_toolsets() -> set[str]:
     """Parse the TOOLSETS env var into a set of enabled toolset names.
 
-    Supports keywords 'all' (all 21 toolsets) and 'default' (6 defaults),
+    Supports keywords 'all' (all 23 toolsets) and 'default' (6 defaults),
     plus comma-separated specific toolset names. Case-insensitive for keywords.
 
     When TOOLSETS is unset or empty, returns all toolsets with a deprecation
@@ -165,9 +175,9 @@ def get_enabled_toolsets() -> set[str]:
         names are given, returns an empty set (fail-closed).
 
     Examples:
-        TOOLSETS unset -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="" -> all 21 toolsets (with deprecation warning)
-        TOOLSETS="all" -> all 21 names
+        TOOLSETS unset -> all 23 toolsets (with deprecation warning)
+        TOOLSETS="" -> all 23 toolsets (with deprecation warning)
+        TOOLSETS="all" -> all 23 names
         TOOLSETS="default" -> 6 default names
         TOOLSETS="default,jira_agile" -> defaults + jira_agile
         TOOLSETS="typo_name" -> set() (fail-closed)

--- a/tests/unit/jira/test_dashboards.py
+++ b/tests/unit/jira/test_dashboards.py
@@ -1,0 +1,323 @@
+"""Tests for the Jira DashboardMixin."""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.jira.dashboards import DashboardMixin, _GADGET_HINT
+
+
+@pytest.fixture
+def dashboard_mixin(jira_fetcher) -> DashboardMixin:
+    """Create a DashboardMixin instance with mocked dependencies."""
+    return jira_fetcher
+
+
+_SENTINEL = object()
+
+
+def _make_dashboard(gadgets: list[dict] | object = _SENTINEL) -> dict:
+    """Build a mock dashboard response. Pass gadgets=None to omit the key."""
+    base: dict = {
+        "id": "14207",
+        "name": "Sprint Overview",
+        "description": "Team sprint board",
+        "owner": {"displayName": "Alice"},
+        "view": "https://jira.example.com/secure/Dashboard.jspa?selectPageId=14207",
+    }
+    if gadgets is not _SENTINEL:
+        base["gadgets"] = gadgets  # type: ignore[assignment]
+    else:
+        base["gadgets"] = []
+    return base
+
+
+def _make_dashboard_no_gadgets_key() -> dict:
+    """Build a mock dashboard response without the gadgets key (DC unsupported)."""
+    return {
+        "id": "14207",
+        "name": "Sprint Overview",
+        "description": "Team sprint board",
+        "owner": {"displayName": "Alice"},
+        "view": "https://jira.example.com/secure/Dashboard.jspa?selectPageId=14207",
+    }
+
+
+def _make_gadget(gadget_id: str, title: str = "Gadget", row: int = 0, col: int = 0) -> dict:
+    return {
+        "id": gadget_id,
+        "title": title,
+        "color": "blue",
+        "position": {"row": row, "column": col},
+    }
+
+
+def test_get_dashboard_success_with_filter_resolution(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """Dashboard with 3 gadgets returns resolved filter_name and jql for all."""
+    gadgets = [
+        _make_gadget("g1", "Sprint Health", 0, 0),
+        _make_gadget("g2", "Backlog Status", 0, 1),
+        _make_gadget("g3", "Velocity Chart", 1, 0),
+    ]
+
+    filter_responses = {
+        "f100": {
+            "id": "f100",
+            "name": "Sprint Health Filter",
+            "jql": "project = ORB AND sprint in openSprints()",
+            "description": None,
+            "favourite": False,
+            "owner": {"name": "alice", "displayName": "Alice", "emailAddress": None},
+            "shared_with": [],
+        },
+        "f101": {
+            "id": "f101",
+            "name": "Backlog Filter",
+            "jql": "project = ORB AND sprint is EMPTY",
+            "description": None,
+            "favourite": False,
+            "owner": {"name": "alice", "displayName": "Alice", "emailAddress": None},
+            "shared_with": [],
+        },
+        "f102": {
+            "id": "f102",
+            "name": "Velocity Filter",
+            "jql": "project = ORB AND sprint in closedSprints()",
+            "description": None,
+            "favourite": False,
+            "owner": {"name": "alice", "displayName": "Alice", "emailAddress": None},
+            "shared_with": [],
+        },
+    }
+
+    gadget_configs = {
+        "g1": {"filterId": "f100"},
+        "g2": {"filterId": "f101"},
+        "g3": {"filterId": "f102"},
+    }
+
+    def get_side_effect(*args, **kwargs):
+        path = kwargs.get("path") or (args[0] if args else "")
+        if path == "rest/api/2/dashboard/14207":
+            return _make_dashboard(gadgets)
+        for gid, config in gadget_configs.items():
+            if f"items/{gid}/properties/config" in path:
+                return {"value": config}
+        for fid, fdata in filter_responses.items():
+            if path == f"rest/api/2/filter/{fid}":
+                return {
+                    "id": fid,
+                    "name": fdata["name"],
+                    "jql": fdata["jql"],
+                    "description": fdata["description"],
+                    "favourite": fdata["favourite"],
+                    "owner": {"name": "alice", "displayName": "Alice"},
+                    "sharePermissions": [],
+                }
+        return {}
+
+    dashboard_mixin.jira.get = MagicMock(side_effect=get_side_effect)
+
+    result = dashboard_mixin.get_dashboard("14207", resolve_filters=True)
+
+    assert result["id"] == "14207"
+    assert result["name"] == "Sprint Overview"
+    assert result["owner"] == "Alice"
+    assert len(result["gadgets"]) == 3
+    assert result["gadget_resolution_warnings"] == []
+    assert result["gadgets_supported"] is True
+    assert result["next_step_hint"] is None
+
+    g1 = result["gadgets"][0]
+    assert g1["filter_id"] == "f100"
+    assert g1["filter_name"] == "Sprint Health Filter"
+    assert "openSprints" in g1["jql"]
+
+    g2 = result["gadgets"][1]
+    assert g2["filter_id"] == "f101"
+    assert g2["filter_name"] == "Backlog Filter"
+
+    g3 = result["gadgets"][2]
+    assert g3["filter_id"] == "f102"
+    assert g3["filter_name"] == "Velocity Filter"
+
+
+def test_get_dashboard_gadget_config_404(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """A gadget whose config returns 404 is added to gadget_resolution_warnings."""
+    gadgets = [
+        _make_gadget("g1", "Resolved Gadget"),
+        _make_gadget("g2", "Unresolvable Gadget"),
+    ]
+
+    def get_side_effect(*args, **kwargs):
+        path = kwargs.get("path") or (args[0] if args else "")
+        if path == "rest/api/2/dashboard/14207":
+            return _make_dashboard(gadgets)
+        if "items/g1/properties/config" in path:
+            return {"value": {"filterId": "f50"}}
+        if "items/g2/properties/config" in path:
+            raise HTTPError(response=Mock(status_code=404))
+        if path == "rest/api/2/filter/f50":
+            return {
+                "id": "f50",
+                "name": "Good Filter",
+                "jql": "project = ORB",
+                "sharePermissions": [],
+                "owner": {"displayName": "Alice"},
+            }
+        return {}
+
+    dashboard_mixin.jira.get = MagicMock(side_effect=get_side_effect)
+
+    result = dashboard_mixin.get_dashboard("14207", resolve_filters=True)
+
+    assert len(result["gadgets"]) == 2
+    assert "g2" in result["gadget_resolution_warnings"]
+    assert "g1" not in result["gadget_resolution_warnings"]
+    assert result["gadgets_supported"] is True
+    assert result["next_step_hint"] is None
+
+    g1 = next(g for g in result["gadgets"] if g["id"] == "g1")
+    assert g1["filter_name"] == "Good Filter"
+
+    g2 = next(g for g in result["gadgets"] if g["id"] == "g2")
+    assert g2["filter_id"] is None
+    assert g2["filter_name"] is None
+
+
+def test_get_dashboard_resolve_filters_false(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """With resolve_filters=False, filter_id is extracted but filter_name/jql stay None."""
+    gadgets = [_make_gadget("g1", "Sprint Board")]
+
+    def get_side_effect(*args, **kwargs):
+        path = kwargs.get("path") or (args[0] if args else "")
+        if path == "rest/api/2/dashboard/14207":
+            return _make_dashboard(gadgets)
+        if "items/g1/properties/config" in path:
+            return {"value": {"filterId": "f77"}}
+        return {}
+
+    dashboard_mixin.jira.get = MagicMock(side_effect=get_side_effect)
+
+    result = dashboard_mixin.get_dashboard("14207", resolve_filters=False)
+
+    assert len(result["gadgets"]) == 1
+    assert result["gadgets_supported"] is True
+    assert result["next_step_hint"] is None
+    g = result["gadgets"][0]
+    assert g["filter_id"] == "f77"
+    assert g["filter_name"] is None
+    assert g["jql"] is None
+
+    # Ensure no /rest/api/2/filter/ call was made
+    for call_args in dashboard_mixin.jira.get.call_args_list:
+        path = call_args.kwargs.get("path") or (call_args.args[0] if call_args.args else "")
+        assert "rest/api/2/filter/" not in path
+
+
+def test_get_dashboard_not_found(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """get_dashboard returns an error dict on 404 without raising."""
+    dashboard_mixin.jira.get = MagicMock(
+        side_effect=HTTPError(response=Mock(status_code=404))
+    )
+
+    result = dashboard_mixin.get_dashboard("99999")
+
+    assert "error" in result
+    assert "99999" in result["error"]
+
+
+def test_get_dashboard_non_dict_response(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """get_dashboard returns an error dict when API returns non-dict data."""
+    dashboard_mixin.jira.get = MagicMock(return_value=None)
+
+    result = dashboard_mixin.get_dashboard("14207")
+
+    assert "error" in result
+
+
+def test_get_dashboard_gadget_position(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """Gadget position row/column is correctly extracted."""
+    gadgets = [_make_gadget("g1", "Gadget", row=2, col=1)]
+
+    dashboard_mixin.jira.get = MagicMock(
+        side_effect=lambda *a, **kw: (
+            _make_dashboard(gadgets)
+            if "rest/api/2/dashboard/14207" in (kw.get("path") or "")
+            else {}
+        )
+    )
+
+    result = dashboard_mixin.get_dashboard("14207", resolve_filters=False)
+
+    g = result["gadgets"][0]
+    assert g["position"]["row"] == 2
+    assert g["position"]["column"] == 1
+
+
+def test_get_dashboard_gadgets_supported_true_when_empty_list(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """gadgets_supported is True when the API returns an explicit empty gadgets list."""
+    dashboard_mixin.jira.get = MagicMock(return_value=_make_dashboard(gadgets=[]))
+
+    result = dashboard_mixin.get_dashboard("14207", resolve_filters=False)
+
+    assert result["gadgets"] == []
+    assert result["gadgets_supported"] is True
+    assert result["next_step_hint"] is None
+
+
+def test_get_dashboard_gadgets_supported_false_when_key_absent(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """gadgets_supported is False when the API response has no gadgets key (DC unsupported)."""
+    dashboard_mixin.jira.get = MagicMock(return_value=_make_dashboard_no_gadgets_key())
+
+    result = dashboard_mixin.get_dashboard("14207", resolve_filters=False)
+
+    assert result["gadgets"] == []
+    assert result["gadgets_supported"] is False
+
+
+def test_get_dashboard_next_step_hint_set_when_unsupported(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """next_step_hint is populated with the guidance string when gadgets_supported is False."""
+    dashboard_mixin.jira.get = MagicMock(return_value=_make_dashboard_no_gadgets_key())
+
+    result = dashboard_mixin.get_dashboard("14207")
+
+    assert result["next_step_hint"] == _GADGET_HINT
+    assert "filter IDs" in result["next_step_hint"]
+
+
+def test_get_dashboard_next_step_hint_none_when_supported(
+    dashboard_mixin: DashboardMixin,
+) -> None:
+    """next_step_hint is None when gadgets_supported is True."""
+    dashboard_mixin.jira.get = MagicMock(
+        side_effect=lambda *a, **kw: (
+            _make_dashboard([_make_gadget("g1")])
+            if "rest/api/2/dashboard/14207" in (kw.get("path") or "")
+            else {}
+        )
+    )
+
+    result = dashboard_mixin.get_dashboard("14207", resolve_filters=False)
+
+    assert result["gadgets_supported"] is True
+    assert result["next_step_hint"] is None

--- a/tests/unit/jira/test_filters.py
+++ b/tests/unit/jira/test_filters.py
@@ -1,0 +1,166 @@
+"""Tests for the Jira FilterMixin."""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.jira.filters import FilterMixin
+
+
+@pytest.fixture
+def filter_mixin(jira_fetcher) -> FilterMixin:
+    """Create a FilterMixin instance with mocked dependencies."""
+    return jira_fetcher
+
+
+def test_get_filter_success(filter_mixin: FilterMixin) -> None:
+    """get_filter returns a well-formed dict for a valid filter ID."""
+    filter_mixin.jira.get = MagicMock(
+        return_value={
+            "id": "12345",
+            "name": "My Open Issues",
+            "jql": "assignee = currentUser() AND statusCategory != Done",
+            "description": "All my open issues",
+            "favourite": True,
+            "owner": {
+                "name": "jdoe",
+                "displayName": "Jane Doe",
+                "emailAddress": "jane@example.com",
+            },
+            "sharePermissions": [
+                {"type": "project", "project": {"name": "ORB"}, "role": None, "group": None}
+            ],
+        }
+    )
+
+    result = filter_mixin.get_filter("12345")
+
+    assert result["id"] == "12345"
+    assert result["name"] == "My Open Issues"
+    assert "assignee = currentUser()" in result["jql"]
+    assert result["favourite"] is True
+    assert result["owner"]["displayName"] == "Jane Doe"
+    assert result["owner"]["emailAddress"] == "jane@example.com"
+    assert len(result["shared_with"]) == 1
+    assert result["shared_with"][0]["type"] == "project"
+
+
+def test_get_filter_not_found(filter_mixin: FilterMixin) -> None:
+    """get_filter returns an error dict on 404 without raising."""
+    filter_mixin.jira.get = MagicMock(
+        side_effect=HTTPError(response=Mock(status_code=404))
+    )
+
+    result = filter_mixin.get_filter("99999")
+
+    assert "error" in result
+    assert "99999" in result["error"]
+
+
+def test_get_filter_non_dict_response(filter_mixin: FilterMixin) -> None:
+    """get_filter returns an error dict when API returns non-dict data."""
+    filter_mixin.jira.get = MagicMock(return_value=None)
+
+    result = filter_mixin.get_filter("12345")
+
+    assert "error" in result
+
+
+def test_get_filter_non_404_http_error_propagates(filter_mixin: FilterMixin) -> None:
+    """get_filter re-raises non-404 HTTPErrors."""
+    filter_mixin.jira.get = MagicMock(
+        side_effect=HTTPError(response=Mock(status_code=500))
+    )
+
+    with pytest.raises(HTTPError):
+        filter_mixin.get_filter("12345")
+
+
+def test_search_filters_success(filter_mixin: FilterMixin) -> None:
+    """search_filters returns simplified filter list from /filter/search."""
+    filter_mixin.jira.get = MagicMock(
+        return_value={
+            "values": [
+                {
+                    "id": "1",
+                    "name": "ORB Sprint Filter",
+                    "jql": "project = ORB",
+                    "owner": {"displayName": "Alice"},
+                },
+                {
+                    "id": "2",
+                    "name": "ORB Bugs",
+                    "jql": "project = ORB AND issuetype = Bug",
+                    "owner": {"displayName": "Bob"},
+                },
+            ]
+        }
+    )
+
+    results = filter_mixin.search_filters(query="ORB", limit=10)
+
+    assert len(results) == 2
+    assert results[0]["id"] == "1"
+    assert results[0]["name"] == "ORB Sprint Filter"
+    assert results[0]["owner_display_name"] == "Alice"
+    assert "project = ORB" in results[0]["jql"]
+
+
+def test_search_filters_fallback_on_404(filter_mixin: FilterMixin) -> None:
+    """search_filters falls back to GET /filter when /filter/search returns 404."""
+    call_count = 0
+
+    def get_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        path = kwargs.get("path") or (args[0] if args else "")
+        if "filter/search" in path:
+            raise HTTPError(response=Mock(status_code=404))
+        # Fallback endpoint returns a list
+        return [
+            {"id": "10", "name": "ORB Filter", "jql": "project = ORB", "owner": {"name": "alice"}},
+            {"id": "11", "name": "Unrelated", "jql": "project = OTHER", "owner": {"name": "bob"}},
+        ]
+
+    filter_mixin.jira.get = MagicMock(side_effect=get_side_effect)
+
+    results = filter_mixin.search_filters(query="ORB", limit=25)
+
+    assert call_count == 2  # first /filter/search, then /filter
+    assert len(results) == 1
+    assert results[0]["name"] == "ORB Filter"
+
+
+def test_search_filters_fallback_no_query(filter_mixin: FilterMixin) -> None:
+    """search_filters fallback without a query returns all accessible filters up to limit."""
+
+    def get_side_effect(*args, **kwargs):
+        path = kwargs.get("path") or (args[0] if args else "")
+        if "filter/search" in path:
+            raise HTTPError(response=Mock(status_code=404))
+        return [
+            {"id": str(i), "name": f"Filter {i}", "jql": f"project = P{i}", "owner": {}}
+            for i in range(10)
+        ]
+
+    filter_mixin.jira.get = MagicMock(side_effect=get_side_effect)
+
+    results = filter_mixin.search_filters(query=None, limit=5)
+
+    assert len(results) == 5
+
+
+def test_search_filters_limit_clamped(filter_mixin: FilterMixin) -> None:
+    """search_filters clamps limit to 1–50 range."""
+    filter_mixin.jira.get = MagicMock(return_value={"values": []})
+
+    # limit=0 should be clamped to 1
+    filter_mixin.search_filters(query=None, limit=0)
+    call_args = filter_mixin.jira.get.call_args
+    assert call_args.kwargs["params"]["maxResults"] == 1
+
+    # limit=100 should be clamped to 50
+    filter_mixin.search_filters(query=None, limit=100)
+    call_args = filter_mixin.jira.get.call_args
+    assert call_args.kwargs["params"]["maxResults"] == 50

--- a/tests/unit/jira/test_velocity.py
+++ b/tests/unit/jira/test_velocity.py
@@ -1,0 +1,167 @@
+"""Tests for the Jira VelocityMixin."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.jira.velocity import VelocityMixin
+
+
+@pytest.fixture
+def velocity_mixin(jira_fetcher) -> VelocityMixin:
+    """Create a VelocityMixin instance with mocked dependencies."""
+    return jira_fetcher
+
+
+def test_get_sprint_velocity_success(velocity_mixin: VelocityMixin) -> None:
+    """Sprint velocity aggregates committed and completed points."""
+
+    def get_side_effect(*args, **kwargs):
+        path = kwargs.get("path") or args[0]
+        if path == "rest/agile/1.0/board/42/configuration":
+            return {
+                "estimation": {
+                    "field": {
+                        "fieldId": "customfield_10016",
+                    }
+                }
+            }
+        if path == "rest/agile/1.0/sprint/101":
+            return {
+                "id": 101,
+                "name": "Sprint 101",
+                "state": "closed",
+                "startDate": "2026-01-01",
+                "endDate": "2026-01-14",
+            }
+        if path == "rest/agile/1.0/sprint/101/issue":
+            return {
+                "issues": [
+                    {
+                        "id": "1",
+                        "fields": {
+                            "customfield_10016": 5,
+                            "status": {
+                                "statusCategory": {
+                                    "key": "done",
+                                    "name": "Done",
+                                }
+                            },
+                            "assignee": {"displayName": "Alice"},
+                        },
+                    },
+                    {
+                        "id": "2",
+                        "fields": {
+                            "customfield_10016": 3,
+                            "status": {
+                                "statusCategory": {
+                                    "key": "indeterminate",
+                                    "name": "In Progress",
+                                }
+                            },
+                            "assignee": {"displayName": "Bob"},
+                        },
+                    },
+                ],
+                "total": 2,
+                "isLast": True,
+            }
+        return {}
+
+    velocity_mixin.jira.get = MagicMock(side_effect=get_side_effect)
+
+    result = velocity_mixin.get_sprint_velocity(board_id="42", sprint_id="101")
+
+    assert result["committed_points"] == pytest.approx(8.0)
+    assert result["completed_points"] == pytest.approx(5.0)
+    assert result["completion_rate"] == pytest.approx(62.5)
+    assert result["story_points_field"] == "customfield_10016"
+    assert len(result["per_assignee"]) == 2
+
+
+def test_get_sprint_velocity_requires_story_points_field(
+    velocity_mixin: VelocityMixin,
+) -> None:
+    """Sprint velocity raises when board has no estimations field."""
+    velocity_mixin.jira.get = MagicMock(return_value={})
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine Story Points field from board configuration.",
+    ):
+        velocity_mixin.get_sprint_velocity(board_id="42", sprint_id="101")
+
+
+def test_get_velocity_report_builds_trend(velocity_mixin: VelocityMixin) -> None:
+    """Velocity report computes aggregate averages and trend."""
+    velocity_mixin.get_all_sprints_from_board = MagicMock(
+        return_value=[
+            {"id": 1, "completeDate": "2026-01-10"},
+            {"id": 2, "completeDate": "2026-01-24"},
+            {"id": 3, "completeDate": "2026-02-07"},
+        ]
+    )
+    velocity_mixin.get_sprint_velocity = MagicMock(
+        side_effect=[
+            {"sprint_id": "1", "completed_points": 10.0, "completion_rate": 70.0},
+            {"sprint_id": "2", "completed_points": 12.0, "completion_rate": 80.0},
+            {"sprint_id": "3", "completed_points": 15.0, "completion_rate": 90.0},
+        ]
+    )
+
+    report = velocity_mixin.get_velocity_report(board_id="42", num_sprints=3)
+
+    assert report["num_sprints_analyzed"] == 3
+    assert report["average_completed_points"] == pytest.approx(12.33)
+    assert report["average_completion_rate"] == pytest.approx(80.0)
+    assert report["velocity_trend"] == "increasing"
+
+
+def test_get_team_sprint_summary_aggregates_assignees(
+    velocity_mixin: VelocityMixin,
+) -> None:
+    """Team summary aggregates assignee stats across sprints."""
+    velocity_mixin.get_velocity_report = MagicMock(
+        return_value={
+            "num_sprints_analyzed": 2,
+            "average_completed_points": 20.0,
+            "average_completion_rate": 88.0,
+            "velocity_trend": "stable",
+            "sprints": [
+                {
+                    "per_assignee": [
+                        {
+                            "assignee": "Alice",
+                            "issue_count": 2,
+                            "committed_points": 8.0,
+                            "completed_points": 6.0,
+                        },
+                        {
+                            "assignee": "Bob",
+                            "issue_count": 1,
+                            "committed_points": 3.0,
+                            "completed_points": 3.0,
+                        },
+                    ]
+                },
+                {
+                    "per_assignee": [
+                        {
+                            "assignee": "Alice",
+                            "issue_count": 1,
+                            "committed_points": 5.0,
+                            "completed_points": 5.0,
+                        }
+                    ]
+                },
+            ],
+        }
+    )
+
+    summary = velocity_mixin.get_team_sprint_summary(board_id="42", num_sprints=2)
+
+    assert summary["num_sprints"] == 2
+    assert summary["velocity"]["trend"] == "stable"
+    assert summary["per_assignee"][0]["assignee"] == "Alice"
+    assert summary["per_assignee"][0]["completed_points"] == pytest.approx(11.0)

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,20 +34,20 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 23 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 23
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
-        """Test 'ALL' keyword is case-insensitive."""
+        """Test 'ALL' keyword is case-insensitive and returns all 23 toolset names."""
         monkeypatch.setenv("TOOLSETS", "ALL")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 23
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,14 +91,14 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 23 entries."""
+        assert len(ALL_TOOLSETS) == 23
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 15
+        assert len(jira_toolsets) == 17
         assert len(confluence_toolsets) == 6
 
 
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 55, f"Expected 55 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
feat: add FilterMixin and DashboardMixin for enhanced Jira filter and dashboard operations

- Introduced FilterMixin for reading saved filters, including methods to get a filter by ID and search for filters.
- Added DashboardMixin for reading dashboard metadata and gadget configurations, with support for resolving filter details.
- Updated toolsets to include new Jira filter and dashboard toolsets.
- Enhanced unit tests for FilterMixin and DashboardMixin to ensure proper functionality and error handling.