### PR TITLE
fix(confluence): add /wiki prefix to Cloud attachment upload and delete URLs

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -32,6 +32,23 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             )
         return None
 
+    def _rest_base_url(self) -> str:
+        """Return the REST API base URL, adding the Cloud ``/wiki`` prefix.
+
+        On Confluence Cloud, ``config.url`` is the bare site URL
+        (``https://site.atlassian.net``) but the REST API is served under
+        ``/wiki``. Hand-built URLs must include this prefix or requests 404.
+        The ``endswith`` guard avoids producing ``/wiki/wiki`` when the
+        configured URL already includes the prefix.
+
+        Returns:
+            The base URL to use for direct REST API calls.
+        """
+        base_url = self.config.url.rstrip("/")
+        if self.config.is_cloud and not base_url.endswith("/wiki"):
+            base_url = f"{base_url}/wiki"
+        return base_url
+
     def upload_attachment(
         self,
         content_id: str,
@@ -467,7 +484,7 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
         """
         try:
             # Build the API endpoint URL
-            base_url = self.config.url.rstrip("/")
+            base_url = self._rest_base_url()
             url = f"{base_url}/rest/api/content/{content_id}/child/attachment"
 
             # Prepare headers (X-Atlassian-Token required for file uploads)
@@ -540,7 +557,7 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
                     f"Using v1 API for token/basic authentication to delete attachment '{attachment_id}'"
                 )
                 # Use v1 API endpoint for deletion
-                base_url = self.config.url.rstrip("/")
+                base_url = self._rest_base_url()
                 url = f"{base_url}/rest/api/content/{attachment_id}"
                 response = self.confluence._session.delete(url)
                 response.raise_for_status()

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -166,6 +166,68 @@ class TestAttachmentsMixin:
             assert call_args[1]["data"]["minorEdit"] == "false"
             # Note: comment is now in files dict as multipart form data, not in data dict
 
+    def _capture_upload_url(self, attachments_mixin, config_url: str) -> str:
+        """Run an upload with the given config URL and return the request URL.
+
+        Sets ``config.url`` (which drives ``is_cloud``), performs an upload with
+        all file I/O mocked, and returns the URL passed to ``session.put``.
+        """
+        attachments_mixin.config.url = config_url
+        self._mock_rest_api_upload(attachments_mixin)
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getsize", return_value=100),
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.abspath", return_value="/absolute/path/test_file.txt"),
+            patch("os.path.basename", return_value="test_file.txt"),
+            patch("builtins.open", mock_open(read_data=b"test content")),
+        ):
+            attachments_mixin.upload_attachment(
+                "123456", "/absolute/path/test_file.txt"
+            )
+
+        return attachments_mixin.confluence._session.put.call_args[0][0]
+
+    def test_upload_attachment_cloud_adds_wiki_prefix(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Cloud bare site URL gets the /wiki prefix (otherwise the call 404s)."""
+        url = self._capture_upload_url(attachments_mixin, "https://test.atlassian.net")
+
+        assert (
+            url == "https://test.atlassian.net/wiki"
+            "/rest/api/content/123456/child/attachment"
+        )
+
+    def test_upload_attachment_cloud_no_double_wiki_prefix(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Cloud URL already ending in /wiki must not become /wiki/wiki."""
+        url = self._capture_upload_url(
+            attachments_mixin, "https://test.atlassian.net/wiki"
+        )
+
+        assert "/wiki/wiki" not in url
+        assert (
+            url == "https://test.atlassian.net/wiki"
+            "/rest/api/content/123456/child/attachment"
+        )
+
+    def test_upload_attachment_server_dc_no_wiki_prefix(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Server/DC URLs are unchanged — no /wiki prefix is added."""
+        url = self._capture_upload_url(
+            attachments_mixin, "https://confluence.example.com"
+        )
+
+        assert "/wiki" not in url
+        assert (
+            url == "https://confluence.example.com"
+            "/rest/api/content/123456/child/attachment"
+        )
+
     def test_upload_attachment_relative_path(self, attachments_mixin: AttachmentsMixin):
         """Test attachment upload with a relative path."""
         # Mock the REST API call
@@ -1093,6 +1155,49 @@ class TestAttachmentsMixin:
         assert result["attachment_id"] == "att123"
         assert "deleted successfully" in result["message"]
         attachments_mixin.confluence._session.delete.assert_called_once()
+
+    def _capture_delete_url(self, attachments_mixin, config_url: str) -> str:
+        """Run a v1 delete with the given config URL and return the request URL."""
+        attachments_mixin.config.auth_type = "basic"  # force v1 path
+        attachments_mixin.config.url = config_url
+
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        attachments_mixin.confluence._session.delete.return_value = mock_response
+
+        attachments_mixin.delete_attachment("att123")
+
+        return attachments_mixin.confluence._session.delete.call_args[0][0]
+
+    def test_delete_attachment_v1_cloud_adds_wiki_prefix(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Cloud bare site URL gets the /wiki prefix on the v1 delete endpoint."""
+        url = self._capture_delete_url(attachments_mixin, "https://test.atlassian.net")
+
+        assert url == "https://test.atlassian.net/wiki/rest/api/content/att123"
+
+    def test_delete_attachment_v1_cloud_no_double_wiki_prefix(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Cloud URL already ending in /wiki must not become /wiki/wiki."""
+        url = self._capture_delete_url(
+            attachments_mixin, "https://test.atlassian.net/wiki"
+        )
+
+        assert "/wiki/wiki" not in url
+        assert url == "https://test.atlassian.net/wiki/rest/api/content/att123"
+
+    def test_delete_attachment_v1_server_dc_no_wiki_prefix(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Server/DC URLs are unchanged — no /wiki prefix is added."""
+        url = self._capture_delete_url(
+            attachments_mixin, "https://confluence.example.com"
+        )
+
+        assert "/wiki" not in url
+        assert url == "https://confluence.example.com/rest/api/content/att123"
 
     def test_delete_attachment_success_v2(self, attachments_mixin: AttachmentsMixin):
         """Test successful deletion using v2 API (OAuth)."""


### PR DESCRIPTION
## Summary

Fixes the HTTP 404 reported in #1321 when uploading or deleting Confluence **Cloud** attachments via `confluence_upload_attachment` / `confluence_upload_attachments` (and the v1/token-auth delete path).

## Root cause

`_upload_attachment_direct` and the v1 branch of `delete_attachment` hand-build their REST URLs from `self.config.url`. On Cloud, `config.url` is the bare site URL (`https://site.atlassian.net`), but Cloud serves the REST API under `/wiki` (`https://site.atlassian.net/wiki/rest/api/...`). The hand-built URLs omit `/wiki`, so the requests 404. Every other Confluence tool works because it goes through `atlassian-python-api`'s higher-level client, which adds `/wiki`; only these two hand-built URLs miss it. (The issue confirms this empirically: identical POST differing only by `/wiki/` → 404 vs 200.)

## Fix

- New helper `_rest_base_url()` that prepends `/wiki` when `config.is_cloud`, guarded by an `endswith("/wiki")` check so configs that already include the prefix don't produce `/wiki/wiki`.
- Used at both hand-built call sites:
  - `_upload_attachment_direct`
  - the v1/token-auth branch of `delete_attachment`
- The OAuth delete path uses the v2 adapter and already constructs correct URLs, so it is left unchanged.

### Why not route through `attach_file()`?

`_upload_attachment_direct` deliberately bypasses `atlassian-python-api`'s `attach_file()` to support the `minorEdit` parameter (see the method's docstring). Routing through that helper would regress `minorEdit`, so the prefix is applied to the direct call instead.

## Tests

Added coverage in `tests/unit/confluence/test_attachments.py` for both upload and delete, asserting on the URL passed to the mocked session:

- **Cloud, bare URL** (`https://test.atlassian.net`) → URL contains the `/wiki` prefix
- **Cloud, URL already ending in `/wiki`** → no double `/wiki/wiki`
- **Server/DC** (`https://confluence.example.com`) → no `/wiki` prefix (unchanged behavior)

`uv run pytest` passes (full suite green) and `ruff-format` / `ruff` are clean.

Fixes #1321