### PR TITLE
fix(jira): support hyphenated numeric parts in issue key pattern

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 # Underscores are also allowed to support non-standard project key formats.
 # Hyphenated numeric parts (e.g., B7-214-68901) are supported for Server/DC
 # instances that use non-standard issue key formats.
-ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d[\d-]*\d$|^[A-Z][A-Z0-9_]+-\d+$"
+ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$"
 PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+$"
 
 jira_mcp = FastMCP(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -29,8 +29,10 @@ logger = logging.getLogger(__name__)
 # Regex patterns for Jira key validation.
 # Per Atlassian docs, Cloud project keys are 2-10 chars. Server/Data Center
 # allows longer keys (configurable). We accept any length to support both.
-# Underscores are also allowed to support non-standard project key formats
-ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+$"
+# Underscores are also allowed to support non-standard project key formats.
+# Hyphenated numeric parts (e.g., B7-214-68901) are supported for Server/DC
+# instances that use non-standard issue key formats.
+ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d[\d-]*\d$|^[A-Z][A-Z0-9_]+-\d+$"
 PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+$"
 
 jira_mcp = FastMCP(

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1549,11 +1549,13 @@ def test_issue_key_pattern_validation():
     assert re.match(ISSUE_KEY_PATTERN, "ABCDEFGHIJ-99")
     assert re.match(ISSUE_KEY_PATTERN, "D_DEV-123")
     assert re.match(ISSUE_KEY_PATTERN, "MY_PROJECT-1")
+    assert re.match(ISSUE_KEY_PATTERN, "B7-214-68901")
     # Invalid issue keys
     assert not re.match(ISSUE_KEY_PATTERN, "a-1")
     assert not re.match(ISSUE_KEY_PATTERN, "PROJ")
     assert not re.match(ISSUE_KEY_PATTERN, "2ABC-1")
-    assert not re.match(ISSUE_KEY_PATTERN, "A-1-2")
+    assert not re.match(ISSUE_KEY_PATTERN, "A4--123")
+    assert not re.match(ISSUE_KEY_PATTERN, "A4-123-")
 
     # Valid project keys
     assert re.match(PROJECT_KEY_PATTERN, "PROJ")

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1888,11 +1888,13 @@ def test_issue_key_pattern_validation():
     assert re.match(ISSUE_KEY_PATTERN, "D_DEV-123")
     assert re.match(ISSUE_KEY_PATTERN, "MY_PROJECT-1")
     assert re.match(ISSUE_KEY_PATTERN, "B7-214-68901")
+    assert re.match(ISSUE_KEY_PATTERN, "A4-1-2")
     # Invalid issue keys
     assert not re.match(ISSUE_KEY_PATTERN, "a-1")
     assert not re.match(ISSUE_KEY_PATTERN, "PROJ")
     assert not re.match(ISSUE_KEY_PATTERN, "2ABC-1")
     assert not re.match(ISSUE_KEY_PATTERN, "A4--123")
+    assert not re.match(ISSUE_KEY_PATTERN, "A4-1--23")
     assert not re.match(ISSUE_KEY_PATTERN, "A4-123-")
 
     # Valid project keys


### PR DESCRIPTION
## Description
The ISSUE_KEY_PATTERN regex rejects valid Jira Server/DC issue keys that contain hyphens in the numeric part (e.g., B7-214-68901). This updates the pattern to accept these non-standard formats while still rejecting malformed keys.

Fixes: #1389 

## Changes

- Updated ISSUE_KEY_PATTERN in jira.py to accept hyphenated numeric parts (e.g., B7-214-68901)
- Added test cases for the new valid format (B7-214-68901) and invalid edge cases (A4--123, A4-123-)
- Updated inline documentation to describe the extended pattern

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed: uv run pytest tests/unit/servers/test_jira_server.py -xvs
- [x] Manual checks performed: `verified pattern matches B7-214-68901 while rejecting A4--123 and A4-123-`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
