### PR TITLE
fix(jira): fail loudly when assignee cannot be resolved in update_issue (silent no-op with modern account IDs)

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1106,7 +1106,13 @@ class IssuesMixin(
                             account_id = self._get_account_id(value)
                             self._add_assignee_to_fields(update_fields, account_id)
                         except ValueError as e:
-                            logger.warning(f"Could not update assignee: {str(e)}")
+                            # An explicit assignee update that cannot be resolved
+                            # must fail loudly. Swallowing it here means the PUT is
+                            # skipped (or runs without the assignee) while the call
+                            # still reports the issue as updated successfully.
+                            raise ValueError(
+                                f"Could not update assignee: {str(e)}"
+                            ) from e
                 elif key == "parent":
                     if isinstance(value, dict) and value.get("key"):
                         update_fields["parent"] = {"key": str(value["key"])}

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -120,8 +120,17 @@ class UsersMixin(JiraClient):
         Raises:
             ValueError: If the account ID could not be found.
         """
-        # If it looks like an account ID already, return it
+        # If it looks like an account ID already, return it.
+        # Cloud account IDs come in two shapes: the legacy 24-char hex format
+        # (e.g. "5b10ac8d82e05b22cc7d4ef5") and the current "<digits>:<uuid>"
+        # format (e.g. "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d").
+        # An explicit "accountid:" prefix is also accepted, matching the
+        # format documented in the create_issue/update_issue tool schemas.
+        if assignee.startswith("accountid:"):
+            return assignee[len("accountid:") :]
         if assignee.startswith("5") and len(assignee) >= 10:
+            return assignee
+        if re.match(r"^\d+:[0-9a-fA-F][0-9a-fA-F-]{7,}$", assignee):
             return assignee
 
         account_id = self._lookup_user_directly(assignee)

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -684,6 +684,17 @@ class TestIssuesMixin:
         assert not issues_mixin._get_account_id.called
         assert document.key == "TEST-123"
 
+    def test_update_issue_assignee_unresolvable_raises(self, issues_mixin: IssuesMixin):
+        """Test that update_issue raises when assignee cannot be resolved."""
+        issues_mixin._get_account_id = MagicMock(
+            side_effect=ValueError("Could not find account ID for user: ghost")
+        )
+
+        with pytest.raises(ValueError, match="Could not update assignee"):
+            issues_mixin.update_issue(issue_key="TEST-123", assignee="ghost")
+
+        issues_mixin.jira.update_issue.assert_not_called()
+
     def test_update_issue_components(self, issues_mixin: IssuesMixin):
         """Test updating an issue's components field."""
         issue_data = {

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -156,6 +156,30 @@ class TestUsersMixin:
         # Verify no lookups were performed
         users_mixin.jira.user_find_by_user_string.assert_not_called()
 
+    def test_get_account_id_modern_cloud_format(self, users_mixin):
+        """Test that _get_account_id returns modern Cloud account IDs unchanged."""
+        # Call the method with a modern Atlassian Cloud account ID
+        account_id = users_mixin._get_account_id(
+            "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d"
+        )
+
+        # Verify result
+        assert account_id == "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d"
+        # Verify no lookups were performed
+        users_mixin.jira.user_find_by_user_string.assert_not_called()
+
+    def test_get_account_id_strips_accountid_prefix(self, users_mixin):
+        """Test that _get_account_id strips the accountid: prefix."""
+        # Call the method with an accountid:-prefixed Cloud account ID
+        account_id = users_mixin._get_account_id(
+            "accountid:712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d"
+        )
+
+        # Verify result
+        assert account_id == "712020:f653aab5-cc61-4c57-8fa8-f7d73b94499d"
+        # Verify no lookups were performed
+        users_mixin.jira.user_find_by_user_string.assert_not_called()
+
     def test_get_account_id_direct_lookup(self, users_mixin):
         """Test that _get_account_id uses direct lookup."""
         # Mock both methods to avoid AttributeError


### PR DESCRIPTION
## Description

`jira_update_issue` with a valid modern Atlassian Cloud account ID (`712020:<uuid>`) reports **"Issue updated successfully" while the assignee never changes**. Two stacked bugs:

1. `_get_account_id()` only recognizes legacy account IDs (`assignee.startswith("5")`). Modern Cloud IDs like `712020:f653aab5-...` fail the heuristic, fall through to the user-search lookups (which query for the literal accountId string), find nothing, and raise `ValueError`.
2. `update_issue()` swallows that `ValueError` with `logger.warning`, so the PUT is skipped entirely and the tool returns the unchanged issue as a successful update.

The MCP client (LLM) has no way to detect this: the response is a success with the refetched — unchanged — issue. Observed in production against Jira Cloud (`712020:`-style accountIds are what Cloud issues `assignee.accountId` actually return today).

Overlaps with #1164 on the recognition half (kudos — same root cause); this PR additionally fixes the silent-failure half, accepts the documented `accountid:` prefix, and adds unit tests for all paths.


## Changes

- `jira/users.py::_get_account_id`: recognize the modern `<digits>:<uuid>` account ID format and strip the documented `accountid:` prefix (the format the `create_issue`/`update_issue` tool schemas advertise). Legacy `5...` IDs and email/username lookup behavior unchanged.
- `jira/issues.py::update_issue`: re-raise assignee resolution failures instead of swallowing them — an explicit assignee update that cannot be resolved now fails loudly instead of silently no-oping.
- Unit tests for both account ID formats, the prefix strip, and the loud failure (asserting the PUT is never issued).

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `verified against a real Jira Cloud instance — update_issue with a 712020:<uuid> assignee now issues the PUT and the assignee actually changes; an unresolvable user now raises instead of returning success. Full unit suite: 2581 passed, 5 skipped.`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
