### PR TITLE
fix(confluence): handle timestamp overflow in TimestampMixin

### DIFF
--- a/src/mcp_atlassian/models/base.py
+++ b/src/mcp_atlassian/models/base.py
@@ -6,10 +6,11 @@ Jira and Confluence models to ensure consistent behavior and reduce
 code duplication.
 """
 
-from datetime import datetime
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
+
+from mcp_atlassian.utils import parse_date
 
 from .constants import EMPTY_STRING
 
@@ -73,23 +74,11 @@ class TimestampMixin:
             return EMPTY_STRING
 
         try:
-            # Parse ISO 8601 format like "2024-01-01T10:00:00.000+0000"
-            # Convert Z format to +00:00 for compatibility with fromisoformat
-            ts = timestamp.replace("Z", "+00:00")
-
-            # Handle timezone format without colon (+0000 -> +00:00)
-            if "+" in ts and ":" not in ts[-5:]:
-                tz_pos = ts.rfind("+")
-                if tz_pos != -1 and len(ts) >= tz_pos + 5:
-                    ts = ts[: tz_pos + 3] + ":" + ts[tz_pos + 3 :]
-            elif "-" in ts and ":" not in ts[-5:]:
-                tz_pos = ts.rfind("-")
-                if tz_pos != -1 and len(ts) >= tz_pos + 5:
-                    ts = ts[: tz_pos + 3] + ":" + ts[tz_pos + 3 :]
-
-            dt = datetime.fromisoformat(ts)
+            dt = parse_date(timestamp)
+            if dt is None:
+                return timestamp or EMPTY_STRING
             return dt.strftime("%Y-%m-%d %H:%M:%S")
-        except (ValueError, TypeError):
+        except ValueError:
             return timestamp or EMPTY_STRING
 
     @staticmethod
@@ -107,20 +96,6 @@ class TimestampMixin:
             return False
 
         try:
-            # Convert Z format to +00:00 for compatibility with fromisoformat
-            ts = timestamp.replace("Z", "+00:00")
-
-            # Handle timezone format without colon (+0000 -> +00:00)
-            if "+" in ts and ":" not in ts[-5:]:
-                tz_pos = ts.rfind("+")
-                if tz_pos != -1 and len(ts) >= tz_pos + 5:
-                    ts = ts[: tz_pos + 3] + ":" + ts[tz_pos + 3 :]
-            elif "-" in ts and ":" not in ts[-5:]:
-                tz_pos = ts.rfind("-")
-                if tz_pos != -1 and len(ts) >= tz_pos + 5:
-                    ts = ts[: tz_pos + 3] + ":" + ts[tz_pos + 3 :]
-
-            datetime.fromisoformat(ts)
-            return True
-        except (ValueError, TypeError):
+            return parse_date(timestamp) is not None
+        except ValueError:
             return False

--- a/tests/unit/models/test_base_models.py
+++ b/tests/unit/models/test_base_models.py
@@ -80,6 +80,38 @@ class TestTimestampMixin:
 
         assert result == invalid_timestamp  # Should return the original string
 
+    def test_format_timestamp_overflow_returns_original(self):
+        """Regression test for #1354: sentinel dates must not crash Confluence tools."""
+        from unittest.mock import patch
+
+        timestamp = "9999-12-31T23:59:59.000+0000"
+        formatter = TimestampMixin()
+
+        with patch("src.mcp_atlassian.models.base.parse_date", return_value=None):
+            result = formatter.format_timestamp(timestamp)
+
+        assert result == timestamp
+
+    def test_is_valid_timestamp_overflow_returns_false(self):
+        """Regression test for #1354: overflow timestamps are treated as invalid."""
+        from unittest.mock import patch
+
+        timestamp = "9999-12-31T23:59:59.000+0000"
+        formatter = TimestampMixin()
+
+        with patch("src.mcp_atlassian.models.base.parse_date", return_value=None):
+            assert formatter.is_valid_timestamp(timestamp) is False
+
+    def test_format_timestamp_epoch_overflow_returns_original(self):
+        """Regression test for #1354: out-of-range epoch strings do not crash."""
+        formatter = TimestampMixin()
+        overflow_epoch = "253402300800000"
+
+        result = formatter.format_timestamp(overflow_epoch)
+
+        assert result == overflow_epoch
+        assert formatter.is_valid_timestamp(overflow_epoch) is False
+
     def test_is_valid_timestamp_valid(self):
         """Test validating a valid ISO 8601 timestamp."""
         timestamp = "2024-01-01T12:34:56.789+0000"


### PR DESCRIPTION
## Summary

Confluence tools could crash with `timestamp too large to convert to C _PyTime_t` when formatting page/comment timestamps from Server/DC instances. This is the same class of bug fixed for Jira in #1033.

## Motivation

`TimestampMixin.format_timestamp()` used `datetime.fromisoformat()` directly and only caught `(ValueError, TypeError)`. Sentinel or out-of-range timestamps (common on legacy Confluence Server/DC) raise `OverflowError`/`OSError` on Windows and Python 3.14+, causing Confluence search and page tools to fail.

## Changes

- Route `TimestampMixin.format_timestamp()` and `is_valid_timestamp()` through the existing `parse_date()` utility, which already handles overflow gracefully for Jira.
- Add regression tests for #1354, including an unmocked out-of-range epoch case.

## Tests

- `uv run pytest tests/unit/models/test_base_models.py` — 12 passed
- `uv run pytest tests/unit/models/` — 224 passed, 5 skipped
- `uv run ruff check` on changed files — clean

## Notes

- Valid ISO timestamps keep the same formatted output as before.
- The reporter's `Retry-After` quota scenario is a separate HTTP path; this PR fixes the Confluence model timestamp crash described in #1354.

Fixes #1354