### PR TITLE
test(e2e): use Atlassian timebomb DC licenses for the Docker harness

### DIFF
--- a/tests/e2e/docker/.env.example
+++ b/tests/e2e/docker/.env.example
@@ -2,3 +2,11 @@ JIRA_VERSION=10.3-jdk17
 CONFLUENCE_VERSION=9.2-jdk17
 JIRA_DB_PASSWORD=jira_e2e_pass
 CONFLUENCE_DB_PASSWORD=confluence_e2e_pass
+
+# Confluence DC timebomb license — supplied at first-time setup via ATL_LICENSE_KEY
+# (Confluence 7.9+; see docker-compose.yml). Skips the wizard license step on first run.
+# Copy the "Confluence Data Center" key (10 user, 3 hours) from:
+#   https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/
+# Leave empty to paste a key in the setup wizard instead.
+# Jira has no equivalent env var — paste the "Jira Software Data Center" key in its wizard.
+CONFLUENCE_LICENSE_KEY=

--- a/tests/e2e/docker/.env.example
+++ b/tests/e2e/docker/.env.example
@@ -5,6 +5,8 @@ CONFLUENCE_DB_PASSWORD=confluence_e2e_pass
 
 # Confluence DC timebomb license — supplied at first-time setup via ATL_LICENSE_KEY
 # (Confluence 7.9+; see docker-compose.yml). Skips the wizard license step on first run.
+# Applied first-run only — a restart does NOT reset the 3h timer (use `down -v`, or
+# `ATL_FORCE_CFG_UPDATE=true docker compose up -d confluence`, to re-apply).
 # Copy the "Confluence Data Center" key (10 user, 3 hours) from:
 #   https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/
 # Leave empty to paste a key in the setup wizard instead.

--- a/tests/e2e/docker/README.md
+++ b/tests/e2e/docker/README.md
@@ -55,9 +55,9 @@ Both Jira and Confluence require completing a setup wizard on first launch.
 
 These tests use Atlassian's published **Data Center timebomb licenses** (10 user, valid **3 hours** from when applied) instead of 30-day my.atlassian.com evals — they are free, public, and need no my.atlassian.com account. Get them from [Atlassian's testing licenses page](https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/) → *Data Center host product licenses* → **Jira Software Data Center** / **Confluence Data Center**.
 
-The 3-hour limit is irrelevant for a normal run (the DC suite completes in well under a minute); it only matters if an instance stays up for hours.
+The 3-hour limit is irrelevant for a normal run (the DC suite typically completes in under a minute); it only matters if an instance stays up for hours.
 
-- **Confluence** — set `CONFLUENCE_LICENSE_KEY` in `.env` (see `.env.example`). Confluence 7.9+ reads it from `ATL_LICENSE_KEY` and applies it at **first-time setup** (skipping the wizard license step), writing it to `confluence.cfg.xml` on the persisted volume. It is **not** re-read on later restarts (`ATL_FORCE_CFG_UPDATE` defaults `false`), so a restart does **not** reset the 3-hour timer. To re-apply after expiry: clean re-setup (`docker compose down -v`) or `ATL_FORCE_CFG_UPDATE=true`. _(Verified on `confluence:9.2.21`: a fresh blank-DB start with this set skips the wizard license step. The no-restart-refresh detail follows Atlassian's container docs.)_
+- **Confluence** — set `CONFLUENCE_LICENSE_KEY` in `.env` (see `.env.example`). Confluence 7.9+ reads it from `ATL_LICENSE_KEY` and applies it at **first-time setup** (skipping the wizard license step), writing it to `confluence.cfg.xml` on the persisted volume. It is **not** re-read on later restarts (`ATL_FORCE_CFG_UPDATE` defaults `false`), so a restart does **not** reset the 3-hour timer. To re-apply after expiry: a clean re-setup (`docker compose down -v`), or force a config refresh with `ATL_FORCE_CFG_UPDATE=true docker compose up -d confluence` (wired in `docker-compose.yml`). _(Verified on `confluence:9.2.21`: a fresh blank-DB start with this set skips the wizard license step. The no-restart-refresh detail follows Atlassian's container docs.)_
 - **Jira** — has no license env var. Paste the timebomb key in the setup wizard. If it expires on a long-lived instance, re-paste at **Administration > System > License** (`/secure/admin/ViewLicense.jspa`, no restart needed) — still no my.atlassian.com.
 
 > A 30-day my.atlassian.com eval also works for either product if you want a longer-lived local instance.
@@ -83,7 +83,7 @@ docker compose down -v
 | Port conflict | Change the host port in `docker-compose.yml` (e.g., `9080:8080`) |
 | DB connection error | Ensure the DB container is healthy: `docker compose ps` |
 | Setup wizard reappears | Data volumes were removed — run `docker compose down` (without `-v`) to preserve them |
-| License expired | See [License (timebomb)](#license-timebomb) — Jira: re-paste in admin; Confluence: `down -v` re-setup or `ATL_FORCE_CFG_UPDATE=true` (a plain restart does **not** refresh it) |
+| License expired | See [License (timebomb)](#license-timebomb) — Jira: re-paste in admin; Confluence: `down -v` re-setup or `ATL_FORCE_CFG_UPDATE=true docker compose up -d confluence` (a plain restart does **not** refresh it) |
 
 ## Environment variables
 

--- a/tests/e2e/docker/README.md
+++ b/tests/e2e/docker/README.md
@@ -38,29 +38,31 @@ Both Jira and Confluence require completing a setup wizard on first launch.
 1. Select **I'll set it up myself**
 2. Choose **My Own Database** — the DB is already configured via environment variables, so Jira should auto-detect it
 3. Set application title and base URL (defaults are fine)
-4. Enter a **license key** — generate a 30-day evaluation license at [my.atlassian.com](https://my.atlassian.com/license/evaluation)
+4. Enter a **license key** — paste the **Jira Software Data Center** timebomb key (10 user, 3 hours) from [Atlassian's testing licenses page](https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/) (under *Data Center host product licenses*). No my.atlassian.com account needed. See [License (timebomb)](#license-timebomb).
 5. Create the admin account (default: `admin` / `admin123`)
 6. Skip email configuration and language prompts
 
 ### Confluence (http://localhost:8090)
 
 1. Select **Production Installation**
-2. Enter a **license key** — generate a 30-day evaluation at [my.atlassian.com](https://my.atlassian.com/license/evaluation)
+2. Enter a **license key** — paste the **Confluence Data Center** timebomb key (10 user, 3 hours) from [Atlassian's testing licenses page](https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/). **Tip:** set `CONFLUENCE_LICENSE_KEY` in `.env` — Confluence 7.9+ reads it from `ATL_LICENSE_KEY` at first-time setup, so this step can be skipped. See [License (timebomb)](#license-timebomb).
 3. Choose **My own database** — again, auto-detected from environment
 4. Skip the demo space
 5. Configure user management (standalone, not connected to Jira)
 6. Create the admin account (default: `admin` / `admin123`)
 
-## License renewal
+## License (timebomb)
 
-Evaluation licenses expire after **30 days**. To renew:
+These tests use Atlassian's published **Data Center timebomb licenses** (10 user, valid **3 hours** from when applied) instead of 30-day my.atlassian.com evals — they are free, public, and need no my.atlassian.com account. Get them from [Atlassian's testing licenses page](https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/) → *Data Center host product licenses* → **Jira Software Data Center** / **Confluence Data Center**.
 
-1. Go to [my.atlassian.com](https://my.atlassian.com/license/evaluation) and generate a new evaluation license for the same product
-2. In Jira: **Administration > System > License** — paste the new key
-3. In Confluence: **Administration > License Details** — paste the new key
-4. No restart required
+The 3-hour limit is irrelevant for a normal run (the DC suite completes in well under a minute); it only matters if an instance stays up for hours.
 
-> **Tip**: If the license has already expired, you may need to access the admin page directly at `/secure/admin/ViewLicense.jspa` (Jira) or `/admin/license.action` (Confluence).
+- **Confluence** — set `CONFLUENCE_LICENSE_KEY` in `.env` (see `.env.example`). Confluence 7.9+ reads it from `ATL_LICENSE_KEY` and applies it at **first-time setup** (skipping the wizard license step), writing it to `confluence.cfg.xml` on the persisted volume. It is **not** re-read on later restarts (`ATL_FORCE_CFG_UPDATE` defaults `false`), so a restart does **not** reset the 3-hour timer. To re-apply after expiry: clean re-setup (`docker compose down -v`) or `ATL_FORCE_CFG_UPDATE=true`. _(Verified on `confluence:9.2.21`: a fresh blank-DB start with this set skips the wizard license step. The no-restart-refresh detail follows Atlassian's container docs.)_
+- **Jira** — has no license env var. Paste the timebomb key in the setup wizard. If it expires on a long-lived instance, re-paste at **Administration > System > License** (`/secure/admin/ViewLicense.jspa`, no restart needed) — still no my.atlassian.com.
+
+> A 30-day my.atlassian.com eval also works for either product if you want a longer-lived local instance.
+>
+> **Fully unattended setup** (zero browser) is future work: seed a pre-configured database dump, or apply the Jira license post-boot via the private REST endpoint `POST /rest/plugins/applications/1.0/installed/jira-software/license`.
 
 ## Stopping and cleaning up
 
@@ -81,7 +83,7 @@ docker compose down -v
 | Port conflict | Change the host port in `docker-compose.yml` (e.g., `9080:8080`) |
 | DB connection error | Ensure the DB container is healthy: `docker compose ps` |
 | Setup wizard reappears | Data volumes were removed — run `docker compose down` (without `-v`) to preserve them |
-| License expired | See [License renewal](#license-renewal) above |
+| License expired | See [License (timebomb)](#license-timebomb) — Jira: re-paste in admin; Confluence: `down -v` re-setup or `ATL_FORCE_CFG_UPDATE=true` (a plain restart does **not** refresh it) |
 
 ## Environment variables
 
@@ -91,6 +93,7 @@ docker compose down -v
 | `CONFLUENCE_VERSION` | `9.2-jdk17` | Confluence DC Docker image tag |
 | `JIRA_DB_PASSWORD` | `jira_e2e_pass` | Jira PostgreSQL password |
 | `CONFLUENCE_DB_PASSWORD` | `confluence_e2e_pass` | Confluence PostgreSQL password |
+| `CONFLUENCE_LICENSE_KEY` | _(empty)_ | Confluence DC timebomb license, supplied at first-time setup via `ATL_LICENSE_KEY` (Confluence 7.9+; see [License](#license-timebomb)) |
 | `JIRA_BASE_URL` | `http://localhost:8080` | Jira base URL (for scripts) |
 | `CONFLUENCE_BASE_URL` | `http://localhost:8090` | Confluence base URL (for scripts) |
 | `DC_ADMIN_CREDENTIALS` | `admin:admin123` | Admin credentials for REST API calls |

--- a/tests/e2e/docker/docker-compose.yml
+++ b/tests/e2e/docker/docker-compose.yml
@@ -67,9 +67,13 @@ services:
       # skipping the wizard's license step. Written to confluence.cfg.xml on FIRST
       # start only — NOT re-read on restart (ATL_FORCE_CFG_UPDATE defaults false), so a
       # restart does not reset the 3h timebomb. Empty -> wizard prompts for a key.
+      # Docs: https://atlassian.github.io/data-center-helm-charts/containers/CONFLUENCE/
       # (Verified 2026-06-18 on confluence:9.2.21: a fresh blank-DB start with this set
-      #  skips the wizard license step. The no-restart-refresh detail above is per Atlassian docs.)
+      #  skips the wizard license step. The no-restart-refresh detail above is per those docs.)
       ATL_LICENSE_KEY: ${CONFLUENCE_LICENSE_KEY:-}
+      # After the 3h timebomb expires, re-apply the key by regenerating confluence.cfg.xml:
+      #   ATL_FORCE_CFG_UPDATE=true docker compose up -d confluence
+      ATL_FORCE_CFG_UPDATE: ${ATL_FORCE_CFG_UPDATE:-false}
       JVM_MINIMUM_MEMORY: 1024m
       JVM_MAXIMUM_MEMORY: 2048m
       CLUSTERED: "false"

--- a/tests/e2e/docker/docker-compose.yml
+++ b/tests/e2e/docker/docker-compose.yml
@@ -63,6 +63,13 @@ services:
       ATL_JDBC_PASSWORD: ${CONFLUENCE_DB_PASSWORD}
       ATL_DB_DRIVER: org.postgresql.Driver
       ATL_DB_TYPE: postgresql
+      # Confluence 7.9+ reads the license from ATL_LICENSE_KEY at first-time setup,
+      # skipping the wizard's license step. Written to confluence.cfg.xml on FIRST
+      # start only — NOT re-read on restart (ATL_FORCE_CFG_UPDATE defaults false), so a
+      # restart does not reset the 3h timebomb. Empty -> wizard prompts for a key.
+      # (Verified 2026-06-18 on confluence:9.2.21: a fresh blank-DB start with this set
+      #  skips the wizard license step. The no-restart-refresh detail above is per Atlassian docs.)
+      ATL_LICENSE_KEY: ${CONFLUENCE_LICENSE_KEY:-}
       JVM_MINIMUM_MEMORY: 1024m
       JVM_MAXIMUM_MEMORY: 2048m
       CLUSTERED: "false"


### PR DESCRIPTION
## Description

The DC end-to-end harness (`tests/e2e/docker/`) required a manually-generated 30-day evaluation license from my.atlassian.com, renewed monthly. This swaps that for Atlassian's public 3-hour **Data Center timebomb licenses** — free, no my.atlassian.com account, no renewal chore. The 3-hour limit is irrelevant for a CI-style run (the DC suite finishes in well under a minute).

No linked issue — maintainer test-infra cleanup.

## Changes

- **docker-compose.yml**: wire `CONFLUENCE_LICENSE_KEY` → `ATL_LICENSE_KEY` so the Confluence DC license is supplied at first-run (Confluence 7.9+), skipping the wizard's license step.
- **.env.example**: document `CONFLUENCE_LICENSE_KEY` and where to copy the timebomb key.
- **README.md**: rewrite the license sections (timebomb instead of 30-day eval; no my.atlassian.com, no renewal). Documents that the 3h timer is wall-clock and is **not** reset by a restart (`confluence.cfg.xml` is written first-run only; use `down -v` or `ATL_FORCE_CFG_UPDATE=true` to re-apply after expiry).

Jira has no license env var upstream, so its timebomb key is still pasted in the wizard. Fully unattended Jira setup (seed DB / private REST) is left as future work.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed — `uv run pytest tests/e2e/ --dc-e2e` → **71 passed, 62 skipped** against Jira DC 10.3 + Confluence DC 9.2 licensed with the timebomb keys
- [x] Manual checks performed: confirmed the `ATL_LICENSE_KEY` path live — a fresh blank-DB `confluence:9.2.21` with the key set skips the wizard license step (lands on deployment-type, no license prompt)

## Checklist

- [x] Code follows project style guidelines (linting passes) — `pre-commit` clean on changed files
- [ ] Tests added/updated for changes — N/A (test-infra/docs only; no `mcp_atlassian` source change)
- [ ] All tests pass locally — DC e2e green (71 passed); unit/integration suite not re-run (no source touched), CI will validate
- [x] Documentation updated (if needed) — harness README rewritten
