### PR TITLE
fix(jira): accept comment alias for add comment

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from requests.exceptions import HTTPError
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
@@ -1738,7 +1738,13 @@ async def add_comment(
             pattern=ISSUE_KEY_PATTERN,
         ),
     ],
-    body: Annotated[str, Field(description="Comment text in Markdown format")],
+    body: Annotated[
+        str,
+        Field(
+            description="Comment text in Markdown format",
+            validation_alias=AliasChoices("body", "comment"),
+        ),
+    ],
     visibility: Annotated[
         str | None,
         Field(

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2001,6 +2001,23 @@ async def test_add_comment(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+async def test_add_comment_accepts_comment_alias(jira_client, mock_jira_fetcher):
+    """Test add_comment accepts 'comment' as a compatibility alias for body."""
+    response = await jira_client.call_tool(
+        "jira_add_comment",
+        {"issue_key": "TEST-123", "comment": "Test comment body"},
+    )
+
+    mock_jira_fetcher.add_comment.assert_called_once_with(
+        "TEST-123", "Test comment body", None, public=None
+    )
+
+    result = json.loads(response.content[0].text)
+    assert result["id"] == "10001"
+    assert result["body"] == "Test comment body"
+
+
+@pytest.mark.anyio
 async def test_edit_comment(jira_client, mock_jira_fetcher):
     """Test edit_comment accepts 'body' parameter matching response field name."""
     response = await jira_client.call_tool(


### PR DESCRIPTION
## Summary
- accept `comment` as a hidden compatibility alias for `jira_add_comment`'s `body` parameter
- add a FastMCP server regression test for the reported `comment` input shape

## Root cause
`jira_add_comment` advertised and required `body`, but a caller sent `comment`. FastMCP/Pydantic validates tool arguments before Jira logic runs, so the request failed with missing `body` and unexpected `comment`.

## Validation
- `uv run pytest tests/unit/servers/test_jira_server.py -q` -> `87 passed`
- `uv run pre-commit run --files src/mcp_atlassian/servers/jira.py tests/unit/servers/test_jira_server.py` -> fails in unrelated baseline mypy check: `src/mcp_atlassian/servers/main.py:363: error: "TTLCache" expects 3 type arguments, but 2 given [type-arg]`
