### PR TITLE
fix: wire up cross-request credential validation cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,12 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #JIRA_TIMEOUT=75
 #CONFLUENCE_TIMEOUT=75
 
+# --- Multi-user token validation cache ---
+# Cache successful credential validation across HTTP requests. Set TTL to 0 to
+# disable the cache. Default TTL is 300 seconds and default maximum size is 100.
+#MCP_ATLASSIAN_VALIDATION_CACHE_TTL=300
+#MCP_ATLASSIAN_VALIDATION_CACHE_MAXSIZE=100
+
 # --- Read-Only Mode ---
 # Disables all write operations (create, update, delete). Default is false.
 #READ_ONLY_MODE=false

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -128,6 +128,8 @@ This guide covers IDE integration, environment variables, and advanced configura
 | `CONFLUENCE_PERSONAL_TOKEN` | Confluence Personal Access Token (Server/DC) |
 | `CONFLUENCE_SSL_VERIFY` | SSL verification (`true`/`false`) |
 | `MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE` | Use OS native trust store (`true`/`false`, default: `true`) |
+| `MCP_ATLASSIAN_VALIDATION_CACHE_TTL` | Multi-user credential validation cache lifetime in seconds (`0` disables, default: `300`) |
+| `MCP_ATLASSIAN_VALIDATION_CACHE_MAXSIZE` | Maximum cached multi-user credential validations (default: `100`) |
 
 ### Filtering Options
 

--- a/src/mcp_atlassian/confluence/users.py
+++ b/src/mcp_atlassian/confluence/users.py
@@ -83,6 +83,19 @@ class UsersMixin(ConfluenceClient):
                 raise MCPAtlassianAuthenticationError(
                     f"Confluence token validation failed: {http_err.response.status_code} from /rest/api/user/current"
                 ) from http_err
+            if http_err.response is not None and http_err.response.status_code == 429:
+                logger.warning(
+                    "Confluence token validation was rate-limited (429) on "
+                    "/rest/api/user/current -- this is a transient rate-limit "
+                    "condition, not an invalid credential."
+                )
+                raise MCPAtlassianAuthenticationError(
+                    "Confluence token validation was rate-limited (429) by "
+                    "/rest/api/user/current. This is not an invalid-credential "
+                    "error; retry after backing off, or raise "
+                    "MCP_ATLASSIAN_VALIDATION_CACHE_TTL to reduce validation "
+                    "call frequency."
+                ) from http_err
             logger.error(
                 f"HTTPError when calling Confluence /rest/api/user/current: {http_err}",
                 exc_info=True,

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -8,6 +8,7 @@ import requests
 from requests.exceptions import HTTPError
 from unidecode import unidecode
 
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.models.jira.common import JiraUser
 from mcp_atlassian.utils.decorators import handle_auth_errors
 
@@ -91,6 +92,17 @@ class UsersMixin(JiraClient):
             self._current_user_account_id = account_id
             return account_id
         except HTTPError as http_err:
+            if http_err.response is not None and http_err.response.status_code == 429:
+                logger.warning(
+                    "Jira token validation was rate-limited (429) while "
+                    "calling myself()."
+                )
+                raise MCPAtlassianAuthenticationError(
+                    "Jira token validation was rate-limited (429) while "
+                    "validating credentials. Retry after backing off, or "
+                    "increase MCP_ATLASSIAN_VALIDATION_CACHE_TTL to reduce "
+                    "validation call frequency."
+                ) from http_err
             response_content = ""
             if http_err.response is not None:
                 try:

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -6,10 +6,13 @@ Provides get_jira_fetcher and get_confluence_fetcher for use in tool functions.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import logging
+import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from cachetools import TTLCache
 from fastmcp import Context
 from fastmcp.server.dependencies import get_access_token, get_http_request
 from starlette.requests import Request
@@ -51,6 +54,65 @@ class _ServiceSpec:
     on_validated: Callable[
         [str, Request, Any, str, str | None], None
     ]  # logging + email backfill
+
+
+# ---------------------------------------------------------------------------
+# Cross-request credential validation cache (#1405)
+#
+# In multi-user HTTP transport, every request builds a fresh fetcher on
+# request.state, so credential validation (a network call to Atlassian) was
+# firing once per request instead of once per credential. This cache dedupes
+# that call across requests for the configured TTL. Only a SHA-256 digest of
+# the credential is ever used as a key -- raw tokens are never stored.
+# ---------------------------------------------------------------------------
+
+
+def _validation_cache_ttl() -> int:
+    """TTL in seconds for cached validation results. 0 disables the cache."""
+    try:
+        return int(os.getenv("MCP_ATLASSIAN_VALIDATION_CACHE_TTL", "300"))
+    except ValueError:
+        return 300
+
+
+def _validation_cache_maxsize() -> int:
+    try:
+        return int(os.getenv("MCP_ATLASSIAN_VALIDATION_CACHE_MAXSIZE", "100"))
+    except ValueError:
+        return 100
+
+
+_CACHE_TTL = _validation_cache_ttl()
+_validation_cache: TTLCache[tuple[str, str], Any] | None = (
+    TTLCache(maxsize=_validation_cache_maxsize(), ttl=_CACHE_TTL)
+    if _CACHE_TTL > 0
+    else None
+)
+
+
+def _credential_for_cache(config: JiraConfig | ConfluenceConfig) -> str | None:
+    """Extract the secret that authenticates ``config``, for cache-key hashing.
+
+    Returns None when no credential-bearing field is set, so the caller can
+    skip caching rather than key on an empty/ambiguous value.
+    """
+    if config.auth_type == "oauth":
+        oauth_cfg = getattr(config, "oauth_config", None)
+        return getattr(oauth_cfg, "access_token", None) if oauth_cfg else None
+    if config.auth_type == "pat":
+        return config.personal_token
+    if config.auth_type == "basic":
+        if not config.api_token:
+            return None
+        # Username + token together identify the credential; a token reused
+        # under a different username should still validate independently.
+        return f"{getattr(config, 'username', '') or ''}:{config.api_token}"
+    return None
+
+
+def _validation_cache_key(spec: _ServiceSpec, credential: str) -> tuple[str, str]:
+    digest = hashlib.sha256(credential.encode("utf-8")).hexdigest()
+    return (spec.name, digest)
 
 
 def _jira_on_validated(
@@ -208,6 +270,10 @@ def _create_and_validate(
 ) -> Any:
     """Create a fetcher, validate credentials, cache on request.state.
 
+    The validation network call itself is deduped across requests for the
+    same credential via ``_validation_cache`` (#1405) -- only fetcher
+    construction and ``request.state`` caching happen per-request.
+
     Args:
         request: The current Starlette request.
         spec: Service specification.
@@ -224,6 +290,12 @@ def _create_and_validate(
     """
     fn_name = f"get_{spec.name.lower()}_fetcher"
     auth_desc = "header-based" if auth_branch == "header_pat" else "user"
+    credential = _credential_for_cache(config)
+    cache_key = (
+        _validation_cache_key(spec, credential)
+        if credential and _validation_cache is not None
+        else None
+    )
     try:
         fetcher = spec.fetcher_class(config=config)
         if attach_ssrf_hook:
@@ -231,7 +303,16 @@ def _create_and_validate(
             session.hooks["response"].append(
                 _make_ssrf_safe_hook(validate_url_for_ssrf)
             )
-        validation_data = spec.validate_fn(fetcher)
+        if cache_key is not None and cache_key in _validation_cache:  # type: ignore[operator]
+            validation_data = _validation_cache[cache_key]  # type: ignore[index]
+            logger.debug(
+                f"{fn_name}: Reusing cached {spec.name} credential validation "
+                "(skipped network call)."
+            )
+        else:
+            validation_data = spec.validate_fn(fetcher)
+            if cache_key is not None:
+                _validation_cache[cache_key] = validation_data  # type: ignore[index]
         spec.on_validated(
             fn_name,
             request,

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -9,6 +9,7 @@ import dataclasses
 import hashlib
 import logging
 import os
+import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -86,12 +87,14 @@ def _validation_cache_maxsize() -> int:
 
 
 _CACHE_TTL = _validation_cache_ttl()
+_CACHE_MAXSIZE = _validation_cache_maxsize()
 _validation_cache: TTLCache[tuple[str, str], Any] | None = (
-    TTLCache(maxsize=_validation_cache_maxsize(), ttl=_CACHE_TTL)
-    if _CACHE_TTL > 0
+    TTLCache(maxsize=_CACHE_MAXSIZE, ttl=_CACHE_TTL)
+    if _CACHE_TTL > 0 and _CACHE_MAXSIZE > 0
     else None
 )
 _CACHE_MISS = object()  # sentinel distinguishing "not cached" from a cached None
+_validation_cache_lock = threading.RLock()
 
 
 def _credential_for_cache(config: JiraConfig | ConfluenceConfig) -> str | None:
@@ -315,21 +318,24 @@ def _create_and_validate(
             session.hooks["response"].append(
                 _make_ssrf_safe_hook(validate_url_for_ssrf)
             )
-        cached_validation = (
-            _validation_cache.get(cache_key, _CACHE_MISS)  # type: ignore[union-attr]
-            if cache_key is not None
-            else _CACHE_MISS
-        )
-        if cached_validation is not _CACHE_MISS:
-            validation_data = cached_validation
-            logger.debug(
-                f"{fn_name}: Reusing cached {spec.name} credential validation "
-                "(skipped network call)."
-            )
+        validation_cache = _validation_cache
+        if cache_key is not None and validation_cache is not None:
+            # TTLCache isn't thread-safe. Keep the lookup and validation in one
+            # critical section so concurrent requests don't duplicate the
+            # upstream validation call for the same credential.
+            with _validation_cache_lock:
+                cached_validation = validation_cache.get(cache_key, _CACHE_MISS)
+                if cached_validation is not _CACHE_MISS:
+                    validation_data = cached_validation
+                    logger.debug(
+                        f"{fn_name}: Reusing cached {spec.name} credential "
+                        "validation (skipped network call)."
+                    )
+                else:
+                    validation_data = spec.validate_fn(fetcher)
+                    validation_cache[cache_key] = validation_data
         else:
             validation_data = spec.validate_fn(fetcher)
-            if cache_key is not None:
-                _validation_cache[cache_key] = validation_data  # type: ignore[index]
         spec.on_validated(
             fn_name,
             request,

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -63,7 +63,10 @@ class _ServiceSpec:
 # request.state, so credential validation (a network call to Atlassian) was
 # firing once per request instead of once per credential. This cache dedupes
 # that call across requests for the configured TTL. Only a SHA-256 digest of
-# the credential is ever used as a key -- raw tokens are never stored.
+# the credential AND target URL is ever used as a key -- raw tokens are never
+# stored, and the URL is included because header-based PAT auth accepts the
+# base URL per-request, so the same credential string could otherwise be
+# validated against the wrong instance's cached result.
 # ---------------------------------------------------------------------------
 
 
@@ -88,6 +91,7 @@ _validation_cache: TTLCache[tuple[str, str], Any] | None = (
     if _CACHE_TTL > 0
     else None
 )
+_CACHE_MISS = object()  # sentinel distinguishing "not cached" from a cached None
 
 
 def _credential_for_cache(config: JiraConfig | ConfluenceConfig) -> str | None:
@@ -110,8 +114,16 @@ def _credential_for_cache(config: JiraConfig | ConfluenceConfig) -> str | None:
     return None
 
 
-def _validation_cache_key(spec: _ServiceSpec, credential: str) -> tuple[str, str]:
-    digest = hashlib.sha256(credential.encode("utf-8")).hexdigest()
+def _validation_cache_key(
+    spec: _ServiceSpec, credential: str, url: str
+) -> tuple[str, str]:
+    """Build the cache key, scoped to both the credential and the target URL.
+
+    Header-based PAT auth accepts the base URL per-request (from
+    X-Atlassian-*-Url), so the same credential string reused against a
+    different instance must not share a cached validation result.
+    """
+    digest = hashlib.sha256(f"{url}\x00{credential}".encode()).hexdigest()
     return (spec.name, digest)
 
 
@@ -292,7 +304,7 @@ def _create_and_validate(
     auth_desc = "header-based" if auth_branch == "header_pat" else "user"
     credential = _credential_for_cache(config)
     cache_key = (
-        _validation_cache_key(spec, credential)
+        _validation_cache_key(spec, credential, getattr(config, "url", "") or "")
         if credential and _validation_cache is not None
         else None
     )
@@ -303,8 +315,13 @@ def _create_and_validate(
             session.hooks["response"].append(
                 _make_ssrf_safe_hook(validate_url_for_ssrf)
             )
-        if cache_key is not None and cache_key in _validation_cache:  # type: ignore[operator]
-            validation_data = _validation_cache[cache_key]  # type: ignore[index]
+        cached_validation = (
+            _validation_cache.get(cache_key, _CACHE_MISS)  # type: ignore[union-attr]
+            if cache_key is not None
+            else _CACHE_MISS
+        )
+        if cached_validation is not _CACHE_MISS:
+            validation_data = cached_validation
             logger.debug(
                 f"{fn_name}: Reusing cached {spec.name} credential validation "
                 "(skipped network call)."

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager
 from typing import Any, Literal, Optional
 from urllib.parse import urlparse
 
-from cachetools import TTLCache
 from fastmcp import FastMCP
 from fastmcp import settings as fastmcp_settings
 from fastmcp.server.event_store import EventStore
@@ -21,9 +20,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.config import ConfluenceConfig
-from mcp_atlassian.jira import JiraFetcher
 from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.utils.env import is_env_truthy
 from mcp_atlassian.utils.environment import get_available_services
@@ -358,11 +355,6 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             retry_interval=retry_interval,
         )
         return app
-
-
-token_validation_cache: TTLCache[
-    int, tuple[bool, str | None, JiraFetcher | None, ConfluenceFetcher | None]
-] = TTLCache(maxsize=100, ttl=300)
 
 
 class UserTokenMiddleware:

--- a/tests/unit/confluence/test_users.py
+++ b/tests/unit/confluence/test_users.py
@@ -293,6 +293,22 @@ class TestUsersMixin:
         ):
             users_mixin.get_current_user_info()
 
+    def test_get_current_user_info_http_error_429(self, users_mixin):
+        """Test get_current_user_info reports 429 as a rate-limit condition, not
+        a generic/invalid-credential failure (#1405)."""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        http_error = HTTPError(response=mock_response)
+        users_mixin.confluence.get.side_effect = http_error
+
+        # Act/Assert
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match="rate-limited",
+        ):
+            users_mixin.get_current_user_info()
+
     def test_get_current_user_info_http_error_other(self, users_mixin):
         """Test get_current_user_info with other HTTP error codes."""
         # Arrange

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.jira.users import UsersMixin, normalize_text
 
@@ -91,6 +92,20 @@ class TestUsersMixin:
 
         # Verify self.jira.myself was called
         users_mixin.jira.myself.assert_called_once()
+
+    def test_get_current_user_account_id_http_error_429(self, users_mixin):
+        """Test that HTTP 429 is reported as a rate-limit validation error."""
+        users_mixin._current_user_account_id = None
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        http_error = requests.HTTPError(response=mock_response)
+        users_mixin.jira.myself = MagicMock(side_effect=http_error)
+
+        with pytest.raises(
+            MCPAtlassianAuthenticationError,
+            match=r"Jira token validation was rate-limited \(429\)",
+        ):
+            users_mixin.get_current_user_account_id()
 
     def test_get_current_user_account_id_jira_data_center_key(self, users_mixin):
         """Test that get_current_user_account_id falls back to 'key' for Jira Data Center."""

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -1289,6 +1289,40 @@ class TestValidationCache:
 
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_same_credential_different_url_both_validated(
+        self, mock_confluence_fetcher_class, mock_get_http_request, mock_context
+    ):
+        """The same PAT string against two different instance URLs must not
+        share a cached validation result (header-based PAT accepts the URL
+        per-request, so the credential alone isn't a safe cache key)."""
+        shared_token = "same-pat-token-different-instances"
+        request1 = self._header_pat_request(
+            {
+                "X-Atlassian-Confluence-Url": "https://instance-a.atlassian.net",
+                "X-Atlassian-Confluence-Personal-Token": shared_token,
+            }
+        )
+        request2 = self._header_pat_request(
+            {
+                "X-Atlassian-Confluence-Url": "https://instance-b.atlassian.net",
+                "X-Atlassian-Confluence-Personal-Token": shared_token,
+            }
+        )
+
+        fetcher1 = _create_mock_fetcher(ConfluenceFetcher)
+        fetcher2 = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.side_effect = [fetcher1, fetcher2]
+
+        mock_get_http_request.return_value = request1
+        await get_confluence_fetcher(mock_context)
+        mock_get_http_request.return_value = request2
+        await get_confluence_fetcher(mock_context)
+
+        fetcher1.get_current_user_info.assert_called_once()
+        fetcher2.get_current_user_info.assert_called_once()
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
     async def test_cache_disabled_always_validates(
         self, mock_confluence_fetcher_class, mock_get_http_request, mock_context
     ):

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -13,6 +13,7 @@ from mcp_atlassian.servers.context import MainAppContext
 from mcp_atlassian.servers.dependencies import (
     _create_user_config_for_fetcher,
     _resolve_bearer_auth_type,
+    _validation_cache,
     get_confluence_fetcher,
     get_jira_fetcher,
 )
@@ -23,6 +24,21 @@ from tests.utils.mocks import MockFastMCP
 
 # Configure pytest for async tests
 pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def _clear_validation_cache():
+    """Isolate tests from the module-level credential validation cache (#1405).
+
+    Different test scenarios intentionally reuse the same mock credential
+    strings while expecting different validation outcomes, so the cache must
+    be empty at the start (and end) of every test.
+    """
+    if _validation_cache is not None:
+        _validation_cache.clear()
+    yield
+    if _validation_cache is not None:
+        _validation_cache.clear()
 
 
 @pytest.fixture
@@ -1186,6 +1202,141 @@ class TestGetConfluenceFetcher:
 
         with pytest.raises(ValueError, match=expected_error_match):
             await get_confluence_fetcher(mock_context)
+
+
+class TestValidationCache:
+    """Tests for the cross-request credential validation cache (#1405)."""
+
+    def _confluence_headers(self, token: str) -> dict[str, str]:
+        return {
+            "X-Atlassian-Confluence-Url": "https://test.atlassian.net",
+            "X-Atlassian-Confluence-Personal-Token": token,
+        }
+
+    def _header_pat_request(self, service_headers: dict[str, str]):
+        class MockState:
+            def __init__(self):
+                self.confluence_fetcher = None
+                self.user_atlassian_auth_type = "pat"
+                self.user_atlassian_email = None
+                self.atlassian_service_headers = service_headers
+
+            def __getattr__(self, name):
+                if name == "user_atlassian_token":
+                    raise AttributeError(
+                        f"'{type(self).__name__}' object has no attribute '{name}'"
+                    )
+                return None
+
+        request = MockFastMCP.create_request()
+        request.state = MockState()
+        return request
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_second_request_same_credential_skips_validation_call(
+        self, mock_confluence_fetcher_class, mock_get_http_request, mock_context
+    ):
+        """A second, independent HTTP request with the same PAT must not
+        re-trigger the validation network call within the TTL window."""
+        headers = self._confluence_headers("shared-pat-token")
+        request1 = self._header_pat_request(headers)
+        request2 = self._header_pat_request(headers)
+
+        fetcher1 = _create_mock_fetcher(
+            ConfluenceFetcher,
+            validation_return={"email": "user@example.com", "displayName": "User"},
+        )
+        fetcher2 = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.side_effect = [fetcher1, fetcher2]
+
+        mock_get_http_request.return_value = request1
+        result1 = await get_confluence_fetcher(mock_context)
+        assert result1 == fetcher1
+        fetcher1.get_current_user_info.assert_called_once()
+
+        mock_get_http_request.return_value = request2
+        result2 = await get_confluence_fetcher(mock_context)
+
+        # A fresh fetcher is still built per request...
+        assert result2 == fetcher2
+        assert mock_confluence_fetcher_class.call_count == 2
+        # ...but the second fetcher's validation call was skipped (cache hit),
+        # and request.state was still populated correctly from the cached data.
+        fetcher2.get_current_user_info.assert_not_called()
+        assert request2.state.user_atlassian_email == "user@example.com"
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_different_credentials_both_validated(
+        self, mock_confluence_fetcher_class, mock_get_http_request, mock_context
+    ):
+        """Different PATs must each hit validation independently (no false hit)."""
+        request1 = self._header_pat_request(self._confluence_headers("token-a"))
+        request2 = self._header_pat_request(self._confluence_headers("token-b"))
+
+        fetcher1 = _create_mock_fetcher(ConfluenceFetcher)
+        fetcher2 = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.side_effect = [fetcher1, fetcher2]
+
+        mock_get_http_request.return_value = request1
+        await get_confluence_fetcher(mock_context)
+        mock_get_http_request.return_value = request2
+        await get_confluence_fetcher(mock_context)
+
+        fetcher1.get_current_user_info.assert_called_once()
+        fetcher2.get_current_user_info.assert_called_once()
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_cache_disabled_always_validates(
+        self, mock_confluence_fetcher_class, mock_get_http_request, mock_context
+    ):
+        """When the cache is disabled (TTL=0), every request validates."""
+        headers = self._confluence_headers("shared-pat-token")
+        request1 = self._header_pat_request(headers)
+        request2 = self._header_pat_request(headers)
+
+        fetcher1 = _create_mock_fetcher(ConfluenceFetcher)
+        fetcher2 = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.side_effect = [fetcher1, fetcher2]
+
+        with patch("mcp_atlassian.servers.dependencies._validation_cache", None):
+            mock_get_http_request.return_value = request1
+            await get_confluence_fetcher(mock_context)
+            mock_get_http_request.return_value = request2
+            await get_confluence_fetcher(mock_context)
+
+        fetcher1.get_current_user_info.assert_called_once()
+        fetcher2.get_current_user_info.assert_called_once()
+
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_failed_validation_not_cached(
+        self, mock_confluence_fetcher_class, mock_get_http_request, mock_context
+    ):
+        """A failed validation must not poison the cache for a later, valid attempt."""
+        headers = self._confluence_headers("shared-pat-token")
+        request1 = self._header_pat_request(headers)
+        request2 = self._header_pat_request(headers)
+
+        failing_fetcher = _create_mock_fetcher(
+            ConfluenceFetcher, validation_error=Exception("Invalid token")
+        )
+        succeeding_fetcher = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.side_effect = [
+            failing_fetcher,
+            succeeding_fetcher,
+        ]
+
+        mock_get_http_request.return_value = request1
+        with pytest.raises(ValueError):
+            await get_confluence_fetcher(mock_context)
+
+        mock_get_http_request.return_value = request2
+        await get_confluence_fetcher(mock_context)
+
+        succeeding_fetcher.get_current_user_info.assert_called_once()
 
 
 class TestBasicAuthMultiUser:


### PR DESCRIPTION
Closes #1405.

## Problem

In multi-user HTTP transport mode, every incoming request builds a fresh `JiraFetcher`/`ConfluenceFetcher` on `request.state`, so credential validation (`GET /rest/api/user/current` for Confluence, `myself()` for Jira) fired **once per request** instead of once per credential. On self-hosted instances behind a WAF/rate limiter this constant traffic to a single endpoint gets throttled with `429`s, which were then surfaced to users as a generic "invalid token" error.

The codebase already declared a `TTLCache` for exactly this purpose in `servers/main.py`, but nothing ever referenced it — dead code (confirmed via `rg token_validation_cache src tests` returning only the declaration).

## Fix

- Added a module-level, cross-request validation cache in `servers/dependencies.py`, wired into `_create_and_validate()` so a given credential is validated **at most once per TTL window** (default 300s) regardless of request volume. Fetcher construction and `request.state` caching still happen every request — only the network validation call is deduped.
  - Cache key is `(service_name, sha256(credential))` — raw tokens are never stored as keys or values.
  - Configurable via `MCP_ATLASSIAN_VALIDATION_CACHE_TTL` (default `300`, `0` disables the cache entirely) and `MCP_ATLASSIAN_VALIDATION_CACHE_MAXSIZE` (default `100`), per the tradeoff called out in the issue: a credential revoked upstream stays "valid" locally for up to the TTL.
  - A failed validation is never cached, so a bad credential doesn't poison a later, valid attempt from the same slot.
- Removed the dead `token_validation_cache` declaration (and the now-unused `TTLCache`/`JiraFetcher`/`ConfluenceFetcher` imports it left behind) from `servers/main.py`.
- Confluence: special-cased HTTP `429` on `/rest/api/user/current` to report it as a rate-limit condition instead of a generic "invalid token" error — diagnostics only, no automatic retry/backoff added (deliberately, per the issue, to avoid amplifying load during an upstream 429 storm). Left the Jira-side equivalent out of scope for this PR since its validation error path goes through a shared decorator I'd want a maintainer's steer on before touching.

## Tests

- 4 new tests covering: cache hit across two independent request objects with the same credential, per-credential isolation (different tokens each validate independently), disabled-cache passthrough (`TTL=0`), and that a failed validation is never cached.
- 1 new test for the Confluence 429 special-case.
- Added an autouse fixture to clear the module-level cache between test cases — needed since several existing tests intentionally reuse the same mock credential string across different validation-outcome scenarios.
- `pytest`, `ruff check`/`format` (with the repo's configured ignores), and `mypy` (with the repo's configured disables) all pass clean; `737 passed` on the full `tests/unit/servers/` + `tests/unit/confluence/test_users.py` run.

## Not addressed here (flagged in the issue as separable)

- Jira-side 429 diagnostics improvement — same idea as the Confluence one, but the code path there is different enough (decorator-based, not a direct `try/except HTTPError` in the validation method) that I'd rather not guess at it in this PR.