### PR TITLE
fix(jira): accept issue keys with hyphens in numeric suffix

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -181,7 +181,9 @@ class JiraPreprocessor(BasePreprocessor):
             link_url = match.group(2)
 
             # Extract issue key if it's a Jira issue link
-            issue_key_match = re.search(r"browse/([A-Z][A-Z0-9_]+-\d+)", link_url)
+            issue_key_match = re.search(
+                r"browse/([A-Z][A-Z0-9_]+-\d+(?:-\d+)*)", link_url
+            )
             # Check if it's a Confluence wiki link
             confluence_match = re.search(
                 r"wiki/spaces/.+?/pages/\d+/(.+?)(?:\?|$)", link_url
@@ -194,7 +196,9 @@ class JiraPreprocessor(BasePreprocessor):
             elif confluence_match:
                 url_title = confluence_match.group(1)
                 readable_title = url_title.replace("+", " ")
-                readable_title = re.sub(r"^[A-Z][A-Z0-9_]+-\d+\s+", "", readable_title)
+                readable_title = re.sub(
+                    r"^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*\s+", "", readable_title
+                )
                 text = text.replace(full_match, f"[{readable_title}]({link_url})")
             else:
                 clean_url = link_url.split("?")[0]

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -29,8 +29,9 @@ logger = logging.getLogger(__name__)
 # Regex patterns for Jira key validation.
 # Per Atlassian docs, Cloud project keys are 2-10 chars. Server/Data Center
 # allows longer keys (configurable). We accept any length to support both.
-# Underscores are also allowed to support non-standard project key formats
-ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+$"
+# Underscores are also allowed to support non-standard project key formats.
+# Server/Data Center may use hyphens in the numeric suffix (e.g. B7-214-68901).
+ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$"
 PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+$"
 
 jira_mcp = FastMCP(

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1549,11 +1549,13 @@ def test_issue_key_pattern_validation():
     assert re.match(ISSUE_KEY_PATTERN, "ABCDEFGHIJ-99")
     assert re.match(ISSUE_KEY_PATTERN, "D_DEV-123")
     assert re.match(ISSUE_KEY_PATTERN, "MY_PROJECT-1")
+    assert re.match(ISSUE_KEY_PATTERN, "B7-214-68901")
     # Invalid issue keys
     assert not re.match(ISSUE_KEY_PATTERN, "a-1")
     assert not re.match(ISSUE_KEY_PATTERN, "PROJ")
     assert not re.match(ISSUE_KEY_PATTERN, "2ABC-1")
-    assert not re.match(ISSUE_KEY_PATTERN, "A-1-2")
+    assert not re.match(ISSUE_KEY_PATTERN, "PROJ-12A")
+    assert not re.match(ISSUE_KEY_PATTERN, "PROJ-")
 
     # Valid project keys
     assert re.match(PROJECT_KEY_PATTERN, "PROJ")


### PR DESCRIPTION
## Summary

Relax `ISSUE_KEY_PATTERN` so Jira Server/Data Center issue keys with hyphenated numeric suffixes (e.g. `B7-214-68901`) pass MCP tool validation.

Fixes #1389

## Motivation

Some Jira Server/DC instances use non-standard issue keys where the numeric part contains hyphens. The previous regex only allowed digits after the project key separator, causing validation errors before the tool could call Jira.

## Changes

- Update `ISSUE_KEY_PATTERN` in `src/mcp_atlassian/servers/jira.py` to `^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$`
- Align browse-link parsing and title-stripping regexes in `src/mcp_atlassian/preprocessing/jira.py`
- Extend unit tests with `B7-214-68901` and clearer invalid-key cases

## Tests

```sh
uv run pytest tests/unit/servers/test_jira_server.py::test_issue_key_pattern_validation \
  tests/unit/servers/test_jira_server.py::test_issue_and_project_key_patterns_accept_long_server_dc_keys \
  tests/unit/servers/test_jira_server.py::test_issue_and_project_key_patterns_reject_invalid_keys -q
```

Result: **3 passed**

## Notes

- Invalid keys with letters in the suffix (e.g. `PROJ-12A`) or a trailing hyphen (`PROJ-`) are still rejected.
- No behavioral change for standard Cloud-style keys like `PROJ-123`.