### PR TITLE
fix(auth): guard per-user OAuthConfig construction against a BYO global config

### DIFF
--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -422,16 +422,18 @@ def _create_user_config_for_fetcher(
                 "or set base_url for Data Center OAuth."
             )
 
-        # For minimal OAuth config (user-provided tokens), use empty strings for client credentials
+        # Minimal OAuth config (user-provided tokens): client credentials fall back
+        # to empty strings. The global oauth_config may be a
+        # BYOAccessTokenOAuthConfig (e.g. a placeholder *_OAUTH_ACCESS_TOKEN set to
+        # suppress the headless OAuth setup flow), which has no
+        # client_id/client_secret/redirect_uri/scope attributes. With the OAuth proxy
+        # active these come from the proxy config, not here, so getattr() with an
+        # empty-string fallback is safe and avoids an AttributeError.
         oauth_config_for_user = OAuthConfig(
-            client_id=global_oauth_cfg.client_id if global_oauth_cfg.client_id else "",
-            client_secret=global_oauth_cfg.client_secret
-            if global_oauth_cfg.client_secret
-            else "",
-            redirect_uri=global_oauth_cfg.redirect_uri
-            if global_oauth_cfg.redirect_uri
-            else "",
-            scope=global_oauth_cfg.scope if global_oauth_cfg.scope else "",
+            client_id=getattr(global_oauth_cfg, "client_id", "") or "",
+            client_secret=getattr(global_oauth_cfg, "client_secret", "") or "",
+            redirect_uri=getattr(global_oauth_cfg, "redirect_uri", "") or "",
+            scope=getattr(global_oauth_cfg, "scope", "") or "",
             access_token=user_access_token,
             refresh_token=None,
             expires_at=None,

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -16,7 +16,7 @@ from mcp_atlassian.servers.dependencies import (
     get_confluence_fetcher,
     get_jira_fetcher,
 )
-from mcp_atlassian.utils.oauth import OAuthConfig
+from mcp_atlassian.utils.oauth import BYOAccessTokenOAuthConfig, OAuthConfig
 from tests.utils.assertions import assert_mock_called_with_partial
 from tests.utils.factories import AuthConfigFactory
 from tests.utils.mocks import MockFastMCP
@@ -249,6 +249,71 @@ class TestCreateUserConfigForFetcher:
         assert (
             result_config.oauth_config.client_secret == ""
         )  # Should preserve minimal config
+
+    @pytest.mark.parametrize(
+        "byo_config,cloud_id_arg,expected_cloud_id,expected_base_url",
+        [
+            pytest.param(
+                BYOAccessTokenOAuthConfig(
+                    access_token="placeholder-startup-token",
+                    base_url="https://jira.dc.example.com",
+                ),
+                None,
+                None,
+                "https://jira.dc.example.com",
+                id="data-center-byo-global-config",
+            ),
+            pytest.param(
+                BYOAccessTokenOAuthConfig(
+                    access_token="placeholder-startup-token",
+                    cloud_id="global-cloud-id",
+                ),
+                "user-cloud-id",
+                "user-cloud-id",
+                None,
+                id="cloud-byo-global-config",
+            ),
+        ],
+    )
+    def test_oauth_user_config_with_byo_global_config(
+        self, byo_config, cloud_id_arg, expected_cloud_id, expected_base_url
+    ):
+        """Regression: global oauth_config may be a BYOAccessTokenOAuthConfig.
+
+        When a placeholder ``*_OAUTH_ACCESS_TOKEN`` suppresses the headless OAuth
+        setup flow, ``get_oauth_config_from_env()`` returns a
+        ``BYOAccessTokenOAuthConfig`` (BYO takes precedence over ``OAuthConfig``).
+        That dataclass has no ``client_id``/``client_secret``/``redirect_uri``/
+        ``scope`` attributes. With per-request OAuth proxy auth enabled, this
+        function previously read those attributes directly off the global config,
+        raising ``AttributeError`` at request time. They must fall back to empty
+        strings (the real client credentials come from the OAuth proxy config).
+        """
+        base_config = JiraConfig(
+            url="https://jira.dc.example.com",
+            auth_type="oauth",
+            oauth_config=byo_config,
+        )
+        credentials = {"oauth_access_token": "user-access-token"}
+
+        # Must not raise AttributeError on the BYO global config.
+        result_config = _create_user_config_for_fetcher(
+            base_config=base_config,
+            auth_type="oauth",
+            credentials=credentials,
+            cloud_id=cloud_id_arg,
+        )
+
+        assert isinstance(result_config, JiraConfig)
+        assert result_config.oauth_config is not None
+        assert result_config.oauth_config.access_token == "user-access-token"
+        # Client credentials fall back to empty strings (supplied by the proxy).
+        assert result_config.oauth_config.client_id == ""
+        assert result_config.oauth_config.client_secret == ""
+        assert result_config.oauth_config.redirect_uri == ""
+        assert result_config.oauth_config.scope == ""
+        assert result_config.oauth_config.cloud_id == expected_cloud_id
+        assert result_config.oauth_config.base_url == expected_base_url
 
     def test_multi_tenant_config_isolation(self):
         """Test that user configs are completely isolated from each other."""


### PR DESCRIPTION
## What

`_create_user_config_for_fetcher()` builds a per-user `OAuthConfig` from the
global `oauth_config`, reading `client_id` / `client_secret` / `redirect_uri` /
`scope` directly. When the global `oauth_config` is a
`BYOAccessTokenOAuthConfig` — which happens whenever a placeholder
`*_OAUTH_ACCESS_TOKEN` is set (BYO takes precedence in
`get_oauth_config_from_env()`) — those attributes don't exist and the per-request
path raises `AttributeError: 'BYOAccessTokenOAuthConfig' object has no attribute
'client_id'` at request time.

This reads the four fields via `getattr(..., "")` with an empty-string fallback,
matching how the adjacent `base_url` / `is_data_center` reads are already guarded.

## Why it's safe

When the per-request OAuth proxy is active, the real client credentials come from
the OAuth proxy config, not from the global Jira/Confluence config. So falling
back to empty strings for the global-config side is correct — those values are
not used to authenticate the per-user request.

## Testing

- New parametrized regression test
  `TestCreateUserConfigForFetcher::test_oauth_user_config_with_byo_global_config`
  covering Data Center (base URL, no cloud_id) and Cloud (cloud_id) BYO global
  configs.
- Verified the test reproduces the bug: against the unpatched code it fails with
  `AttributeError: 'BYOAccessTokenOAuthConfig' object has no attribute
  'client_id'`; with the fix both cases pass.
- `tests/unit/servers/test_dependencies.py`: 60 passed.
- `ruff format --check` clean; no new `ruff check` findings on the changed lines.

## Scope

One-line-per-field change in `src/mcp_atlassian/servers/dependencies.py` plus the
regression test. No behavior change for the existing full-`OAuthConfig` path.

Closes #1363.