### PR TITLE
fix(jira): parse full markdown table blocks and strip cell whitespace (#1343)

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -269,9 +269,11 @@ class JiraPreprocessor(BasePreprocessor):
         # Text formatting (bold, italic)
         output = re.sub(
             r"([*_])(.*?)\1",
-            lambda match: ("**" if match.group(1) == "*" else "*")
-            + match.group(2)
-            + ("**" if match.group(1) == "*" else "*"),
+            lambda match: (
+                ("**" if match.group(1) == "*" else "*")
+                + match.group(2)
+                + ("**" if match.group(1) == "*" else "*")
+            ),
             output,
         )
 
@@ -464,9 +466,7 @@ class JiraPreprocessor(BasePreprocessor):
         # Headers with = or - underlines
         output = re.sub(
             r"^(.*?)\n([=-])+$",
-            lambda match: (
-                f"h{1 if match.group(2)[0] == '=' else 2}. {match.group(1)}"
-            ),
+            lambda match: f"h{1 if match.group(2)[0] == '=' else 2}. {match.group(1)}",
             output,
             flags=re.MULTILINE,
         )
@@ -487,9 +487,11 @@ class JiraPreprocessor(BasePreprocessor):
                 return line
             return re.sub(
                 r"([*_]+)(.*?)\1",
-                lambda m: ("_" if len(m.group(1)) == 1 else "*")
-                + m.group(2)
-                + ("_" if len(m.group(1)) == 1 else "*"),
+                lambda m: (
+                    ("_" if len(m.group(1)) == 1 else "*")
+                    + m.group(2)
+                    + ("_" if len(m.group(1)) == 1 else "*")
+                ),
                 line,
             )
 
@@ -567,12 +569,32 @@ class JiraPreprocessor(BasePreprocessor):
         output = re.sub(r"<([^>]+)>", r"[\1]", output)
 
         # Convert markdown tables to Jira table format
+        # Issue #1343: parse full table blocks (header + separator + data rows),
+        # strip whitespace from each cell, convert header to ||cell|| and data
+        # rows to |cell|.
         lines = output.split("\n")
         i = 0
         while i < len(lines):
-            if i < len(lines) - 1 and re.match(r"\|[-\s|]+\|", lines[i + 1]):
-                lines[i] = lines[i].replace("|", "||")
-                lines.pop(i + 1)
+            # Look for a header row followed by a markdown separator line
+            if (
+                i < len(lines) - 1
+                and re.match(r"^\|[-\s|:]+\|$", lines[i + 1])
+                and re.match(r"^\|.*\|$", lines[i])
+            ):
+                # Header row
+                header_cells = [cell.strip() for cell in lines[i].split("|")[1:-1]]
+                lines[i] = "||" + "||".join(header_cells) + "||"
+                lines.pop(i + 1)  # drop separator
+
+                # Consume data rows while they look like table rows
+                while i < len(lines) and re.match(
+                    r"^\|.*\|$", lines[i + 1] if i + 1 < len(lines) else ""
+                ):
+                    data_cells = [
+                        cell.strip() for cell in lines[i + 1].split("|")[1:-1]
+                    ]
+                    lines[i + 1] = "|" + "|".join(data_cells) + "|"
+                    i += 1
             i += 1
 
         # Rejoin the lines

--- a/tests/unit/preprocessing/test_markdown_table_to_jira.py
+++ b/tests/unit/preprocessing/test_markdown_table_to_jira.py
@@ -1,0 +1,91 @@
+"""Regression tests for Issue #1343 — Markdown pipe table conversion."""
+
+import pytest
+
+from mcp_atlassian.preprocessing.jira import JiraPreprocessor
+
+
+@pytest.fixture
+def preprocessor():
+    return JiraPreprocessor()
+
+
+def test_markdown_table_with_spaces(preprocessor):
+    """Markdown tables with padded cells must be stripped when converted to Jira."""
+    markdown = """| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |"""
+
+    jira = preprocessor.markdown_to_jira(markdown)
+
+    lines = jira.strip().split("\n")
+    assert lines[0] == "||Header 1||Header 2||Header 3||"
+    assert lines[1] == "|Cell 1|Cell 2|Cell 3|"
+    assert lines[2] == "|Cell 4|Cell 5|Cell 6|"
+
+
+def test_markdown_table_no_spaces(preprocessor):
+    """Markdown tables without padding should still convert correctly."""
+    markdown = """|H1|H2|
+|--|--|
+|A|B|
+|C|D|"""
+
+    jira = preprocessor.markdown_to_jira(markdown)
+
+    lines = jira.strip().split("\n")
+    assert lines[0] == "||H1||H2||"
+    assert lines[1] == "|A|B|"
+    assert lines[2] == "|C|D|"
+
+
+def test_markdown_table_with_alignment(preprocessor):
+    """Markdown tables with alignment separators ( :---: ) should work."""
+    markdown = """| Left | Center | Right |
+|:-----|:------:|------:|
+| L    |   C    |     R |"""
+
+    jira = preprocessor.markdown_to_jira(markdown)
+
+    lines = jira.strip().split("\n")
+    assert lines[0] == "||Left||Center||Right||"
+    assert lines[1] == "|L|C|R|"
+
+
+def test_markdown_table_single_column(preprocessor):
+    """Single-column markdown tables should convert correctly."""
+    markdown = """| Name |
+|------|
+| Alice |
+| Bob   |"""
+
+    jira = preprocessor.markdown_to_jira(markdown)
+
+    lines = jira.strip().split("\n")
+    assert lines[0] == "||Name||"
+    assert lines[1] == "|Alice|"
+    assert lines[2] == "|Bob|"
+
+
+def test_non_table_pipes_unchanged(preprocessor):
+    """Lines that look like tables but lack a separator should be left alone."""
+    markdown = "This | is | not | a | table"
+
+    jira = preprocessor.markdown_to_jira(markdown)
+
+    assert jira.strip() == "This | is | not | a | table"
+
+
+def test_table_with_inline_formatting(preprocessor):
+    """Inline markdown formatting inside table cells should be preserved."""
+    markdown = """| Name | Status |
+|------|--------|
+| **Bold** | _italic_ |"""
+
+    jira = preprocessor.markdown_to_jira(markdown)
+
+    lines = jira.strip().split("\n")
+    assert lines[0] == "||Name||Status||"
+    assert "*Bold*" in lines[1]
+    assert "_italic_" in lines[1]


### PR DESCRIPTION
## Problem

The `markdown_to_jira()` table converter only replaced `|` with `||` in the header row and deleted the separator, leaving data rows untouched with spaces around content (e.g. `| east |` instead of `|east|`). This caused Jira to render table cells with unwanted padding or as plain text.

Issue #1343.

## Changes

### `src/mcp_atlassian/preprocessing/jira.py`

- Rewrote the markdown→Jira table loop to parse **full table blocks** (header + separator + 1+ data rows)
- Strip whitespace from each cell in both header and data rows
- Convert header delimiters to `||cell||` (Jira header syntax)
- Keep data row delimiters as `|cell|` (Jira data syntax)
- Drop the markdown separator line
- Support alignment separators (`:---:`, `------:`, etc.)

## Tests

- `tests/unit/preprocessing/test_markdown_table_to_jira.py`: 6 focused tests covering:
  1. Tables with padded cells (the original bug)
  2. Tables without padding
  3. Tables with alignment separators
  4. Single-column tables
  5. Non-table pipes left untouched
  6. Inline formatting preserved inside cells

## Verification

```bash
uv run pytest tests/unit/preprocessing/test_markdown_table_to_jira.py -v
# 6 passed

uv run pytest tests/unit/preprocessing/ -v
# 119 passed
```

Fixes #1343