### PR TITLE
feat(confluence): support base64 content in upload_attachment

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -167,6 +167,84 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             "failed": failed,
         }
 
+    def upload_attachment_from_content(
+        self,
+        content_id: str,
+        filename: str,
+        content: bytes,
+        comment: str | None = None,
+        minor_edit: bool = True,
+    ) -> dict[str, Any]:
+        """
+        Upload a single attachment from in-memory bytes.
+
+        This is the filesystem-free counterpart to ``upload_attachment``. It is
+        intended for deployments where the server cannot read host file paths
+        (for example, a remote or containerized MCP server): the caller provides
+        the raw file content directly instead of a path.
+
+        Args:
+            content_id: The Confluence content ID
+            filename: Name of the attachment (determines title and file type)
+            content: Raw file bytes to upload
+            comment: Optional comment for the attachment
+            minor_edit: Whether this is a minor edit (default: True)
+
+        Returns:
+            A dictionary with upload result information
+        """
+        if not content_id:
+            logger.error("No content ID provided for attachment upload")
+            return {"success": False, "error": "No content ID provided"}
+
+        if not filename:
+            logger.error("No filename provided for attachment upload")
+            return {"success": False, "error": "No filename provided"}
+
+        if content is None:
+            logger.error("No file content provided for attachment upload")
+            return {"success": False, "error": "No file content provided"}
+
+        try:
+            logger.info(
+                f"Uploading attachment {filename} ({len(content)} bytes) to "
+                f"content {content_id} (minor_edit={minor_edit})"
+            )
+
+            attachment = self._upload_attachment_from_bytes(
+                content_id, filename, content, comment, minor_edit
+            )
+
+            if attachment:
+                logger.info(
+                    f"Successfully uploaded attachment {filename} to content "
+                    f"{content_id} (size: {len(content)} bytes)"
+                )
+                return {
+                    "success": True,
+                    "content_id": content_id,
+                    "filename": filename,
+                    "size": len(content),
+                    "id": attachment.get("id")
+                    if isinstance(attachment, dict)
+                    else None,
+                }
+
+            logger.error(
+                f"Failed to upload attachment {filename} to content {content_id}"
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"Failed to upload attachment {filename} to content {content_id}"
+                ),
+            }
+
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error uploading attachment from content: {error_msg}")
+            return {"success": False, "error": error_msg}
+
     def fetch_attachment_content(self, url: str) -> bytes | None:
         """Fetch attachment content into memory.
 
@@ -465,51 +543,114 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
         Returns:
             Attachment metadata dict if successful, None otherwise
         """
+        file_handle = None
         try:
-            # Build the API endpoint URL
-            base_url = self.config.url.rstrip("/")
-            url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
-
-            # Prepare headers (X-Atlassian-Token required for file uploads)
-            headers = {"X-Atlassian-Token": "nocheck"}
-
-            # Prepare multipart form data
-            files = {"file": (filename, open(file_path, "rb"))}
-
-            # Comment must be sent with text/plain content-type for proper encoding
-            if comment:
-                files["comment"] = (None, comment, "text/plain; charset=utf-8")
-
-            data = {}
-            if minor_edit is not None:
-                data["minorEdit"] = str(minor_edit).lower()
-
-            # Use PUT to support creating new versions of existing attachments
-            # PUT will create a new attachment if it doesn't exist, OR create a new
-            # version if an attachment with the same filename already exists
-            response = self.confluence._session.put(
-                url, headers=headers, files=files, data=data
+            # Open the file and reuse the shared multipart upload helper
+            file_handle = open(file_path, "rb")
+            return self._send_attachment_request(
+                content_id, filename, file_handle, comment, minor_edit
             )
-            response.raise_for_status()
-
-            # Parse response
-            result = response.json()
-
-            # Return first result if it's a list
-            if isinstance(result, dict) and "results" in result:
-                results = result.get("results", [])
-                return results[0] if results else result
-            return result
-
         except Exception as e:
             logger.error(f"Direct API upload failed: {e}")
             return None
         finally:
-            # Close file handles (only for actual file objects, not text fields like comment)
-            if "files" in locals() and "file" in files:
-                file_tuple = files["file"]
-                if len(file_tuple) >= 2 and hasattr(file_tuple[1], "close"):
-                    file_tuple[1].close()
+            if file_handle is not None:
+                file_handle.close()
+
+    def _upload_attachment_from_bytes(
+        self,
+        content_id: str,
+        filename: str,
+        content: bytes,
+        comment: str | None,
+        minor_edit: bool,
+    ) -> dict[str, Any] | None:
+        """
+        Upload attachment from in-memory bytes using a direct REST API call.
+
+        Unlike ``_upload_attachment_direct`` this never touches the filesystem,
+        which is required when the server cannot read host file paths (for
+        example when running inside a container).
+
+        Args:
+            content_id: The Confluence content ID
+            filename: Name of the file (determines the attachment title/type)
+            content: Raw file bytes to upload
+            comment: Optional comment for the attachment
+            minor_edit: Whether this is a minor edit
+
+        Returns:
+            Attachment metadata dict if successful, None otherwise
+        """
+        try:
+            return self._send_attachment_request(
+                content_id, filename, content, comment, minor_edit
+            )
+        except Exception as e:
+            logger.error(f"In-memory API upload failed: {e}")
+            return None
+
+    def _send_attachment_request(
+        self,
+        content_id: str,
+        filename: str,
+        file_obj: Any,
+        comment: str | None,
+        minor_edit: bool,
+    ) -> dict[str, Any]:
+        """
+        Send the multipart attachment upload request to the Confluence REST API.
+
+        This uses the REST API directly to support the ``minorEdit`` parameter,
+        which is not available in the atlassian-python-api library's
+        ``attach_file()`` method. ``file_obj`` may be any value accepted by the
+        ``requests`` library as multipart content (an open file handle or raw
+        ``bytes``).
+
+        Args:
+            content_id: The Confluence content ID
+            filename: Name of the file
+            file_obj: File-like object or raw bytes to upload
+            comment: Optional comment for the attachment
+            minor_edit: Whether this is a minor edit
+
+        Returns:
+            Attachment metadata dict.
+        """
+        # Build the API endpoint URL
+        base_url = self.config.url.rstrip("/")
+        url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
+
+        # Prepare headers (X-Atlassian-Token required for file uploads)
+        headers = {"X-Atlassian-Token": "nocheck"}
+
+        # Prepare multipart form data
+        files = {"file": (filename, file_obj)}
+
+        # Comment must be sent with text/plain content-type for proper encoding
+        if comment:
+            files["comment"] = (None, comment, "text/plain; charset=utf-8")
+
+        data = {}
+        if minor_edit is not None:
+            data["minorEdit"] = str(minor_edit).lower()
+
+        # Use PUT to support creating new versions of existing attachments
+        # PUT will create a new attachment if it doesn't exist, OR create a new
+        # version if an attachment with the same filename already exists
+        response = self.confluence._session.put(
+            url, headers=headers, files=files, data=data
+        )
+        response.raise_for_status()
+
+        # Parse response
+        result = response.json()
+
+        # Return first result if it's a list
+        if isinstance(result, dict) and "results" in result:
+            results = result.get("results", [])
+            return results[0] if results else result
+        return result
 
     def delete_attachment(self, attachment_id: str) -> dict[str, Any]:
         """

--- a/src/mcp_atlassian/confluence/protocols.py
+++ b/src/mcp_atlassian/confluence/protocols.py
@@ -50,6 +50,29 @@ class AttachmentsOperationsProto(Protocol):
         """
 
     @abstractmethod
+    def upload_attachment_from_content(
+        self,
+        content_id: str,
+        filename: str,
+        content: bytes,
+        comment: str | None = None,
+        minor_edit: bool = True,
+    ) -> dict[str, Any]:
+        """
+        Upload a single attachment from in-memory bytes.
+
+        Args:
+            content_id: The ID of the content (page/blog post) to attach the file to
+            filename: Name of the attachment (determines title and file type)
+            content: Raw file bytes to upload
+            comment: Optional comment for the attachment
+            minor_edit: Whether this is a minor edit (default: True)
+
+        Returns:
+            A dictionary with upload result information
+        """
+
+    @abstractmethod
     def download_attachment(self, url: str, target_path: str) -> bool:
         """
         Download a Confluence attachment to the specified path.

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -1,6 +1,7 @@
 """Confluence FastMCP server instance and tool definitions."""
 
 import base64
+import binascii
 import json
 import logging
 import mimetypes
@@ -1305,15 +1306,43 @@ async def upload_attachment(
         ),
     ],
     file_path: Annotated[
-        str,
+        str | None,
         Field(
             description=(
                 "Full path to the file to upload. Can be absolute (e.g., '/home/user/document.pdf' or 'C:\\Users\\name\\file.docx') "
                 "or relative to the current working directory (e.g., './uploads/document.pdf'). "
-                "If a file with the same name already exists, a new version will be created."
-            )
+                "If a file with the same name already exists, a new version will be created. "
+                "Requires the server to be able to read the path; for remote or "
+                "containerized servers use 'content_base64' instead. Provide either "
+                "'file_path' or 'content_base64', not both."
+            ),
+            default=None,
         ),
-    ],
+    ] = None,
+    content_base64: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Base64-encoded file content to upload directly, without "
+                "the server reading from disk. Use this when the server cannot access "
+                "host file paths (e.g. a remote or containerized MCP server). "
+                "Requires 'filename'. Provide either 'file_path' or 'content_base64', "
+                "not both."
+            ),
+            default=None,
+        ),
+    ] = None,
+    filename: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Attachment filename, including extension (e.g. "
+                "'report.pdf'). Required when using 'content_base64'; it determines "
+                "the attachment title and file type. Ignored when 'file_path' is used."
+            ),
+            default=None,
+        ),
+    ] = None,
     comment: Annotated[
         str | None,
         Field(
@@ -1337,6 +1366,11 @@ async def upload_attachment(
 ) -> str:
     """Upload an attachment to Confluence content (page or blog post).
 
+    Provide the file either as a server-readable path ('file_path') or as
+    base64-encoded content ('content_base64' together with 'filename'). The
+    base64 form is intended for remote or containerized servers that cannot
+    read host file paths. Exactly one of the two must be supplied.
+
     If the attachment already exists (same filename), a new version is created.
     This is useful for:
     - Attaching documents, images, or files to a page
@@ -1346,21 +1380,42 @@ async def upload_attachment(
     Args:
         ctx: The FastMCP context.
         content_id: The ID of the content to attach to.
-        file_path: Path to the file to upload.
+        file_path: Path to the file to upload (server-readable).
+        content_base64: Base64-encoded file content (filesystem-free upload).
+        filename: Attachment filename, required with content_base64.
         comment: Optional comment for the attachment.
         minor_edit: Whether this is a minor edit (no notifications).
 
     Returns:
         JSON string with upload confirmation and attachment metadata.
     """
+    if bool(file_path) == bool(content_base64):
+        raise ValueError("Provide exactly one of 'file_path' or 'content_base64'.")
+
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
-    result = confluence_fetcher.upload_attachment(
-        content_id=content_id,
-        file_path=file_path,
-        comment=comment,
-        minor_edit=minor_edit,
-    )
+    if content_base64:
+        if not filename:
+            raise ValueError("'filename' is required when using 'content_base64'.")
+        try:
+            content = base64.b64decode(content_base64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(f"Invalid base64 content: {exc}") from exc
+
+        result = confluence_fetcher.upload_attachment_from_content(
+            content_id=content_id,
+            filename=filename,
+            content=content,
+            comment=comment,
+            minor_edit=minor_edit,
+        )
+    else:
+        result = confluence_fetcher.upload_attachment(
+            content_id=content_id,
+            file_path=file_path,
+            comment=comment,
+            minor_edit=minor_edit,
+        )
 
     return json.dumps(
         {"message": "Attachment uploaded successfully", "attachment": result},

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -383,6 +383,76 @@ class TestAttachmentsMixin:
         assert result["success"] is False
         assert "No content ID provided" in result["error"]
 
+    # Tests for upload_attachment_from_content method
+
+    def test_upload_attachment_from_content_success(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test successful in-memory attachment upload (no filesystem access)."""
+        self._mock_rest_api_upload(attachments_mixin)
+
+        result = attachments_mixin.upload_attachment_from_content(
+            "123456",
+            "test_file.txt",
+            b"test content",
+            comment="Test comment",
+            minor_edit=False,
+        )
+
+        assert result["success"] is True
+        assert result["content_id"] == "123456"
+        assert result["filename"] == "test_file.txt"
+        assert result["size"] == len(b"test content")
+        assert result["id"] == "att12345"
+
+        # The REST API must be called without ever touching the filesystem
+        attachments_mixin.confluence._session.put.assert_called_once()
+        call_args = attachments_mixin.confluence._session.put.call_args
+        assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
+        assert call_args[1]["headers"]["X-Atlassian-Token"] == "nocheck"
+        assert call_args[1]["data"]["minorEdit"] == "false"
+        # The raw bytes are sent directly as the multipart file payload
+        assert call_args[1]["files"]["file"] == ("test_file.txt", b"test content")
+
+    def test_upload_attachment_from_content_no_content_id(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test in-memory upload with no content ID."""
+        result = attachments_mixin.upload_attachment_from_content(
+            "", "test_file.txt", b"data"
+        )
+
+        assert result["success"] is False
+        assert "No content ID provided" in result["error"]
+        attachments_mixin.confluence._session.put.assert_not_called()
+
+    def test_upload_attachment_from_content_no_filename(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test in-memory upload with no filename."""
+        result = attachments_mixin.upload_attachment_from_content("123456", "", b"data")
+
+        assert result["success"] is False
+        assert "No filename provided" in result["error"]
+        attachments_mixin.confluence._session.put.assert_not_called()
+
+    def test_upload_attachment_from_content_api_error(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test in-memory upload surfaces API errors as a failure result."""
+        from requests.exceptions import HTTPError
+
+        self._mock_rest_api_upload(
+            attachments_mixin, raise_error=HTTPError("API Error")
+        )
+
+        result = attachments_mixin.upload_attachment_from_content(
+            "123456", "test_file.txt", b"data"
+        )
+
+        assert result["success"] is False
+        assert "Failed to upload attachment" in result["error"]
+
     # Tests for download_attachment method
 
     def test_download_attachment_success(self, attachments_mixin: AttachmentsMixin):

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -117,6 +117,13 @@ def mock_confluence_fetcher():
             "extensions": {"fileSize": 1024},
         },
     }
+    mock_fetcher.upload_attachment_from_content.return_value = {
+        "success": True,
+        "content_id": "123456",
+        "filename": "test-file.txt",
+        "size": 1024,
+        "id": "att123",
+    }
     mock_fetcher.upload_attachments.return_value = {
         "success": True,
         "content_id": "123456",
@@ -769,6 +776,87 @@ async def test_upload_attachment(client, mock_confluence_fetcher):
     assert "attachment" in result_data
     assert result_data["attachment"]["attachment"]["id"] == "att123"
     assert result_data["attachment"]["attachment"]["title"] == "test-file.txt"
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_base64(client, mock_confluence_fetcher):
+    """Test uploading an attachment via base64 content (filesystem-free)."""
+    import base64
+
+    raw = b"hello base64 world"
+    encoded = base64.b64encode(raw).decode("ascii")
+
+    response = await client.call_tool(
+        "confluence_upload_attachment",
+        {
+            "content_id": "123456",
+            "content_base64": encoded,
+            "filename": "test-file.txt",
+            "comment": "Test attachment",
+            "minor_edit": True,
+        },
+    )
+
+    mock_confluence_fetcher.upload_attachment_from_content.assert_called_once_with(
+        content_id="123456",
+        filename="test-file.txt",
+        content=raw,
+        comment="Test attachment",
+        minor_edit=True,
+    )
+    # The filesystem-based path must not be used in base64 mode
+    mock_confluence_fetcher.upload_attachment.assert_not_called()
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["message"] == "Attachment uploaded successfully"
+    assert result_data["attachment"]["id"] == "att123"
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_requires_exactly_one_source(
+    client, mock_confluence_fetcher
+):
+    """Test that providing neither or both file_path and content_base64 fails."""
+    # Neither provided
+    with pytest.raises(Exception, match="exactly one of 'file_path'"):
+        await client.call_tool("confluence_upload_attachment", {"content_id": "123456"})
+
+    # Both provided
+    with pytest.raises(Exception, match="exactly one of 'file_path'"):
+        await client.call_tool(
+            "confluence_upload_attachment",
+            {
+                "content_id": "123456",
+                "file_path": "/path/to/file.txt",
+                "content_base64": "Zm9v",
+            },
+        )
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_base64_requires_filename(
+    client, mock_confluence_fetcher
+):
+    """Test that base64 uploads require a filename."""
+    with pytest.raises(Exception, match="'filename' is required"):
+        await client.call_tool(
+            "confluence_upload_attachment",
+            {"content_id": "123456", "content_base64": "Zm9v"},
+        )
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_invalid_base64(client, mock_confluence_fetcher):
+    """Test that invalid base64 content is rejected."""
+    with pytest.raises(Exception, match="Invalid base64 content"):
+        await client.call_tool(
+            "confluence_upload_attachment",
+            {
+                "content_id": "123456",
+                "content_base64": "not valid base64!!!",
+                "filename": "test-file.txt",
+            },
+        )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

`confluence_upload_attachment` currently requires a server-readable `file_path`. This does not work when the MCP server runs **remotely or in a container** and has no access to the calling client's filesystem — the path the client knows simply does not exist on the server.

This PR adds an alternative, **filesystem-free** upload path while keeping the existing `file_path` behaviour fully intact.

## Changes

- **`AttachmentsMixin.upload_attachment_from_content(content_id, filename, content, comment, minor_edit)`** — uploads raw `bytes` directly. The multipart REST request is extracted into a shared `_send_attachment_request` helper reused by both the file-path and in-memory paths, so the existing upload behaviour is unchanged (`requests` accepts raw bytes as multipart content, so no temp file is needed).
- **`confluence_upload_attachment` tool** gains two parameters:
  - `content_base64` — base64-encoded file content
  - `filename` — required with `content_base64` (determines title/type)

  `file_path` is now optional. Callers must provide **exactly one** of `file_path` / `content_base64`. Invalid base64 and a missing `filename` are rejected with clear `ValueError`s.
- New abstract method added to `AttachmentsOperationsProto`.

## Backwards compatibility

Fully backwards compatible — existing `file_path` calls are unchanged. The only signature change is `file_path` becoming optional.

## Tests

- Mixin: success / no-content-id / no-filename / API-error for the in-memory path.
- Tool: base64 upload, mutual-exclusion (neither/both source), missing-filename, invalid-base64.

All new and existing attachment/server tests pass; `ruff`, `ruff-format` and `mypy` are clean on the changed files under the project config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)