### PR TITLE
concurrency for initial tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,10 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #JIRA_TIMEOUT=75
 #CONFLUENCE_TIMEOUT=75
 
+# --- Jira Fetcher Concurrency ---
+# Maximum concurrent Jira fetcher calls offloaded to worker threads. Default is 8.
+#JIRA_FETCHER_MAX_WORKERS=8
+
 # --- Read-Only Mode ---
 # Disables all write operations (create, update, delete). Default is false.
 #READ_ONLY_MODE=false

--- a/src/mcp_atlassian/servers/async_utils.py
+++ b/src/mcp_atlassian/servers/async_utils.py
@@ -1,0 +1,63 @@
+"""Async helpers for server tool implementations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from functools import partial
+from typing import ParamSpec, TypeVar
+
+import anyio
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+JIRA_FETCHER_MAX_WORKERS_ENV = "JIRA_FETCHER_MAX_WORKERS"
+DEFAULT_JIRA_FETCHER_MAX_WORKERS = 8
+
+_jira_fetcher_limiter: anyio.CapacityLimiter | None = None
+_jira_fetcher_limiter_size: int | None = None
+
+
+def get_jira_fetcher_max_workers() -> int:
+    """Return the configured maximum concurrent Jira fetcher calls."""
+    raw_value = os.getenv(JIRA_FETCHER_MAX_WORKERS_ENV)
+    if not raw_value:
+        return DEFAULT_JIRA_FETCHER_MAX_WORKERS
+
+    try:
+        worker_count = int(raw_value)
+    except ValueError:
+        return DEFAULT_JIRA_FETCHER_MAX_WORKERS
+
+    if worker_count <= 0:
+        return DEFAULT_JIRA_FETCHER_MAX_WORKERS
+    return worker_count
+
+
+def _get_jira_fetcher_limiter() -> anyio.CapacityLimiter:
+    """Return a process-wide limiter for Jira fetcher worker threads."""
+    global _jira_fetcher_limiter, _jira_fetcher_limiter_size
+
+    worker_count = get_jira_fetcher_max_workers()
+    if (
+        _jira_fetcher_limiter is None
+        or _jira_fetcher_limiter_size != worker_count
+    ):
+        _jira_fetcher_limiter = anyio.CapacityLimiter(worker_count)
+        _jira_fetcher_limiter_size = worker_count
+    return _jira_fetcher_limiter
+
+
+async def run_jira_fetcher_call(
+    func: Callable[P, T],
+    /,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> T:
+    """Run a blocking Jira fetcher call in a bounded worker thread."""
+    call = partial(func, *args, **kwargs)
+    return await anyio.to_thread.run_sync(
+        call,
+        limiter=_get_jira_fetcher_limiter(),
+    )

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -15,6 +15,7 @@ from mcp_atlassian.jira.constants import DEFAULT_READ_JIRA_FIELDS
 from mcp_atlassian.jira.forms_common import convert_datetime_to_timestamp
 from mcp_atlassian.models.jira import JiraAttachment
 from mcp_atlassian.models.jira.common import JiraUser
+from mcp_atlassian.servers.async_utils import run_jira_fetcher_call
 from mcp_atlassian.servers.dependencies import get_jira_fetcher
 from mcp_atlassian.utils.decorators import check_write_access
 from mcp_atlassian.utils.media import (
@@ -371,7 +372,8 @@ async def get_issue(
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
 
-    issue = jira.get_issue(
+    issue = await run_jira_fetcher_call(
+        jira.get_issue,
         issue_key=issue_key,
         fields=fields_list,
         expand=expand,
@@ -472,7 +474,8 @@ async def search(
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
 
-    search_result = jira.search_issues(
+    search_result = await run_jira_fetcher_call(
+        jira.search_issues,
         jql=jql,
         fields=fields_list,
         limit=limit,

--- a/tests/unit/servers/test_async_utils.py
+++ b/tests/unit/servers/test_async_utils.py
@@ -1,0 +1,128 @@
+"""Tests for server async utility helpers."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
+from threading import Lock
+
+import anyio
+import pytest
+
+from src.mcp_atlassian.servers.async_utils import (
+    DEFAULT_JIRA_FETCHER_MAX_WORKERS,
+    JIRA_FETCHER_MAX_WORKERS_ENV,
+    get_jira_fetcher_max_workers,
+    run_jira_fetcher_call,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_jira_fetcher_workers(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset the Jira worker limit env var between tests."""
+    monkeypatch.delenv(JIRA_FETCHER_MAX_WORKERS_ENV, raising=False)
+    yield
+    monkeypatch.delenv(JIRA_FETCHER_MAX_WORKERS_ENV, raising=False)
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (None, DEFAULT_JIRA_FETCHER_MAX_WORKERS),
+        ("1", 1),
+        ("8", 8),
+        ("16", 16),
+        ("0", DEFAULT_JIRA_FETCHER_MAX_WORKERS),
+        ("-1", DEFAULT_JIRA_FETCHER_MAX_WORKERS),
+        ("abc", DEFAULT_JIRA_FETCHER_MAX_WORKERS),
+        ("", DEFAULT_JIRA_FETCHER_MAX_WORKERS),
+    ],
+)
+def test_get_jira_fetcher_max_workers(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: str | None,
+    expected: int,
+) -> None:
+    """Jira worker limit falls back unless env var is a positive integer."""
+    if raw_value is None:
+        monkeypatch.delenv(JIRA_FETCHER_MAX_WORKERS_ENV, raising=False)
+    else:
+        monkeypatch.setenv(JIRA_FETCHER_MAX_WORKERS_ENV, raw_value)
+
+    assert get_jira_fetcher_max_workers() == expected
+
+
+@pytest.mark.anyio
+async def test_run_jira_fetcher_call_allows_bounded_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blocking Jira calls can overlap while respecting the configured limit."""
+    monkeypatch.setenv(JIRA_FETCHER_MAX_WORKERS_ENV, "2")
+    active = 0
+    max_active = 0
+    lock = Lock()
+
+    def blocking_call(value: int) -> int:
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+        return value
+
+    results: list[int] = []
+
+    async def call(value: int) -> None:
+        results.append(await run_jira_fetcher_call(blocking_call, value))
+
+    async with anyio.create_task_group() as task_group:
+        for value in range(4):
+            task_group.start_soon(call, value)
+
+    assert sorted(results) == [0, 1, 2, 3]
+    assert max_active > 1
+    assert max_active <= 2
+
+
+@pytest.mark.anyio
+async def test_run_jira_fetcher_call_respects_single_worker_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured single-worker limit serializes offloaded blocking calls."""
+    monkeypatch.setenv(JIRA_FETCHER_MAX_WORKERS_ENV, "1")
+    active = 0
+    max_active = 0
+    lock = Lock()
+
+    def blocking_call(value: int) -> int:
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.02)
+        with lock:
+            active -= 1
+        return value
+
+    async with anyio.create_task_group() as task_group:
+        for value in range(3):
+            task_group.start_soon(run_jira_fetcher_call, blocking_call, value)
+
+    assert max_active == 1
+
+
+def test_run_jira_fetcher_call_works_from_foreign_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Limiter creation is safe when the first call happens outside the main thread."""
+    monkeypatch.setenv(JIRA_FETCHER_MAX_WORKERS_ENV, "2")
+
+    def run_from_worker() -> int:
+        return anyio.run(run_jira_fetcher_call, lambda: 42)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future: Future[int] = executor.submit(run_from_worker)
+        assert future.result(timeout=5) == 42


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Adds bounded worker-thread concurrency for the initial Jira read tools so blocking Jira fetcher calls no longer block the async MCP server event loop. The worker limit is configurable via `JIRA_FETCHER_MAX_WORKERS` and defaults safely when unset or invalid.

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- Added Jira server async utilities for offloading blocking fetcher calls through an `anyio` worker-thread capacity limiter.
- Updated `jira_get_issue` and `jira_search` to use the bounded async offload helper.
- Documented the new `JIRA_FETCHER_MAX_WORKERS` environment variable in `.env.example`.
- Added unit coverage for default/invalid worker configuration, bounded concurrency, single-worker serialization, and first-use from a non-main thread.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated: `tests/unit/servers/test_async_utils.py`
- [ ] Integration tests passed
- [x] Manual checks performed: Yes with multiple clients

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).