### PR TITLE
test(integration): modernize real-API tests to current fetcher API

### DIFF
--- a/tests/integration/test_real_api.py
+++ b/tests/integration/test_real_api.py
@@ -1,13 +1,16 @@
 """
 Integration tests with real Atlassian APIs.
 
-These tests are skipped by default and only run with --integration --use-real-data flags.
-They require proper environment configuration and will create/modify real data.
+These tests are skipped by default and only run with the
+--integration --use-real-data flags. They require proper environment
+configuration and will create/modify real data.
 """
 
 import os
 import time
 import uuid
+from collections.abc import Callable
+from typing import TypeVar
 
 import pytest
 
@@ -16,6 +19,29 @@ from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.jira.config import JiraConfig
 from tests.utils.base import BaseAuthTest
+
+T = TypeVar("T")
+
+
+def _retry_until(
+    fn: Callable[[], T],
+    ok: Callable[[T], object],
+    *,
+    tries: int = 15,
+    delay: float = 2.0,
+) -> T:
+    """Call ``fn`` until ``ok(result)`` is truthy, then return that result.
+
+    Absorbs Atlassian search-index lag in live tests. Returns the last result
+    even if ``ok`` never became truthy, so the caller's assertions still run.
+    """
+    result = fn()
+    for _ in range(tries - 1):
+        if ok(result):
+            return result
+        time.sleep(delay)
+        result = fn()
+    return result
 
 
 @pytest.mark.integration
@@ -59,58 +85,61 @@ class TestRealJiraAPI(BaseAuthTest):
         summary = f"Integration Test Issue {unique_id}"
 
         # 1. Create issue
-        issue_data = {
-            "project": {"key": test_project_key},
-            "summary": summary,
-            "description": "This is an integration test issue that will be deleted",
-            "issuetype": {"name": "Task"},
-        }
-
-        created_issue = jira_client.create_issue(**issue_data)
+        created_issue = jira_client.create_issue(
+            project_key=test_project_key,
+            summary=summary,
+            issue_type="Task",
+            description="This is an integration test issue that will be deleted",
+        )
         created_issues.append(created_issue.key)
 
-        assert created_issue.key.startswith(test_project_key)
-        assert created_issue.fields.summary == summary
+        try:
+            assert created_issue.key.startswith(test_project_key)
+            assert created_issue.summary == summary
 
-        # 2. Update issue
-        update_data = {
-            "summary": f"{summary} - Updated",
-            "description": "Updated description",
-        }
-
-        updated_issue = jira_client.update_issue(
-            issue_key=created_issue.key, **update_data
-        )
-
-        assert updated_issue.fields.summary == f"{summary} - Updated"
-
-        # 3. Add comment
-        comment = jira_client.add_comment(
-            issue_key=created_issue.key, body="Test comment from integration test"
-        )
-
-        assert comment.body == "Test comment from integration test"
-
-        # 4. Get available transitions
-        transitions = jira_client.get_transitions(issue_key=created_issue.key)
-        assert len(transitions) > 0
-
-        # 5. Transition issue (if "Done" transition available)
-        done_transition = next(
-            (t for t in transitions if "done" in t.name.lower()), None
-        )
-        if done_transition:
-            jira_client.transition_issue(
-                issue_key=created_issue.key, transition_id=done_transition.id
+            # 2. Update issue
+            updated_issue = jira_client.update_issue(
+                issue_key=created_issue.key,
+                summary=f"{summary} - Updated",
+                description="Updated description",
             )
+            assert updated_issue.summary == f"{summary} - Updated"
 
-        # 6. Delete issue
-        jira_client.delete_issue(issue_key=created_issue.key)
-        created_issues.remove(created_issue.key)
+            # 3. Add comment (returns a dict)
+            comment = jira_client.add_comment(
+                issue_key=created_issue.key,
+                comment="Test comment from integration test",
+            )
+            assert "Test comment from integration test" in comment["body"]
 
-        # Verify deletion
-        with pytest.raises(Exception):
-            jira_client.get_issue(issue_key=created_issue.key)
+            # 4. Get available transitions (list of dicts)
+            transitions = jira_client.get_transitions(issue_key=created_issue.key)
+            assert len(transitions) > 0
+
+            # 5. Transition issue (if a "Done" transition is available)
+            done_transition = next(
+                (t for t in transitions if "done" in t["name"].lower()), None
+            )
+            if done_transition:
+                jira_client.transition_issue(
+                    issue_key=created_issue.key,
+                    transition_id=done_transition["id"],
+                )
+
+            # 6. Delete issue
+            jira_client.delete_issue(issue_key=created_issue.key)
+            created_issues.remove(created_issue.key)
+
+            # Verify deletion
+            with pytest.raises(Exception):
+                jira_client.get_issue(issue_key=created_issue.key)
+        finally:
+            if created_issue.key in created_issues:
+                try:
+                    jira_client.delete_issue(issue_key=created_issue.key)
+                    created_issues.remove(created_issue.key)
+                except Exception:  # noqa: BLE001
+                    pass
 
     def test_attachment_upload_download(
         self, jira_client, test_project_key, created_issues, tmp_path
@@ -118,84 +147,118 @@ class TestRealJiraAPI(BaseAuthTest):
         """Test attachment upload and download flow."""
         # Create test issue
         unique_id = str(uuid.uuid4())[:8]
-        issue_data = {
-            "project": {"key": test_project_key},
-            "summary": f"Attachment Test {unique_id}",
-            "issuetype": {"name": "Task"},
-        }
-
-        issue = jira_client.create_issue(**issue_data)
+        issue = jira_client.create_issue(
+            project_key=test_project_key,
+            summary=f"Attachment Test {unique_id}",
+            issue_type="Task",
+        )
         created_issues.append(issue.key)
 
         try:
             # Create test file
             test_file = tmp_path / "test_attachment.txt"
-            test_content = f"Test content {unique_id}"
-            test_file.write_text(test_content)
+            test_file.write_text(f"Test content {unique_id}")
 
-            # Upload attachment
-            with open(test_file, "rb") as f:
-                attachments = jira_client.add_attachment(
-                    issue_key=issue.key, filename="test_attachment.txt", data=f.read()
-                )
-
-            assert len(attachments) == 1
-            attachment = attachments[0]
-            assert attachment.filename == "test_attachment.txt"
+            # Upload attachment (returns a result dict)
+            result = jira_client.upload_attachment(
+                issue_key=issue.key, file_path=str(test_file)
+            )
+            assert result["success"]
+            assert result["filename"] == "test_attachment.txt"
 
             # Get issue with attachments
             issue_with_attachments = jira_client.get_issue(
-                issue_key=issue.key, expand="attachment"
+                issue_key=issue.key, fields="attachment"
             )
-
-            assert len(issue_with_attachments.fields.attachment) == 1
+            assert any(
+                a.filename == "test_attachment.txt"
+                for a in issue_with_attachments.attachments
+            )
 
         finally:
             # Cleanup
             jira_client.delete_issue(issue_key=issue.key)
             created_issues.remove(issue.key)
 
-    def test_jql_search_with_pagination(self, jira_client, test_project_key):
-        """Test JQL search with pagination."""
-        # Search for recent issues in test project
-        jql = f"project = {test_project_key} ORDER BY created DESC"
+    def test_jql_search_with_pagination(
+        self, jira_client, test_project_key, created_issues
+    ):
+        """Test JQL search pagination across two pages.
 
-        # First page
-        results_page1 = jira_client.search_issues(jql=jql, start_at=0, max_results=2)
+        Cloud ignores ``start`` and returns ``total = -1``; the only way to
+        page is ``next_page_token``. Seed exactly 3 issues so a real second
+        page exists (limit=2 -> page1 of 2, page2 of 1).
+        """
+        unique_id = str(uuid.uuid4())[:8]
 
-        assert results_page1.total >= 0
+        seeded = []
+        try:
+            for i in range(3):
+                issue = jira_client.create_issue(
+                    project_key=test_project_key,
+                    summary=f"Pagination Test {i + 1} - {unique_id}",
+                    issue_type="Task",
+                )
+                seeded.append(issue.key)
+                created_issues.append(issue.key)
 
-        if results_page1.total > 2:
-            # Second page
-            results_page2 = jira_client.search_issues(
-                jql=jql, start_at=2, max_results=2
-            )
+            # Precise JQL matching exactly the 3 seeded issues.
+            jql = f"issuekey in ({', '.join(seeded)}) ORDER BY created DESC"
 
-            # Ensure different issues
-            page1_keys = [i.key for i in results_page1.issues]
-            page2_keys = [i.key for i in results_page2.issues]
-            assert not set(page1_keys).intersection(set(page2_keys))
+            # The search index can lag; retry page 1 until the index reflects a
+            # full first page with more available.
+            if jira_client.config.is_cloud:
+                page1 = _retry_until(
+                    lambda: jira_client.search_issues(jql, limit=2),
+                    lambda r: bool(r.next_page_token),
+                )
+            else:
+                # Server/DC: total is a real count — wait until all 3 are
+                # indexed so page 2 isn't empty from a partially-indexed state.
+                page1 = _retry_until(
+                    lambda: jira_client.search_issues(jql, limit=2),
+                    lambda r: len(r.issues) == 2 and r.total >= 3,
+                )
+
+            page1_keys = [i.key for i in page1.issues]
+            assert len(page1_keys) == 2
+
+            if jira_client.config.is_cloud:
+                # Cloud paginates only via next_page_token (start is ignored).
+                assert page1.next_page_token
+                page2 = jira_client.search_issues(
+                    jql, limit=2, page_token=page1.next_page_token
+                )
+            else:
+                # Server/DC uses offset paging.
+                page2 = jira_client.search_issues(jql, start=2, limit=2)
+
+            page2_keys = [i.key for i in page2.issues]
+            # Pages must be disjoint and together cover the seeded issues.
+            assert not set(page1_keys).intersection(page2_keys)
+            assert set(page1_keys) | set(page2_keys) == set(seeded)
+
+        finally:
+            for key in seeded:
+                try:
+                    jira_client.delete_issue(issue_key=key)
+                    created_issues.remove(key)
+                except Exception:  # noqa: BLE001
+                    pass
 
     def test_bulk_issue_creation(self, jira_client, test_project_key, created_issues):
         """Test creating multiple issues in bulk."""
         unique_id = str(uuid.uuid4())[:8]
-        issues_data = []
-
-        # Prepare 3 issues
-        for i in range(3):
-            issues_data.append(
-                {
-                    "project": {"key": test_project_key},
-                    "summary": f"Bulk Test Issue {i + 1} - {unique_id}",
-                    "issuetype": {"name": "Task"},
-                }
-            )
 
         # Create issues
         created = []
         try:
-            for issue_data in issues_data:
-                issue = jira_client.create_issue(**issue_data)
+            for i in range(3):
+                issue = jira_client.create_issue(
+                    project_key=test_project_key,
+                    summary=f"Bulk Test Issue {i + 1} - {unique_id}",
+                    issue_type="Task",
+                )
                 created.append(issue)
                 created_issues.append(issue.key)
 
@@ -203,7 +266,7 @@ class TestRealJiraAPI(BaseAuthTest):
 
             # Verify all created
             for i, issue in enumerate(created):
-                assert f"Bulk Test Issue {i + 1}" in issue.fields.summary
+                assert f"Bulk Test Issue {i + 1}" in issue.summary
 
         finally:
             # Cleanup all created issues
@@ -211,7 +274,7 @@ class TestRealJiraAPI(BaseAuthTest):
                 try:
                     jira_client.delete_issue(issue_key=issue.key)
                     created_issues.remove(issue.key)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
     def test_rate_limiting_behavior(self, jira_client):
@@ -222,7 +285,7 @@ class TestRealJiraAPI(BaseAuthTest):
         for _i in range(5):
             try:
                 jira_client.get_fields()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 if "429" in str(e) or "rate limit" in str(e).lower():
                     # Rate limit hit - this is expected
                     assert True
@@ -338,95 +401,125 @@ class TestRealConfluenceAPI(BaseAuthTest):
         unique_id = str(uuid.uuid4())[:8]
         title = f"Integration Test Page {unique_id}"
 
-        # 1. Create page
+        # 1. Create page (markdown body; is_markdown=True is the default)
         page = confluence_client.create_page(
             space_key=test_space_key,
             title=title,
-            body="<p>This is an integration test page</p>",
+            body="This is an integration test page",
         )
         created_pages.append(page.id)
 
-        assert page.title == title
-        assert page.space.key == test_space_key
+        try:
+            assert page.title == title
+            assert page.space.key == test_space_key
 
-        # 2. Update page
-        updated_page = confluence_client.update_page(
-            page_id=page.id,
-            title=f"{title} - Updated",
-            body="<p>Updated content</p>",
-            version_number=page.version.number + 1,
-        )
+            # 2. Update page (version auto-increments; no version_number arg)
+            updated_page = confluence_client.update_page(
+                page_id=page.id,
+                title=f"{title} - Updated",
+                body="Updated content",
+            )
 
-        assert updated_page.title == f"{title} - Updated"
-        assert updated_page.version.number == page.version.number + 1
+            assert updated_page.title == f"{title} - Updated"
+            assert updated_page.version.number == page.version.number + 1
 
-        # 3. Add comment
-        comment = confluence_client.add_comment(
-            page_id=page.id, body="Test comment from integration test"
-        )
+            # 3. Add comment (kwarg is `content`; body is a flat string)
+            comment = confluence_client.add_comment(
+                page_id=page.id, content="Test comment from integration test"
+            )
 
-        assert "Test comment" in comment.body.storage.value
+            assert comment is not None and comment.id
+            # The v1 path may not expand body.view; assert only when present.
+            if comment.body:
+                assert "Test comment" in comment.body
 
-        # 4. Delete page
-        confluence_client.delete_page(page_id=page.id)
-        created_pages.remove(page.id)
+            # 4. Delete page
+            confluence_client.delete_page(page_id=page.id)
+            created_pages.remove(page.id)
 
-        # Verify deletion
-        with pytest.raises(Exception):
-            confluence_client.get_page_by_id(page_id=page.id)
+            # Verify deletion
+            with pytest.raises(Exception):
+                confluence_client.get_page_content(page.id)
+        finally:
+            if page.id in created_pages:
+                try:
+                    confluence_client.delete_page(page_id=page.id)
+                    created_pages.remove(page.id)
+                except Exception:  # noqa: BLE001
+                    pass
 
     def test_page_hierarchy(self, confluence_client, test_space_key, created_pages):
         """Test creating page hierarchy with parent-child relationships."""
         unique_id = str(uuid.uuid4())[:8]
 
-        # Create parent page
-        parent = confluence_client.create_page(
-            space_key=test_space_key,
-            title=f"Parent Page {unique_id}",
-            body="<p>Parent content</p>",
-        )
-        created_pages.append(parent.id)
-
+        parent = None
+        child = None
         try:
+            # Create parent page
+            parent = confluence_client.create_page(
+                space_key=test_space_key,
+                title=f"Parent Page {unique_id}",
+                body="Parent content",
+            )
+            created_pages.append(parent.id)
+
             # Create child page
             child = confluence_client.create_page(
                 space_key=test_space_key,
                 title=f"Child Page {unique_id}",
-                body="<p>Child content</p>",
+                body="Child content",
                 parent_id=parent.id,
             )
             created_pages.append(child.id)
 
-            # Get child pages
-            children = confluence_client.get_page_children(
-                page_id=parent.id, expand="body.storage"
-            )
-
-            assert len(children.results) == 1
-            assert children.results[0].id == child.id
-
-            # Delete child first, then parent
-            confluence_client.delete_page(page_id=child.id)
-            created_pages.remove(child.id)
+            # Get child pages (returns a list)
+            children = confluence_client.get_page_children(parent.id)
+            child_ids = [c.id for c in children]
+            assert child.id in child_ids
 
         finally:
-            # Cleanup parent
-            confluence_client.delete_page(page_id=parent.id)
-            created_pages.remove(parent.id)
+            # Delete child first, then parent, each guarded independently.
+            if child is not None and child.id in created_pages:
+                try:
+                    confluence_client.delete_page(page_id=child.id)
+                    created_pages.remove(child.id)
+                except Exception:  # noqa: BLE001
+                    pass
+            if parent is not None and parent.id in created_pages:
+                try:
+                    confluence_client.delete_page(page_id=parent.id)
+                    created_pages.remove(parent.id)
+                except Exception:  # noqa: BLE001
+                    pass
 
-    def test_cql_search(self, confluence_client, test_space_key):
-        """Test CQL search functionality."""
-        # Search for pages in test space
-        cql = f'space = "{test_space_key}" and type = "page"'
+    def test_cql_search(self, confluence_client, test_space_key, created_pages):
+        """Test CQL search finds a freshly created page."""
+        unique_id = str(uuid.uuid4())[:8]
+        marker = f"cqlmarker{unique_id}"
+        title = f"CQL Search Test {marker}"
 
-        results = confluence_client.search_content(cql=cql, limit=5)
+        page = confluence_client.create_page(
+            space_key=test_space_key, title=title, body="searchable content"
+        )
+        created_pages.append(page.id)
 
-        assert results.size >= 0
+        try:
+            cql = f'space = "{test_space_key}" and title ~ "{marker}"'
 
-        # Verify all results are from test space
-        for result in results.results:
-            if hasattr(result, "space"):
-                assert result.space.key == test_space_key
+            # Search index lags; retry until the new page appears.
+            results = _retry_until(
+                lambda: confluence_client.search(cql, limit=10),
+                lambda r: any(p.id == page.id for p in r),
+            )
+
+            assert any(p.id == page.id for p in results)
+            for result in results:
+                if result.space is not None:
+                    assert result.space.key == test_space_key
+
+        finally:
+            confluence_client.delete_page(page_id=page.id)
+            created_pages.remove(page.id)
 
     def test_attachment_handling(
         self, confluence_client, test_space_key, created_pages, tmp_path
@@ -438,28 +531,27 @@ class TestRealConfluenceAPI(BaseAuthTest):
         page = confluence_client.create_page(
             space_key=test_space_key,
             title=f"Attachment Test Page {unique_id}",
-            body="<p>Page with attachments</p>",
+            body="Page with attachments",
         )
         created_pages.append(page.id)
 
         try:
             # Create test file
             test_file = tmp_path / "confluence_test.txt"
-            test_content = f"Confluence test content {unique_id}"
-            test_file.write_text(test_content)
+            test_file.write_text(f"Confluence test content {unique_id}")
 
-            # Upload attachment
-            with open(test_file, "rb") as f:
-                attachment = confluence_client.create_attachment(
-                    page_id=page.id, filename="confluence_test.txt", data=f.read()
-                )
+            # Upload attachment (returns a result dict)
+            result = confluence_client.upload_attachment(
+                content_id=page.id, file_path=str(test_file)
+            )
+            assert result["success"]
+            assert result["filename"] == "confluence_test.txt"
 
-            assert attachment.title == "confluence_test.txt"
-
-            # Get page attachments
-            attachments = confluence_client.get_attachments(page_id=page.id)
-            assert len(attachments.results) == 1
-            assert attachments.results[0].title == "confluence_test.txt"
+            # Get page attachments (returns a dict with raw attachment dicts)
+            attachments = confluence_client.get_content_attachments(content_id=page.id)
+            assert any(
+                a["title"] == "confluence_test.txt" for a in attachments["attachments"]
+            )
 
         finally:
             # Cleanup
@@ -469,11 +561,11 @@ class TestRealConfluenceAPI(BaseAuthTest):
     def test_large_content_handling(
         self, confluence_client, test_space_key, created_pages
     ):
-        """Test handling of large content (>1MB)."""
+        """Test handling of large content (~210KB round-trip)."""
         unique_id = str(uuid.uuid4())[:8]
 
-        # Create large content (approximately 1MB)
-        large_content = "<p>" + ("Large content block. " * 10000) + "</p>"
+        # Create large content (markdown/plain text, ~210KB)
+        large_content = "Large content block. " * 10000
 
         # Create page with large content
         page = confluence_client.create_page(
@@ -485,11 +577,9 @@ class TestRealConfluenceAPI(BaseAuthTest):
 
         try:
             # Retrieve and verify
-            retrieved = confluence_client.get_page_by_id(
-                page_id=page.id, expand="body.storage"
-            )
+            retrieved = confluence_client.get_page_content(page.id)
 
-            assert len(retrieved.body.storage.value) > 100000  # At least 100KB
+            assert len(retrieved.content) > 100000  # At least 100KB
 
         finally:
             # Cleanup
@@ -558,47 +648,58 @@ class TestCrossServiceIntegration:
     ):
         """Test linking between Jira issues and Confluence pages."""
         unique_id = str(uuid.uuid4())[:8]
-
-        # Create Jira issue
-        issue = jira_client.create_issue(
-            project={"key": test_project_key},
-            summary=f"Linked Issue {unique_id}",
-            issuetype={"name": "Task"},
-        )
-        created_issues.append(issue.key)
-
-        # Create Confluence page with Jira issue link
-        page_content = f'<p>Related to Jira issue: <a href="{jira_client.config.url}/browse/{issue.key}">{issue.key}</a></p>'
-
-        page = confluence_client.create_page(
-            space_key=test_space_key,
-            title=f"Linked Page {unique_id}",
-            body=page_content,
-        )
-        created_pages.append(page.id)
+        issue = None
+        page = None
 
         try:
-            # Add comment in Jira referencing Confluence page
+            # Create Jira issue
+            issue = jira_client.create_issue(
+                project_key=test_project_key,
+                summary=f"Linked Issue {unique_id}",
+                issue_type="Task",
+            )
+            created_issues.append(issue.key)
+
+            # Create Confluence page with a Jira issue link (markdown link)
+            issue_url = f"{jira_client.config.url}/browse/{issue.key}"
+            page = confluence_client.create_page(
+                space_key=test_space_key,
+                title=f"Linked Page {unique_id}",
+                body=f"Related to Jira issue: [{issue.key}]({issue_url})",
+            )
+            created_pages.append(page.id)
+
+            # Add comment in Jira referencing the Confluence page. Include the
+            # page id as plain text so it survives the ADF round-trip even if
+            # the bare URL is reshaped into a smartlink.
             confluence_url = (
                 f"{confluence_client.config.url}/pages/viewpage.action?pageId={page.id}"
             )
             jira_client.add_comment(
                 issue_key=issue.key,
-                body=f"Documentation available at: {confluence_url}",
+                comment=f"Documentation for page {page.id}: {confluence_url}",
             )
 
-            # Verify both exist and contain cross-references
-            issue_comments = jira_client.get_comments(issue_key=issue.key)
-            assert any(confluence_url in c.body for c in issue_comments.comments)
+            # Read comments back via the ADF-safe model path and key on the
+            # page id substring (the URL itself is reshaped on the round-trip).
+            fetched_issue = jira_client.get_issue(issue_key=issue.key, fields="comment")
+            assert any(str(page.id) in c.body for c in fetched_issue.comments)
 
-            retrieved_page = confluence_client.get_page_by_id(
-                page_id=page.id, expand="body.storage"
-            )
-            assert issue.key in retrieved_page.body.storage.value
+            # Verify the page still references the Jira issue
+            retrieved_page = confluence_client.get_page_content(page.id)
+            assert issue.key in retrieved_page.content
 
         finally:
-            # Cleanup
-            jira_client.delete_issue(issue_key=issue.key)
-            created_issues.remove(issue.key)
-            confluence_client.delete_page(page_id=page.id)
-            created_pages.remove(page.id)
+            # Cleanup each resource independently so one failure can't leak the other.
+            if issue is not None and issue.key in created_issues:
+                try:
+                    jira_client.delete_issue(issue_key=issue.key)
+                    created_issues.remove(issue.key)
+                except Exception:  # noqa: BLE001
+                    pass
+            if page is not None and page.id in created_pages:
+                try:
+                    confluence_client.delete_page(page_id=page.id)
+                    created_pages.remove(page.id)
+                except Exception:  # noqa: BLE001
+                    pass


### PR DESCRIPTION
## Description

The real-API integration tests (`tests/integration/test_real_api.py`) were frozen on the pre-refactor fetcher API, so 10 of the 13 live tests failed against Cloud (dict-shaped `create_issue`, `.fields.*` access, dropped `version_number`/`start_at` args, renamed/removed methods). The 3 current-API tests still passed, which hid it. This rewrites the 10 to the current fetcher surface so the suite is green again, and tightens cleanup so a failing test can't leak pages/issues.

## Changes

- Jira: `create_issue(project_key=..., issue_type=...)`, dict-returning `add_comment`, flat `JiraIssue` attrs (`.summary`/`.labels`/`.attachments`), `upload_attachment(file_path=...)`, token-based search pagination (Cloud ignores `start` and returns `total = -1`, so page 2 goes via `next_page_token`).
- Confluence: `get_page_content`/`.content`, list-returning `get_page_children` and `search`, `add_comment(content=...)`, `upload_attachment`/`get_content_attachments`.
- Cleanup hardening: per-resource `try/except` guards in `finally` so one failed delete can't leak the other; seed JQL pagination so a real second page is exercised; make the CQL search assertion non-vacuous; read cross-service comments back via the ADF-safe model path.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: ran `tests/integration/ --integration --use-real-data` against a live Cloud instance: 23 passed / 0 failed, nothing left behind.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
