### PR TITLE
chore: drop invalid allow rules from committed Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,5 @@
 {
   "permissions": {
-    "allow": [
-      "Edit:*",
-      "Write:*",
-      "MultiEdit:*",
-      "Bash:*"
-    ],
-    "defaultMode": "acceptEdits"
+    "defaultMode": "auto"
   }
 }


### PR DESCRIPTION
## Description

The committed `.claude/settings.json` listed wildcard tool names under `permissions.allow`: `Edit:*`, `Write:*`, `MultiEdit:*`, `Bash:*`. Wildcard tool names are only valid in `deny` and `ask` rules, so Claude Code skipped all four on every config load. They stayed silent until a fresh `git worktree` re-validated the tracked settings and printed them as a Settings Warning.

This drops the broken allow list. `defaultMode` stays for the auto-accept workflow (`acceptEdits` to `auto`).

## Changes

- Remove invalid wildcard allow rules (`Edit:*`, `Write:*`, `MultiEdit:*`, `Bash:*`)
- Set `defaultMode` to `auto`

## Testing

- [x] Manual checks performed: `started Claude Code in a fresh worktree, no Settings Warning`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes. (N/A: config-only change)
- [x] All tests pass locally. (N/A: no code change)
- [ ] Documentation updated (if needed).
