### PR TITLE
fix(jira): raise MCPAtlassianError so isError=true on the MCP wire

### DIFF
--- a/src/mcp_atlassian/exceptions.py
+++ b/src/mcp_atlassian/exceptions.py
@@ -1,4 +1,16 @@
-class MCPAtlassianAuthenticationError(Exception):
+class MCPAtlassianError(Exception):
+    """Base exception for MCP Atlassian tool failures.
+
+    Raised from `@jira_mcp.tool()` / `@confluence_mcp.tool()` handlers so the
+    failure surfaces on the MCP wire as `isError=true` (not as a JSON-encoded
+    success content block). The original cause should be chained via
+    `raise MCPAtlassianError(...) from e` to preserve the traceback.
+    """
+
+    pass
+
+
+class MCPAtlassianAuthenticationError(MCPAtlassianError):
     """Raised when Atlassian API authentication fails (401/403)."""
 
     pass

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2439,13 +2439,15 @@ async def get_all_projects(
         If JIRA_PROJECTS_FILTER is configured, only returns projects matching those keys.
 
     Raises:
-        ValueError: If the Jira client is not configured or available.
+        MCPAtlassianError: If fetching projects fails.
     """
     try:
         jira = await get_jira_fetcher(ctx)
         projects = jira.get_all_projects(include_archived=include_archived)
-    except (MCPAtlassianAuthenticationError, HTTPError, OSError, ValueError) as e:
-        error_message = ""
+    # Convert every handler failure, including unexpected client exceptions,
+    # to an MCP error so FastMCP marks the tool result as an error.
+    except Exception as e:
+        error_message = str(e)
         log_level = logging.ERROR
         if isinstance(e, MCPAtlassianAuthenticationError):
             error_message = f"Authentication/Permission Error: {str(e)}"
@@ -2453,11 +2455,8 @@ async def get_all_projects(
             error_message = f"Network or API Error: {str(e)}"
         elif isinstance(e, ValueError):
             error_message = f"Configuration Error: {str(e)}"
-
-        error_result = {
-            "success": False,
-            "error": error_message,
-        }
+        else:
+            logger.exception("Unexpected error in get_all_projects")
         logger.log(log_level, f"get_all_projects failed: {error_message}")
         raise MCPAtlassianError(error_message) from e
 
@@ -3068,7 +3067,6 @@ async def get_issue_dates(
         return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error getting issue dates for {issue_key}: {str(e)}")
-        error_result = {"success": False, "error": str(e), "issue_key": issue_key}
         raise MCPAtlassianError(str(e)) from e
 
 
@@ -3149,7 +3147,6 @@ async def get_issue_sla(
         return json.dumps(result.to_simplified_dict(), indent=2, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error calculating SLA for {issue_key}: {str(e)}")
-        error_result = {"success": False, "error": str(e), "issue_key": issue_key}
         raise MCPAtlassianError(str(e)) from e
 
 
@@ -3209,7 +3206,6 @@ async def get_issue_development_info(
         return json.dumps(result, indent=2, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error getting development info for {issue_key}: {str(e)}")
-        error_result = {"success": False, "error": str(e), "issue_key": issue_key}
         raise MCPAtlassianError(str(e)) from e
 
 
@@ -3271,5 +3267,4 @@ async def get_issues_development_info(
         return json.dumps(results, indent=2, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error getting development info for issues: {str(e)}")
-        error_result = {"success": False, "error": str(e)}
         raise MCPAtlassianError(str(e)) from e

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -10,7 +10,7 @@ from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, Text
 from pydantic import Field
 from requests.exceptions import HTTPError
 
-from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError, MCPAtlassianError
 from mcp_atlassian.jira.constants import DEFAULT_READ_JIRA_FIELDS
 from mcp_atlassian.jira.forms_common import convert_datetime_to_timestamp
 from mcp_atlassian.models.jira import JiraAttachment
@@ -2459,7 +2459,7 @@ async def get_all_projects(
             "error": error_message,
         }
         logger.log(log_level, f"get_all_projects failed: {error_message}")
-        return json.dumps(error_result, indent=2, ensure_ascii=False)
+        raise MCPAtlassianError(error_message) from e
 
     # Ensure all project keys are uppercase
     for project in projects:
@@ -3069,7 +3069,7 @@ async def get_issue_dates(
     except Exception as e:
         logger.error(f"Error getting issue dates for {issue_key}: {str(e)}")
         error_result = {"success": False, "error": str(e), "issue_key": issue_key}
-        return json.dumps(error_result, indent=2, ensure_ascii=False)
+        raise MCPAtlassianError(str(e)) from e
 
 
 @jira_mcp.tool(
@@ -3150,7 +3150,7 @@ async def get_issue_sla(
     except Exception as e:
         logger.error(f"Error calculating SLA for {issue_key}: {str(e)}")
         error_result = {"success": False, "error": str(e), "issue_key": issue_key}
-        return json.dumps(error_result, indent=2, ensure_ascii=False)
+        raise MCPAtlassianError(str(e)) from e
 
 
 @jira_mcp.tool(
@@ -3210,7 +3210,7 @@ async def get_issue_development_info(
     except Exception as e:
         logger.error(f"Error getting development info for {issue_key}: {str(e)}")
         error_result = {"success": False, "error": str(e), "issue_key": issue_key}
-        return json.dumps(error_result, indent=2, ensure_ascii=False)
+        raise MCPAtlassianError(str(e)) from e
 
 
 @jira_mcp.tool(
@@ -3272,4 +3272,4 @@ async def get_issues_development_info(
     except Exception as e:
         logger.error(f"Error getting development info for issues: {str(e)}")
         error_result = {"success": False, "error": str(e)}
-        return json.dumps(error_result, indent=2, ensure_ascii=False)
+        raise MCPAtlassianError(str(e)) from e

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1316,16 +1316,16 @@ async def test_get_all_projects_tool_api_error_handling(jira_client, mock_jira_f
 
     mock_jira_fetcher.get_all_projects.side_effect = HTTPError("API Error")
 
-    response = await jira_client.call_tool("jira_get_all_projects", {})
+    response = await jira_client.call_tool(
+        "jira_get_all_projects", {}, raise_on_error=False
+    )
 
     assert hasattr(response, "content")
+    assert response.is_error is True
     assert len(response.content) == 1
     msg = response.content[0]
     assert msg.type == "text"
-
-    data = json.loads(msg.text)
-    assert data["success"] is False
-    assert "API Error" in data["error"]
+    assert "Network or API Error: API Error" in msg.text
 
 
 @pytest.mark.anyio
@@ -1339,16 +1339,16 @@ async def test_get_all_projects_tool_authentication_error_handling(
         "Authentication failed"
     )
 
-    response = await jira_client.call_tool("jira_get_all_projects", {})
+    response = await jira_client.call_tool(
+        "jira_get_all_projects", {}, raise_on_error=False
+    )
 
     assert hasattr(response, "content")
+    assert response.is_error is True
     assert len(response.content) == 1
     msg = response.content[0]
     assert msg.type == "text"
-
-    data = json.loads(msg.text)
-    assert data["success"] is False
-    assert "Authentication/Permission Error" in data["error"]
+    assert "Authentication/Permission Error: Authentication failed" in msg.text
 
 
 @pytest.mark.anyio
@@ -1360,16 +1360,16 @@ async def test_get_all_projects_tool_configuration_error_handling(
         "Jira client not configured"
     )
 
-    response = await jira_client.call_tool("jira_get_all_projects", {})
+    response = await jira_client.call_tool(
+        "jira_get_all_projects", {}, raise_on_error=False
+    )
 
     assert hasattr(response, "content")
+    assert response.is_error is True
     assert len(response.content) == 1
     msg = response.content[0]
     assert msg.type == "text"
-
-    data = json.loads(msg.text)
-    assert data["success"] is False
-    assert "Configuration Error" in data["error"]
+    assert "Configuration Error: Jira client not configured" in msg.text
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_iserror_compliance.py
+++ b/tests/unit/test_iserror_compliance.py
@@ -13,57 +13,58 @@ while preserving the formatted message in `content` for the LLM.
 Reference: https://composio.dev/blog/mcp-security-vulnerabilities (Dayna
 Blackwell MCP security audit, June 2026).
 """
+
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from mcp_atlassian.exceptions import MCPAtlassianError
-from mcp_atlassian.servers.jira import jira_mcp
 
 
 @pytest.mark.asyncio
-async def test_get_all_projects_failure_raises_iserror() -> None:
-    """A failing get_all_projects call must surface as MCPAtlassianError
-    → isError=true on the MCP wire, not as a JSON-encoded success content."""
-    from mcp_atlassian.servers.jira import get_all_projects
+@pytest.mark.parametrize(
+    ("tool_name", "fetcher_method", "tool_kwargs"),
+    [
+        ("get_all_projects", "get_all_projects", {"include_archived": False}),
+        ("get_issue_dates", "get_issue_dates", {"issue_key": "PROJ-1"}),
+        ("get_issue_sla", "get_issue_sla", {"issue_key": "PROJ-1"}),
+        (
+            "get_issue_development_info",
+            "get_issue_development_info",
+            {"issue_key": "PROJ-1"},
+        ),
+        (
+            "get_issues_development_info",
+            "get_issues_development_info",
+            {"issue_keys": "PROJ-1,PROJ-2"},
+        ),
+    ],
+)
+async def test_jira_handler_failure_raises_iserror(
+    tool_name: str,
+    fetcher_method: str,
+    tool_kwargs: dict[str, object],
+) -> None:
+    """Each targeted Jira handler must surface failures as MCP errors."""
+    from mcp_atlassian.servers import jira as jira_server
 
     fake_fetcher = MagicMock()
-    fake_fetcher.get_all_projects.side_effect = RuntimeError("api down")
+    original_error = RuntimeError("api down")
+    getattr(fake_fetcher, fetcher_method).side_effect = original_error
 
     fake_ctx = MagicMock()
-    fake_ctx.request_context.lifespan_context = {"jira": fake_fetcher}
 
     with patch(
-        "mcp_atlassian.servers.jira.get_jira_fetcher", new=AsyncMock(return_value=fake_fetcher)
+        "mcp_atlassian.servers.jira.get_jira_fetcher",
+        new=AsyncMock(return_value=fake_fetcher),
     ):
         with pytest.raises(MCPAtlassianError) as exc_info:
-            await get_all_projects.fn(ctx=fake_ctx, include_archived=False)
-        assert "api down" in str(exc_info.value) or "Network" in str(exc_info.value)
+            await getattr(jira_server, tool_name).fn(ctx=fake_ctx, **tool_kwargs)
 
-
-@pytest.mark.asyncio
-async def test_get_issue_dates_failure_raises_iserror() -> None:
-    """A failing get_issue_dates call must surface as MCPAtlassianError."""
-    from mcp_atlassian.servers.jira import get_issue_dates
-
-    fake_fetcher = MagicMock()
-    fake_fetcher.get_issue_dates = MagicMock(side_effect=ValueError("missing key"))
-
-    fake_ctx = MagicMock()
-    fake_ctx.request_context.lifespan_context = {"jira": fake_fetcher}
-
-    with patch(
-        "mcp_atlassian.servers.jira.get_jira_fetcher", new=AsyncMock(return_value=fake_fetcher)
-    ):
-        with pytest.raises(MCPAtlassianError) as exc_info:
-            await get_issue_dates.fn(
-                ctx=fake_ctx,
-                issue_key="PROJ-1",
-            )
-        assert "missing key" in str(exc_info.value)
+    assert str(exc_info.value) == "api down"
+    assert exc_info.value.__cause__ is original_error
 
 
 def test_mcp_atlassian_error_is_subclass_of_exception() -> None:

--- a/tests/unit/test_iserror_compliance.py
+++ b/tests/unit/test_iserror_compliance.py
@@ -1,0 +1,80 @@
+"""Regression tests for isError-compliance in mcp-atlassian.
+
+5 `@jira_mcp.tool()` handlers caught exceptions and returned a JSON-encoded
+`{"success": False, "error": ...}` string. FastMCP wraps the return value
+as success content with `isError=false`, so MCP clients treat the failure
+as data and the LLM often proceeds as if the call had succeeded.
+
+The fix introduces `MCPAtlassianError` (base class for Atlassian-side
+failures) and replaces each swallowed-error return with `raise
+MCPAtlassianError(...) from e` so FastMCP sets `isError=true` on the wire
+while preserving the formatted message in `content` for the LLM.
+
+Reference: https://composio.dev/blog/mcp-security-vulnerabilities (Dayna
+Blackwell MCP security audit, June 2026).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.exceptions import MCPAtlassianError
+from mcp_atlassian.servers.jira import jira_mcp
+
+
+@pytest.mark.asyncio
+async def test_get_all_projects_failure_raises_iserror() -> None:
+    """A failing get_all_projects call must surface as MCPAtlassianError
+    → isError=true on the MCP wire, not as a JSON-encoded success content."""
+    from mcp_atlassian.servers.jira import get_all_projects
+
+    fake_fetcher = MagicMock()
+    fake_fetcher.get_all_projects.side_effect = RuntimeError("api down")
+
+    fake_ctx = MagicMock()
+    fake_ctx.request_context.lifespan_context = {"jira": fake_fetcher}
+
+    with patch(
+        "mcp_atlassian.servers.jira.get_jira_fetcher", new=AsyncMock(return_value=fake_fetcher)
+    ):
+        with pytest.raises(MCPAtlassianError) as exc_info:
+            await get_all_projects.fn(ctx=fake_ctx, include_archived=False)
+        assert "api down" in str(exc_info.value) or "Network" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_get_issue_dates_failure_raises_iserror() -> None:
+    """A failing get_issue_dates call must surface as MCPAtlassianError."""
+    from mcp_atlassian.servers.jira import get_issue_dates
+
+    fake_fetcher = MagicMock()
+    fake_fetcher.get_issue_dates = MagicMock(side_effect=ValueError("missing key"))
+
+    fake_ctx = MagicMock()
+    fake_ctx.request_context.lifespan_context = {"jira": fake_fetcher}
+
+    with patch(
+        "mcp_atlassian.servers.jira.get_jira_fetcher", new=AsyncMock(return_value=fake_fetcher)
+    ):
+        with pytest.raises(MCPAtlassianError) as exc_info:
+            await get_issue_dates.fn(
+                ctx=fake_ctx,
+                issue_key="PROJ-1",
+            )
+        assert "missing key" in str(exc_info.value)
+
+
+def test_mcp_atlassian_error_is_subclass_of_exception() -> None:
+    """Sanity: the new base class is a real Exception subclass so it
+    can be raised from `except Exception` clauses and propagate cleanly."""
+    assert issubclass(MCPAtlassianError, Exception)
+
+
+def test_existing_authentication_error_still_subclass() -> None:
+    """Backward compat: MCPAtlassianAuthenticationError must remain a
+    subclass of the new base so `except MCPAtlassianError` catches it."""
+    from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+
+    assert issubclass(MCPAtlassianAuthenticationError, MCPAtlassianError)


### PR DESCRIPTION
## Summary

5 `@jira_mcp.tool()` handlers in `src/mcp_atlassian/servers/jira.py` (`get_all_projects`, `get_issue_dates`, `get_issue_sla`, `get_issue_development_info`, `get_issues_development_info`) caught exceptions and returned a JSON-encoded `{"success": False, "error": ...}` string. FastMCP wraps the return value as success content with `isError=false`, so MCP clients treat the failure as data and the LLM often proceeds as if the call had succeeded.

This is the same `isError`-compliance gap flagged in the recent MCP security audit (Dayna Blackwell, Tool Poisoning, Rug Pulls, and Prompt Injections — oh my!).

## Changes

- `src/mcp_atlassian/exceptions.py`: introduces `MCPAtlassianError` as the new base class. `MCPAtlassianAuthenticationError` is re-rooted to subclass it for backward compatibility — `except MCPAtlassianAuthenticationError` keeps working.
- `src/mcp_atlassian/servers/jira.py`: each swallowed-error `return json.dumps(error_result, ...)` is replaced with `raise MCPAtlassianError(message) from e`. FastMCP sets `isError=true` on the wire while preserving the formatted message in `content` for the LLM.
- `tests/unit/test_iserror_compliance.py`: regression coverage asserting a failing call to `get_all_projects` / `get_issue_dates` raises `MCPAtlassianError` (which FastMCP maps to `isError=true` on the wire), plus backward-compat assertions on the new exception hierarchy.

## Tests

```
$ pytest tests/unit/test_iserror_compliance.py -v
test_get_all_projects_failure_raises_iserror PASSED
test_get_issue_dates_failure_raises_iserror PASSED
test_mcp_atlassian_error_is_subclass_of_exception PASSED
test_existing_authentication_error_still_subclass PASSED
```

Reference: https://composio.dev/blog/mcp-security-vulnerabilities