### PR TITLE
fix(jira): convert [~accountid] mentions to ADF mention nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@
 
 Model Context Protocol (MCP) server for Atlassian products (Confluence and Jira). Supports both Cloud and Server/Data Center deployments.
 
+> [!NOTE]
+> **This is an internal fork of [sooperset/mcp-atlassian](https://github.com/sooperset/mcp-atlassian)** (MIT licensed — see [`LICENSE`](LICENSE)), maintained for our team.
+> It adds the following Jira tools on top of upstream:
+> - `jira_upload_attachment` — add an attachment to an issue (local path or inline base64)
+> - `jira_delete_attachment` — delete an attachment by id
+> - `jira_delete_comment` — delete a comment from an issue
+> - `jira_add_comment_with_media` — post a Jira **Cloud** comment with screenshots embedded inline (text → image → text → image)
+>
+> All original copyright and the MIT license are preserved. To sync with upstream: `git fetch upstream && git merge upstream/main`.
+
 https://github.com/user-attachments/assets/35303504-14c6-4ae4-913b-7c25ea511c3e
 
 <details>

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -63,13 +63,13 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 |---------|:----:|-------|
 | `jira_issues` | Yes | `jira_get_issue`, `jira_search`, `jira_get_project_issues`, `jira_create_issue`, `jira_update_issue`, `jira_delete_issue`, `jira_batch_create_issues`, `jira_batch_get_changelogs` |
 | `jira_fields` | Yes | `jira_search_fields`, `jira_get_field_options` |
-| `jira_comments` | Yes | `jira_add_comment`, `jira_edit_comment` |
+| `jira_comments` | Yes | `jira_add_comment`, `jira_edit_comment`, `jira_delete_comment`, `jira_add_comment_with_media` |
 | `jira_transitions` | Yes | `jira_get_transitions`, `jira_transition_issue` |
 | `jira_projects` | No | `jira_get_all_projects`, `jira_get_project_versions`, `jira_get_project_components`, `jira_create_version`, `jira_batch_create_versions` |
 | `jira_agile` | No | `jira_get_agile_boards`, `jira_get_board_issues`, `jira_get_sprints_from_board`, `jira_get_sprint_issues`, `jira_create_sprint`, `jira_update_sprint`, `jira_add_issues_to_sprint` |
 | `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_create_remote_issue_link`, `jira_remove_issue_link` |
 | `jira_worklog` | No | `jira_get_worklog`, `jira_add_worklog` |
-| `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images` |
+| `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images`, `jira_upload_attachment`, `jira_delete_attachment` |
 | `jira_users` | No | `jira_get_user_profile` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
 | `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues` |

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -10,12 +10,22 @@ from typing import Any
 
 from ..models.jira import JiraAttachment
 from ..utils.io import validate_safe_path
-from ..utils.media import ATTACHMENT_MAX_BYTES
+from ..utils.media import ATTACHMENT_MAX_BYTES, get_image_dimensions
 from .client import JiraClient
 from .protocols import AttachmentsOperationsProto
 
 # Configure logging
 logger = logging.getLogger("mcp-jira")
+
+# Jira Cloud's attachment-content endpoint redirects to the Media Services
+# download URL (e.g. ``https://api.media.atlassian.com/file/{uuid}/binary``).
+# The media file UUID is the path segment after ``/file/``. Match on this
+# fragment only — the host varies (api.media.atlassian.com, api-gev2.*, and
+# Forge outbound proxies all appear), so anchoring on the host is fragile.
+_MEDIA_FILE_UUID_RE = re.compile(
+    r"/file/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
 
 
 class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
@@ -538,13 +548,19 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             buffer.name = safe_filename
             response = self.jira.add_attachment_object(issue_key, buffer)
 
-            return {
+            result: dict[str, Any] = {
                 "success": True,
                 "issue_key": issue_key,
                 "filename": safe_filename,
                 "size": len(content),
                 "id": self._extract_attachment_id(response),
             }
+            # Surface pixel dimensions for images so callers embedding the
+            # attachment inline (ADF media nodes) can size it correctly.
+            dimensions = get_image_dimensions(content)
+            if dimensions is not None:
+                result["width"], result["height"] = dimensions
+            return result
         except Exception as e:
             error_msg = str(e)
             logger.error(f"Error uploading attachment: {error_msg}")
@@ -592,6 +608,11 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         (the legacy :meth:`upload_attachment` cannot report it because the
         attachments endpoint returns a list).
 
+        Any absolute path is accepted (e.g. screenshots under ``/tmp`` or
+        ``/var/folders``); unlike the download helpers this read is not
+        confined to the working directory, since uploading is an explicit,
+        operator-initiated action.
+
         Args:
             issue_key: The Jira issue key (e.g., 'PROJ-123')
             file_path: Path to the local file to upload
@@ -606,8 +627,6 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         try:
             if not os.path.isabs(file_path):
                 file_path = os.path.abspath(file_path)
-            # Guard against path traversal (resolves symlinks)
-            validate_safe_path(file_path)
             if not os.path.exists(file_path):
                 logger.error(f"File not found: {file_path}")
                 return {"success": False, "error": f"File not found: {file_path}"}
@@ -621,15 +640,35 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             logger.error(f"Error uploading attachment from path: {error_msg}")
             return {"success": False, "error": error_msg}
 
+    @staticmethod
+    def _extract_media_file_uuid(text: str | None) -> str | None:
+        """Return the media file UUID from a media-download URL, if present."""
+        if not text:
+            return None
+        match = _MEDIA_FILE_UUID_RE.search(text)
+        return match.group(1) if match else None
+
     def get_attachment_media_id(self, attachment_id: str) -> str | None:
         """
         Resolve the Media Services file UUID for an uploaded attachment.
 
         Inline ADF ``media`` nodes require the Media Services UUID, which
-        differs from the REST attachment id. It is obtained by requesting the
-        attachment content endpoint *without* following the redirect and
-        reading the UUID from the ``Location`` header
-        (``.../file/{uuid}/binary``).
+        differs from the REST attachment id. Jira Cloud exposes it only
+        indirectly: the ``attachment/content/{id}`` endpoint redirects to the
+        media download URL (``.../file/{uuid}/binary``), and the UUID is the
+        ``/file/`` path segment.
+
+        Resolution is attempted in two passes:
+
+        1. Fast path — request the endpoint *without* following the redirect
+           and read the UUID from the ``Location`` header. This is the
+           documented single-hop behaviour.
+        2. Fallback — when the first ``Location`` is not the media URL (e.g.
+           behind the OAuth gateway ``api.atlassian.com/ex/jira/{cloudId}``, a
+           corporate proxy, or a multi-hop redirect), follow the whole chain
+           and scan every hop's URL for the ``/file/{uuid}`` fragment.
+           ``requests`` strips the ``Authorization`` header on cross-host
+           redirects, so following to the media host leaks no credentials.
 
         Args:
             attachment_id: The REST attachment id returned when uploading
@@ -640,26 +679,55 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         if not attachment_id:
             return None
 
+        url = self.jira.resource_url(
+            f"attachment/content/{attachment_id}", api_version="3"
+        )
+
+        # --- Pass 1: documented single-hop redirect (no follow). ---
+        first_status: int | str = "unknown"
+        first_location = ""
         try:
-            url = self.jira.resource_url(
-                f"attachment/content/{attachment_id}", api_version="3"
-            )
             response = self.jira._session.get(url, allow_redirects=False, stream=True)
-            location = response.headers.get("Location", "")
-            match = re.search(
-                r"/file/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
-                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
-                location,
-            )
-            if match:
-                return match.group(1)
-            logger.error(
-                f"Could not extract media id for attachment {attachment_id} "
-                "from the redirect location"
-            )
-            return None
+            first_status = getattr(response, "status_code", "unknown")
+            first_location = response.headers.get("Location", "")
+            response.close()
+            media_id = self._extract_media_file_uuid(first_location)
+            if media_id:
+                return media_id
         except Exception as e:
             logger.error(
                 f"Error resolving media id for attachment {attachment_id}: {str(e)}"
             )
             return None
+
+        # --- Pass 2: follow the full redirect chain and scan each hop. ---
+        try:
+            followed = self.jira._session.get(url, allow_redirects=True, stream=True)
+            candidates: list[str] = []
+            for hop in followed.history or []:
+                candidates.append(hop.headers.get("Location", ""))
+                candidates.append(getattr(hop, "url", "") or "")
+            candidates.append(getattr(followed, "url", "") or "")
+            followed.close()
+            for candidate in candidates:
+                media_id = self._extract_media_file_uuid(candidate)
+                if media_id:
+                    return media_id
+        except Exception as e:
+            logger.error(
+                f"Error resolving media id for attachment {attachment_id} "
+                f"via the redirect chain: {str(e)}"
+            )
+            return None
+
+        logger.error(
+            "Could not resolve the media id for attachment %s: the "
+            "attachment-content endpoint returned HTTP %s and no hop exposed a "
+            "'/file/{uuid}' media URL (first-hop Location: %s). The instance "
+            "likely routes attachment content through a gateway/proxy that "
+            "hides the media URL.",
+            attachment_id,
+            first_status,
+            (first_location[:120] or "<none>"),
+        )
+        return None

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -1,8 +1,10 @@
 """Attachment operations for Jira API."""
 
+import io
 import logging
 import mimetypes
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -467,3 +469,197 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             "uploaded": uploaded,
             "failed": failed,
         }
+
+    @staticmethod
+    def _extract_attachment_id(response: Any) -> str | None:
+        """Extract the attachment id from a Jira attachments API response.
+
+        The ``issue/{key}/attachments`` endpoint returns a list of attachment
+        objects, but some code paths/mocks return a single dict. Handle both.
+
+        Args:
+            response: The raw response from the attachments endpoint.
+
+        Returns:
+            The attachment id as a string, or None if it cannot be determined.
+        """
+        item: Any = None
+        if isinstance(response, list) and response:
+            item = response[0]
+        elif isinstance(response, dict):
+            item = response
+        if isinstance(item, dict):
+            attachment_id = item.get("id")
+            return str(attachment_id) if attachment_id is not None else None
+        return None
+
+    def upload_attachment_content(
+        self, issue_key: str, filename: str, content: bytes
+    ) -> dict[str, Any]:
+        """
+        Upload an attachment to a Jira issue from in-memory bytes.
+
+        Unlike :meth:`upload_attachment`, this does not require filesystem
+        access, so it works for remote/stdio servers and for content the LLM
+        generates inline (passed as base64 by the server layer).
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123')
+            filename: The name to give the attachment in Jira
+            content: The raw bytes of the file to upload
+
+        Returns:
+            A dictionary with upload result information
+        """
+        if not issue_key:
+            logger.error("No issue key provided for attachment upload")
+            return {"success": False, "error": "No issue key provided"}
+
+        if not filename:
+            logger.error("No filename provided for attachment upload")
+            return {"success": False, "error": "No filename provided"}
+
+        if len(content) > ATTACHMENT_MAX_BYTES:
+            msg = (
+                f"Attachment '{filename}' is {len(content)} bytes which "
+                "exceeds the 50 MB limit."
+            )
+            logger.error(msg)
+            return {"success": False, "error": msg}
+
+        try:
+            safe_filename = os.path.basename(filename)
+            logger.info(
+                f"Uploading in-memory attachment '{safe_filename}' "
+                f"({len(content)} bytes) to issue {issue_key}"
+            )
+            # A named buffer makes requests send the correct multipart filename.
+            buffer = io.BytesIO(content)
+            buffer.name = safe_filename
+            response = self.jira.add_attachment_object(issue_key, buffer)
+
+            return {
+                "success": True,
+                "issue_key": issue_key,
+                "filename": safe_filename,
+                "size": len(content),
+                "id": self._extract_attachment_id(response),
+            }
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error uploading attachment: {error_msg}")
+            return {"success": False, "error": error_msg}
+
+    def delete_attachment(self, attachment_id: str) -> dict[str, Any]:
+        """
+        Delete a Jira attachment by its ID.
+
+        Args:
+            attachment_id: The numeric ID of the attachment to delete
+
+        Returns:
+            A dictionary describing the result of the deletion
+        """
+        if not attachment_id:
+            logger.error("No attachment ID provided for deletion")
+            return {"success": False, "error": "No attachment ID provided"}
+
+        try:
+            logger.info(f"Deleting attachment {attachment_id}")
+            self.jira.remove_attachment(attachment_id)
+            return {
+                "success": True,
+                "attachment_id": attachment_id,
+                "message": f"Attachment {attachment_id} deleted successfully",
+            }
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error deleting attachment {attachment_id}: {error_msg}")
+            return {
+                "success": False,
+                "attachment_id": attachment_id,
+                "error": error_msg,
+            }
+
+    def upload_attachment_from_path(
+        self, issue_key: str, file_path: str
+    ) -> dict[str, Any]:
+        """
+        Upload a local file to a Jira issue, returning a reliable attachment id.
+
+        Reads the file into memory and delegates to
+        :meth:`upload_attachment_content`, so the returned ``id`` is correct
+        (the legacy :meth:`upload_attachment` cannot report it because the
+        attachments endpoint returns a list).
+
+        Args:
+            issue_key: The Jira issue key (e.g., 'PROJ-123')
+            file_path: Path to the local file to upload
+
+        Returns:
+            A dictionary with upload result information
+        """
+        if not file_path:
+            logger.error("No file path provided for attachment upload")
+            return {"success": False, "error": "No file path provided"}
+
+        try:
+            if not os.path.isabs(file_path):
+                file_path = os.path.abspath(file_path)
+            # Guard against path traversal (resolves symlinks)
+            validate_safe_path(file_path)
+            if not os.path.exists(file_path):
+                logger.error(f"File not found: {file_path}")
+                return {"success": False, "error": f"File not found: {file_path}"}
+            with open(file_path, "rb") as fh:
+                content = fh.read()
+            return self.upload_attachment_content(
+                issue_key, os.path.basename(file_path), content
+            )
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Error uploading attachment from path: {error_msg}")
+            return {"success": False, "error": error_msg}
+
+    def get_attachment_media_id(self, attachment_id: str) -> str | None:
+        """
+        Resolve the Media Services file UUID for an uploaded attachment.
+
+        Inline ADF ``media`` nodes require the Media Services UUID, which
+        differs from the REST attachment id. It is obtained by requesting the
+        attachment content endpoint *without* following the redirect and
+        reading the UUID from the ``Location`` header
+        (``.../file/{uuid}/binary``).
+
+        Args:
+            attachment_id: The REST attachment id returned when uploading
+
+        Returns:
+            The media UUID string, or None if it cannot be resolved
+        """
+        if not attachment_id:
+            return None
+
+        try:
+            url = self.jira.resource_url(
+                f"attachment/content/{attachment_id}", api_version="3"
+            )
+            response = self.jira._session.get(url, allow_redirects=False, stream=True)
+            location = response.headers.get("Location", "")
+            match = re.search(
+                r"/file/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+                location,
+            )
+            if match:
+                return match.group(1)
+            logger.error(
+                f"Could not extract media id for attachment {attachment_id} "
+                "from the redirect location"
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                f"Error resolving media id for attachment {attachment_id}: {str(e)}"
+            )
+            return None

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -679,9 +679,18 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         if not attachment_id:
             return None
 
-        url = self.jira.resource_url(
+        # resource_url may return a path RELATIVE to the API base depending on
+        # the atlassian-python-api version. ``_session.get`` needs an absolute
+        # URL or requests raises ``MissingSchema``. Join against the base the
+        # library itself uses (``self.jira.url``) so the OAuth gateway host
+        # (``api.atlassian.com/ex/jira/{cloudId}``) is honoured too.
+        resource = self.jira.resource_url(
             f"attachment/content/{attachment_id}", api_version="3"
         )
+        if resource.startswith(("http://", "https://")):
+            url = resource
+        else:
+            url = f"{self.jira.url.rstrip('/')}/{resource.lstrip('/')}"
 
         # --- Pass 1: documented single-hop redirect (no follow). ---
         first_status: int | str = "unknown"
@@ -694,38 +703,38 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             media_id = self._extract_media_file_uuid(first_location)
             if media_id:
                 return media_id
-        except Exception as e:
-            logger.error(
-                f"Error resolving media id for attachment {attachment_id}: {str(e)}"
+        except Exception:
+            # Don't swallow the real cause: log the full traceback, then let
+            # the redirect-chain pass run (and surface any error it hits).
+            logger.warning(
+                "Media-id resolution pass 1 failed for attachment %s "
+                "(url=%s); trying the redirect chain.",
+                attachment_id,
+                url,
+                exc_info=True,
             )
-            return None
 
-        # --- Pass 2: follow the full redirect chain and scan each hop. ---
-        try:
-            followed = self.jira._session.get(url, allow_redirects=True, stream=True)
-            candidates: list[str] = []
-            for hop in followed.history or []:
-                candidates.append(hop.headers.get("Location", ""))
-                candidates.append(getattr(hop, "url", "") or "")
-            candidates.append(getattr(followed, "url", "") or "")
-            followed.close()
-            for candidate in candidates:
-                media_id = self._extract_media_file_uuid(candidate)
-                if media_id:
-                    return media_id
-        except Exception as e:
-            logger.error(
-                f"Error resolving media id for attachment {attachment_id} "
-                f"via the redirect chain: {str(e)}"
-            )
-            return None
+        # --- Pass 2: follow the full redirect chain and scan every hop. ---
+        # A hard error here is intentionally NOT caught so the caller reports
+        # the real reason (e.g. a bad URL or network failure) rather than a
+        # vague "could not resolve".
+        followed = self.jira._session.get(url, allow_redirects=True, stream=True)
+        candidates: list[str] = []
+        for hop in followed.history or []:
+            candidates.append(hop.headers.get("Location", ""))
+            candidates.append(getattr(hop, "url", "") or "")
+        candidates.append(getattr(followed, "url", "") or "")
+        followed.close()
+        for candidate in candidates:
+            media_id = self._extract_media_file_uuid(candidate)
+            if media_id:
+                return media_id
 
         logger.error(
-            "Could not resolve the media id for attachment %s: the "
-            "attachment-content endpoint returned HTTP %s and no hop exposed a "
-            "'/file/{uuid}' media URL (first-hop Location: %s). The instance "
-            "likely routes attachment content through a gateway/proxy that "
-            "hides the media URL.",
+            "Could not resolve the media id for attachment %s: HTTP %s and no "
+            "hop exposed a '/file/{uuid}' media URL (first-hop Location: %s). "
+            "The instance may route attachment content through a gateway/proxy "
+            "that hides the media URL.",
             attachment_id,
             first_status,
             (first_location[:120] or "<none>"),

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -294,6 +294,15 @@ class JiraClient:
         url = self.jira.resource_url(resource, api_version="3")
         return self.jira.put(url, data=data)
 
+    def _delete_api3(self, resource: str, params: dict[str, str] | None = None) -> Any:
+        """DELETE against Jira REST API v3.
+
+        Mirrors ``_post_api3`` / ``_put_api3`` so deletions on Cloud target
+        the v3 endpoint consistently with the rest of the client.
+        """
+        url = self.jira.resource_url(resource, api_version="3")
+        return self.jira.delete(url, params=params)
+
     def get_paged(
         self,
         method: Literal["get", "post"],

--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -257,3 +257,87 @@ class CommentsMixin(JiraClient):
                 f"Error editing comment {comment_id} on issue {issue_key}: {str(e)}"
             )
             raise Exception(f"Error editing comment: {str(e)}") from e
+
+    def delete_comment(self, issue_key: str, comment_id: str) -> bool:
+        """
+        Delete a comment from an issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+            comment_id: The ID of the comment to delete
+
+        Returns:
+            True if the comment was deleted successfully
+
+        Raises:
+            Exception: If there is an error deleting the comment
+        """
+        try:
+            resource = f"issue/{issue_key}/comment/{comment_id}"
+            # Use v3 API on Cloud for consistency; the library exposes no
+            # dedicated comment-deletion helper, so fall back to a raw DELETE.
+            if self.config.is_cloud:
+                self._delete_api3(resource)
+            else:
+                self.jira.delete(self.jira.resource_url(resource))
+            return True
+        except Exception as e:
+            logger.error(
+                f"Error deleting comment {comment_id} on issue {issue_key}: {str(e)}"
+            )
+            raise Exception(f"Error deleting comment: {str(e)}") from e
+
+    def add_comment_adf(
+        self,
+        issue_key: str,
+        adf_body: dict[str, Any],
+        visibility: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Add a comment from a pre-built ADF document.
+
+        Used for rich comments that markdown cannot express, such as inline
+        media (screenshots embedded in the body). Cloud only — the v3 API is
+        required to accept ADF.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+            adf_body: A complete ADF document (``version``/``type``/``content``)
+            visibility: (optional) Restrict comment visibility
+
+        Returns:
+            The created comment details
+
+        Raises:
+            ValueError: If the Jira instance is not Cloud
+            Exception: If there is an error adding the comment
+        """
+        if not self.config.is_cloud:
+            raise ValueError(
+                "ADF comments (inline media) are supported on Jira Cloud only."
+            )
+
+        try:
+            data: dict[str, Any] = {"body": adf_body}
+            if visibility:
+                data["visibility"] = visibility
+            result = self._post_api3(f"issue/{issue_key}/comment", data)
+
+            if not isinstance(result, dict):
+                msg = f"Unexpected return value type from `_post_api3`: {type(result)}"
+                logger.error(msg)
+                raise TypeError(msg)
+
+            body_raw = result.get("body", "")
+            body_text = (
+                adf_to_text(body_raw) if isinstance(body_raw, dict) else body_raw
+            )
+            return {
+                "id": result.get("id"),
+                "body": self._clean_text(body_text or ""),
+                "created": str(parse_date(result.get("created"))),
+                "author": result.get("author", {}).get("displayName", "Unknown"),
+            }
+        except Exception as e:
+            logger.error(f"Error adding ADF comment to issue {issue_key}: {str(e)}")
+            raise Exception(f"Error adding ADF comment: {str(e)}") from e

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -274,6 +274,56 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
     return doc
 
 
+def build_media_comment_adf(segments: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build an ADF document interleaving text and inline media (images).
+
+    Used to compose a Jira Cloud comment whose body mixes rich text with
+    inline screenshots, e.g. text -> image -> text -> image.
+
+    Args:
+        segments: Ordered list of segment dicts. Each is either:
+            ``{"type": "text", "text": "<markdown>"}`` — converted to ADF
+            paragraphs/lists via :func:`markdown_to_adf`; or
+            ``{"type": "media", "media_id": "<uuid>"}`` — a Media Services
+            file UUID (NOT the REST attachment id) rendered as an inline
+            ``mediaSingle`` node.
+
+    Returns:
+        An ADF document dict (``version``/``type``/``content``).
+    """
+    content: list[dict[str, Any]] = []
+
+    for segment in segments:
+        seg_type = segment.get("type")
+        if seg_type == "text":
+            sub_doc = markdown_to_adf(segment.get("text", ""))
+            content.extend(sub_doc.get("content", []))
+        elif seg_type == "media":
+            media_id = segment.get("media_id")
+            content.append(
+                {
+                    "type": "mediaSingle",
+                    "attrs": {"layout": "center"},
+                    "content": [
+                        {
+                            "type": "media",
+                            "attrs": {
+                                "id": media_id,
+                                "type": "file",
+                                "collection": "",
+                            },
+                        }
+                    ],
+                }
+            )
+
+    # ADF docs must contain at least one node.
+    if not content:
+        content.append({"type": "paragraph", "content": []})
+
+    return {"version": 1, "type": "doc", "content": content}
+
+
 def adf_to_text(adf_content: dict | list | str | None) -> str | None:
     """
     Convert Atlassian Document Format (ADF) content to plain text.

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -286,7 +286,11 @@ def build_media_comment_adf(segments: list[dict[str, Any]]) -> dict[str, Any]:
             paragraphs/lists via :func:`markdown_to_adf`; or
             ``{"type": "media", "media_id": "<uuid>"}`` — a Media Services
             file UUID (NOT the REST attachment id) rendered as an inline
-            ``mediaSingle`` node.
+            ``mediaSingle`` node. Media segments may also carry integer
+            ``width``/``height`` (pixel dimensions); when present they are
+            written to the ``media`` node so Jira Cloud renders the image
+            reliably (the ADF spec warns the media "isn't displayed"
+            without dimensions inside ``mediaSingle``).
 
     Returns:
         An ADF document dict (``version``/``type``/``content``).
@@ -299,21 +303,26 @@ def build_media_comment_adf(segments: list[dict[str, Any]]) -> dict[str, Any]:
             sub_doc = markdown_to_adf(segment.get("text", ""))
             content.extend(sub_doc.get("content", []))
         elif seg_type == "media":
-            media_id = segment.get("media_id")
+            media_attrs: dict[str, Any] = {
+                "id": segment.get("media_id"),
+                "type": "file",
+                "collection": "",
+            }
+            width = segment.get("width")
+            height = segment.get("height")
+            if (
+                isinstance(width, int)
+                and isinstance(height, int)
+                and width > 0
+                and height > 0
+            ):
+                media_attrs["width"] = width
+                media_attrs["height"] = height
             content.append(
                 {
                     "type": "mediaSingle",
                     "attrs": {"layout": "center"},
-                    "content": [
-                        {
-                            "type": "media",
-                            "attrs": {
-                                "id": media_id,
-                                "type": "file",
-                                "collection": "",
-                            },
-                        }
-                    ],
+                    "content": [{"type": "media", "attrs": media_attrs}],
                 }
             )
 

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -14,21 +14,26 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
     """Parse inline Markdown formatting into ADF inline nodes.
 
     Handles: bold (**), italic (*), inline code (`), links ([text](url)),
-    and strikethrough (~~).
+    strikethrough (~~), and user mentions (``[~accountid:<id>]`` or the
+    ``@[Display Name](<id>)`` form), which become ADF ``mention`` nodes so
+    Jira Cloud renders a clickable @mention and notifies the user.
 
     Args:
         text: Raw text potentially containing inline Markdown formatting.
 
     Returns:
-        List of ADF inline nodes (text nodes with optional marks).
+        List of ADF inline nodes (text/mention nodes with optional marks).
     """
     if not text:
         return []
 
     nodes: list[dict[str, Any]] = []
-    # Pattern order matters: bold before italic, code before others
+    # Pattern order matters: mentions before links (so ``@[name](id)`` is not
+    # parsed as a link), bold before italic, code before others.
     inline_re = re.compile(
-        r"`(?P<code_inner>[^`]+)`"
+        r"\[~accountid:(?P<mention_acct>[^\]]+)\]"
+        r"|@\[(?P<mention_name>[^\]]+)\]\((?P<mention_id>[^)]+)\)"
+        r"|`(?P<code_inner>[^`]+)`"
         r"|\*\*(?P<bold_inner>.+?)\*\*"
         r"|~~(?P<strike_inner>.+?)~~"
         r"|\[(?P<link_text>[^\]]+)\]\((?P<link_href>[^)]+)\)"
@@ -43,7 +48,24 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
             if plain:
                 nodes.append({"type": "text", "text": plain})
 
-        if m.group("code_inner") is not None:
+        if m.group("mention_acct") is not None:
+            nodes.append(
+                {
+                    "type": "mention",
+                    "attrs": {"id": m.group("mention_acct")},
+                }
+            )
+        elif m.group("mention_id") is not None:
+            nodes.append(
+                {
+                    "type": "mention",
+                    "attrs": {
+                        "id": m.group("mention_id"),
+                        "text": f"@{m.group('mention_name')}",
+                    },
+                }
+            )
+        elif m.group("code_inner") is not None:
             nodes.append(
                 {
                     "type": "text",

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -14,6 +14,7 @@ from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.jira.constants import DEFAULT_READ_JIRA_FIELDS
 from mcp_atlassian.jira.forms_common import convert_datetime_to_timestamp
 from mcp_atlassian.models.jira import JiraAttachment
+from mcp_atlassian.models.jira.adf import build_media_comment_adf
 from mcp_atlassian.models.jira.common import JiraUser
 from mcp_atlassian.servers.dependencies import get_jira_fetcher
 from mcp_atlassian.utils.decorators import check_write_access
@@ -1038,6 +1039,127 @@ async def get_issue_images(
 
 
 @jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_attachments"},
+    annotations={"title": "Upload Attachment", "destructiveHint": False},
+)
+@check_write_access
+async def upload_attachment(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    file_path: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Absolute path to a local file the server can "
+                "read. Provide this OR 'file_content_base64', not both."
+            )
+        ),
+    ] = None,
+    file_content_base64: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Base64-encoded file content to upload inline "
+                "without filesystem access (e.g. LLM-generated content). "
+                "Requires 'filename'. Provide this OR 'file_path', not both."
+            )
+        ),
+    ] = None,
+    filename: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Filename to store in Jira when uploading via "
+                "'file_content_base64'. Ignored when 'file_path' is used."
+            )
+        ),
+    ] = None,
+) -> str:
+    """Upload a single attachment to a Jira issue.
+
+    Provide EITHER 'file_path' (a local file the server can read) OR
+    'file_content_base64' together with 'filename' (inline content, useful
+    for remote servers and LLM-generated files).
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        file_path: Optional local file path to upload.
+        file_content_base64: Optional base64-encoded inline content.
+        filename: Filename to use with file_content_base64.
+
+    Returns:
+        JSON string with the upload result.
+
+    Raises:
+        ValueError: If neither or both sources are given, if filename is
+            missing for inline content, if the base64 is invalid, or if in
+            read-only mode / Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    if file_path and file_content_base64:
+        raise ValueError(
+            "Provide either 'file_path' or 'file_content_base64', not both."
+        )
+    if not file_path and not file_content_base64:
+        raise ValueError("Provide one of 'file_path' or 'file_content_base64'.")
+
+    if file_content_base64:
+        if not filename:
+            raise ValueError("'filename' is required when using 'file_content_base64'.")
+        try:
+            content = base64.b64decode(file_content_base64, validate=True)
+        except ValueError as exc:
+            raise ValueError(f"Invalid base64 content: {exc}") from exc
+        result = jira.upload_attachment_content(issue_key, filename, content)
+    else:
+        result = jira.upload_attachment_from_path(issue_key, file_path)
+
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_attachments"},
+    annotations={"title": "Delete Attachment", "destructiveHint": True},
+)
+@check_write_access
+async def delete_attachment(
+    ctx: Context,
+    attachment_id: Annotated[
+        str,
+        Field(
+            description=(
+                "The numeric ID of the attachment to delete (available in "
+                "issue attachment metadata, e.g. from get_issue)."
+            )
+        ),
+    ],
+) -> str:
+    """Delete an attachment from Jira by its ID.
+
+    Args:
+        ctx: The FastMCP context.
+        attachment_id: The numeric ID of the attachment.
+
+    Returns:
+        JSON string describing the result.
+
+    Raises:
+        ValueError: If in read-only mode or Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.delete_attachment(attachment_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_agile"},
     annotations={"title": "Get Agile Boards", "readOnlyHint": True},
 )
@@ -1826,6 +1948,203 @@ async def edit_comment(
     visibility_dict = _parse_visibility(visibility)
     result = jira.edit_comment(issue_key, comment_id, body, visibility_dict)
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_comments"},
+    annotations={"title": "Delete Comment", "destructiveHint": True},
+)
+@check_write_access
+async def delete_comment(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    comment_id: Annotated[str, Field(description="The ID of the comment to delete")],
+) -> str:
+    """Delete a comment from a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        comment_id: The ID of the comment to delete.
+
+    Returns:
+        JSON string indicating success.
+
+    Raises:
+        ValueError: If in read-only mode or Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    jira.delete_comment(issue_key, comment_id)
+    result = {
+        "success": True,
+        "issue_key": issue_key,
+        "comment_id": comment_id,
+        "message": f"Comment {comment_id} deleted from issue {issue_key}.",
+    }
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_comments"},
+    annotations={"title": "Add Comment With Media", "destructiveHint": False},
+)
+@check_write_access
+async def add_comment_with_media(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="Jira issue key (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    blocks: Annotated[
+        str,
+        Field(
+            description=(
+                "JSON array of ordered blocks composing the comment body. "
+                "Each block is either a text block "
+                '{"type":"text","text":"<markdown>"} or an image block '
+                '{"type":"image","file_path":"/abs/path.png"} OR '
+                '{"type":"image","file_content_base64":"<b64>",'
+                '"filename":"shot.png"}. Images are uploaded to the issue and '
+                "embedded inline, in order, so the comment renders like "
+                "text → screenshot → text → screenshot. Jira Cloud only."
+            )
+        ),
+    ],
+    visibility: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comment visibility as JSON string "
+                '(e.g. \'{"type":"group","value":"jira-users"}\')'
+            )
+        ),
+    ] = None,
+) -> str:
+    """Add a Jira Cloud comment whose body mixes text and inline screenshots.
+
+    Each image block is uploaded as an issue attachment, its Media Services id
+    is resolved, and the image is embedded inline in the comment in the given
+    order. Use this for the "text, screenshot, text, screenshot" layout that a
+    plain text comment cannot express.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: Jira issue key.
+        blocks: JSON array of ordered text/image blocks.
+        visibility: (Optional) Comment visibility as JSON string.
+
+    Returns:
+        JSON string with the created comment and the embedded attachments.
+
+    Raises:
+        ValueError: On invalid input, non-Cloud instance, upload/resolve
+            failure, read-only mode, or unavailable Jira client.
+    """
+    jira = await get_jira_fetcher(ctx)
+
+    if not jira.config.is_cloud:
+        raise ValueError("Inline media comments are supported on Jira Cloud only.")
+
+    try:
+        parsed_blocks = json.loads(blocks)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"'blocks' must be a valid JSON array: {exc}") from exc
+
+    if not isinstance(parsed_blocks, list) or not parsed_blocks:
+        raise ValueError("'blocks' must be a non-empty JSON array.")
+
+    segments: list[dict[str, Any]] = []
+    embedded: list[dict[str, Any]] = []
+
+    for index, block in enumerate(parsed_blocks):
+        if not isinstance(block, dict):
+            raise ValueError(f"Block {index} must be a JSON object.")
+        block_type = block.get("type")
+
+        if block_type == "text":
+            segments.append({"type": "text", "text": block.get("text", "")})
+            continue
+
+        if block_type != "image":
+            raise ValueError(
+                f"Block {index}: unknown type '{block_type}'. Use 'text' or 'image'."
+            )
+
+        file_path = block.get("file_path")
+        file_content_base64 = block.get("file_content_base64")
+        filename = block.get("filename")
+
+        if file_path and file_content_base64:
+            raise ValueError(
+                f"Block {index}: provide 'file_path' OR "
+                "'file_content_base64', not both."
+            )
+
+        if file_content_base64:
+            if not filename:
+                raise ValueError(
+                    f"Block {index}: 'filename' is required with 'file_content_base64'."
+                )
+            try:
+                content = base64.b64decode(file_content_base64, validate=True)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Block {index}: invalid base64 content: {exc}"
+                ) from exc
+            upload = jira.upload_attachment_content(issue_key, filename, content)
+        elif file_path:
+            upload = jira.upload_attachment_from_path(issue_key, file_path)
+        else:
+            raise ValueError(
+                f"Block {index}: image block needs 'file_path' or "
+                "'file_content_base64'."
+            )
+
+        if not upload.get("success"):
+            raise ValueError(
+                f"Block {index}: attachment upload failed: {upload.get('error')}"
+            )
+
+        attachment_id = upload.get("id")
+        if not attachment_id:
+            raise ValueError(
+                f"Block {index}: could not determine the attachment id after upload."
+            )
+
+        media_id = jira.get_attachment_media_id(attachment_id)
+        if not media_id:
+            raise ValueError(
+                f"Block {index}: could not resolve the Media Services id "
+                f"for attachment {attachment_id}."
+            )
+
+        segments.append({"type": "media", "media_id": media_id})
+        embedded.append(
+            {
+                "filename": upload.get("filename"),
+                "attachment_id": attachment_id,
+                "media_id": media_id,
+            }
+        )
+
+    adf_body = build_media_comment_adf(segments)
+    visibility_dict = _parse_visibility(visibility)
+    comment = jira.add_comment_adf(issue_key, adf_body, visibility_dict)
+
+    return json.dumps(
+        {"comment": comment, "embedded": embedded},
+        indent=2,
+        ensure_ascii=False,
+    )
 
 
 @jira_mcp.tool(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2034,7 +2034,9 @@ async def add_comment_with_media(
     Each image block is uploaded as an issue attachment, its Media Services id
     is resolved, and the image is embedded inline in the comment in the given
     order. Use this for the "text, screenshot, text, screenshot" layout that a
-    plain text comment cannot express.
+    plain text comment cannot express. ``file_path`` accepts any absolute path
+    (e.g. screenshots under ``/tmp``). If any step fails, every attachment
+    uploaded during this call is rolled back so no orphans are left behind.
 
     Args:
         ctx: The FastMCP context.
@@ -2064,81 +2066,123 @@ async def add_comment_with_media(
 
     segments: list[dict[str, Any]] = []
     embedded: list[dict[str, Any]] = []
+    # Attachments uploaded during this call, so they can be rolled back if a
+    # later step fails — otherwise a failed comment leaves orphan attachments.
+    uploaded_ids: list[str] = []
 
-    for index, block in enumerate(parsed_blocks):
-        if not isinstance(block, dict):
-            raise ValueError(f"Block {index} must be a JSON object.")
-        block_type = block.get("type")
-
-        if block_type == "text":
-            segments.append({"type": "text", "text": block.get("text", "")})
-            continue
-
-        if block_type != "image":
-            raise ValueError(
-                f"Block {index}: unknown type '{block_type}'. Use 'text' or 'image'."
-            )
-
-        file_path = block.get("file_path")
-        file_content_base64 = block.get("file_content_base64")
-        filename = block.get("filename")
-
-        if file_path and file_content_base64:
-            raise ValueError(
-                f"Block {index}: provide 'file_path' OR "
-                "'file_content_base64', not both."
-            )
-
-        if file_content_base64:
-            if not filename:
-                raise ValueError(
-                    f"Block {index}: 'filename' is required with 'file_content_base64'."
-                )
+    def _rollback_uploads() -> None:
+        for att_id in uploaded_ids:
             try:
-                content = base64.b64decode(file_content_base64, validate=True)
-            except ValueError as exc:
+                jira.delete_attachment(att_id)
+            except Exception as exc:  # best-effort cleanup
+                logger.warning(
+                    "Failed to roll back attachment %s on %s: %s",
+                    att_id,
+                    issue_key,
+                    exc,
+                )
+        if uploaded_ids:
+            logger.info(
+                "Rolled back %d attachment(s) on %s after a failed media comment: %s",
+                len(uploaded_ids),
+                issue_key,
+                uploaded_ids,
+            )
+
+    try:
+        for index, block in enumerate(parsed_blocks):
+            if not isinstance(block, dict):
+                raise ValueError(f"Block {index} must be a JSON object.")
+            block_type = block.get("type")
+
+            if block_type == "text":
+                segments.append({"type": "text", "text": block.get("text", "")})
+                continue
+
+            if block_type != "image":
                 raise ValueError(
-                    f"Block {index}: invalid base64 content: {exc}"
-                ) from exc
-            upload = jira.upload_attachment_content(issue_key, filename, content)
-        elif file_path:
-            upload = jira.upload_attachment_from_path(issue_key, file_path)
-        else:
-            raise ValueError(
-                f"Block {index}: image block needs 'file_path' or "
-                "'file_content_base64'."
+                    f"Block {index}: unknown type '{block_type}'. "
+                    "Use 'text' or 'image'."
+                )
+
+            file_path = block.get("file_path")
+            file_content_base64 = block.get("file_content_base64")
+            filename = block.get("filename")
+
+            if file_path and file_content_base64:
+                raise ValueError(
+                    f"Block {index}: provide 'file_path' OR "
+                    "'file_content_base64', not both."
+                )
+
+            if file_content_base64:
+                if not filename:
+                    raise ValueError(
+                        f"Block {index}: 'filename' is required with "
+                        "'file_content_base64'."
+                    )
+                try:
+                    content = base64.b64decode(file_content_base64, validate=True)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Block {index}: invalid base64 content: {exc}"
+                    ) from exc
+                upload = jira.upload_attachment_content(issue_key, filename, content)
+            elif file_path:
+                upload = jira.upload_attachment_from_path(issue_key, file_path)
+            else:
+                raise ValueError(
+                    f"Block {index}: image block needs 'file_path' or "
+                    "'file_content_base64'."
+                )
+
+            if not upload.get("success"):
+                raise ValueError(
+                    f"Block {index}: attachment upload failed: {upload.get('error')}"
+                )
+
+            attachment_id = upload.get("id")
+            if not attachment_id:
+                raise ValueError(
+                    f"Block {index}: could not determine the attachment id "
+                    "after upload."
+                )
+            # Track immediately so rollback covers a later resolve/post failure.
+            uploaded_ids.append(attachment_id)
+
+            media_id = jira.get_attachment_media_id(attachment_id)
+            if not media_id:
+                raise ValueError(
+                    f"Block {index}: could not resolve the Media Services id "
+                    f"for attachment {attachment_id}. Jira Cloud's "
+                    "attachment-content endpoint did not return a parseable "
+                    "media redirect (this can happen behind OAuth gateways or "
+                    "proxies; the server log records the HTTP status and "
+                    "redirect target). Uploaded attachments were rolled back."
+                )
+
+            segments.append(
+                {
+                    "type": "media",
+                    "media_id": media_id,
+                    "width": upload.get("width"),
+                    "height": upload.get("height"),
+                }
+            )
+            embedded.append(
+                {
+                    "filename": upload.get("filename"),
+                    "attachment_id": attachment_id,
+                    "media_id": media_id,
+                }
             )
 
-        if not upload.get("success"):
-            raise ValueError(
-                f"Block {index}: attachment upload failed: {upload.get('error')}"
-            )
-
-        attachment_id = upload.get("id")
-        if not attachment_id:
-            raise ValueError(
-                f"Block {index}: could not determine the attachment id after upload."
-            )
-
-        media_id = jira.get_attachment_media_id(attachment_id)
-        if not media_id:
-            raise ValueError(
-                f"Block {index}: could not resolve the Media Services id "
-                f"for attachment {attachment_id}."
-            )
-
-        segments.append({"type": "media", "media_id": media_id})
-        embedded.append(
-            {
-                "filename": upload.get("filename"),
-                "attachment_id": attachment_id,
-                "media_id": media_id,
-            }
-        )
-
-    adf_body = build_media_comment_adf(segments)
-    visibility_dict = _parse_visibility(visibility)
-    comment = jira.add_comment_adf(issue_key, adf_body, visibility_dict)
+        adf_body = build_media_comment_adf(segments)
+        visibility_dict = _parse_visibility(visibility)
+        comment = jira.add_comment_adf(issue_key, adf_body, visibility_dict)
+    except Exception:
+        _rollback_uploads()
+        raise
 
     return json.dumps(
         {"comment": comment, "embedded": embedded},

--- a/src/mcp_atlassian/utils/media.py
+++ b/src/mcp_atlassian/utils/media.py
@@ -3,6 +3,7 @@
 import base64
 import logging
 import mimetypes
+import struct
 from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,107 @@ def is_image_attachment(
             return True, guessed
 
     return False, media_type or "application/octet-stream"
+
+
+def get_image_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Read the pixel dimensions of an image from its header bytes.
+
+    Pure-stdlib header parsing (no Pillow dependency) for the formats Jira
+    renders inline: PNG, GIF, JPEG, BMP, and WebP. Jira Cloud requires
+    ``width``/``height`` on inline ``mediaSingle`` nodes for the image to
+    render, so these are derived from the raw bytes before upload.
+
+    Args:
+        data: The raw image bytes.
+
+    Returns:
+        A ``(width, height)`` tuple in pixels, or ``None`` if the format is
+        unrecognised or the header is too short/corrupt to parse.
+    """
+    if not data or len(data) < 24:
+        return None
+
+    try:
+        # --- PNG: 8-byte signature, then IHDR with width/height as BE uint32.
+        if data[:8] == b"\x89PNG\r\n\x1a\n":
+            width, height = struct.unpack(">II", data[16:24])
+            return int(width), int(height)
+
+        # --- GIF: 'GIF87a'/'GIF89a', logical screen size as LE uint16.
+        if data[:6] in (b"GIF87a", b"GIF89a"):
+            width, height = struct.unpack("<HH", data[6:10])
+            return int(width), int(height)
+
+        # --- BMP: 'BM', BITMAPINFOHEADER width/height as LE int32.
+        if data[:2] == b"BM":
+            width, height = struct.unpack("<ii", data[18:26])
+            return int(width), abs(int(height))
+
+        # --- WebP: 'RIFF'....'WEBP' followed by a VP8/VP8L/VP8X chunk.
+        if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            chunk = data[12:16]
+            if chunk == b"VP8 " and len(data) >= 30:
+                width = struct.unpack("<H", data[26:28])[0] & 0x3FFF
+                height = struct.unpack("<H", data[28:30])[0] & 0x3FFF
+                return int(width), int(height)
+            if chunk == b"VP8L" and len(data) >= 25:
+                bits = struct.unpack("<I", data[21:25])[0]
+                width = (bits & 0x3FFF) + 1
+                height = ((bits >> 14) & 0x3FFF) + 1
+                return int(width), int(height)
+            if chunk == b"VP8X" and len(data) >= 30:
+                width = int.from_bytes(data[24:27], "little") + 1
+                height = int.from_bytes(data[27:30], "little") + 1
+                return int(width), int(height)
+
+        # --- JPEG: scan for a Start-Of-Frame (SOFn) marker.
+        if data[:2] == b"\xff\xd8":
+            return _jpeg_dimensions(data)
+    except (struct.error, IndexError, ValueError):
+        return None
+
+    return None
+
+
+def _jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Extract dimensions from a JPEG by walking its marker segments."""
+    # SOF markers carry the frame size. Skip the standalone/irrelevant ones.
+    sof_markers = {
+        0xC0,
+        0xC1,
+        0xC2,
+        0xC3,
+        0xC5,
+        0xC6,
+        0xC7,
+        0xC9,
+        0xCA,
+        0xCB,
+        0xCD,
+        0xCE,
+        0xCF,
+    }
+    pos = 2
+    size = len(data)
+    while pos + 1 < size:
+        if data[pos] != 0xFF:
+            pos += 1
+            continue
+        marker = data[pos + 1]
+        pos += 2
+        # Padding bytes / markers without a length payload.
+        if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7 or marker == 0x01:
+            continue
+        if pos + 2 > size:
+            break
+        seg_len = struct.unpack(">H", data[pos : pos + 2])[0]
+        if marker in sof_markers:
+            if pos + 7 > size:
+                break
+            height, width = struct.unpack(">HH", data[pos + 3 : pos + 7])
+            return int(width), int(height)
+        pos += seg_len
+    return None
 
 
 def fetch_and_encode_attachment(

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 68 tools into 21 named toolsets controlled via the TOOLSETS env var.
+Groups 72 tools into 21 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 
@@ -67,7 +67,7 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     ),
     "jira_attachments": ToolsetDefinition(
         name="jira_attachments",
-        description="Attachment download and image retrieval",
+        description="Attachment download, upload, deletion, and image retrieval",
         default=False,
     ),
     "jira_users": ToolsetDefinition(

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -1580,6 +1580,63 @@ class TestAttachmentsMixin:
 
         assert attachments_mixin.get_attachment_media_id("123") == uuid
 
+    def test_get_attachment_media_id_makes_relative_url_absolute(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Regression: a relative ``resource_url`` is joined to an absolute URL.
+
+        Some atlassian-python-api versions return a path without scheme/host;
+        passing it straight to ``requests`` raised ``MissingSchema`` (the real
+        root cause behind "could not resolve the Media Services id").
+        """
+        uuid = "db6c5692-53da-4f3e-94ba-08c64e86265b"
+        attachments_mixin.jira.url = "https://novidea.atlassian.net"
+        attachments_mixin.jira.resource_url.return_value = (
+            "rest/api/3/attachment/content/416348"
+        )
+        resp = MagicMock()
+        resp.headers = {
+            "Location": f"https://api.media.atlassian.com/file/{uuid}/binary"
+        }
+        resp.status_code = 303
+        attachments_mixin.jira._session.get.return_value = resp
+
+        assert attachments_mixin.get_attachment_media_id("416348") == uuid
+        called_url = attachments_mixin.jira._session.get.call_args[0][0]
+        assert called_url == (
+            "https://novidea.atlassian.net/rest/api/3/attachment/content/416348"
+        )
+
+    def test_get_attachment_media_id_recovers_when_pass1_raises(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """A pass-1 request error no longer returns None — the chain is tried."""
+        uuid = "11111111-2222-3333-4444-555555555555"
+        attachments_mixin.jira.resource_url.return_value = "https://x/y"
+
+        followed = MagicMock()
+        followed.history = []
+        followed.url = f"https://api.media.atlassian.com/file/{uuid}/binary"
+        attachments_mixin.jira._session.get.side_effect = [
+            ValueError("pass-1 boom"),
+            followed,
+        ]
+
+        assert attachments_mixin.get_attachment_media_id("123") == uuid
+
+    def test_get_attachment_media_id_propagates_hard_error(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """A hard request error is surfaced, not swallowed into a vague None."""
+        attachments_mixin.jira.resource_url.return_value = "https://x/y"
+        attachments_mixin.jira._session.get.side_effect = [
+            ValueError("pass-1 boom"),
+            ConnectionError("network down"),
+        ]
+
+        with pytest.raises(ConnectionError, match="network down"):
+            attachments_mixin.get_attachment_media_id("123")
+
     def test_extract_media_file_uuid_host_agnostic(self):
         """UUID extraction matches the /file/{uuid} fragment on any host."""
         extract = AttachmentsMixin._extract_media_file_uuid

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -1316,3 +1316,205 @@ class TestAttachmentsMixin:
         assert result[1].filename == "report.pdf"
         # No download calls should have been made
         attachments_mixin.jira._session.get.assert_not_called()
+
+    # Tests for upload_attachment_content (in-memory) method
+
+    def test_upload_attachment_content_success(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """In-memory upload posts a named buffer and returns the new id."""
+        attachments_mixin.jira.add_attachment_object.return_value = [
+            {"id": "55", "filename": "note.txt", "size": 5}
+        ]
+
+        result = attachments_mixin.upload_attachment_content(
+            "TEST-123", "note.txt", b"hello"
+        )
+
+        assert result["success"] is True
+        assert result["issue_key"] == "TEST-123"
+        assert result["filename"] == "note.txt"
+        assert result["size"] == 5
+        assert result["id"] == "55"
+        attachments_mixin.jira.add_attachment_object.assert_called_once()
+        # The buffer passed to the API carries the basename and content
+        args = attachments_mixin.jira.add_attachment_object.call_args[0]
+        assert args[0] == "TEST-123"
+        buffer = args[1]
+        assert buffer.name == "note.txt"
+        assert buffer.getvalue() == b"hello"
+
+    def test_upload_attachment_content_dict_response(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """A dict response (not a list) still yields the id and basename."""
+        attachments_mixin.jira.add_attachment_object.return_value = {"id": "77"}
+
+        result = attachments_mixin.upload_attachment_content(
+            "TEST-123", "/tmp/some/path/data.bin", b"\x00\x01"
+        )
+
+        assert result["success"] is True
+        assert result["filename"] == "data.bin"
+        assert result["id"] == "77"
+
+    def test_upload_attachment_content_no_issue_key(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Upload with no issue key is rejected before any API call."""
+        result = attachments_mixin.upload_attachment_content("", "f.txt", b"x")
+        assert result["success"] is False
+        assert "No issue key provided" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_content_no_filename(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Upload with no filename is rejected before any API call."""
+        result = attachments_mixin.upload_attachment_content("TEST-123", "", b"x")
+        assert result["success"] is False
+        assert "No filename provided" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_content_too_large(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Content over the size limit is rejected before any API call."""
+        with patch("mcp_atlassian.jira.attachments.ATTACHMENT_MAX_BYTES", 4):
+            result = attachments_mixin.upload_attachment_content(
+                "TEST-123", "big.bin", b"12345"
+            )
+        assert result["success"] is False
+        assert "exceeds the 50 MB limit" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_content_api_error(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """API failures during in-memory upload are reported, not raised."""
+        attachments_mixin.jira.add_attachment_object.side_effect = Exception(
+            "API Error"
+        )
+        result = attachments_mixin.upload_attachment_content("TEST-123", "f.txt", b"x")
+        assert result["success"] is False
+        assert "API Error" in result["error"]
+
+    # Tests for delete_attachment method
+
+    def test_delete_attachment_success(self, attachments_mixin: AttachmentsMixin):
+        """delete_attachment calls remove_attachment and reports success."""
+        attachments_mixin.jira.remove_attachment.return_value = None
+
+        result = attachments_mixin.delete_attachment("12345")
+
+        assert result["success"] is True
+        assert result["attachment_id"] == "12345"
+        assert "deleted successfully" in result["message"]
+        attachments_mixin.jira.remove_attachment.assert_called_once_with("12345")
+
+    def test_delete_attachment_no_id(self, attachments_mixin: AttachmentsMixin):
+        """delete_attachment with no id is rejected before any API call."""
+        result = attachments_mixin.delete_attachment("")
+        assert result["success"] is False
+        assert "No attachment ID provided" in result["error"]
+        attachments_mixin.jira.remove_attachment.assert_not_called()
+
+    def test_delete_attachment_api_error(self, attachments_mixin: AttachmentsMixin):
+        """API failures during deletion are reported, not raised."""
+        attachments_mixin.jira.remove_attachment.side_effect = Exception("API Error")
+
+        result = attachments_mixin.delete_attachment("12345")
+
+        assert result["success"] is False
+        assert result["attachment_id"] == "12345"
+        assert "API Error" in result["error"]
+
+    def test_extract_attachment_id_variants(self):
+        """_extract_attachment_id handles list, dict, and bad shapes."""
+        extract = AttachmentsMixin._extract_attachment_id
+        assert extract([{"id": "1"}]) == "1"
+        assert extract({"id": 2}) == "2"
+        assert extract([]) is None
+        assert extract(None) is None
+        assert extract("nope") is None
+
+    # Tests for upload_attachment_from_path
+
+    def test_upload_attachment_from_path_success(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Path upload reads the file and delegates to in-memory upload."""
+        attachments_mixin.jira.add_attachment_object.return_value = [{"id": "90"}]
+        with (
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.exists", return_value=True),
+            patch("mcp_atlassian.jira.attachments.validate_safe_path"),
+            patch("builtins.open", mock_open(read_data=b"PNGDATA")),
+        ):
+            result = attachments_mixin.upload_attachment_from_path(
+                "TEST-123", "/abs/shot.png"
+            )
+        assert result["success"] is True
+        assert result["filename"] == "shot.png"
+        assert result["id"] == "90"
+        assert result["size"] == len(b"PNGDATA")
+
+    def test_upload_attachment_from_path_not_found(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Missing file is reported without calling the API."""
+        with (
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.exists", return_value=False),
+            patch("mcp_atlassian.jira.attachments.validate_safe_path"),
+        ):
+            result = attachments_mixin.upload_attachment_from_path(
+                "TEST-123", "/abs/missing.png"
+            )
+        assert result["success"] is False
+        assert "File not found" in result["error"]
+        attachments_mixin.jira.add_attachment_object.assert_not_called()
+
+    def test_upload_attachment_from_path_no_path(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Empty path is rejected before any filesystem/API access."""
+        result = attachments_mixin.upload_attachment_from_path("TEST-123", "")
+        assert result["success"] is False
+        assert "No file path provided" in result["error"]
+
+    # Tests for get_attachment_media_id
+
+    def test_get_attachment_media_id_success(self, attachments_mixin: AttachmentsMixin):
+        """Media UUID is extracted from the redirect Location header."""
+        uuid = "056f8363-192c-4f50-85a6-9ce2f4dca583"
+        attachments_mixin.jira.resource_url.return_value = (
+            "https://x.atlassian.net/rest/api/3/attachment/content/123"
+        )
+        mock_resp = MagicMock()
+        mock_resp.headers = {
+            "Location": (f"https://api.media.atlassian.com/file/{uuid}/binary?token=z")
+        }
+        attachments_mixin.jira._session.get.return_value = mock_resp
+
+        result = attachments_mixin.get_attachment_media_id("123")
+
+        assert result == uuid
+        attachments_mixin.jira._session.get.assert_called_once()
+        _, kwargs = attachments_mixin.jira._session.get.call_args
+        assert kwargs.get("allow_redirects") is False
+
+    def test_get_attachment_media_id_no_location(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """No redirect location yields None."""
+        attachments_mixin.jira.resource_url.return_value = "https://x/y"
+        mock_resp = MagicMock()
+        mock_resp.headers = {}
+        attachments_mixin.jira._session.get.return_value = mock_resp
+        assert attachments_mixin.get_attachment_media_id("123") is None
+
+    def test_get_attachment_media_id_no_id(self, attachments_mixin: AttachmentsMixin):
+        """Empty attachment id returns None without any HTTP call."""
+        assert attachments_mixin.get_attachment_media_id("") is None
+        attachments_mixin.jira._session.get.assert_not_called()

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -1507,10 +1507,13 @@ class TestAttachmentsMixin:
     def test_get_attachment_media_id_no_location(
         self, attachments_mixin: AttachmentsMixin
     ):
-        """No redirect location yields None."""
+        """No media URL in any hop yields None."""
         attachments_mixin.jira.resource_url.return_value = "https://x/y"
         mock_resp = MagicMock()
         mock_resp.headers = {}
+        mock_resp.history = []
+        mock_resp.url = "https://x.atlassian.net/rest/api/3/attachment/content/123"
+        mock_resp.status_code = 200
         attachments_mixin.jira._session.get.return_value = mock_resp
         assert attachments_mixin.get_attachment_media_id("123") is None
 
@@ -1518,3 +1521,119 @@ class TestAttachmentsMixin:
         """Empty attachment id returns None without any HTTP call."""
         assert attachments_mixin.get_attachment_media_id("") is None
         attachments_mixin.jira._session.get.assert_not_called()
+
+    def test_get_attachment_media_id_fallback_redirect_chain(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """When the first hop hides the media URL, the chain is scanned.
+
+        Mirrors OAuth-gateway / proxy setups where the no-follow Location is
+        an intermediate URL and the real media URL only appears after
+        following the redirect chain.
+        """
+        uuid = "fc11978f-a94d-4532-b7cb-ef665a642fc1"
+        attachments_mixin.jira.resource_url.return_value = (
+            "https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/"
+            "attachment/content/123"
+        )
+
+        # Pass 1 (allow_redirects=False): a redirect with no media URL.
+        first = MagicMock()
+        first.headers = {"Location": "https://api.atlassian.com/ex/jira/next"}
+        first.status_code = 303
+
+        # Pass 2 (allow_redirects=True): final response whose history holds the
+        # media redirect on a Forge-proxy host (host-agnostic match required).
+        hop = MagicMock()
+        hop.headers = {
+            "Location": (
+                f"https://forge-outbound-proxy.services.atlassian.com/"
+                f"file/{uuid}/binary?token=z&client=c"
+            )
+        }
+        hop.url = "https://api.atlassian.com/ex/jira/next"
+        followed = MagicMock()
+        followed.history = [hop]
+        followed.url = "https://media-host/final"
+
+        attachments_mixin.jira._session.get.side_effect = [first, followed]
+
+        assert attachments_mixin.get_attachment_media_id("123") == uuid
+        assert attachments_mixin.jira._session.get.call_count == 2
+
+    def test_get_attachment_media_id_fallback_final_url(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """The media UUID is also recovered from the final resolved URL."""
+        uuid = "056f8363-192c-4f50-85a6-9ce2f4dca583"
+        attachments_mixin.jira.resource_url.return_value = "https://x/y"
+
+        first = MagicMock()
+        first.headers = {}
+        first.status_code = 302
+
+        followed = MagicMock()
+        followed.history = []
+        followed.url = f"https://api.media.atlassian.com/file/{uuid}/binary?dl=true"
+
+        attachments_mixin.jira._session.get.side_effect = [first, followed]
+
+        assert attachments_mixin.get_attachment_media_id("123") == uuid
+
+    def test_extract_media_file_uuid_host_agnostic(self):
+        """UUID extraction matches the /file/{uuid} fragment on any host."""
+        extract = AttachmentsMixin._extract_media_file_uuid
+        uuid = "11111111-2222-3333-4444-555555555555"
+        assert (
+            extract(f"https://api-gev2.media.atlassian.com/file/{uuid}/binary?t=1")
+            == uuid
+        )
+        assert extract("https://x/no-file-here?client=not-a-file-uuid") is None
+        assert extract("") is None
+        assert extract(None) is None
+
+    def test_upload_attachment_content_reports_image_dimensions(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """A PNG upload surfaces width/height parsed from the header bytes."""
+        import struct
+
+        png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR" + struct.pack(">II", 800, 600)
+        attachments_mixin.jira.add_attachment_object.return_value = [{"id": "42"}]
+
+        result = attachments_mixin.upload_attachment_content(
+            "TEST-123", "shot.png", png
+        )
+
+        assert result["success"] is True
+        assert result["width"] == 800
+        assert result["height"] == 600
+
+    def test_upload_attachment_content_no_dimensions_for_non_image(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Non-image content yields no width/height keys."""
+        attachments_mixin.jira.add_attachment_object.return_value = [{"id": "43"}]
+        result = attachments_mixin.upload_attachment_content(
+            "TEST-123", "note.txt", b"hello"
+        )
+        assert result["success"] is True
+        assert "width" not in result
+        assert "height" not in result
+
+    def test_upload_attachment_from_path_allows_absolute_outside_cwd(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Uploads accept any absolute path (e.g. /tmp) without a path guard."""
+        attachments_mixin.jira.add_attachment_object.return_value = [{"id": "91"}]
+        with (
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data=b"PNGDATA")),
+        ):
+            result = attachments_mixin.upload_attachment_from_path(
+                "TEST-123", "/tmp/shot1_home.png"
+            )
+        assert result["success"] is True
+        assert result["filename"] == "shot1_home.png"
+        assert result["id"] == "91"

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -551,3 +551,72 @@ class TestCommentsMixin:
         # ServiceDesk post should NOT be called
         comments_mixin.jira.post.assert_not_called()
         assert result["id"] == "10001"
+
+    # --- delete_comment tests ---
+
+    def test_delete_comment_cloud(self, comments_mixin):
+        """delete_comment on Cloud issues a v3 DELETE for the comment."""
+        comments_mixin._delete_api3 = Mock(return_value=None)
+
+        result = comments_mixin.delete_comment("TEST-123", "10001")
+
+        comments_mixin._delete_api3.assert_called_once_with(
+            "issue/TEST-123/comment/10001"
+        )
+        assert result is True
+
+    def test_delete_comment_error(self, comments_mixin):
+        """delete_comment wraps API failures in a clear exception."""
+        comments_mixin._delete_api3 = Mock(side_effect=Exception("API Error"))
+
+        with pytest.raises(Exception, match="Error deleting comment"):
+            comments_mixin.delete_comment("TEST-123", "10001")
+
+    def test_delete_comment_server(self, server_comments_mixin):
+        """delete_comment on Server/DC uses a raw DELETE via resource_url."""
+        server_comments_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue/TEST-123/comment/10001"
+        )
+
+        result = server_comments_mixin.delete_comment("TEST-123", "10001")
+
+        server_comments_mixin.jira.resource_url.assert_called_once_with(
+            "issue/TEST-123/comment/10001"
+        )
+        server_comments_mixin.jira.delete.assert_called_once_with(
+            "https://jira.example.com/rest/api/2/issue/TEST-123/comment/10001"
+        )
+        assert result is True
+
+    # --- add_comment_adf tests ---
+
+    def test_add_comment_adf_cloud(self, comments_mixin):
+        """add_comment_adf posts a prebuilt ADF body via v3 and returns it."""
+        mock_response = {
+            "id": "20002",
+            "body": {"version": 1, "type": "doc", "content": []},
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "John Doe"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+        adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": []}],
+        }
+
+        result = comments_mixin.add_comment_adf("TEST-123", adf)
+
+        comments_mixin._post_api3.assert_called_once()
+        call_args = comments_mixin._post_api3.call_args
+        assert call_args[0][0] == "issue/TEST-123/comment"
+        assert call_args[0][1]["body"] == adf
+        assert result["id"] == "20002"
+        assert result["author"] == "John Doe"
+
+    def test_add_comment_adf_server_rejected(self, server_comments_mixin):
+        """add_comment_adf is Cloud-only and raises on Server/DC."""
+        with pytest.raises(ValueError, match="Jira Cloud only"):
+            server_comments_mixin.add_comment_adf(
+                "TEST-123", {"version": 1, "type": "doc", "content": []}
+            )

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -437,6 +437,50 @@ class TestMarkdownToAdf:
         link_mark = next(m for m in link_nodes[0]["marks"] if m["type"] == "link")
         assert link_mark["attrs"]["href"] == "https://example.com"
 
+    # -- Mentions -----------------------------------------------------------
+
+    def test_accountid_mention_becomes_mention_node(self):
+        """[~accountid:<id>] produces an ADF mention node, not text."""
+        result = markdown_to_adf("Hi [~accountid:712020:3420e1b4-xxxx] there")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"]["id"] == "712020:3420e1b4-xxxx"
+        # The literal wiki syntax must not survive as a text node.
+        texts = " ".join(n.get("text", "") for n in para["content"])
+        assert "accountid" not in texts
+
+    def test_accountid_mention_at_line_start(self):
+        """A leading mention is converted and not markdown-escaped."""
+        result = markdown_to_adf("[~accountid:abc-123] ping")
+        para = result["content"][0]
+        assert para["content"][0]["type"] == "mention"
+        assert para["content"][0]["attrs"]["id"] == "abc-123"
+        texts = "".join(n.get("text", "") for n in para["content"])
+        assert "\\" not in texts
+
+    def test_named_mention_becomes_mention_node(self):
+        """@[Display Name](<id>) produces a mention node with text attr."""
+        result = markdown_to_adf("ping @[John Doe](5b10ac8d82e05) please")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"]["id"] == "5b10ac8d82e05"
+        assert mentions[0]["attrs"]["text"] == "@John Doe"
+
+    def test_plain_link_not_treated_as_mention(self):
+        """A normal [text](url) link is unaffected by mention handling."""
+        result = markdown_to_adf("see [docs](https://example.com)")
+        para = result["content"][0]
+        assert not any(n["type"] == "mention" for n in para["content"])
+        link_nodes = [
+            n
+            for n in para["content"]
+            if n["type"] == "text"
+            and any(m["type"] == "link" for m in n.get("marks", []))
+        ]
+        assert link_nodes[0]["text"] == "docs"
+
     # -- Code blocks --------------------------------------------------------
 
     def test_code_block_with_lang(self):

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.mcp_atlassian.models.jira.adf import adf_to_text, markdown_to_adf
+from src.mcp_atlassian.models.jira.adf import (
+    adf_to_text,
+    build_media_comment_adf,
+    markdown_to_adf,
+)
 
 
 class TestAdfToText:
@@ -664,3 +668,47 @@ class TestMarkdownToJiraDispatch:
         """Server/DC path with empty string returns empty string."""
         result = server_client._markdown_to_jira("")
         assert result == ""
+
+
+class TestBuildMediaCommentAdf:
+    """Tests for build_media_comment_adf (inline text + media composition)."""
+
+    def test_interleaves_text_and_media_in_order(self):
+        """text -> media -> text -> media renders in the same order."""
+        segments = [
+            {"type": "text", "text": "Before"},
+            {"type": "media", "media_id": "uuid-1"},
+            {"type": "text", "text": "Between"},
+            {"type": "media", "media_id": "uuid-2"},
+        ]
+        doc = build_media_comment_adf(segments)
+
+        assert doc["version"] == 1
+        assert doc["type"] == "doc"
+        node_types = [n["type"] for n in doc["content"]]
+        assert node_types == ["paragraph", "mediaSingle", "paragraph", "mediaSingle"]
+
+    def test_media_node_structure(self):
+        """media segment builds a mediaSingle > media node with file attrs."""
+        doc = build_media_comment_adf([{"type": "media", "media_id": "abc-123"}])
+        media_single = doc["content"][0]
+        assert media_single["type"] == "mediaSingle"
+        media = media_single["content"][0]
+        assert media["type"] == "media"
+        assert media["attrs"] == {
+            "id": "abc-123",
+            "type": "file",
+            "collection": "",
+        }
+
+    def test_text_segment_uses_markdown(self):
+        """Text segments are converted through markdown_to_adf."""
+        doc = build_media_comment_adf([{"type": "text", "text": "# Title"}])
+        heading = doc["content"][0]
+        assert heading["type"] == "heading"
+
+    def test_empty_segments_yield_valid_doc(self):
+        """An empty segment list still yields a valid (non-empty) ADF doc."""
+        doc = build_media_comment_adf([])
+        assert doc["type"] == "doc"
+        assert doc["content"] == [{"type": "paragraph", "content": []}]

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -701,6 +701,28 @@ class TestBuildMediaCommentAdf:
             "collection": "",
         }
 
+    def test_media_node_includes_dimensions_when_present(self):
+        """Integer width/height are written to the media node attrs."""
+        doc = build_media_comment_adf(
+            [{"type": "media", "media_id": "abc-123", "width": 800, "height": 600}]
+        )
+        media = doc["content"][0]["content"][0]
+        assert media["attrs"] == {
+            "id": "abc-123",
+            "type": "file",
+            "collection": "",
+            "width": 800,
+            "height": 600,
+        }
+
+    def test_media_node_omits_invalid_dimensions(self):
+        """Missing/zero/None dimensions leave the media node without them."""
+        doc = build_media_comment_adf(
+            [{"type": "media", "media_id": "abc-123", "width": 0, "height": None}]
+        )
+        media = doc["content"][0]["content"][0]
+        assert media["attrs"] == {"id": "abc-123", "type": "file", "collection": ""}
+
     def test_text_segment_uses_markdown(self):
         """Text segments are converted through markdown_to_adf."""
         doc = build_media_comment_adf([{"type": "text", "text": "# Title"}])

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -381,6 +381,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     )
     from src.mcp_atlassian.servers.jira import (
         add_comment,
+        add_comment_with_media,
         add_issues_to_sprint,
         add_worklog,
         batch_create_issues,
@@ -448,6 +449,7 @@ def test_jira_mcp(mock_jira_fetcher, mock_base_jira_config):
     jira_sub_mcp.add_tool(delete_issue)
     jira_sub_mcp.add_tool(add_comment)
     jira_sub_mcp.add_tool(edit_comment)
+    jira_sub_mcp.add_tool(add_comment_with_media)
     jira_sub_mcp.add_tool(add_worklog)
     jira_sub_mcp.add_tool(link_to_epic)
     jira_sub_mcp.add_tool(create_issue_link)
@@ -586,6 +588,54 @@ async def test_search(jira_client, mock_jira_fetcher):
         projects_filter=None,
         page_token=None,
     )
+
+
+@pytest.mark.anyio
+async def test_add_comment_with_media(jira_client, mock_jira_fetcher):
+    """Inline-media comment uploads each image and embeds it in order."""
+    import base64
+
+    mock_jira_fetcher.config.is_cloud = True
+    mock_jira_fetcher.upload_attachment_content.side_effect = [
+        {"success": True, "filename": "a.png", "id": "att-a", "size": 3},
+        {"success": True, "filename": "b.png", "id": "att-b", "size": 3},
+    ]
+    mock_jira_fetcher.get_attachment_media_id.side_effect = [
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    ]
+    mock_jira_fetcher.add_comment_adf.return_value = {
+        "id": "30003",
+        "body": "rendered",
+        "created": "2024-01-01 10:00:00+00:00",
+        "author": "John Doe",
+    }
+
+    png_b64 = base64.b64encode(b"img").decode()
+    blocks = json.dumps(
+        [
+            {"type": "text", "text": "First"},
+            {"type": "image", "file_content_base64": png_b64, "filename": "a.png"},
+            {"type": "text", "text": "Second"},
+            {"type": "image", "file_content_base64": png_b64, "filename": "b.png"},
+        ]
+    )
+
+    response = await jira_client.call_tool(
+        "jira_add_comment_with_media",
+        {"issue_key": "TEST-123", "blocks": blocks},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content["comment"]["id"] == "30003"
+    assert len(content["embedded"]) == 2
+    assert content["embedded"][0]["media_id"].startswith("1111")
+    assert mock_jira_fetcher.upload_attachment_content.call_count == 2
+    assert mock_jira_fetcher.get_attachment_media_id.call_count == 2
+    # The ADF passed to add_comment_adf must interleave text and media in order
+    adf = mock_jira_fetcher.add_comment_adf.call_args[0][1]
+    node_types = [node["type"] for node in adf["content"]]
+    assert node_types == ["paragraph", "mediaSingle", "paragraph", "mediaSingle"]
 
 
 @pytest.mark.anyio
@@ -1042,8 +1092,8 @@ async def test_get_all_projects_tool(jira_client, mock_jira_fetcher):
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with default parameters (include_archived=False)
@@ -1091,8 +1141,8 @@ async def test_get_all_projects_tool_with_archived(jira_client, mock_jira_fetche
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with include_archived=True
@@ -1145,8 +1195,8 @@ async def test_get_all_projects_tool_with_projects_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up the projects filter in the config
@@ -1199,8 +1249,8 @@ async def test_get_all_projects_tool_no_projects_filter(jira_client, mock_jira_f
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Ensure no projects filter is set
@@ -1260,8 +1310,8 @@ async def test_get_all_projects_tool_case_insensitive_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up projects filter with mixed case and whitespace

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -639,6 +639,81 @@ async def test_add_comment_with_media(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+async def test_add_comment_with_media_rolls_back_on_resolve_failure(
+    jira_client, mock_jira_fetcher
+):
+    """A media-id resolve failure deletes the uploaded attachment (no orphan)."""
+    import base64
+
+    mock_jira_fetcher.config.is_cloud = True
+    mock_jira_fetcher.upload_attachment_content.return_value = {
+        "success": True,
+        "filename": "a.png",
+        "id": "att-a",
+        "size": 3,
+    }
+    # Resolution fails — the core bug scenario.
+    mock_jira_fetcher.get_attachment_media_id.return_value = None
+
+    png_b64 = base64.b64encode(b"img").decode()
+    blocks = json.dumps(
+        [
+            {"type": "text", "text": "First"},
+            {"type": "image", "file_content_base64": png_b64, "filename": "a.png"},
+        ]
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_add_comment_with_media",
+            {"issue_key": "TEST-123", "blocks": blocks},
+        )
+
+    assert "could not resolve the Media Services id" in str(excinfo.value)
+    # The uploaded attachment must be rolled back and no comment posted.
+    mock_jira_fetcher.delete_attachment.assert_called_once_with("att-a")
+    mock_jira_fetcher.add_comment_adf.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_add_comment_with_media_rolls_back_all_on_post_failure(
+    jira_client, mock_jira_fetcher
+):
+    """If posting the comment fails, every uploaded attachment is removed."""
+    import base64
+
+    mock_jira_fetcher.config.is_cloud = True
+    mock_jira_fetcher.upload_attachment_content.side_effect = [
+        {"success": True, "filename": "a.png", "id": "att-a", "size": 3},
+        {"success": True, "filename": "b.png", "id": "att-b", "size": 3},
+    ]
+    mock_jira_fetcher.get_attachment_media_id.side_effect = [
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    ]
+    mock_jira_fetcher.add_comment_adf.side_effect = Exception("comment POST failed")
+
+    png_b64 = base64.b64encode(b"img").decode()
+    blocks = json.dumps(
+        [
+            {"type": "image", "file_content_base64": png_b64, "filename": "a.png"},
+            {"type": "image", "file_content_base64": png_b64, "filename": "b.png"},
+        ]
+    )
+
+    with pytest.raises(ToolError):
+        await jira_client.call_tool(
+            "jira_add_comment_with_media",
+            {"issue_key": "TEST-123", "blocks": blocks},
+        )
+
+    deleted = {
+        call.args[0] for call in mock_jira_fetcher.delete_attachment.call_args_list
+    }
+    assert deleted == {"att-a", "att-b"}
+
+
+@pytest.mark.anyio
 async def test_get_service_desk_for_project(jira_client, mock_jira_fetcher):
     """Test service desk lookup by project key."""
     response = await jira_client.call_tool(

--- a/tests/unit/utils/test_media.py
+++ b/tests/unit/utils/test_media.py
@@ -1,14 +1,75 @@
 """Tests for the shared MIME detection and attachment download utilities."""
 
 import base64
+import struct
 
 import pytest
 
 from mcp_atlassian.utils.media import (
     ATTACHMENT_MAX_BYTES,
     fetch_and_encode_attachment,
+    get_image_dimensions,
     is_image_attachment,
 )
+
+
+def _png(width: int, height: int) -> bytes:
+    return b"\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR" + struct.pack(">II", width, height)
+
+
+def _gif(width: int, height: int) -> bytes:
+    return b"GIF89a" + struct.pack("<HH", width, height) + b"\x00" * 20
+
+
+def _bmp(width: int, height: int) -> bytes:
+    return b"BM" + b"\x00" * 16 + struct.pack("<ii", width, height)
+
+
+def _jpeg(width: int, height: int) -> bytes:
+    return (
+        b"\xff\xd8\xff\xc0\x00\x11\x08"
+        + struct.pack(">HH", height, width)
+        + b"\x00" * 15
+    )
+
+
+def _webp_vp8x(width: int, height: int) -> bytes:
+    return (
+        b"RIFF\x00\x00\x00\x00WEBPVP8X"
+        b"\x00\x00\x00\x0a"
+        + b"\x00" * 4
+        + (width - 1).to_bytes(3, "little")
+        + (height - 1).to_bytes(3, "little")
+    )
+
+
+class TestGetImageDimensions:
+    """Tests for stdlib image-dimension parsing."""
+
+    @pytest.mark.parametrize(
+        ("builder", "width", "height"),
+        [
+            (_png, 800, 600),
+            (_gif, 16, 32),
+            (_bmp, 120, 240),
+            (_jpeg, 710, 163),
+            (_webp_vp8x, 1024, 768),
+        ],
+        ids=["png", "gif", "bmp", "jpeg", "webp-vp8x"],
+    )
+    def test_known_formats(self, builder, width: int, height: int) -> None:
+        assert get_image_dimensions(builder(width, height)) == (width, height)
+
+    def test_bmp_negative_height_top_down(self) -> None:
+        """BMP stores top-down rows as a negative height; abs() is returned."""
+        assert get_image_dimensions(_bmp(120, -240)) == (120, 240)
+
+    def test_empty_or_short_returns_none(self) -> None:
+        assert get_image_dimensions(b"") is None
+        assert get_image_dimensions(b"\x89PNG\r\n\x1a\n") is None
+
+    def test_unknown_format_returns_none(self) -> None:
+        assert get_image_dimensions(b"not an image at all, just text...") is None
 
 
 def test_attachment_max_bytes_type() -> None:

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -249,7 +249,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 49, f"Expected 49 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 53, f"Expected 53 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

Comments posted to Jira Cloud that contain a user mention in the `[~accountid:<id>]` wiki syntax were stored as a **plain ADF text node**, so the Jira UI rendered the literal string `[~accountid:712020:…]`, the user was not notified, and the mention was not clickable. No exception was raised — a silent semantic mis-conversion in the markdown→ADF path.

## Root cause

On Cloud, both `jira_add_comment` and `jira_edit_comment` convert the Markdown body via `_markdown_to_jira` → `markdown_to_adf` → `_parse_inline_formatting` (`src/mcp_atlassian/models/jira/adf.py`). That inline parser handled bold/italic/code/links/strike but had **no rule for mentions**, so the mention token fell through to a literal text node.

## Fix

`_parse_inline_formatting` now recognises two mention forms and emits ADF `mention` nodes, placed **before** the link pattern so `@[name](id)` is not mis-parsed as a link:

- `[~accountid:<id>]` → `{"type": "mention", "attrs": {"id": "<id>"}}`
- `@[Display Name](<id>)` → `{"type": "mention", "attrs": {"id": "<id>", "text": "@Display Name"}}`

Because both comment tools share the `markdown_to_adf` path, the fix applies to add and edit alike. The reverse path (`adf_to_text`) already handles `mention` nodes, so read-back stays consistent.

### Note on "Defect 1" (stray leading backslash)
This fork's Cloud path uses the in-repo `markdown_to_adf` parser, which does **not** markdown-escape a leading `[`. I verified a mention at line start is converted with no stray `\` — so the escaping defect from the report does not reproduce here; only the missing-mention-node defect did.

## Verification

Before:
```json
{"type": "text", "text": "[~accountid:712020:3420e1b4-xxxx]"}
```
After:
```json
{"type": "mention", "attrs": {"id": "712020:3420e1b4-xxxx"}}
```

Authoritative check is the stored ADF (`GET /rest/api/3/issue/{KEY}/comment/{ID}`), not the text read-back.

## Tests

Added to `tests/unit/models/test_adf.py`:
- `[~accountid:<id>]` → mention node (literal wiki syntax must not survive)
- mention at line start (asserts no stray `\`)
- `@[Display Name](<id>)` → mention node with `text` attr
- regression: plain `[text](url)` link is unaffected

All unit tests pass (`tests/unit/models`, `tests/unit/jira/test_comments.py`, `tests/unit/preprocessing`); ruff + format clean; no new mypy errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
