### PR TITLE
fix(http): cache multi-user token validation across requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,12 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 
 # --- HTTP Timeout ---
 # Timeout in seconds for HTTP requests to Atlassian APIs. Default is 75 seconds.
+
+# --- Multi-user token validation cache ---
+# Cache successful credential validation across HTTP requests (multi-user mode).
+# Reduces repeated calls to /rest/api/user/current and Jira myself() during bursts.
+#MCP_ATLASSIAN_VALIDATION_CACHE_TTL=300
+#MCP_ATLASSIAN_VALIDATION_CACHE_MAXSIZE=100
 #JIRA_TIMEOUT=75
 #CONFLUENCE_TIMEOUT=75
 

--- a/src/mcp_atlassian/confluence/users.py
+++ b/src/mcp_atlassian/confluence/users.py
@@ -83,6 +83,15 @@ class UsersMixin(ConfluenceClient):
                 raise MCPAtlassianAuthenticationError(
                     f"Confluence token validation failed: {http_err.response.status_code} from /rest/api/user/current"
                 ) from http_err
+            if http_err.response is not None and http_err.response.status_code == 429:
+                logger.warning(
+                    "Confluence token validation rate-limited with HTTP 429 "
+                    "for /rest/api/user/current."
+                )
+                raise MCPAtlassianAuthenticationError(
+                    "Confluence token validation rate-limited (HTTP 429) by "
+                    "/rest/api/user/current. Retry later or reduce request volume."
+                ) from http_err
             logger.error(
                 f"HTTPError when calling Confluence /rest/api/user/current: {http_err}",
                 exc_info=True,

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -8,6 +8,7 @@ import requests
 from requests.exceptions import HTTPError
 from unidecode import unidecode
 
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.models.jira.common import JiraUser
 from mcp_atlassian.utils.decorators import handle_auth_errors
 
@@ -91,6 +92,15 @@ class UsersMixin(JiraClient):
             self._current_user_account_id = account_id
             return account_id
         except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code == 429:
+                logger.warning(
+                    "Jira token validation rate-limited with HTTP 429 while "
+                    "calling myself()."
+                )
+                raise MCPAtlassianAuthenticationError(
+                    "Jira token validation rate-limited (HTTP 429) while "
+                    "validating credentials. Retry later or reduce request volume."
+                ) from http_err
             response_content = ""
             if http_err.response is not None:
                 try:

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -13,7 +13,6 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from cachetools import TTLCache
-
 from fastmcp import Context
 from fastmcp.server.dependencies import get_access_token, get_http_request
 from starlette.requests import Request

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -6,9 +6,13 @@ Provides get_jira_fetcher and get_confluence_fetcher for use in tool functions.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import logging
+import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
+
+from cachetools import TTLCache
 
 from fastmcp import Context
 from fastmcp.server.dependencies import get_access_token, get_http_request
@@ -27,6 +31,38 @@ if TYPE_CHECKING:
     from mcp_atlassian.jira.config import JiraConfig as UserJiraConfigType
 
 logger = logging.getLogger("mcp-atlassian.servers.dependencies")
+
+_validation_cache: TTLCache[str, Any] | None = None
+
+
+def _get_validation_cache() -> TTLCache[str, Any] | None:
+    """Return the cross-request validation cache, or None when disabled."""
+    global _validation_cache
+    try:
+        ttl = int(os.getenv("MCP_ATLASSIAN_VALIDATION_CACHE_TTL", "300"))
+    except ValueError:
+        ttl = 300
+    if ttl <= 0:
+        return None
+
+    try:
+        maxsize = int(os.getenv("MCP_ATLASSIAN_VALIDATION_CACHE_MAXSIZE", "100"))
+    except ValueError:
+        maxsize = 100
+
+    if (
+        _validation_cache is None
+        or _validation_cache.ttl != ttl
+        or _validation_cache.maxsize != maxsize
+    ):
+        _validation_cache = TTLCache(maxsize=maxsize, ttl=ttl)
+    return _validation_cache
+
+
+def _clear_validation_cache_for_tests() -> None:
+    """Reset the validation cache (test helper)."""
+    global _validation_cache
+    _validation_cache = None
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +200,49 @@ def _confluence_spec() -> _ServiceSpec:
     )
 
 
+def _validation_cache_key(spec: _ServiceSpec, config: Any) -> str | None:
+    """Build a stable cache key from service name and hashed credentials."""
+    url = getattr(config, "url", None)
+    auth_type = getattr(config, "auth_type", None)
+    if not isinstance(url, str) or not isinstance(auth_type, str):
+        return None
+
+    secret_parts: list[str] = [spec.name, url, auth_type]
+
+    if auth_type == "pat":
+        token = getattr(config, "personal_token", None)
+        if not isinstance(token, str) or not token:
+            return None
+        secret_parts.append(token)
+    elif auth_type == "basic":
+        username = getattr(config, "username", None)
+        api_token = getattr(config, "api_token", None)
+        if (
+            not isinstance(username, str)
+            or not username
+            or not isinstance(api_token, str)
+            or not api_token
+        ):
+            return None
+        secret_parts.extend([username, api_token])
+    elif auth_type == "oauth":
+        oauth_config = getattr(config, "oauth_config", None)
+        if oauth_config is None:
+            return None
+        access_token = getattr(oauth_config, "access_token", None)
+        if not isinstance(access_token, str) or not access_token:
+            return None
+        secret_parts.append(access_token)
+        cloud_id = getattr(oauth_config, "cloud_id", None)
+        if isinstance(cloud_id, str) and cloud_id:
+            secret_parts.append(cloud_id)
+    else:
+        return None
+
+    digest = hashlib.sha256("|".join(secret_parts).encode()).hexdigest()
+    return digest
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -231,7 +310,17 @@ def _create_and_validate(
             session.hooks["response"].append(
                 _make_ssrf_safe_hook(validate_url_for_ssrf)
             )
-        validation_data = spec.validate_fn(fetcher)
+        cache_key = _validation_cache_key(spec, config)
+        validation_cache = _get_validation_cache()
+        validation_data = (
+            validation_cache.get(cache_key)
+            if cache_key and validation_cache is not None
+            else None
+        )
+        if validation_data is None:
+            validation_data = spec.validate_fn(fetcher)
+            if cache_key and validation_cache is not None:
+                validation_cache[cache_key] = validation_data
         spec.on_validated(
             fn_name,
             request,

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -20,9 +20,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.config import ConfluenceConfig
-from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.utils.env import is_env_truthy
 from mcp_atlassian.utils.environment import get_available_services

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager
 from typing import Any, Literal, Optional
 from urllib.parse import urlparse
 
-from cachetools import TTLCache
 from fastmcp import FastMCP
 from fastmcp import settings as fastmcp_settings
 from fastmcp.server.event_store import EventStore
@@ -358,11 +357,6 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             retry_interval=retry_interval,
         )
         return app
-
-
-token_validation_cache: TTLCache[
-    int, tuple[bool, str | None, JiraFetcher | None, ConfluenceFetcher | None]
-] = TTLCache(maxsize=100, ttl=300)
 
 
 class UserTokenMiddleware:

--- a/tests/unit/confluence/test_users.py
+++ b/tests/unit/confluence/test_users.py
@@ -293,6 +293,19 @@ class TestUsersMixin:
         ):
             users_mixin.get_current_user_info()
 
+    def test_get_current_user_info_http_error_429(self, users_mixin):
+        """Test get_current_user_info with 429 rate limit error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        http_error = HTTPError(response=mock_response)
+        users_mixin.confluence.get.side_effect = http_error
+
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match="Confluence token validation rate-limited \\(HTTP 429\\)",
+        ):
+            users_mixin.get_current_user_info()
+
     def test_get_current_user_info_http_error_other(self, users_mixin):
         """Test get_current_user_info with other HTTP error codes."""
         # Arrange

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.jira.users import UsersMixin, normalize_text
 
@@ -91,6 +92,20 @@ class TestUsersMixin:
 
         # Verify self.jira.myself was called
         users_mixin.jira.myself.assert_called_once()
+
+    def test_get_current_user_account_id_http_error_429(self, users_mixin):
+        """Test that HTTP 429 is reported as a rate-limit validation error."""
+        users_mixin._current_user_account_id = None
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        http_error = requests.HTTPError(response=mock_response)
+        users_mixin.jira.myself = MagicMock(side_effect=http_error)
+
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match="Jira token validation rate-limited \\(HTTP 429\\)",
+        ):
+            users_mixin.get_current_user_account_id()
 
     def test_get_current_user_account_id_jira_data_center_key(self, users_mixin):
         """Test that get_current_user_account_id falls back to 'key' for Jira Data Center."""

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -11,6 +11,7 @@ from mcp_atlassian.confluence import ConfluenceConfig, ConfluenceFetcher
 from mcp_atlassian.jira import JiraConfig, JiraFetcher
 from mcp_atlassian.servers.context import MainAppContext
 from mcp_atlassian.servers.dependencies import (
+    _clear_validation_cache_for_tests,
     _create_user_config_for_fetcher,
     _resolve_bearer_auth_type,
     get_confluence_fetcher,
@@ -23,6 +24,14 @@ from tests.utils.mocks import MockFastMCP
 
 # Configure pytest for async tests
 pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def _reset_validation_cache():
+    """Prevent cross-request validation cache from leaking between tests."""
+    _clear_validation_cache_for_tests()
+    yield
+    _clear_validation_cache_for_tests()
 
 
 @pytest.fixture
@@ -1518,3 +1527,95 @@ class TestSsrfProtection:
 
         result = hook(mock_response)
         assert result == mock_response
+
+
+class TestValidationCache:
+    """Tests for cross-request token validation caching."""
+
+    def setup_method(self) -> None:
+        from mcp_atlassian.servers.dependencies import _clear_validation_cache_for_tests
+
+        _clear_validation_cache_for_tests()
+
+    def teardown_method(self) -> None:
+        from mcp_atlassian.servers.dependencies import _clear_validation_cache_for_tests
+
+        _clear_validation_cache_for_tests()
+
+    def test_create_and_validate_uses_cache_for_same_credentials(self, monkeypatch):
+        import dataclasses
+
+        from mcp_atlassian.jira import JiraConfig
+        from mcp_atlassian.servers.dependencies import (
+            _clear_validation_cache_for_tests,
+            _create_and_validate,
+            _jira_spec,
+        )
+
+        _clear_validation_cache_for_tests()
+        monkeypatch.setenv("MCP_ATLASSIAN_VALIDATION_CACHE_TTL", "300")
+
+        request = MagicMock()
+        request.state = MagicMock()
+        validate_fn = MagicMock(return_value="cached-account-id")
+        mock_fetcher = MagicMock()
+        spec = dataclasses.replace(
+            _jira_spec(),
+            validate_fn=validate_fn,
+            fetcher_class=MagicMock(return_value=mock_fetcher),
+        )
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="pat",
+            personal_token="shared-pat",
+            ssl_verify=True,
+            http_proxy=None,
+            https_proxy=None,
+            no_proxy=None,
+            socks_proxy=None,
+            projects_filter=None,
+        )
+
+        _create_and_validate(request, spec, config, "header_pat")
+        _create_and_validate(request, spec, config, "header_pat")
+
+        assert validate_fn.call_count == 1
+
+    def test_create_and_validate_skips_cache_when_disabled(self, monkeypatch):
+        import dataclasses
+
+        from mcp_atlassian.jira import JiraConfig
+        from mcp_atlassian.servers.dependencies import (
+            _clear_validation_cache_for_tests,
+            _create_and_validate,
+            _jira_spec,
+        )
+
+        _clear_validation_cache_for_tests()
+        monkeypatch.setenv("MCP_ATLASSIAN_VALIDATION_CACHE_TTL", "0")
+
+        request = MagicMock()
+        request.state = MagicMock()
+        validate_fn = MagicMock(return_value="cached-account-id")
+        mock_fetcher = MagicMock()
+        spec = dataclasses.replace(
+            _jira_spec(),
+            validate_fn=validate_fn,
+            fetcher_class=MagicMock(return_value=mock_fetcher),
+        )
+        config = JiraConfig(
+            url="https://test.atlassian.net",
+            auth_type="pat",
+            personal_token="shared-pat",
+            ssl_verify=True,
+            http_proxy=None,
+            https_proxy=None,
+            no_proxy=None,
+            socks_proxy=None,
+            projects_filter=None,
+        )
+
+        _create_and_validate(request, spec, config, "header_pat")
+        _create_and_validate(request, spec, config, "header_pat")
+
+        assert validate_fn.call_count == 2


### PR DESCRIPTION
## Description

Fixes #1405

In multi-user HTTP transport mode, every request re-validated upstream credentials against Atlassian (`/rest/api/user/current`, Jira `myself()`), even when the same credential was validated moments earlier. A `token_validation_cache` existed in `main.py` but was never wired up.

This PR adds a cross-request validation cache in `dependencies.py` and removes the dead declaration from `main.py`.

## Changes

- Cache successful `validate_fn` results keyed by SHA-256(service + url + credentials)
- Configurable via `MCP_ATLASSIAN_VALIDATION_CACHE_TTL` (default 300, `0` disables) and `MCP_ATLASSIAN_VALIDATION_CACHE_MAXSIZE` (default 100)
- Report HTTP 429 during token validation as rate-limit errors (Jira + Confluence) instead of generic invalid-token failures
- Document new env vars in `.env.example`

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: targeted pytest for dependencies + user validation modules

```
uv run pytest tests/unit/servers/test_dependencies.py tests/unit/confluence/test_users.py tests/unit/jira/test_users.py -q
# 139 passed
```

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).