### PR TITLE
feat(jira): add attachment upload/delete, comment delete, and inline-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@
 
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.
 
+> [!NOTE]
+> **This is an internal fork of [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian)** (MIT licensed — see [`LICENSE`](LICENSE)), maintained for our team.
+> It adds the following Jira tools on top of upstream:
+> - `jira_upload_attachment` — add an attachment to an issue (local path or inline base64)
+> - `jira_delete_attachment` — delete an attachment by id
+> - `jira_delete_comment` — delete a comment from an issue
+> - `jira_add_comment_with_media` — post a Jira **Cloud** comment with screenshots embedded inline (text → image → text → image)
+>
+> All original copyright and the MIT license are preserved. To sync with upstream: `git fetch upstream && git merge upstream/main`.
+
 https://github.com/user-attachments/assets/35303504-14c6-4ae4-913b-7c25ea511c3e
 
 <details>

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -63,13 +63,13 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 |---------|:----:|-------|
 | `jira_issues` | Yes | `jira_get_issue`, `jira_search`, `jira_get_project_issues`, `jira_create_issue`, `jira_update_issue`, `jira_delete_issue`, `jira_batch_create_issues`, `jira_batch_get_changelogs` |
 | `jira_fields` | Yes | `jira_search_fields`, `jira_get_field_options` |
-| `jira_comments` | Yes | `jira_add_comment`, `jira_edit_comment` |
+| `jira_comments` | Yes | `jira_add_comment`, `jira_edit_comment`, `jira_delete_comment`, `jira_add_comment_with_media` |
 | `jira_transitions` | Yes | `jira_get_transitions`, `jira_transition_issue` |
 | `jira_projects` | No | `jira_get_all_projects`, `jira_get_project_versions`, `jira_get_project_components`, `jira_create_version`, `jira_batch_create_versions` |
 | `jira_agile` | No | `jira_get_agile_boards`, `jira_get_board_issues`, `jira_get_sprints_from_board`, `jira_get_sprint_issues`, `jira_create_sprint`, `jira_update_sprint`, `jira_add_issues_to_sprint` |
 | `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_create_remote_issue_link`, `jira_remove_issue_link` |
 | `jira_worklog` | No | `jira_get_worklog`, `jira_add_worklog` |
-| `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images` |
+| `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images`, `jira_upload_attachment`, `jira_delete_attachment` |
 | `jira_users` | No | `jira_get_user_profile` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
 | `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues` |

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -1,8 +1,10 @@
 """Attachment operations for Jira API."""
 
+import io
 import logging
 import mimetypes
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -467,3 +469,197 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             "uploaded": uploaded,
             "failed": failed,
         }
+
+    @staticmethod
+    def _extract_attachment_id(response: Any) -> str | None:
+        """Extract the attachment id from a Jira attachments API response.
+
+        The ``issue/{key}/attachments`` endpoint returns a list of attachment
+        objects, but some code paths/mocks return a single dict. Handle both.
+
+        Args:
+            response: The raw response from the attachments endpoint.
+
+        Returns:
+            The attachment id as a string, or None if it cannot be determined.
+        """
+        item: Any = None
+        if isinstance(response, list) and response:
+            item = response[0]
+        elif isinstance(response, dict):
+            item = response
+        if isinstance(item, dict):
+            attachment_id = item.get("id")
+            return str(attachment_id) if attachment_id is not None else None
+        return None
+
+    def upload_attachment_content(
+        self, issue_key: str, filename: str, content: bytes
+    ) -> dict[str, Any]:
+        """
+        Upload an attachment to a Jira issue from in-memory bytes.
+
+        Unlike :meth:`upload_attachment`, this does not require filesystem
+        access, so it works for remote/stdio servers and for content the LLM
+        generates inline (passed as base64 by the server layer).
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123')
+            filename: The name to give the attachment in Jira
+            content: The raw bytes of the file to upload
+
+        Returns:
+            A dictionary with upload result information
+        """
+        if not issue_key:
+            logger.error("No issue key provided for attachment upload")
+            return {"success": False, "error": "No issue key provided"}
+
+        if not filename:
+            logger.error("No filename provided for attachment upload")
+            return {"success": False, "error": "No filename provided"}
+
+        if len(content) > ATTACHMENT_MAX_BYTES:
+            msg = (
+                f"Attachment '{filename}' is {len(content)} bytes which "
+                "exceeds the 50 MB limit."
+            )
+            logger.error(msg)
+            return {"success": False, "error": msg}
+
+        try:
+            safe_filename = os.path.basename(filename)
+            logger.info(
+                f"Uploading in-memory attachment '{safe_filename}' "
+                f"({len(content)} bytes) to issue {issue_key}"
+            )
+            # A named buffer makes requests send the correct multipart filename.
+            buffer = io.BytesIO(content)
+            buffer.name = safe_filename
+            response = self.jira.add_attachment_object(issue_key, buffer)
+
+            return {
+                "success": True,
+                "issue_key": issue_key,
+                "filename": safe_filename,
+                "size": len(content),
+                "id": self._extract_attachment_id(response),
+            }
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error uploading attachment: {error_msg}")
+            return {"success": False, "error": error_msg}
+
+    def delete_attachment(self, attachment_id: str) -> dict[str, Any]:
+        """
+        Delete a Jira attachment by its ID.
+
+        Args:
+            attachment_id: The numeric ID of the attachment to delete
+
+        Returns:
+            A dictionary describing the result of the deletion
+        """
+        if not attachment_id:
+            logger.error("No attachment ID provided for deletion")
+            return {"success": False, "error": "No attachment ID provided"}
+
+        try:
+            logger.info(f"Deleting attachment {attachment_id}")
+            self.jira.remove_attachment(attachment_id)
+            return {
+                "success": True,
+                "attachment_id": attachment_id,
+                "message": f"Attachment {attachment_id} deleted successfully",
+            }
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error deleting attachment {attachment_id}: {error_msg}")
+            return {
+                "success": False,
+                "attachment_id": attachment_id,
+                "error": error_msg,
+            }
+
+    def upload_attachment_from_path(
+        self, issue_key: str, file_path: str
+    ) -> dict[str, Any]:
+        """
+        Upload a local file to a Jira issue, returning a reliable attachment id.
+
+        Reads the file into memory and delegates to
+        :meth:`upload_attachment_content`, so the returned ``id`` is correct
+        (the legacy :meth:`upload_attachment` cannot report it because the
+        attachments endpoint returns a list).
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123')
+            file_path: Path to the local file to upload
+
+        Returns:
+            A dictionary with upload result information
+        """
+        if not file_path:
+            logger.error("No file path provided for attachment upload")
+            return {"success": False, "error": "No file path provided"}
+
+        try:
+            if not os.path.isabs(file_path):
+                file_path = os.path.abspath(file_path)
+            # Guard against path traversal (resolves symlinks)
+            validate_safe_path(file_path)
+            if not os.path.exists(file_path):
+                logger.error(f"File not found: {file_path}")
+                return {"success": False, "error": f"File not found: {file_path}"}
+            with open(file_path, "rb") as fh:
+                content = fh.read()
+            return self.upload_attachment_content(
+                issue_key, os.path.basename(file_path), content
+            )
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error uploading attachment from path: {error_msg}")
+            return {"success": False, "error": error_msg}
+
+    def get_attachment_media_id(self, attachment_id: str) -> str | None:
+        """
+        Resolve the Media Services file UUID for an uploaded attachment.
+
+        Inline ADF ``media`` nodes require the Media Services UUID, which
+        differs from the REST attachment id. It is obtained by requesting the
+        attachment content endpoint *without* following the redirect and
+        reading the UUID from the ``Location`` header
+        (``.../file/{uuid}/binary``).
+
+        Args:
+            attachment_id: The REST attachment id returned when uploading
+
+        Returns:
+            The media UUID string, or None if it cannot be resolved
+        """
+        if not attachment_id:
+            return None
+
+        try:
+            url = self.jira.resource_url(
+                f"attachment/content/{attachment_id}", api_version="3"
+            )
+            response = self.jira._session.get(url, allow_redirects=False, stream=True)
+            location = response.headers.get("Location", "")
+            match = re.search(
+                r"/file/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+                location,
+            )
+            if match:
+                return match.group(1)
+            logger.error(
+                f"Could not extract media id for attachment {attachment_id} "
+                "from the redirect location"
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                f"Error resolving media id for attachment {attachment_id}: {str(e)}"
+            )
+            return None

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -294,6 +294,15 @@ class JiraClient:
         url = self.jira.resource_url(resource, api_version="3")
         return self.jira.put(url, data=data)
 
+    def _delete_api3(self, resource: str, params: dict[str, str] | None = None) -> Any:
+        """DELETE against Jira REST API v3.
+
+        Mirrors ``_post_api3`` / ``_put_api3`` so deletions on Cloud target
+        the v3 endpoint consistently with the rest of the client.
+        """
+        url = self.jira.resource_url(resource, api_version="3")
+        return self.jira.delete(url, params=params)
+
     def get_paged(
         self,
         method: Literal["get", "post"],

--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -257,3 +257,87 @@ class CommentsMixin(JiraClient):
                 f"Error editing comment {comment_id} on issue {issue_key}: {str(e)}"
             )
             raise Exception(f"Error editing comment: {str(e)}") from e
+
+    def delete_comment(self, issue_key: str, comment_id: str) -> bool:
+        """
+        Delete a comment from an issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+            comment_id: The ID of the comment to delete
+
+        Returns:
+            True if the comment was deleted successfully
+
+        Raises:
+            Exception: If there is an error deleting the comment
+        """
+        try:
+            resource = f"issue/{issue_key}/comment/{comment_id}"
+            # Use v3 API on Cloud for consistency; the library exposes no
+            # dedicated comment-deletion helper, so fall back to a raw DELETE.
+            if self.config.is_cloud:
+                self._delete_api3(resource)
+            else:
+                self.jira.delete(self.jira.resource_url(resource))
+            return True
+        except Exception as e:
+            logger.error(
+                f"Error deleting comment {comment_id} on issue {issue_key}: {str(e)}"
+            )
+            raise Exception(f"Error deleting comment: {str(e)}") from e
+
+    def add_comment_adf(
+        self,
+        issue_key: str,
+        adf_body: dict[str, Any],
+        visibility: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Add a comment from a pre-built ADF document.
+
+        Used for rich comments that markdown cannot express, such as inline
+        media (screenshots embedded in the body). Cloud only — the v3 API is
+        required to accept ADF.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+            adf_body: A complete ADF document (``version``/``type``/``content``)
+            visibility: (optional) Restrict comment visibility
+
+        Returns:
+            The created comment details
+
+        Raises:
+            ValueError: If the Jira instance is not Cloud
+            Exception: If there is an error adding the comment
+        """
+        if not self.config.is_cloud:
+            raise ValueError(
+                "ADF comments (inline media) are supported on Jira Cloud only."
+            )
+
+        try:
+            data: dict[str, Any] = {"body": adf_body}
+            if visibility:
+                data["visibility"] = visibility
+            result = self._post_api3(f"issue/{issue_key}/comment", data)
+
+            if not isinstance(result, dict):
+                msg = f"Unexpected return value type from `_post_api3`: {type(result)}"
+                logger.error(msg)
+                raise TypeError(msg)
+
+            body_raw = result.get("body", "")
+            body_text = (
+                adf_to_text(body_raw) if isinstance(body_raw, dict) else body_raw
+            )
+            return {
+                "id": result.get("id"),
+                "body": self._clean_text(body_text or ""),
+                "created": str(parse_date(result.get("created"))),
+                "author": result.get("author", {}).get("displayName", "Unknown"),
+            }
+        except Exception as e:
+            logger.error(f"Error adding ADF comment to issue {issue_key}: {str(e)}")
+            raise Exception(f"Error adding ADF comment: {str(e)}") from e

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -274,6 +274,56 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
     return doc
 
 
+def build_media_comment_adf(segments: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build an ADF document interleaving text and inline media (images).
+
+    Used to compose a Jira Cloud comment whose body mixes rich text with
+    inline screenshots, e.g. text -> image -> text -> image.
+
+    Args:
+        segments: Ordered list of segment dicts. Each is either:
+            ``{"type": "text", "text": "<markdown>"}`` — converted to ADF
+            paragraphs/lists via :func:`markdown_to_adf`; or
+            ``{"type": "media", "media_id": "<uuid>"}`` — a Media Services
+            file UUID (NOT the REST attachment id) rendered as an inline
+            ``mediaSingle`` node.
+
+    Returns:
+        An ADF document dict (``version``/``type``/``content``).
+    """
+    content: list[dict[str, Any]] = []
+
+    for segment in segments:
+        seg_type = segment.get("type")
+        if seg_type == "text":
+            sub_doc = markdown_to_adf(segment.get("text", ""))
+            content.extend(sub_doc.get("content", []))
+        elif seg_type == "media":
+            media_id = segment.get("media_id")
+            content.append(
+                {
+                    "type": "mediaSingle",
+                    "attrs": {"layout": "center"},
+                    "content": [
+                        {
+                            "type": "media",
+                            "attrs": {
+                                "id": media_id,
+                                "type": "file",
+                                "collection": "",
+                            },
+                        }
+                    ],
+                }
+            )
+
+    # ADF docs must contain at least one node.
+    if not content:
+        content.append({"type": "paragraph", "content": []})
+
+    return {"version": 1, "type": "doc", "content": content}
+
+
 def adf_to_text(adf_content: dict | list | str | None) -> str | None:
     """
     Convert Atlassian Document Format (ADF) content to plain text.

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -14,6 +14,7 @@ from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.jira.constants import DEFAULT_READ_JIRA_FIELDS
 from mcp_atlassian.jira.forms_common import convert_datetime_to_timestamp
 from mcp_atlassian.models.jira import JiraAttachment
+from mcp_atlassian.models.jira.adf import build_media_comment_adf
 from mcp_atlassian.models.jira.common import JiraUser
 from mcp_atlassian.servers.dependencies import get_jira_fetcher
 from mcp_atlassian.utils.decorators import check_write_access
@@ -1038,6 +1039,127 @@ async def get_issue_images(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_attachments"},
+    annotations={"title": "Upload Attachment", "destructiveHint": False},
+)
+@check_write_access
+async def upload_attachment(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    file_path: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Absolute path to a local file the server can "
+                "read. Provide this OR 'file_content_base64', not both."
+            )
+        ),
+    ] = None,
+    file_content_base64: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Base64-encoded file content to upload inline "
+                "without filesystem access (e.g. LLM-generated content). "
+                "Requires 'filename'. Provide this OR 'file_path', not both."
+            )
+        ),
+    ] = None,
+    filename: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Filename to store in Jira when uploading via "
+                "'file_content_base64'. Ignored when 'file_path' is used."
+            )
+        ),
+    ] = None,
+) -> str:
+    """Upload a single attachment to a Jira issue.
+
+    Provide EITHER 'file_path' (a local file the server can read) OR
+    'file_content_base64' together with 'filename' (inline content, useful
+    for remote servers and LLM-generated files).
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        file_path: Optional local file path to upload.
+        file_content_base64: Optional base64-encoded inline content.
+        filename: Filename to use with file_content_base64.
+
+    Returns:
+        JSON string with the upload result.
+
+    Raises:
+        ValueError: If neither or both sources are given, if filename is
+            missing for inline content, if the base64 is invalid, or if in
+            read-only mode / Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    if file_path and file_content_base64:
+        raise ValueError(
+            "Provide either 'file_path' or 'file_content_base64', not both."
+        )
+    if not file_path and not file_content_base64:
+        raise ValueError("Provide one of 'file_path' or 'file_content_base64'.")
+
+    if file_content_base64:
+        if not filename:
+            raise ValueError("'filename' is required when using 'file_content_base64'.")
+        try:
+            content = base64.b64decode(file_content_base64, validate=True)
+        except ValueError as exc:
+            raise ValueError(f"Invalid base64 content: {exc}") from exc
+        result = jira.upload_attachment_content(issue_key, filename, content)
+    else:
+        result = jira.upload_attachment_from_path(issue_key, file_path)
+
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_attachments"},
+    annotations={"title": "Delete Attachment", "destructiveHint": True},
+)
+@check_write_access
+async def delete_attachment(
+    ctx: Context,
+    attachment_id: Annotated[
+        str,
+        Field(
+            description=(
+                "The numeric ID of the attachment to delete (available in "
+                "issue attachment metadata, e.g. from get_issue)."
+            )
+        ),
+    ],
+) -> str:
+    """Delete an attachment from Jira by its ID.
+
+    Args:
+        ctx: The FastMCP context.
+        attachment_id: The numeric ID of the attachment.
+
+    Returns:
+        JSON string describing the result.
+
+    Raises:
+        ValueError: If in read-only mode or Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.delete_attachment(attachment_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_agile"},
     annotations={"title": "Get Agile Boards", "readOnlyHint": True},
 )
@@ -1826,6 +1948,203 @@ async def edit_comment(
     visibility_dict = _parse_visibility(visibility)
     result = jira.edit_comment(issue_key, comment_id, body, visibility_dict)
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_comments"},
+    annotations={"title": "Delete Comment", "destructiveHint": True},
+)
+@check_write_access
+async def delete_comment(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    comment_id: Annotated[str, Field(description="The ID of the comment to delete")],
+) -> str:
+    """Delete a comment from a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        comment_id: The ID of the comment to delete.
+
+    Returns:
+        JSON string indicating success.
+
+    Raises:
+        ValueError: If in read-only mode or Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    jira.delete_comment(issue_key, comment_id)
+    result = {
+        "success": True,
+        "issue_key": issue_key,
+        "comment_id": comment_id,
+        "message": f"Comment {comment_id} deleted from issue {issue_key}.",
+    }
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_comments"},
+    annotations={"title": "Add Comment With Media", "destructiveHint": False},
+)
+@check_write_access
+async def add_comment_with_media(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    blocks: Annotated[
+        str,
+        Field(
+            description=(
+                "JSON array of ordered blocks composing the comment body. "
+                "Each block is either a text block "
+                '{"type":"text","text":"<markdown>"} or an image block '
+                '{"type":"image","file_path":"/abs/path.png"} OR '
+                '{"type":"image","file_content_base64":"<b64>",'
+                '"filename":"shot.png"}. Images are uploaded to the issue and '
+                "embedded inline, in order, so the comment renders like "
+                "text → screenshot → text → screenshot. Jira Cloud only."
+            )
+        ),
+    ],
+    visibility: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comment visibility as JSON string "
+                '(e.g. \'{"type":"group","value":"jira-users"}\')'
+            )
+        ),
+    ] = None,
+) -> str:
+    """Add a Jira Cloud comment whose body mixes text and inline screenshots.
+
+    Each image block is uploaded as an issue attachment, its Media Services id
+    is resolved, and the image is embedded inline in the comment in the given
+    order. Use this for the "text, screenshot, text, screenshot" layout that a
+    plain text comment cannot express.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        blocks: JSON array of ordered text/image blocks.
+        visibility: (Optional) Comment visibility as JSON string.
+
+    Returns:
+        JSON string with the created comment and the embedded attachments.
+
+    Raises:
+        ValueError: On invalid input, non-Cloud instance, upload/resolve
+            failure, read-only mode, or unavailable Jira client.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    if not jira.config.is_cloud:
+        raise ValueError("Inline media comments are supported on Jira Cloud only.")
+
+    try:
+        parsed_blocks = json.loads(blocks)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"'blocks' must be a valid JSON array: {exc}") from exc
+
+    if not isinstance(parsed_blocks, list) or not parsed_blocks:
+        raise ValueError("'blocks' must be a non-empty JSON array.")
+
+    segments: list[dict[str, Any]] = []
+    embedded: list[dict[str, Any]] = []
+
+    for index, block in enumerate(parsed_blocks):
+        if not isinstance(block, dict):
+            raise ValueError(f"Block {index} must be a JSON object.")
+        block_type = block.get("type")
+
+        if block_type == "text":
+            segments.append({"type": "text", "text": block.get("text", "")})
+            continue
+
+        if block_type != "image":
+            raise ValueError(
+                f"Block {index}: unknown type '{block_type}'. Use 'text' or 'image'."
+            )
+
+        file_path = block.get("file_path")
+        file_content_base64 = block.get("file_content_base64")
+        filename = block.get("filename")
+
+        if file_path and file_content_base64:
+            raise ValueError(
+                f"Block {index}: provide 'file_path' OR "
+                "'file_content_base64', not both."
+            )
+
+        if file_content_base64:
+            if not filename:
+                raise ValueError(
+                    f"Block {index}: 'filename' is required with 'file_content_base64'."
+                )
+            try:
+                content = base64.b64decode(file_content_base64, validate=True)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Block {index}: invalid base64 content: {exc}"
+                ) from exc
+            upload = jira.upload_attachment_content(issue_key, filename, content)
+        elif file_path:
+            upload = jira.upload_attachment_from_path(issue_key, file_path)
+        else:
+            raise ValueError(
+                f"Block {index}: image block needs 'file_path' or "
+                "'file_content_base64'."
+            )
+
+        if not upload.get("success"):
+            raise ValueError(
+                f"Block {index}: attachment upload failed: {upload.get('error')}"
+            )
+
+        attachment_id = upload.get("id")
+        if not attachment_id:
+            raise ValueError(
+                f"Block {index}: could not determine the attachment id after upload."
+            )
+
+        media_id = jira.get_attachment_media_id(attachment_id)
+        if not media_id:
+            raise ValueError(
+                f"Block {index}: could not resolve the Media Services id "
+                f"for attachment {attachment_id}."
+            )
+
+        segments.append({"type": "media", "media_id": media_id})
+        embedded.append(
+            {
+                "filename": upload.get("filename"),
+                "attachment_id": attachment_id,
+                "media_id": media_id,
+            }
+        )
+
+    adf_body = build_media_comment_adf(segments)
+    visibility_dict = _parse_visibility(visibility)
+    comment = jira.add_comment_adf(issue_key, adf_body, visibility_dict)
+
+    return json.dumps(
+        {"comment": comment, "embedded": embedded},
+        indent=2,
+        ensure_ascii=False,
+    )
 
 
 @jira_mcp.tool(

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 72 tools into 21 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -67,7 +67,7 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     ),
     "jira_attachments": ToolsetDefinition(
         name="jira_attachments",
-        description="Attachment download and image retrieval",
+        description="Attachment download, upload, deletion, and image retrieval",
         default=False,
     ),
     "jira_users": ToolsetDefinition(

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -1316,3 +1316,205 @@ class TestAttachmentsMixin:
         assert result[1].filename == "report.pdf"
         # No download calls should have been made
         attachments_mixin.jira._session.get.assert_not_called()
+
+    # Tests for upload_attachment_content (in-memory) method
+
+    def test_upload_attachment_content_success(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """In-memory upload posts a named buffer and returns the new id."""
+        attachments_mixin.jira.add_attachment_object.return_value = [
+            {"id": "55", "filename": "note.txt", "size": 5}
+        ]
+
+        result = attachments_mixin.upload_attachment_content(
+            "TEST-123", "note.txt", b"hello"
+        )
+
+        assert result["success"] is True
+        assert result["issue_key"] == "TEST-123"
+        assert result["filename"] == "note.txt"
+        assert result["size"] == 5
+        assert result["id"] == "55"
+        attachments_mixin.jira.add_attachment_object.assert_called_once()
+        # The buffer passed to the API carries the basename and content
+        args = attachments_mixin.jira.add_attachment_object.call_args[0]
+        assert args[0] == "TEST-123"
+        buffer = args[1]
+        assert buffer.name == "note.txt"
+        assert buffer.getvalue() == b"hello"
+
+    def test_upload_attachment_content_dict_response(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """A dict response (not a list) still yields the id and basename."""
+        attachments_mixin.jira.add_attachment_object.return_value = {"id": "77"}
+
+        result = attachments_mixin.upload_attachment_content(
+            "TEST-123", "/tmp/some/path/data.bin", b"\x00\x01"
+        )
+
+        assert result["success"] is True
+        assert result["filename"] == "data.bin"
+        assert result["id"] == "77"
+
+    def test_upload_attachment_content_no_issue_key(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Upload with no issue key is rejected before any API call."""
+        result = attachments_mixin.upload_attachment_content("", "f.txt", b"x")
+        assert result["success"] is False
+        assert "No issue key provided" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_content_no_filename(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Upload with no filename is rejected before any API call."""
+        result = attachments_mixin.upload_attachment_content("TEST-123", "", b"x")
+        assert result["success"] is False
+        assert "No filename provided" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_content_too_large(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Content over the size limit is rejected before any API call."""
+        with patch("mcp_atlassian.jira.attachments.ATTACHMENT_MAX_BYTES", 4):
+            result = attachments_mixin.upload_attachment_content(
+                "TEST-123", "big.bin", b"12345"
+            )
+        assert result["success"] is False
+        assert "exceeds the 50 MB limit" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_content_api_error(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """API failures during in-memory upload are reported, not raised."""
+        attachments_mixin.jira.add_attachment_object.side_effect = Exception(
+            "API Error"
+        )
+        result = attachments_mixin.upload_attachment_content("TEST-123", "f.txt", b"x")
+        assert result["success"] is False
+        assert "API Error" in result["error"]
+
+    # Tests for delete_attachment method
+
+    def test_delete_attachment_success(self, attachments_mixin: AttachmentsMixin):
+        """delete_attachment calls remove_attachment and reports success."""
+        attachments_mixin.jira.remove_attachment.return_value = None
+
+        result = attachments_mixin.delete_attachment("12345")
+
+        assert result["success"] is True
+        assert result["attachment_id"] == "12345"
+        assert "deleted successfully" in result["message"]
+        attachments_mixin.jira.remove_attachment.assert_called_once_with("12345")
+
+    def test_delete_attachment_no_id(self, attachments_mixin: AttachmentsMixin):
+        """delete_attachment with no id is rejected before any API call."""
+        result = attachments_mixin.delete_attachment("")
+        assert result["success"] is False
+        assert "No attachment ID provided" in result["error"]
+        attachments_mixin.jira.remove_attachment.assert_not_called()
+
+    def test_delete_attachment_api_error(self, attachments_mixin: AttachmentsMixin):
+        """API failures during deletion are reported, not raised."""
+        attachments_mixin.jira.remove_attachment.side_effect = Exception("API Error")
+
+        result = attachments_mixin.delete_attachment("12345")
+
+        assert result["success"] is False
+        assert result["attachment_id"] == "12345"
+        assert "API Error" in result["error"]
+
+    def test_extract_attachment_id_variants(self):
+        """_extract_attachment_id handles list, dict, and bad shapes."""
+        extract = AttachmentsMixin._extract_attachment_id
+        assert extract([{"id": "1"}]) == "1"
+        assert extract({"id": 2}) == "2"
+        assert extract([]) is None
+        assert extract(None) is None
+        assert extract("nope") is None
+
+    # Tests for upload_attachment_from_path
+
+    def test_upload_attachment_from_path_success(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Path upload reads the file and delegates to in-memory upload."""
+        attachments_mixin.jira.add_attachment_object.return_value = [{"id": "90"}]
+        with (
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.exists", return_value=True),
+            patch("mcp_atlassian.jira.attachments.validate_safe_path"),
+            patch("builtins.open", mock_open(read_data=b"PNGDATA")),
+        ):
+            result = attachments_mixin.upload_attachment_from_path(
+                "TEST-123", "/abs/shot.png"
+            )
+        assert result["success"] is True
+        assert result["filename"] == "shot.png"
+        assert result["id"] == "90"
+        assert result["size"] == len(b"PNGDATA")
+
+    def test_upload_attachment_from_path_not_found(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Missing file is reported without calling the API."""
+        with (
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.exists", return_value=False),
+            patch("mcp_atlassian.jira.attachments.validate_safe_path"),
+        ):
+            result = attachments_mixin.upload_attachment_from_path(
+                "TEST-123", "/abs/missing.png"
+            )
+        assert result["success"] is False
+        assert "File not found" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_from_path_no_path(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Empty path is rejected before any filesystem/API access."""
+        result = attachments_mixin.upload_attachment_from_path("TEST-123", "")
+        assert result["success"] is False
+        assert "No file path provided" in result["error"]
+
+    # Tests for get_attachment_media_id
+
+    def test_get_attachment_media_id_success(self, attachments_mixin: AttachmentsMixin):
+        """Media UUID is extracted from the redirect Location header."""
+        uuid = "056f8363-192c-4f50-85a6-9ce2f4dca583"
+        attachments_mixin.jira.resource_url.return_value = (
+            "https://x.atlassian.net/rest/api/3/attachment/content/123"
+        )
+        mock_resp = MagicMock()
+        mock_resp.headers = {
+            "Location": (f"https://api.media.atlassian.com/file/{uuid}/binary?token=z")
+        }
+        attachments_mixin.jira._session.get.return_value = mock_resp
+
+        result = attachments_mixin.get_attachment_media_id("123")
+
+        assert result == uuid
+        attachments_mixin.jira._session.get.assert_called_once()
+        _, kwargs = attachments_mixin.jira._session.get.call_args
+        assert kwargs.get("allow_redirects") is False
+
+    def test_get_attachment_media_id_no_location(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """No redirect location yields None."""
+        attachments_mixin.jira.resource_url.return_value = "https://x/y"
+        mock_resp = MagicMock()
+        mock_resp.headers = {}
+        attachments_mixin.jira._session.get.return_value = mock_resp
+        assert attachments_mixin.get_attachment_media_id("123") is None
+
+    def test_get_attachment_media_id_no_id(self, attachments_mixin: AttachmentsMixin):
+        """Empty attachment id returns None without any HTTP call."""
+        assert attachments_mixin.get_attachment_media_id("") is None
+        attachments_mixin.jira._session.get.assert_not_called()

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -551,3 +551,72 @@ class TestCommentsMixin:
         # ServiceDesk post should NOT be called
         comments_mixin.jira.post.assert_not_called()
         assert result["id"] == "10001"
+
+    # --- delete_comment tests ---
+
+    def test_delete_comment_cloud(self, comments_mixin):
+        """delete_comment on Cloud issues a v3 DELETE for the comment."""
+        comments_mixin._delete_api3 = Mock(return_value=None)
+
+        result = comments_mixin.delete_comment("TEST-123", "10001")
+
+        comments_mixin._delete_api3.assert_called_once_with(
+            "issue/TEST-123/comment/10001"
+        )
+        assert result is True
+
+    def test_delete_comment_error(self, comments_mixin):
+        """delete_comment wraps API failures in a clear exception."""
+        comments_mixin._delete_api3 = Mock(side_effect=Exception("API Error"))
+
+        with pytest.raises(Exception, match="Error deleting comment"):
+            comments_mixin.delete_comment("TEST-123", "10001")
+
+    def test_delete_comment_server(self, server_comments_mixin):
+        """delete_comment on Server/DC uses a raw DELETE via resource_url."""
+        server_comments_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue/TEST-123/comment/10001"
+        )
+
+        result = server_comments_mixin.delete_comment("TEST-123", "10001")
+
+        server_comments_mixin.jira.resource_url.assert_called_once_with(
+            "issue/TEST-123/comment/10001"
+        )
+        server_comments_mixin.jira.delete.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/comment/10001"
+        )
+        assert result is True
+
+    # --- add_comment_adf tests ---
+
+    def test_add_comment_adf_cloud(self, comments_mixin):
+        """add_comment_adf posts a prebuilt ADF body via v3 and returns it."""
+        mock_response = {
+            "id": "20002",
+            "body": {"version": 1, "type": "doc", "content": []},
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "John Doe"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+        adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": []}],
+        }
+
+        result = comments_mixin.add_comment_adf("TEST-123", adf)
+
+        comments_mixin._post_api3.assert_called_once()
+        call_args = comments_mixin._post_api3.call_args
+        assert call_args[0][0] == "issue/TEST-123/comment"
+        assert call_args[0][1]["body"] == adf
+        assert result["id"] == "20002"
+        assert result["author"] == "John Doe"
+
+    def test_add_comment_adf_server_rejected(self, server_comments_mixin):
+        """add_comment_adf is Cloud-only and raises on Server/DC."""
+        with pytest.raises(ValueError, match="Jira Cloud only"):
+            server_comments_mixin.add_comment_adf(
+                "TEST-123", {"version": 1, "type": "doc", "content": []}
+            )

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.mcp_atlassian.models.jira.adf import adf_to_text, markdown_to_adf
+from src.mcp_atlassian.models.jira.adf import (
+    adf_to_text,
+    build_media_comment_adf,
+    markdown_to_adf,
+)
 
 
 class TestAdfToText:
@@ -664,3 +668,47 @@ class TestMarkdownToJiraDispatch:
         """Server/DC path with empty string returns empty string."""
         result = server_client._markdown_to_jira("")
         assert result == ""
+
+
+class TestBuildMediaCommentAdf:
+    """Tests for build_media_comment_adf (inline text + media composition)."""
+
+    def test_interleaves_text_and_media_in_order(self):
+        """text -> media -> text -> media renders in the same order."""
+        segments = [
+            {"type": "text", "text": "Before"},
+            {"type": "media", "media_id": "uuid-1"},
+            {"type": "text", "text": "Between"},
+            {"type": "media", "media_id": "uuid-2"},
+        ]
+        doc = build_media_comment_adf(segments)
+
+        assert doc["version"] == 1
+        assert doc["type"] == "doc"
+        node_types = [n["type"] for n in doc["content"]]
+        assert node_types == ["paragraph", "mediaSingle", "paragraph", "mediaSingle"]
+
+    def test_media_node_structure(self):
+        """media segment builds a mediaSingle > media node with file attrs."""
+        doc = build_media_comment_adf([{"type": "media", "media_id": "abc-123"}])
+        media_single = doc["content"][0]
+        assert media_single["type"] == "mediaSingle"
+        media = media_single["content"][0]
+        assert media["type"] == "media"
+        assert media["attrs"] == {
+            "id": "abc-123",
+            "type": "file",
+            "collection": "",
+        }
+
+    def test_text_segment_uses_markdown(self):
+        """Text segments are converted through markdown_to_adf."""
+        doc = build_media_comment_adf([{"type": "text", "text": "# Title"}])
+        heading = doc["content"][0]
+        assert heading["type"] == "heading"
+
+    def test_empty_segments_yield_valid_doc(self):
+        """An empty segment list still yields a valid (non-empty) ADF doc."""
+        doc = build_media_comment_adf([])
+        assert doc["type"] == "doc"
+        assert doc["content"] == [{"type": "paragraph", "content": []}]

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -381,6 +381,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     )
     from src.mcp_atlassian.servers.jira import (
         add_comment,
+        add_comment_with_media,
         add_issues_to_sprint,
         add_worklog,
         batch_create_issues,
@@ -448,6 +449,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(delete_issue)
     jira_sub_mcp.add_tool(add_comment)
     jira_sub_mcp.add_tool(edit_comment)
+    jira_sub_mcp.add_tool(add_comment_with_media)
     jira_sub_mcp.add_tool(add_worklog)
     jira_sub_mcp.add_tool(link_to_epic)
     jira_sub_mcp.add_tool(create_issue_link)
@@ -586,6 +588,54 @@ async def test_search(jira_client, mock_jira_fetcher):
         projects_filter=None,
         page_token=None,
     )
+
+
+@pytest.mark.anyio
+async def test_add_comment_with_media(jira_client, mock_jira_fetcher):
+    """Inline-media comment uploads each image and embeds it in order."""
+    import base64
+
+    mock_jira_fetcher.config.is_cloud = True
+    mock_jira_fetcher.upload_attachment_content.side_effect = [
+        {"success": True, "filename": "a.png", "id": "att-a", "size": 3},
+        {"success": True, "filename": "b.png", "id": "att-b", "size": 3},
+    ]
+    mock_jira_fetcher.get_attachment_media_id.side_effect = [
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    ]
+    mock_jira_fetcher.add_comment_adf.return_value = {
+        "id": "30003",
+        "body": "rendered",
+        "created": "2024-01-01 10:00:00+00:00",
+        "author": "John Doe",
+    }
+
+    png_b64 = base64.b64encode(b"img").decode()
+    blocks = json.dumps(
+        [
+            {"type": "text", "text": "First"},
+            {"type": "image", "file_content_base64": png_b64, "filename": "a.png"},
+            {"type": "text", "text": "Second"},
+            {"type": "image", "file_content_base64": png_b64, "filename": "b.png"},
+        ]
+    )
+
+    response = await jira_client.call_tool(
+        "jira_add_comment_with_media",
+        {"issue_key": "TEST-123", "blocks": blocks},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content["comment"]["id"] == "30003"
+    assert len(content["embedded"]) == 2
+    assert content["embedded"][0]["media_id"].startswith("1111")
+    assert mock_jira_fetcher.upload_attachment_content.call_count == 2
+    assert mock_jira_fetcher.get_attachment_media_id.call_count == 2
+    # The ADF passed to add_comment_adf must interleave text and media in order
+    adf = mock_jira_fetcher.add_comment_adf.call_args[0][1]
+    node_types = [node["type"] for node in adf["content"]]
+    assert node_types == ["paragraph", "mediaSingle", "paragraph", "mediaSingle"]
 
 
 @pytest.mark.anyio
@@ -1042,8 +1092,8 @@ async def test_get_all_projects_tool(jira_client, mock_jira_fetcher):
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with default parameters (include_archived=False)
@@ -1091,8 +1141,8 @@ async def test_get_all_projects_tool_with_archived(jira_client, mock_jira_fetche
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with include_archived=True
@@ -1145,8 +1195,8 @@ async def test_get_all_projects_tool_with_projects_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up the projects filter in the config
@@ -1199,8 +1249,8 @@ async def test_get_all_projects_tool_no_projects_filter(jira_client, mock_jira_f
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Ensure no projects filter is set
@@ -1260,8 +1310,8 @@ async def test_get_all_projects_tool_case_insensitive_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up projects filter with mixed case and whitespace

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 53, f"Expected 53 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
…media comments

Add four Jira tools on top of upstream:
- jira_upload_attachment (local path or inline base64)
- jira_delete_attachment
- jira_delete_comment
- jira_add_comment_with_media (Cloud: screenshots embedded inline in the body)

Supporting client methods: _delete_api3, delete_comment, add_comment_adf, upload_attachment_content, upload_attachment_from_path, delete_attachment, get_attachment_media_id, and build_media_comment_adf (ADF builder). Includes unit tests, docs-reference updates, and a fork-attribution note in the README.

<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

-
-
-

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [ ] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: `[briefly describe]`

## Checklist

- [ ] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [ ] All tests pass locally.
- [ ] Documentation updated (if needed).
