### PR TITLE
fix(confluence): save reply body on Server/DC comment threads

### DIFF
--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -172,13 +172,27 @@ class CommentsMixin(ConfluenceClient):
                 )
                 space_key = ""
             else:
-                # v1 API: POST /rest/api/content/ with container type "comment"
+                # v1 API (Server/DC): thread replies under the parent page with
+                # ancestors, not as a direct child of the parent comment.
+                # Using container.type="comment" creates an empty stub on Server/DC.
+                parent_comment = self.confluence.get_page_by_id(
+                    page_id=comment_id, expand="container"
+                )
+                page_id = parent_comment.get("container", {}).get("id")
+                if not page_id:
+                    logger.error(
+                        "Failed to resolve container page for parent comment %s",
+                        comment_id,
+                    )
+                    return None
+
                 data: dict[str, Any] = {
                     "type": "comment",
                     "container": {
-                        "id": comment_id,
-                        "type": "comment",
+                        "id": page_id,
+                        "type": "page",
                     },
+                    "ancestors": [{"id": comment_id}],
                     "body": {
                         "storage": {
                             "value": content,

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -172,9 +172,10 @@ class CommentsMixin(ConfluenceClient):
                 )
                 space_key = ""
             else:
-                # v1 API (Server/DC): thread replies under the parent page with
-                # ancestors, not as a direct child of the parent comment.
-                # Using container.type="comment" creates an empty stub on Server/DC.
+                # v1 API (Cloud Basic and Server/DC): thread replies under the
+                # parent page with ancestors, not as a direct child of the
+                # parent comment. Using container.type="comment" creates an
+                # empty stub on Server/DC.
                 parent_comment = self.confluence.get_page_by_id(
                     page_id=comment_id, expand="container"
                 )

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -137,3 +137,34 @@ class TestConfluenceCloudComments:
 
         comments = confluence_fetcher.get_page_comments(page.id)
         assert len(comments) > 0
+
+    def test_reply_to_comment_preserves_body(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Reply Test {uid}",
+            body="<p>For reply testing.</p>",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        parent = confluence_fetcher.add_comment(
+            page_id=page.id,
+            content=f"Cloud E2E parent comment {uid}",
+        )
+        assert parent is not None
+
+        reply = confluence_fetcher.reply_to_comment(
+            comment_id=parent.id,
+            content=f"Cloud E2E reply body {uid}",
+        )
+        assert reply is not None
+
+        comments = confluence_fetcher.get_page_comments(page.id)
+        assert any(
+            f"Cloud E2E reply body {uid}" in comment.body for comment in comments
+        )

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -121,3 +121,32 @@ class TestConfluenceDCComments:
 
         comments = confluence_fetcher.get_page_comments(page.id)
         assert len(comments) > 0
+
+    def test_reply_to_comment_preserves_body(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        dc_instance: DCInstanceInfo,
+        resource_tracker: DCResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=dc_instance.space_key,
+            title=f"E2E Reply Test {uid}",
+            body="<p>For reply testing.</p>",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        parent = confluence_fetcher.add_comment(
+            page_id=page.id,
+            content=f"E2E parent comment {uid}",
+        )
+        assert parent is not None
+
+        reply = confluence_fetcher.reply_to_comment(
+            comment_id=parent.id,
+            content=f"E2E reply body {uid}",
+        )
+        assert reply is not None
+
+        comments = confluence_fetcher.get_page_comments(page.id)
+        assert any(f"E2E reply body {uid}" in comment.body for comment in comments)

--- a/tests/fixtures/confluence_mocks.py
+++ b/tests/fixtures/confluence_mocks.py
@@ -538,6 +538,19 @@ MOCK_PAGES_FROM_SPACE_RESPONSE = [
 # Comment Reply Mock Data
 # ============================================================================
 
+MOCK_PARENT_COMMENT_V1_RESPONSE = {
+    "id": "456789123",
+    "type": "comment",
+    "status": "current",
+    "title": "Original Comment",
+    "container": {
+        "id": "987654321",
+        "type": "page",
+        "status": "current",
+        "title": "Example Page",
+    },
+}
+
 MOCK_COMMENT_REPLY_V1_RESPONSE = {
     "id": "111222333",
     "type": "comment",

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -275,8 +275,9 @@ class TestCommentsMixin:
 class TestReplyToComment:
     """Tests for reply_to_comment method."""
 
-    def test_reply_to_comment_v1_success(self, comments_mixin):
-        """T1: reply_to_comment v1 success - parent_comment_id set."""
+    def test_reply_to_comment_v1_cloud_basic_success(self, comments_mixin):
+        """T1: v1 Cloud Basic replies use the parent page as the container."""
+        assert comments_mixin.config.is_cloud is True
         comments_mixin.confluence.get_page_by_id.return_value = (
             MOCK_PARENT_COMMENT_V1_RESPONSE
         )
@@ -311,8 +312,42 @@ class TestReplyToComment:
             },
         )
 
+    def test_reply_to_comment_v1_server_dc_success(self, comments_mixin):
+        """T2: v1 Server/DC replies use the parent page as the container."""
+        comments_mixin.config.url = "https://confluence.example.com"
+        assert comments_mixin.config.is_cloud is False
+        comments_mixin.confluence.get_page_by_id.return_value = (
+            MOCK_PARENT_COMMENT_V1_RESPONSE
+        )
+        comments_mixin.confluence.post.return_value = MOCK_COMMENT_REPLY_V1_RESPONSE
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>This is a reply</p>"
+        )
+
+        result = comments_mixin.reply_to_comment("456789123", "This is a reply")
+
+        assert result is not None
+        assert result.parent_comment_id == "456789123"
+        comments_mixin.confluence.get_page_by_id.assert_called_once_with(
+            page_id="456789123", expand="container"
+        )
+        comments_mixin.confluence.post.assert_called_once_with(
+            "rest/api/content/",
+            data={
+                "type": "comment",
+                "container": {"id": "987654321", "type": "page"},
+                "ancestors": [{"id": "456789123"}],
+                "body": {
+                    "storage": {
+                        "value": "<p>This is a reply</p>",
+                        "representation": "storage",
+                    },
+                },
+            },
+        )
+
     def test_reply_to_comment_v2_oauth_success(self, comments_mixin):
-        """T2: reply_to_comment v2/OAuth routes through v2_adapter."""
+        """T3: reply_to_comment v2/OAuth routes through v2_adapter."""
         # Configure as OAuth Cloud
         comments_mixin.config.auth_type = "oauth"
         comments_mixin.config.url = "https://test.atlassian.net/wiki"
@@ -358,7 +393,7 @@ class TestReplyToComment:
         )
 
     def test_reply_with_html_content(self, comments_mixin):
-        """T3: Reply with HTML content skips markdown conversion."""
+        """T4: Reply with HTML content skips markdown conversion."""
         comments_mixin.confluence.get_page_by_id.return_value = (
             MOCK_PARENT_COMMENT_V1_RESPONSE
         )
@@ -374,7 +409,7 @@ class TestReplyToComment:
         comments_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
 
     def test_reply_network_error(self, comments_mixin):
-        """T4: Network error returns None."""
+        """T5: Network error returns None."""
         comments_mixin.confluence.get_page_by_id.return_value = (
             MOCK_PARENT_COMMENT_V1_RESPONSE
         )
@@ -390,7 +425,7 @@ class TestReplyToComment:
         assert result is None
 
     def test_reply_empty_response(self, comments_mixin):
-        """T5: Empty API response returns None."""
+        """T6: Empty API response returns None."""
         comments_mixin.confluence.get_page_by_id.return_value = (
             MOCK_PARENT_COMMENT_V1_RESPONSE
         )
@@ -404,7 +439,7 @@ class TestReplyToComment:
         assert result is None
 
     def test_reply_missing_container_page_returns_none(self, comments_mixin):
-        """T6: Missing parent page container returns None instead of empty stub."""
+        """T7: Missing parent page container returns None instead of empty stub."""
         comments_mixin.confluence.get_page_by_id.return_value = {
             "id": "456789123",
             "type": "comment",

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -10,6 +10,7 @@ from mcp_atlassian.models.confluence import ConfluenceComment
 from tests.fixtures.confluence_mocks import (
     MOCK_COMMENT_REPLY_V1_RESPONSE,
     MOCK_COMMENT_REPLY_V2_RESPONSE,
+    MOCK_PARENT_COMMENT_V1_RESPONSE,
 )
 
 
@@ -276,9 +277,10 @@ class TestReplyToComment:
 
     def test_reply_to_comment_v1_success(self, comments_mixin):
         """T1: reply_to_comment v1 success - parent_comment_id set."""
-        # Mock the POST call for v1 API
+        comments_mixin.confluence.get_page_by_id.return_value = (
+            MOCK_PARENT_COMMENT_V1_RESPONSE
+        )
         comments_mixin.confluence.post.return_value = MOCK_COMMENT_REPLY_V1_RESPONSE
-        # Mock preprocessor
         comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
             "<p>This is a reply</p>"
         )
@@ -291,7 +293,23 @@ class TestReplyToComment:
 
         assert result is not None
         assert result.parent_comment_id == "456789123"
-        comments_mixin.confluence.post.assert_called_once()
+        comments_mixin.confluence.get_page_by_id.assert_called_once_with(
+            page_id="456789123", expand="container"
+        )
+        comments_mixin.confluence.post.assert_called_once_with(
+            "rest/api/content/",
+            data={
+                "type": "comment",
+                "container": {"id": "987654321", "type": "page"},
+                "ancestors": [{"id": "456789123"}],
+                "body": {
+                    "storage": {
+                        "value": "<p>This is a reply</p>",
+                        "representation": "storage",
+                    },
+                },
+            },
+        )
 
     def test_reply_to_comment_v2_oauth_success(self, comments_mixin):
         """T2: reply_to_comment v2/OAuth routes through v2_adapter."""
@@ -341,6 +359,9 @@ class TestReplyToComment:
 
     def test_reply_with_html_content(self, comments_mixin):
         """T3: Reply with HTML content skips markdown conversion."""
+        comments_mixin.confluence.get_page_by_id.return_value = (
+            MOCK_PARENT_COMMENT_V1_RESPONSE
+        )
         comments_mixin.confluence.post.return_value = MOCK_COMMENT_REPLY_V1_RESPONSE
         comments_mixin.preprocessor.process_html_content.return_value = (
             "<p>HTML reply</p>",
@@ -354,6 +375,9 @@ class TestReplyToComment:
 
     def test_reply_network_error(self, comments_mixin):
         """T4: Network error returns None."""
+        comments_mixin.confluence.get_page_by_id.return_value = (
+            MOCK_PARENT_COMMENT_V1_RESPONSE
+        )
         comments_mixin.confluence.post.side_effect = requests.RequestException(
             "Connection error"
         )
@@ -367,6 +391,9 @@ class TestReplyToComment:
 
     def test_reply_empty_response(self, comments_mixin):
         """T5: Empty API response returns None."""
+        comments_mixin.confluence.get_page_by_id.return_value = (
+            MOCK_PARENT_COMMENT_V1_RESPONSE
+        )
         comments_mixin.confluence.post.return_value = None
         comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
             "<p>Test</p>"
@@ -375,6 +402,22 @@ class TestReplyToComment:
         result = comments_mixin.reply_to_comment("456789123", "Test")
 
         assert result is None
+
+    def test_reply_missing_container_page_returns_none(self, comments_mixin):
+        """T6: Missing parent page container returns None instead of empty stub."""
+        comments_mixin.confluence.get_page_by_id.return_value = {
+            "id": "456789123",
+            "type": "comment",
+            "container": {},
+        }
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Test</p>"
+        )
+
+        result = comments_mixin.reply_to_comment("456789123", "Test")
+
+        assert result is None
+        comments_mixin.confluence.post.assert_not_called()
 
 
 class TestAddCommentV2Routing:


### PR DESCRIPTION
## Summary

Fixes `confluence_reply_to_comment` creating empty comment stubs on Confluence Server/Data Center.

## Motivation

On Server/DC, the v1 reply path posted with `container: {id: parent_comment_id, type: "comment"}`. Confluence accepted the request but persisted an empty body, so the tool reported success while the UI showed blank replies (#1409).

## Changes

- Resolve the parent comment's container page via `get_page_by_id(..., expand="container")`
- Create threaded replies with `container: {id: page_id, type: "page"}` and `ancestors: [{id: parent_comment_id}]`
- Return `None` when the parent page cannot be resolved instead of posting a stub
- Add regression tests for the Server/DC POST payload and missing-container handling

OAuth Cloud v2 routing is unchanged.

## Tests

```text
uv run pytest tests/unit/confluence/test_comments.py -q
# 27 passed

uv run ruff check src/mcp_atlassian/confluence/comments.py tests/unit/confluence/test_comments.py tests/fixtures/confluence_mocks.py
# All checks passed
```

## Notes

- Reviewed with composer-2.5: APPROVE
- Blog-post-hosted comments may need `container.type` propagated from the parent fetch in a follow-up; this issue is page-thread scoped

Fixes #1409