### PR TITLE
fix(confluence): fix attachment upload on Confluence Server instances

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -466,12 +466,20 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             Attachment metadata dict if successful, None otherwise
         """
         try:
-            # Build the API endpoint URL
             base_url = self.config.url.rstrip("/")
-            url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
+
+            # Confluence Server rejects POST to the create endpoint when an attachment
+            # with the same filename already exists. Route to the update endpoint instead.
+            existing = self.get_content_attachments(content_id, filename=filename)
+            existing_list = existing.get("attachments", [])
+            if existing_list:
+                attachment_id = existing_list[0].get("id")
+                url = f"{base_url}/rest/api/content/{content_id}/child/attachment/{attachment_id}/data"
+            else:
+                url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
 
             # Prepare headers (X-Atlassian-Token required for file uploads)
-            headers = {"X-Atlassian-Token": "nocheck"}
+            headers = {"X-Atlassian-Token": "no-check"}
 
             # Prepare multipart form data
             files = {"file": (filename, open(file_path, "rb"))}
@@ -484,10 +492,8 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             if minor_edit is not None:
                 data["minorEdit"] = str(minor_edit).lower()
 
-            # Use PUT to support creating new versions of existing attachments
-            # PUT will create a new attachment if it doesn't exist, OR create a new
-            # version if an attachment with the same filename already exists
-            response = self.confluence._session.put(
+            # Use POST to create new attachment or new version of existing attachment
+            response = self.confluence._session.post(
                 url, headers=headers, files=files, data=data
             )
             response.raise_for_status()

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -104,13 +104,11 @@ class TestAttachmentsMixin:
 
         mock_response = Mock()
         if raise_error:
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.side_effect = raise_error
+            attachments_mixin.confluence._session.post.side_effect = raise_error
         else:
             mock_response.json.return_value = response_data
             mock_response.raise_for_status.return_value = None
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.return_value = mock_response
+            attachments_mixin.confluence._session.post.return_value = mock_response
 
         return mock_response
 
@@ -129,6 +127,11 @@ class TestAttachmentsMixin:
             patch("os.path.abspath") as mock_abspath,
             patch("os.path.basename") as mock_basename,
             patch("builtins.open", mock_open(read_data=b"test content")),
+            patch.object(
+                attachments_mixin,
+                "get_content_attachments",
+                return_value={"attachments": []},
+            ),
         ):
             mock_exists.return_value = True
             mock_getsize.return_value = 100
@@ -152,19 +155,58 @@ class TestAttachmentsMixin:
             assert result["id"] == "att12345"
 
             # Verify the REST API was called with correct parameters
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.assert_called_once()
-            call_args = attachments_mixin.confluence._session.put.call_args
+            attachments_mixin.confluence._session.post.assert_called_once()
+            call_args = attachments_mixin.confluence._session.post.call_args
 
-            # Check URL
-            assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
+            # Check URL targets the create endpoint (no existing attachment)
+            assert call_args[0][0].endswith("/rest/api/content/123456/child/attachment")
 
-            # Check headers include X-Atlassian-Token
-            assert call_args[1]["headers"]["X-Atlassian-Token"] == "nocheck"
+            # Check headers include correct X-Atlassian-Token value
+            assert call_args[1]["headers"]["X-Atlassian-Token"] == "no-check"
 
             # Check minorEdit was passed in data
             assert call_args[1]["data"]["minorEdit"] == "false"
-            # Note: comment is now in files dict as multipart form data, not in data dict
+            # Note: comment is in files dict as multipart form data, not in data dict
+
+    def test_upload_attachment_update_existing(self, attachments_mixin: AttachmentsMixin):
+        """Test that re-uploading an existing attachment routes to the update endpoint."""
+        self._mock_rest_api_upload(attachments_mixin)
+
+        existing_attachment = [{"id": "att12345", "title": "test_file.txt"}]
+
+        with (
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.getsize") as mock_getsize,
+            patch("os.path.isabs") as mock_isabs,
+            patch("os.path.abspath") as mock_abspath,
+            patch("os.path.basename") as mock_basename,
+            patch("builtins.open", mock_open(read_data=b"updated content")),
+            patch.object(
+                attachments_mixin,
+                "get_content_attachments",
+                return_value={"attachments": existing_attachment},
+            ),
+        ):
+            mock_exists.return_value = True
+            mock_getsize.return_value = 100
+            mock_isabs.return_value = True
+            mock_abspath.return_value = "/absolute/path/test_file.txt"
+            mock_basename.return_value = "test_file.txt"
+
+            result = attachments_mixin.upload_attachment(
+                "123456", "/absolute/path/test_file.txt"
+            )
+
+            assert result["success"] is True
+
+            attachments_mixin.confluence._session.post.assert_called_once()
+            call_args = attachments_mixin.confluence._session.post.call_args
+
+            # Update path must target the /data endpoint for the existing attachment
+            assert call_args[0][0].endswith(
+                "/rest/api/content/123456/child/attachment/att12345/data"
+            )
+            assert call_args[1]["headers"]["X-Atlassian-Token"] == "no-check"
 
     def test_upload_attachment_relative_path(self, attachments_mixin: AttachmentsMixin):
         """Test attachment upload with a relative path."""
@@ -179,6 +221,11 @@ class TestAttachmentsMixin:
             patch("os.path.abspath") as mock_abspath,
             patch("os.path.basename") as mock_basename,
             patch("builtins.open", mock_open(read_data=b"test content")),
+            patch.object(
+                attachments_mixin,
+                "get_content_attachments",
+                return_value={"attachments": []},
+            ),
         ):
             mock_exists.return_value = True
             mock_getsize.return_value = 100
@@ -255,6 +302,11 @@ class TestAttachmentsMixin:
             patch("os.path.basename") as mock_basename,
             patch("os.path.getsize") as mock_getsize,
             patch("builtins.open", mock_open(read_data=b"test content")),
+            patch.object(
+                attachments_mixin,
+                "get_content_attachments",
+                return_value={"attachments": []},
+            ),
         ):
             mock_exists.return_value = True
             mock_isabs.return_value = True

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -168,7 +168,9 @@ class TestAttachmentsMixin:
             assert call_args[1]["data"]["minorEdit"] == "false"
             # Note: comment is in files dict as multipart form data, not in data dict
 
-    def test_upload_attachment_update_existing(self, attachments_mixin: AttachmentsMixin):
+    def test_upload_attachment_update_existing(
+        self, attachments_mixin: AttachmentsMixin
+    ):
         """Test that re-uploading an existing attachment routes to the update endpoint."""
         self._mock_rest_api_upload(attachments_mixin)
 

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -378,6 +378,11 @@ def test_confluence_fetcher_attachment_method_calls():
         fetcher = ConfluenceFetcher()
 
         # Test upload_attachment can be called
+        # Pre-configure the existing-attachment check to return empty (new attachment case)
+        mock_confluence.get_attachments_from_content.return_value = {
+            "results": [],
+            "size": 0,
+        }
         with (
             patch("os.path.exists", return_value=True),
             patch("os.path.isabs", return_value=True),
@@ -389,11 +394,8 @@ def test_confluence_fetcher_attachment_method_calls():
             assert result["success"] is True
             assert result["content_id"] == "123"
 
-        # Test get_content_attachments can be called
-        mock_confluence.get_attachments_from_content.return_value = {
-            "results": [],
-            "size": 0,
-        }
+        # Test get_content_attachments can be called (reset to isolate call count)
+        mock_confluence.get_attachments_from_content.reset_mock()
         result = fetcher.get_content_attachments("123")
         assert result["success"] is True
         mock_confluence.get_attachments_from_content.assert_called_once()


### PR DESCRIPTION
## Description

Fixes attachment uploads failing on Confluence Server (on-premises) instances.

## Changes

- Fix `X-Atlassian-Token` header value: `nocheck` → `no-check` (missing hyphen caused 403 Forbidden on Confluence Server)
- Fix HTTP method: `PUT` → `POST` for the create endpoint (PUT returned 405 Method Not Allowed)
- Add existing-attachment detection: before uploading, check whether an attachment with the same filename already exists; if so, route to the `/attachment/{id}/data` update endpoint instead of the create endpoint (avoids 409 Conflict on re-upload)

## Testing

- [x] Unit tests added/updated for changes
- [x] Integration tests passed
- [x] Manual checks performed: tested against Confluence Server (on-premises, PAT auth) — initial upload creates attachment, re-upload of same filename creates version 2 successfully

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
