### PR TITLE
fix(jira): support project version creation on self-managed Jira (Dat…

### DIFF
--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -382,7 +382,12 @@ class JiraClient:
         if description:
             payload["description"] = description
         logger.info(f"Creating Jira version: {payload}")
-        result = self.jira.post("/rest/api/3/version", json=payload)
+
+	if self.config.is_cloud:
+            result = self.jira.post("/rest/api/3/version", json=payload)
+        else:
+            result = self.jira.post("/rest/api/2/version", data=payload)
+
         if not isinstance(result, dict):
             error_message = f"Unexpected response from Jira API: {result}"
             raise ValueError(error_message)

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -383,7 +383,7 @@ class JiraClient:
             payload["description"] = description
         logger.info(f"Creating Jira version: {payload}")
 
-	if self.config.is_cloud:
+        if self.config.is_cloud:
             result = self.jira.post("/rest/api/3/version", json=payload)
         else:
             result = self.jira.post("/rest/api/2/version", data=payload)


### PR DESCRIPTION
## Description

Self-managed Jira (Server/Data Center) only supports the v2 REST API. The `create_version` method was hardcoded to call `/rest/api/3/version`, which is exclusive to Jira Cloud and causes failures on self-hosted instances.

**References:**
- Jira Cloud API v3 – version creation: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-versions/#api-rest-api-3-version-post
- Jira Server/DC API v2 – version creation: https://developer.atlassian.com/server/jira/platform/rest/v10000/api-group-version/#api-rest-api-2-version-post

## Changes

- Check `is_cloud` config flag in `create_version` to select the correct API version
- Jira Cloud uses `/rest/api/3/version` with `json=` payload
- Jira Server/Data Center uses `/rest/api/2/version` with `data=` payload

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: verified version creation on self-managed Jira instance using API v2 endpoint

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
