### PR TITLE
fix(jira): autolink issue keys in cloud ADF

### DIFF
--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -10,6 +10,12 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.preprocessing import JiraPreprocessor
+from mcp_atlassian.utils.http import (
+    configure_circuit_breaker,
+    configure_concurrency,
+    configure_rate_limit,
+    configure_retry,
+)
 from mcp_atlassian.utils.logging import (
     get_masked_session_headers,
     log_config_param,
@@ -17,6 +23,9 @@ from mcp_atlassian.utils.logging import (
 )
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
+from mcp_atlassian.utils.ssrf_adapter import mount_ssrf_pinning
+from mcp_atlassian.utils.urls import make_ssrf_redirect_hook
+from mcp_atlassian.utils.user_agent import get_default_user_agent
 
 from ..models.jira.adf import markdown_to_adf
 from .config import JiraConfig
@@ -46,6 +55,7 @@ class JiraClient:
         """
         # Load configuration from environment variables if not provided
         self.config = config or JiraConfig.from_env()
+        transport_url = self.config.url
 
         # Initialize the Jira client based on auth type
         if self.config.auth_type == "oauth":
@@ -78,6 +88,7 @@ class JiraClient:
                 # Cloud: use the Atlassian Cloud API URL
                 api_url = f"https://api.atlassian.com/ex/jira/{self.config.oauth_config.cloud_id}"
                 is_cloud = True
+            transport_url = api_url
 
             # Initialize Jira with the session
             self.jira = Jira(
@@ -125,16 +136,38 @@ class JiraClient:
         if self.config.auth_type in ("pat", "oauth"):
             self.jira._session.trust_env = False
 
+        if self.config.no_proxy and isinstance(self.config.no_proxy, str):
+            os.environ["NO_PROXY"] = self.config.no_proxy
+            log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
+
         # Configure SSL verification using the shared utility
         configure_ssl_verification(
             service_name="Jira",
-            url=self.config.url,
+            url=transport_url,
             session=self.jira._session,
             ssl_verify=self.config.ssl_verify,
             client_cert=self.config.client_cert,
             client_key=self.config.client_key,
             client_key_password=self.config.client_key_password,
+            no_proxy=self.config.no_proxy,
         )
+
+        # Validate redirects for SSRF on every outbound call from this session
+        # (covers direct _session.get() paths and global/stdio fetchers, not just
+        # the per-user HTTP path).
+        self.jira._session.hooks["response"].append(make_ssrf_redirect_hook())
+        # Pin DNS resolution against rebinding: resolve+validate once and connect
+        # to that address, closing the validate→reconnect TOCTOU. Preserves TLS SNI.
+        mount_ssrf_pinning(self.jira._session, transport_url)
+
+        # Apply opt-in HTTP hardening after SSL setup and after the pinning
+        # adapter is mounted: these wrappers patch send() in place on whatever
+        # adapters are mounted now, so mounting the pinning adapter later would
+        # silently drop them.
+        configure_retry(self.jira._session, service="Jira")
+        configure_concurrency(self.jira._session, service="Jira")
+        configure_rate_limit(self.jira._session, service="Jira")
+        configure_circuit_breaker(self.jira._session, service="Jira")
 
         # Proxy configuration
         proxies = {}
@@ -150,9 +183,11 @@ class JiraClient:
                 log_config_param(
                     logger, "Jira", f"{k.upper()}_PROXY", v, sensitive=True
                 )
-        if self.config.no_proxy and isinstance(self.config.no_proxy, str):
-            os.environ["NO_PROXY"] = self.config.no_proxy
-            log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
+
+        # Set an explicit User-Agent so requests aren't blocked by WAFs that
+        # reject the default ``python-requests/X.Y`` header. User-supplied
+        # custom headers below can still override this.
+        self.jira._session.headers["User-Agent"] = get_default_user_agent()
 
         # Apply custom headers if configured
         if self.config.custom_headers:
@@ -382,7 +417,57 @@ class JiraClient:
         if description:
             payload["description"] = description
         logger.info(f"Creating Jira version: {payload}")
-        result = self.jira.post("/rest/api/3/version", json=payload)
+        result = self.jira.post("/rest/api/2/version", json=payload)
+        if not isinstance(result, dict):
+            error_message = f"Unexpected response from Jira API: {result}"
+            raise ValueError(error_message)
+        return result
+
+    def update_version(
+        self,
+        version_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        start_date: str | None = None,
+        release_date: str | None = None,
+        archived: bool | None = None,
+        released: bool | None = None,
+    ) -> dict[str, Any]:
+        """
+        Update an existing version in a Jira project.
+
+        Only fields that are not None are sent in the request, so callers can
+        toggle a single attribute (e.g. archived) without touching the others.
+
+        Args:
+            version_id: The numeric ID of the version to update.
+            name: New name for the version (optional).
+            description: New description for the version (optional).
+            start_date: New start date (YYYY-MM-DD, optional).
+            release_date: New release date (YYYY-MM-DD, optional).
+            archived: Archived flag (optional).
+            released: Released flag (optional).
+
+        Returns:
+            The updated version object as returned by Jira.
+        """
+        payload: dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if start_date is not None:
+            payload["startDate"] = start_date
+        if release_date is not None:
+            payload["releaseDate"] = release_date
+        if archived is not None:
+            payload["archived"] = archived
+        if released is not None:
+            payload["released"] = released
+        if not payload:
+            raise ValueError("update_version requires at least one field to update")
+        logger.info(f"Updating Jira version {version_id}: {payload}")
+        result = self.jira.put(f"/rest/api/2/version/{version_id}", data=payload)
         if not isinstance(result, dict):
             error_message = f"Unexpected response from Jira API: {result}"
             raise ValueError(error_message)

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -254,7 +254,7 @@ class JiraClient:
 
         if self.config.is_cloud:
             try:
-                return markdown_to_adf(markdown_text)
+                return markdown_to_adf(markdown_text, jira_base_url=self.config.url)
             except Exception as e:
                 logger.warning(f"Error converting markdown to ADF: {e}")
                 return {

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -9,15 +9,64 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 
+_JIRA_ISSUE_KEY_RE = re.compile(r"(?<![A-Z0-9_/])([A-Z][A-Z0-9_]+-\d+)(?![A-Z0-9_])")
 
-def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
+
+def _append_text_nodes(
+    nodes: list[dict[str, Any]],
+    text: str,
+    jira_base_url: str = "",
+    marks: list[dict[str, Any]] | None = None,
+) -> None:
+    """Append text nodes, linking Jira issue keys when a base URL is known."""
+    if not text:
+        return
+
+    normalized_base_url = jira_base_url.rstrip("/")
+    if not normalized_base_url:
+        node: dict[str, Any] = {"type": "text", "text": text}
+        if marks:
+            node["marks"] = marks
+        nodes.append(node)
+        return
+
+    pos = 0
+    for match in _JIRA_ISSUE_KEY_RE.finditer(text):
+        if match.start() > pos:
+            node = {"type": "text", "text": text[pos : match.start()]}
+            if marks:
+                node["marks"] = marks
+            nodes.append(node)
+
+        issue_key = match.group(1)
+        link_marks = [
+            *(marks or []),
+            {
+                "type": "link",
+                "attrs": {"href": f"{normalized_base_url}/browse/{issue_key}"},
+            },
+        ]
+        nodes.append({"type": "text", "text": issue_key, "marks": link_marks})
+        pos = match.end()
+
+    if pos < len(text):
+        node = {"type": "text", "text": text[pos:]}
+        if marks:
+            node["marks"] = marks
+        nodes.append(node)
+
+
+def _parse_inline_formatting(
+    text: str, jira_base_url: str = ""
+) -> list[dict[str, Any]]:
     """Parse inline Markdown formatting into ADF inline nodes.
 
     Handles: bold (**), italic (*), inline code (`), links ([text](url)),
-    and strikethrough (~~).
+    strikethrough (~~), and Jira issue keys.
 
     Args:
         text: Raw text potentially containing inline Markdown formatting.
+        jira_base_url: Jira base URL used to link bare issue keys.
 
     Returns:
         List of ADF inline nodes (text nodes with optional marks).
@@ -40,8 +89,7 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
         # Add any plain text before this match
         if m.start() > pos:
             plain = text[pos : m.start()]
-            if plain:
-                nodes.append({"type": "text", "text": plain})
+            _append_text_nodes(nodes, plain, jira_base_url)
 
         if m.group("code_inner") is not None:
             nodes.append(
@@ -52,20 +100,18 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
                 }
             )
         elif m.group("bold_inner") is not None:
-            nodes.append(
-                {
-                    "type": "text",
-                    "text": m.group("bold_inner"),
-                    "marks": [{"type": "strong"}],
-                }
+            _append_text_nodes(
+                nodes,
+                m.group("bold_inner"),
+                jira_base_url,
+                [{"type": "strong"}],
             )
         elif m.group("strike_inner") is not None:
-            nodes.append(
-                {
-                    "type": "text",
-                    "text": m.group("strike_inner"),
-                    "marks": [{"type": "strike"}],
-                }
+            _append_text_nodes(
+                nodes,
+                m.group("strike_inner"),
+                jira_base_url,
+                [{"type": "strike"}],
             )
         elif m.group("link_text") is not None:
             nodes.append(
@@ -81,12 +127,11 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
                 }
             )
         elif m.group("italic_inner") is not None:
-            nodes.append(
-                {
-                    "type": "text",
-                    "text": m.group("italic_inner"),
-                    "marks": [{"type": "em"}],
-                }
+            _append_text_nodes(
+                nodes,
+                m.group("italic_inner"),
+                jira_base_url,
+                [{"type": "em"}],
             )
 
         pos = m.end()
@@ -94,30 +139,29 @@ def _parse_inline_formatting(text: str) -> list[dict[str, Any]]:
     # Remaining plain text after last match
     if pos < len(text):
         remaining = text[pos:]
-        if remaining:
-            nodes.append({"type": "text", "text": remaining})
+        _append_text_nodes(nodes, remaining, jira_base_url)
 
     # If no patterns matched, return the whole thing as plain text
     if not nodes and text:
-        nodes.append({"type": "text", "text": text})
+        _append_text_nodes(nodes, text, jira_base_url)
 
     return nodes
 
 
-def _make_paragraph(text: str) -> dict[str, Any]:
+def _make_paragraph(text: str, jira_base_url: str = "") -> dict[str, Any]:
     """Create an ADF paragraph node from text with inline formatting."""
-    content = _parse_inline_formatting(text)
+    content = _parse_inline_formatting(text, jira_base_url)
     if not content:
         content = [{"type": "text", "text": ""}]
     return {"type": "paragraph", "content": content}
 
 
-def _make_list_item(text: str) -> dict[str, Any]:
+def _make_list_item(text: str, jira_base_url: str = "") -> dict[str, Any]:
     """Create an ADF listItem node wrapping a paragraph."""
-    return {"type": "listItem", "content": [_make_paragraph(text)]}
+    return {"type": "listItem", "content": [_make_paragraph(text, jira_base_url)]}
 
 
-def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
+def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, Any]:
     """Convert Markdown text to ADF (Atlassian Document Format) document.
 
     Implements a line-by-line parser that handles common Markdown constructs.
@@ -125,6 +169,7 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
 
     Args:
         markdown_text: Markdown-formatted text to convert.
+        jira_base_url: Jira base URL used to link bare issue keys.
 
     Returns:
         ADF document dict with version, type, and content keys.
@@ -181,7 +226,7 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
             heading_node: dict[str, Any] = {
                 "type": "heading",
                 "attrs": {"level": level},
-                "content": _parse_inline_formatting(text),
+                "content": _parse_inline_formatting(text, jira_base_url),
             }
             doc["content"].append(heading_node)
             i += 1
@@ -193,7 +238,7 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
             while i < len(lines) and lines[i].startswith("> "):
                 quote_lines.append(lines[i][2:])
                 i += 1
-            bq_content = [_make_paragraph(ln) for ln in quote_lines]
+            bq_content = [_make_paragraph(ln, jira_base_url) for ln in quote_lines]
             doc["content"].append({"type": "blockquote", "content": bq_content})
             continue
 
@@ -202,7 +247,7 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
             items: list[dict[str, Any]] = []
             while i < len(lines) and re.match(r"^[-*]\s+", lines[i]):
                 item_text = re.sub(r"^[-*]\s+", "", lines[i])
-                items.append(_make_list_item(item_text))
+                items.append(_make_list_item(item_text, jira_base_url))
                 i += 1
             doc["content"].append({"type": "bulletList", "content": items})
             continue
@@ -212,7 +257,7 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
             items_ol: list[dict[str, Any]] = []
             while i < len(lines) and re.match(r"^\d+\.\s+", lines[i]):
                 item_text = re.sub(r"^\d+\.\s+", "", lines[i])
-                items_ol.append(_make_list_item(item_text))
+                items_ol.append(_make_list_item(item_text, jira_base_url))
                 i += 1
             doc["content"].append({"type": "orderedList", "content": items_ol})
             continue
@@ -238,7 +283,7 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
                     cell_type = "tableHeader" if idx == 0 else "tableCell"
                     adf_cells = []
                     for cell_text in cells:
-                        content = _parse_inline_formatting(cell_text)
+                        content = _parse_inline_formatting(cell_text, jira_base_url)
                         if not content:
                             content = [{"type": "text", "text": ""}]
                         adf_cells.append(
@@ -264,7 +309,7 @@ def markdown_to_adf(markdown_text: str) -> dict[str, Any]:
             continue
 
         # --- Paragraph (default) ---
-        doc["content"].append(_make_paragraph(line))
+        doc["content"].append(_make_paragraph(line, jira_base_url))
         i += 1
 
     # Ensure at least one content node

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -5,10 +5,13 @@ This module provides utilities for converting between ADF and other formats.
 Supports both ADF → plain text (for reading) and Markdown → ADF (for writing).
 """
 
+import copy
+import json
 import re
 from datetime import datetime, timezone
 from typing import Any
 
+_MEDIA_NODE_TYPES = frozenset({"media", "mediaSingle", "mediaGroup"})
 _JIRA_ISSUE_KEY_RE = re.compile(r"(?<![A-Z0-9_/])([A-Z][A-Z0-9_]+-\d+)(?![A-Z0-9_])")
 
 
@@ -62,22 +65,36 @@ def _parse_inline_formatting(
     """Parse inline Markdown formatting into ADF inline nodes.
 
     Handles: bold (**), italic (*), inline code (`), links ([text](url)),
-    strikethrough (~~), and Jira issue keys.
+    strikethrough (~~), and Jira-flavored user mentions
+    ([~accountid:ACCOUNT_ID] or @[Display Name](accountid:ACCOUNT_ID)).
+
+    Bare Jira issue keys are converted to links when ``jira_base_url`` is set.
+
+    The [~accountid:...] mention syntax mirrors what Jira's v2 wiki text
+    returns when a real ADF mention is read back, so the read and write paths
+    are symmetric. The display-name syntax also includes the mention text in
+    the ADF node.
 
     Args:
         text: Raw text potentially containing inline Markdown formatting.
         jira_base_url: Jira base URL used to link bare issue keys.
 
     Returns:
-        List of ADF inline nodes (text nodes with optional marks).
+        List of ADF inline nodes (text nodes with optional marks, plus
+        mention nodes when [~accountid:...] or
+        @[Display Name](accountid:...) is present).
     """
     if not text:
         return []
 
     nodes: list[dict[str, Any]] = []
-    # Pattern order matters: bold before italic, code before others
+    # Pattern order matters: mention before link, bold before italic,
+    # code before others.
     inline_re = re.compile(
-        r"`(?P<code_inner>[^`]+)`"
+        r"\[~accountid:(?P<wiki_mention_id>[^\]]+)\]"
+        r"|@\[(?P<display_mention_text>[^\]]+)\]"
+        r"\(accountid:(?P<display_mention_id>[^)]+)\)"
+        r"|`(?P<code_inner>[^`]+)`"
         r"|\*\*(?P<bold_inner>.+?)\*\*"
         r"|~~(?P<strike_inner>.+?)~~"
         r"|\[(?P<link_text>[^\]]+)\]\((?P<link_href>[^)]+)\)"
@@ -91,7 +108,24 @@ def _parse_inline_formatting(
             plain = text[pos : m.start()]
             _append_text_nodes(nodes, plain, jira_base_url)
 
-        if m.group("code_inner") is not None:
+        if m.group("wiki_mention_id") is not None:
+            nodes.append(
+                {
+                    "type": "mention",
+                    "attrs": {"id": m.group("wiki_mention_id")},
+                }
+            )
+        elif m.group("display_mention_id") is not None:
+            nodes.append(
+                {
+                    "type": "mention",
+                    "attrs": {
+                        "id": m.group("display_mention_id"),
+                        "text": f"@{m.group('display_mention_text')}",
+                    },
+                }
+            )
+        elif m.group("code_inner") is not None:
             nodes.append(
                 {
                     "type": "text",
@@ -161,11 +195,27 @@ def _make_list_item(text: str, jira_base_url: str = "") -> dict[str, Any]:
     return {"type": "listItem", "content": [_make_paragraph(text, jira_base_url)]}
 
 
+def _make_task_item(
+    text: str,
+    checked: bool,
+    local_id: str,
+    jira_base_url: str = "",
+) -> dict[str, Any]:
+    """Create an ADF taskItem node."""
+    return {
+        "type": "taskItem",
+        "attrs": {"localId": local_id, "state": "DONE" if checked else "TODO"},
+        "content": _parse_inline_formatting(text, jira_base_url)
+        or [{"type": "text", "text": text}],
+    }
+
+
 def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, Any]:
     """Convert Markdown text to ADF (Atlassian Document Format) document.
 
     Implements a line-by-line parser that handles common Markdown constructs.
-    No external dependencies required.
+    Jira Cloud expand blocks can be written as
+    ``{expand:Title}...{expand}``. No external dependencies required.
 
     Args:
         markdown_text: Markdown-formatted text to convert.
@@ -185,6 +235,29 @@ def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, An
 
     while i < len(lines):
         line = lines[i]
+
+        # --- Expand/collapse block ({expand:Title}...{expand}) ---
+        expand_match = re.match(r"^\{expand(?::(.+?))?\}\s*$", line)
+        if expand_match:
+            expand_title = expand_match.group(1) or ""
+            expand_lines: list[str] = []
+            i += 1
+            while i < len(lines) and not re.match(r"^\{expand\}\s*$", lines[i]):
+                expand_lines.append(lines[i])
+                i += 1
+            # Skip closing {expand}
+            if i < len(lines):
+                i += 1
+            # Recursively parse the inner content as ADF
+            inner_markdown = "\n".join(expand_lines)
+            inner_doc = markdown_to_adf(inner_markdown, jira_base_url)
+            expand_node: dict[str, Any] = {
+                "type": "expand",
+                "attrs": {"title": expand_title},
+                "content": inner_doc.get("content", []),
+            }
+            doc["content"].append(expand_node)
+            continue
 
         # --- Fenced code block ---
         if line.startswith("```"):
@@ -241,6 +314,56 @@ def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, An
             bq_content = [_make_paragraph(ln, jira_base_url) for ln in quote_lines]
             doc["content"].append({"type": "blockquote", "content": bq_content})
             continue
+
+        # --- Task list (- [ ] / - [x]) ---
+        if re.match(r"^[-*]\s+\[[ xX]\]\s+", line):
+            task_items: list[dict[str, Any]] = []
+            task_counter = 0
+            while i < len(lines) and re.match(r"^[-*]\s+\[[ xX]\]\s+", lines[i]):
+                checked = bool(re.match(r"^[-*]\s+\[[xX]\]\s+", lines[i]))
+                item_text = re.sub(r"^[-*]\s+\[[ xX]\]\s+", "", lines[i])
+                task_counter += 1
+                task_items.append(
+                    _make_task_item(
+                        item_text,
+                        checked,
+                        f"task-{id(doc)}-{task_counter}",
+                        jira_base_url,
+                    )
+                )
+                i += 1
+            doc["content"].append(
+                {
+                    "type": "taskList",
+                    "attrs": {"localId": f"tasklist-{id(doc)}-{i}"},
+                    "content": task_items,
+                }
+            )
+            continue
+
+        # --- Panel block ---
+        panel_match = re.match(r"^:::(\w+)\s*$", line)
+        if panel_match:
+            panel_type = panel_match.group(1).lower()
+            valid_panel_types = {"note", "info", "warning", "success", "error"}
+            if panel_type in valid_panel_types:
+                panel_lines: list[str] = []
+                i += 1
+                while i < len(lines) and lines[i].strip() != ":::":
+                    panel_lines.append(lines[i])
+                    i += 1
+                # Skip closing :::
+                if i < len(lines):
+                    i += 1
+                # Recursively parse panel content
+                inner_doc = markdown_to_adf("\n".join(panel_lines), jira_base_url)
+                panel_node: dict[str, Any] = {
+                    "type": "panel",
+                    "attrs": {"panelType": panel_type},
+                    "content": inner_doc["content"],
+                }
+                doc["content"].append(panel_node)
+                continue
 
         # --- Unordered list ---
         if re.match(r"^[-*]\s+", line):
@@ -317,6 +440,74 @@ def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, An
         doc["content"].append({"type": "paragraph", "content": []})
 
     return doc
+
+
+def _adf_node_contains_media(node: dict[str, Any]) -> bool:
+    """Return True when an ADF node contains media content."""
+    if node.get("type") in _MEDIA_NODE_TYPES:
+        return True
+
+    content = node.get("content")
+    if isinstance(content, list):
+        return any(
+            _adf_node_contains_media(child)
+            for child in content
+            if isinstance(child, dict)
+        )
+
+    return False
+
+
+def extract_top_level_media_nodes(
+    adf_document: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Extract top-level ADF nodes that contain media content."""
+    if not isinstance(adf_document, dict):
+        return []
+
+    content = adf_document.get("content")
+    if not isinstance(content, list):
+        return []
+
+    return [
+        copy.deepcopy(node)
+        for node in content
+        if isinstance(node, dict) and _adf_node_contains_media(node)
+    ]
+
+
+def merge_adf_with_preserved_media(
+    target_adf: dict[str, Any],
+    source_adf: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Append existing media nodes from one ADF document into another.
+
+    This is intentionally narrow: it preserves existing media-bearing blocks
+    when a caller rewrites the surrounding description text, without attempting
+    to merge all prior formatting or layout.
+    """
+    preserved_media = extract_top_level_media_nodes(source_adf)
+    if not preserved_media:
+        return target_adf
+
+    merged = copy.deepcopy(target_adf)
+    content = merged.get("content")
+    if not isinstance(content, list):
+        content = []
+        merged["content"] = content
+
+    existing_signatures = {
+        json.dumps(node, sort_keys=True, separators=(",", ":"))
+        for node in extract_top_level_media_nodes(merged)
+    }
+    for media_node in preserved_media:
+        signature = json.dumps(media_node, sort_keys=True, separators=(",", ":"))
+        if signature in existing_signatures:
+            continue
+        content.append(media_node)
+        existing_signatures.add(signature)
+
+    return merged
 
 
 def adf_to_text(adf_content: dict | list | str | None) -> str | None:

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -389,6 +389,17 @@ class TestCommentsMixin:
         assert result["type"] == "doc"
         comments_mixin.preprocessor.markdown_to_jira.assert_not_called()
 
+    def test_markdown_to_jira_cloud_links_issue_keys(self, comments_mixin):
+        """Cloud ADF links bare Jira issue keys to the configured Jira site."""
+        result = comments_mixin._markdown_to_jira("Blocked by PROJ-123.")
+        assert isinstance(result, dict)
+        para = result["content"][0]
+        link_node = next(n for n in para["content"] if n.get("text") == "PROJ-123")
+        link_mark = next(m for m in link_node["marks"] if m["type"] == "link")
+        assert (
+            link_mark["attrs"]["href"] == "https://test.atlassian.net/browse/PROJ-123"
+        )
+
     def test_markdown_to_jira_cloud_empty(self, comments_mixin):
         """Test _markdown_to_jira with empty text on Cloud returns ADF."""
         result = comments_mixin._markdown_to_jira("")

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -206,6 +206,29 @@ class TestCommentsMixin:
         comments_mixin.preprocessor.markdown_to_jira.assert_not_called()
         assert result["body"] == "Heading and content"
 
+    def test_add_comment_with_accountid_mention_uses_adf_node(
+        self, comments_mixin: CommentsMixin
+    ) -> None:
+        """Test [~accountid:...] comments become ADF mention nodes on Cloud."""
+        mock_response = {
+            "id": "10001",
+            "body": "Mention comment",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "John Doe"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+
+        account_id = "712020:1cfc6d16-950f-4096-8e57-f2c6c60d8ffa"
+        comments_mixin.add_comment("TEST-123", f"Hello [~accountid:{account_id}]")
+
+        call_args = comments_mixin._post_api3.call_args
+        adf_body = call_args[0][1]["body"]
+        assert adf_body["content"][0]["content"] == [
+            {"type": "text", "text": "Hello "},
+            {"type": "mention", "attrs": {"id": account_id}},
+        ]
+        comments_mixin.preprocessor.markdown_to_jira.assert_not_called()
+
     def test_add_comment_with_empty_comment(self, comments_mixin):
         """Test add_comment with an empty comment (Cloud → minimal ADF)."""
         # Setup mock response for v3 API path
@@ -256,6 +279,34 @@ class TestCommentsMixin:
         assert result["body"] == "This is a comment"
         assert result["created"] == "2024-01-01 10:00:00+00:00"
         assert result["author"] == "John Doe"
+
+    def test_add_comment_with_role_visibility(self, comments_mixin):
+        """Test add_comment with role visibility set (Cloud → ADF via v3)."""
+        mock_response = {
+            "id": "10002",
+            "body": "Admin-only comment",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "Jane Smith"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+
+        result = comments_mixin.add_comment(
+            "TEST-456",
+            "Admin-only comment",
+            visibility={"type": "role", "value": "Administrators"},
+        )
+
+        call_args = comments_mixin._post_api3.call_args
+        assert call_args[0][0] == "issue/TEST-456/comment"
+        payload = call_args[0][1]
+        assert isinstance(payload["body"], dict)
+        assert payload["body"]["version"] == 1
+        assert payload["visibility"] == {"type": "role", "value": "Administrators"}
+        comments_mixin.preprocessor.markdown_to_jira.assert_not_called()
+        assert result["id"] == "10002"
+        assert result["body"] == "Admin-only comment"
+        assert result["created"] == "2024-01-01 10:00:00+00:00"
+        assert result["author"] == "Jane Smith"
 
     def test_add_comment_with_error(self, comments_mixin):
         """Test add_comment with an error response."""
@@ -562,3 +613,97 @@ class TestCommentsMixin:
         # ServiceDesk post should NOT be called
         comments_mixin.jira.post.assert_not_called()
         assert result["id"] == "10001"
+
+
+class TestInternalCommentPublicParam:
+    """Regression tests for add_comment public parameter (internal comments).
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/716
+    Feature was requested: make comment internal (public: false) via JSM API.
+    Already implemented: add_comment(public=False) routes through
+    _add_servicedesk_comment which posts to rest/servicedeskapi/request/.../comment.
+    """
+
+    SERVICEDESK_COMMENT_RESPONSE = {
+        "id": 10001,
+        "body": "Test comment",
+        "public": True,
+        "created": {
+            "iso8601": "2024-01-01T10:00:00.000+0000",
+            "jira": "2024-01-01T10:00:00.000+0000",
+            "friendly": "Today 10:00 AM",
+            "epochMillis": 1704099600000,
+        },
+        "author": {
+            "accountId": "test-id",
+            "displayName": "Test User",
+        },
+    }
+
+    @pytest.fixture
+    def comments_mixin(self, jira_client):
+        """Create a CommentsMixin instance with mocked dependencies."""
+        mixin = CommentsMixin(config=jira_client.config)
+        mixin.jira = jira_client.jira
+        mixin.preprocessor = Mock()
+        mixin.preprocessor.markdown_to_jira = Mock(
+            return_value="*This* is _Jira_ formatted"
+        )
+        mixin._clean_text = Mock(side_effect=lambda x: x)
+        return mixin
+
+    def test_public_false_calls_servicedesk_comment(self, comments_mixin):
+        """add_comment(public=False) routes through _add_servicedesk_comment."""
+        captured: list[tuple] = []
+        original = comments_mixin._add_servicedesk_comment
+
+        def spy(*args, **kwargs):
+            captured.append((args, kwargs))
+            return original(*args, **kwargs)
+
+        comments_mixin._add_servicedesk_comment = spy
+        response = {**self.SERVICEDESK_COMMENT_RESPONSE, "public": False}
+        comments_mixin.jira.post.return_value = response
+
+        comments_mixin.add_comment("ISSUE-1", "Internal note", public=False)
+
+        assert len(captured) == 1
+        assert captured[0][0] == ("ISSUE-1", "Internal note", False)  # noqa: FBT003
+
+    def test_public_true_calls_servicedesk_comment(self, comments_mixin):
+        """add_comment(public=True) routes through _add_servicedesk_comment."""
+        captured: list[tuple] = []
+        original = comments_mixin._add_servicedesk_comment
+
+        def spy(*args, **kwargs):
+            captured.append((args, kwargs))
+            return original(*args, **kwargs)
+
+        comments_mixin._add_servicedesk_comment = spy
+        response = {**self.SERVICEDESK_COMMENT_RESPONSE, "public": True}
+        comments_mixin.jira.post.return_value = response
+
+        comments_mixin.add_comment("ISSUE-1", "Customer reply", public=True)
+
+        assert len(captured) == 1
+        assert captured[0][0] == ("ISSUE-1", "Customer reply", True)  # noqa: FBT003
+
+    def test_public_none_does_not_call_servicedesk_comment(self, comments_mixin):
+        """add_comment(public=None default) does NOT call _add_servicedesk_comment."""
+        captured: list[tuple] = []
+
+        def spy(*args, **kwargs):
+            captured.append((args, kwargs))
+
+        comments_mixin._add_servicedesk_comment = spy
+        mock_response = {
+            "id": "10001",
+            "body": "Normal comment",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "author": {"displayName": "John Doe"},
+        }
+        comments_mixin._post_api3 = Mock(return_value=mock_response)
+
+        comments_mixin.add_comment("ISSUE-1", "text")
+
+        assert len(captured) == 0

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -433,6 +433,17 @@ class TestMarkdownToAdf:
         link_mark = next(m for m in link_nodes[0]["marks"] if m["type"] == "link")
         assert link_mark["attrs"]["href"] == "https://example.com"
 
+    def test_jira_issue_key_links_to_browse_url(self):
+        """Bare Jira issue keys become Jira links when a base URL is available."""
+        result = markdown_to_adf(
+            "Blocked by PROJ-123.",
+            jira_base_url="https://jira.example.com/",
+        )
+        para = result["content"][0]
+        link_node = next(n for n in para["content"] if n.get("text") == "PROJ-123")
+        link_mark = next(m for m in link_node["marks"] if m["type"] == "link")
+        assert link_mark["attrs"]["href"] == "https://jira.example.com/browse/PROJ-123"
+
     # -- Code blocks --------------------------------------------------------
 
     def test_code_block_with_lang(self):

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -6,11 +6,17 @@ including handling of various inline and block node types,
 and the reverse conversion from Markdown to ADF.
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.mcp_atlassian.models.jira.adf import adf_to_text, markdown_to_adf
+from src.mcp_atlassian.models.jira.adf import (
+    adf_to_text,
+    extract_top_level_media_nodes,
+    markdown_to_adf,
+    merge_adf_with_preserved_media,
+)
 
 
 class TestAdfToText:
@@ -433,6 +439,108 @@ class TestMarkdownToAdf:
         link_mark = next(m for m in link_nodes[0]["marks"] if m["type"] == "link")
         assert link_mark["attrs"]["href"] == "https://example.com"
 
+    # -- Mentions -----------------------------------------------------------
+
+    def test_mention_modern_account_id(self):
+        """[~accountid:712020:UUID] emits an ADF mention node with id attr."""
+        account_id = "712020:1cfc6d16-950f-4096-8e57-f2c6c60d8ffa"
+        result = markdown_to_adf(f"[~accountid:{account_id}]")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"]["id"] == account_id
+
+    def test_mention_legacy_account_id(self):
+        """[~accountid:24-hex] (no 712020: prefix) is also accepted."""
+        account_id = "6315cc7b3310c2492b5b1513"
+        result = markdown_to_adf(f"[~accountid:{account_id}]")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"]["id"] == account_id
+
+    def test_mention_display_name_account_id(self) -> None:
+        """@[Name](accountid:...) emits an ADF mention node with text attr."""
+        account_id = "712020:abc-123-def-456"
+        result = markdown_to_adf(f"@[John Doe](accountid:{account_id})")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"] == {
+            "id": account_id,
+            "text": "@John Doe",
+        }
+
+    def test_mention_display_name_inline_with_link(self) -> None:
+        """Display-name mentions coexist with normal Markdown links."""
+        account_id = "712020:abc-def"
+        result = markdown_to_adf(
+            f"Ask @[Jane Doe](accountid:{account_id}) via "
+            "[the runbook](https://example.com)."
+        )
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        links = [
+            n
+            for n in para["content"]
+            if n["type"] == "text"
+            and any(m["type"] == "link" for m in n.get("marks", []))
+        ]
+
+        assert len(mentions) == 1
+        assert mentions[0]["attrs"]["id"] == account_id
+        assert mentions[0]["attrs"]["text"] == "@Jane Doe"
+        assert len(links) == 1
+        assert links[0]["text"] == "the runbook"
+
+    def test_mixed_mention_syntaxes_in_one_paragraph(self) -> None:
+        """Both supported mention syntaxes can appear in the same paragraph."""
+        first = "712020:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        second = "712020:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        result = markdown_to_adf(f"@[Ada](accountid:{first}) and [~accountid:{second}]")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+
+        assert [n["attrs"]["id"] for n in mentions] == [first, second]
+        assert mentions[0]["attrs"]["text"] == "@Ada"
+        assert "text" not in mentions[1]["attrs"]
+
+    def test_mention_inline_with_surrounding_text(self):
+        """Mention preserves surrounding text nodes in the same paragraph."""
+        account_id = "712020:abc-def"
+        result = markdown_to_adf(f"hi [~accountid:{account_id}] please review")
+        para = result["content"][0]
+        types_in_order = [n["type"] for n in para["content"]]
+        assert types_in_order == ["text", "mention", "text"]
+        assert para["content"][0]["text"] == "hi "
+        assert para["content"][1]["attrs"]["id"] == account_id
+        assert para["content"][2]["text"] == " please review"
+
+    def test_mention_does_not_swallow_regular_link(self):
+        """[text](url) without the ~accountid: marker stays a link, not a mention."""
+        result = markdown_to_adf("[click](https://example.com)")
+        para = result["content"][0]
+        mentions = [n for n in para["content"] if n["type"] == "mention"]
+        links = [
+            n
+            for n in para["content"]
+            if n["type"] == "text"
+            and any(m["type"] == "link" for m in n.get("marks", []))
+        ]
+        assert mentions == []
+        assert len(links) == 1
+
+    def test_multiple_mentions_in_one_paragraph(self):
+        """Several mentions in one line each get their own mention node."""
+        a = "712020:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        b = "712020:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        result = markdown_to_adf(f"[~accountid:{a}] and [~accountid:{b}]")
+        para = result["content"][0]
+        mention_ids = [
+            n["attrs"]["id"] for n in para["content"] if n["type"] == "mention"
+        ]
+        assert mention_ids == [a, b]
+
     def test_jira_issue_key_links_to_browse_url(self):
         """Bare Jira issue keys become Jira links when a base URL is available."""
         result = markdown_to_adf(
@@ -489,6 +597,42 @@ class TestMarkdownToAdf:
             assert item["type"] == "listItem"
             assert item["content"][0]["type"] == "paragraph"
 
+    def test_task_list_checked(self):
+        """- [x] items produce a taskList with taskItem state=DONE."""
+        md = "- [x] done task"
+        result = markdown_to_adf(md)
+        tl = next(n for n in result["content"] if n["type"] == "taskList")
+        assert len(tl["content"]) == 1
+        item = tl["content"][0]
+        assert item["type"] == "taskItem"
+        assert item["attrs"]["state"] == "DONE"
+        assert item["content"][0]["text"] == "done task"
+
+    def test_task_list_unchecked(self):
+        """- [ ] items produce a taskList with taskItem state=TODO."""
+        md = "- [ ] pending task"
+        result = markdown_to_adf(md)
+        tl = next(n for n in result["content"] if n["type"] == "taskList")
+        item = tl["content"][0]
+        assert item["attrs"]["state"] == "TODO"
+
+    def test_task_list_mixed(self):
+        """Mixed checked/unchecked items in one taskList."""
+        md = "- [x] done\n- [ ] todo\n- [X] also done"
+        result = markdown_to_adf(md)
+        tl = next(n for n in result["content"] if n["type"] == "taskList")
+        assert len(tl["content"]) == 3
+        assert tl["content"][0]["attrs"]["state"] == "DONE"
+        assert tl["content"][1]["attrs"]["state"] == "TODO"
+        assert tl["content"][2]["attrs"]["state"] == "DONE"
+
+    def test_task_list_not_confused_with_bullet_list(self):
+        """Regular - items without [ ] are still bulletList, not taskList."""
+        md = "- regular item"
+        result = markdown_to_adf(md)
+        assert any(n["type"] == "bulletList" for n in result["content"])
+        assert not any(n["type"] == "taskList" for n in result["content"])
+
     # -- Blockquote ---------------------------------------------------------
 
     def test_blockquote(self):
@@ -507,6 +651,40 @@ class TestMarkdownToAdf:
         result = markdown_to_adf(md)
         rule_nodes = [n for n in result["content"] if n["type"] == "rule"]
         assert len(rule_nodes) >= 1
+
+    # -- Expand/collapse block ----------------------------------------------
+
+    def test_expand_with_title(self) -> None:
+        """Expand block with title produces an expand node."""
+        md = "{expand:Details}\n* bullet one\n* bullet two\n{expand}"
+        result = markdown_to_adf(md)
+        expand = next(n for n in result["content"] if n["type"] == "expand")
+        assert expand["attrs"]["title"] == "Details"
+        assert any(n["type"] == "bulletList" for n in expand["content"])
+
+    def test_expand_without_title(self) -> None:
+        """Expand block without a title uses an empty string."""
+        md = "{expand}\nSome content\n{expand}"
+        result = markdown_to_adf(md)
+        expand = next(n for n in result["content"] if n["type"] == "expand")
+        assert expand["attrs"]["title"] == ""
+        assert any(n["type"] == "paragraph" for n in expand["content"])
+
+    def test_expand_with_nested_formatting(self) -> None:
+        """Expand block recursively parses inner markdown."""
+        md = "{expand:Steps}\n## Heading\n1. First\n1. Second\n{expand}"
+        result = markdown_to_adf(md)
+        expand = next(n for n in result["content"] if n["type"] == "expand")
+        inner_types = [n["type"] for n in expand["content"]]
+        assert "heading" in inner_types
+        assert "orderedList" in inner_types
+
+    def test_expand_preserves_surrounding_content(self) -> None:
+        """Content before and after expand block is preserved."""
+        md = "Before\n{expand:Title}\nInside\n{expand}\nAfter"
+        result = markdown_to_adf(md)
+        types = [n["type"] for n in result["content"]]
+        assert types == ["paragraph", "expand", "paragraph"]
 
     # -- Mixed formatting ---------------------------------------------------
 
@@ -614,6 +792,152 @@ class TestMarkdownToAdf:
         text_back = adf_to_text(adf) or ""
         for word in ["Hello", "world", "bold", "italic", "text"]:
             assert word in text_back
+
+
+class TestAdfMediaPreservation:
+    """Tests for preserving existing media nodes during description rewrites."""
+
+    def test_extract_top_level_media_nodes(self):
+        """Media blocks are extracted from the document root."""
+        media_single = {
+            "type": "mediaSingle",
+            "attrs": {"layout": "center"},
+            "content": [
+                {
+                    "type": "media",
+                    "attrs": {
+                        "id": "video-123",
+                        "type": "file",
+                        "collection": "",
+                    },
+                }
+            ],
+        }
+        adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Intro"}]},
+                media_single,
+            ],
+        }
+
+        extracted = extract_top_level_media_nodes(adf)
+
+        assert extracted == [media_single]
+
+    def test_merge_adf_with_preserved_media_appends_media_blocks(self):
+        """Existing media blocks are preserved in the outgoing ADF document."""
+        media_single = {
+            "type": "mediaSingle",
+            "attrs": {"layout": "center"},
+            "content": [
+                {
+                    "type": "media",
+                    "attrs": {
+                        "id": "video-123",
+                        "type": "file",
+                        "collection": "",
+                    },
+                }
+            ],
+        }
+        source_adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Old"}]},
+                media_single,
+            ],
+        }
+        target_adf = markdown_to_adf("Updated text")
+
+        merged = merge_adf_with_preserved_media(target_adf, source_adf)
+
+        assert merged["content"][-1] == media_single
+        assert merged["content"][0]["type"] == "paragraph"
+
+    def test_merge_adf_with_preserved_media_skips_duplicates(self):
+        """Media nodes already present in the target are not duplicated."""
+        media_single = {
+            "type": "mediaSingle",
+            "attrs": {"layout": "center"},
+            "content": [
+                {
+                    "type": "media",
+                    "attrs": {
+                        "id": "video-123",
+                        "type": "file",
+                        "collection": "",
+                    },
+                }
+            ],
+        }
+        target_adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [media_single],
+        }
+        source_adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [media_single],
+        }
+
+        merged = merge_adf_with_preserved_media(target_adf, source_adf)
+
+        assert merged["content"] == [media_single]
+
+
+class TestMarkdownToAdfPanels:
+    """Tests for panel node support in markdown_to_adf."""
+
+    def _assert_valid_adf(self, result: dict[str, Any]) -> None:
+        """Helper: assert the result is a valid ADF document."""
+        assert result["version"] == 1
+        assert result["type"] == "doc"
+        assert isinstance(result["content"], list)
+
+    @pytest.mark.parametrize(
+        "panel_type",
+        ["note", "info", "warning", "success", "error"],
+        ids=["note", "info", "warning", "success", "error"],
+    )
+    def test_all_valid_panel_types(self, panel_type: str) -> None:
+        """All five valid panel types produce a panel node."""
+        result = markdown_to_adf(f":::{panel_type}\ntext\n:::")
+        self._assert_valid_adf(result)
+        assert result["content"][0]["type"] == "panel"
+        assert result["content"][0]["attrs"]["panelType"] == panel_type
+
+    def test_panel_content_is_paragraph(self) -> None:
+        """Panel body text becomes a paragraph node inside the panel."""
+        result = markdown_to_adf(":::note\nThis is a note.\n:::")
+        panel = result["content"][0]
+        assert panel["type"] == "panel"
+        assert panel["content"][0]["type"] == "paragraph"
+
+    def test_panel_with_nested_heading_and_list(self) -> None:
+        """Panel content supports nested headings and bullet lists."""
+        result = markdown_to_adf(":::info\n## Title\n- item 1\n- item 2\n:::")
+        panel = result["content"][0]
+        assert panel["type"] == "panel"
+        assert panel["attrs"]["panelType"] == "info"
+        inner_types = [n["type"] for n in panel["content"]]
+        assert "heading" in inner_types
+        assert "bulletList" in inner_types
+
+    def test_invalid_panel_type_falls_through_as_paragraph(self) -> None:
+        """Unknown panel type (:::custom) is not converted to a panel node."""
+        result = markdown_to_adf(":::custom\nsome text\n:::")
+        types = [n["type"] for n in result["content"]]
+        assert "panel" not in types
+
+    def test_panel_mixed_with_other_content(self) -> None:
+        """Panel can appear alongside headings and lists in a document."""
+        result = markdown_to_adf("## Heading\n\n:::note\nA note.\n:::\n\n- list item")
+        types = [n["type"] for n in result["content"]]
+        assert types == ["heading", "panel", "bulletList"]
 
 
 class TestMarkdownToJiraDispatch:


### PR DESCRIPTION
## Summary

- Link bare Jira issue keys when converting Markdown to Jira Cloud ADF.
- Pass the configured Jira base URL into the Cloud ADF converter.
- Add regression coverage for converter output and the Jira Cloud helper path.

## Root cause

Jira Cloud descriptions and comments are sent as ADF. Bare `PROJ-123` text in ADF is just text, so Jira's wiki-style issue key autolinker does not run over it. The converter now emits an ADF `link` mark pointing at `/browse/KEY` when a Jira base URL is available.

## Validation

- `uv run pytest -q` -> `2580 passed, 161 skipped`
- `uv run pre-commit run --files src/mcp_atlassian/jira/client.py src/mcp_atlassian/models/jira/adf.py tests/unit/jira/test_comments.py tests/unit/models/test_adf.py` -> passed
- `uv run pre-commit run --all-files` -> existing unrelated mypy failure on `src/mcp_atlassian/servers/main.py:363` (`TTLCache` expects 3 type arguments, but 2 given)
