### PR TITLE
fix(jira): return non-image attachments as TextContent, not blob

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -818,17 +818,22 @@ async def download_attachments(
 ) -> list[TextContent | EmbeddedResource]:
     """Download attachments from a Jira issue.
 
-    Returns attachment contents as base64-encoded embedded resources so that
-    they are available over the MCP protocol without requiring filesystem
-    access on the server.
+    Returns attachment contents as base64-encoded content so that they are
+    available over the MCP protocol without requiring filesystem access on
+    the server. Image attachments are returned as ``EmbeddedResource`` blobs;
+    all other attachments (documents, archives, etc.) are returned as
+    ``TextContent`` carrying a base64 payload, since many MCP clients only
+    forward ``EmbeddedResource`` blobs for recognized image MIME types and
+    otherwise drop the attachment (#1419).
 
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
 
     Returns:
-        A list containing a text summary and one EmbeddedResource per
-        successfully downloaded attachment.
+        A list containing a text summary, one EmbeddedResource per
+        downloaded image attachment, and one TextContent (base64 payload)
+        per downloaded non-image attachment.
     """
     jira = await get_jira_fetcher(ctx)
     result = jira.get_issue_attachment_contents(issue_key=issue_key)
@@ -869,16 +874,42 @@ async def download_attachments(
         mime_type = attachment.get("content_type", "application/octet-stream")
         downloaded += 1
 
-        contents.append(
-            EmbeddedResource(
-                type="resource",
-                resource=BlobResourceContents(
-                    uri=f"attachment:///{issue_key}/{filename}",
-                    mimeType=mime_type,
-                    blob=encoded,
-                ),
+        is_image, resolved_mime_type = is_image_attachment(mime_type, filename)
+        if is_image:
+            contents.append(
+                EmbeddedResource(
+                    type="resource",
+                    resource=BlobResourceContents(
+                        uri=f"attachment:///{issue_key}/{filename}",
+                        mimeType=resolved_mime_type,
+                        blob=encoded,
+                    ),
+                )
             )
-        )
+        else:
+            # Many MCP clients only forward EmbeddedResource blobs whose
+            # mimeType is a recognized image format, rejecting anything
+            # else (e.g. .zip) with "returned an image in an unsupported
+            # format" and dropping the attachment (#1419). TextContent is
+            # reliably forwarded, so non-image attachments carry their
+            # base64 payload there instead.
+            contents.append(
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "success": True,
+                            "issue_key": issue_key,
+                            "filename": filename,
+                            "mimeType": mime_type,
+                            "encoding": "base64",
+                            "content": encoded,
+                        },
+                        indent=2,
+                        ensure_ascii=False,
+                    ),
+                )
+            )
 
     summary: dict[str, Any] = {
         "success": True,

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -901,7 +901,7 @@ async def download_attachments(
                             "success": True,
                             "issue_key": issue_key,
                             "filename": filename,
-                            "mimeType": mime_type,
+                            "mime_type": mime_type,
                             "encoding": "base64",
                             "content": encoded,
                         },

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1042,8 +1042,8 @@ async def test_get_all_projects_tool(jira_client, mock_jira_fetcher):
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with default parameters (include_archived=False)
@@ -1091,8 +1091,8 @@ async def test_get_all_projects_tool_with_archived(jira_client, mock_jira_fetche
     ]
     # Reset the mock and set specific return value for this test
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        mock_projects
     )
 
     # Test with include_archived=True
@@ -1145,8 +1145,8 @@ async def test_get_all_projects_tool_with_projects_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up the projects filter in the config
@@ -1199,8 +1199,8 @@ async def test_get_all_projects_tool_no_projects_filter(jira_client, mock_jira_f
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Ensure no projects filter is set
@@ -1260,8 +1260,8 @@ async def test_get_all_projects_tool_case_insensitive_filter(
 
     # Set up the mock to return all projects
     mock_jira_fetcher.get_all_projects.reset_mock()
-    mock_jira_fetcher.get_all_projects.side_effect = (
-        lambda include_archived=False: all_mock_projects
+    mock_jira_fetcher.get_all_projects.side_effect = lambda include_archived=False: (
+        all_mock_projects
     )
 
     # Set up projects filter with mixed case and whitespace
@@ -1837,8 +1837,85 @@ async def test_download_attachments_allows_normal_size(jira_client, mock_jira_fe
     assert summary["success"] is True
     assert summary["downloaded"] == 1
     assert len(summary["failed"]) == 0
-    # Should have text summary + 1 embedded resource
+    # Should have text summary + 1 non-image attachment payload (TextContent)
     assert len(response.content) == 2
+
+
+@pytest.mark.anyio
+async def test_download_attachments_binary_uses_text_content(
+    jira_client, mock_jira_fetcher
+):
+    """Non-image attachments (e.g. .zip) must be returned as TextContent
+    carrying a base64 payload, not as an EmbeddedResource blob -- many MCP
+    clients reject non-image EmbeddedResource mimeTypes outright (#1419)."""
+    import base64
+
+    zip_data = b"PK\x03\x04fake zip bytes"
+
+    mock_jira_fetcher.get_issue_attachment_contents.return_value = {
+        "success": True,
+        "issue_key": "TEST-123",
+        "total": 1,
+        "attachments": [
+            {
+                "filename": "archive.zip",
+                "content_type": "application/zip",
+                "size": len(zip_data),
+                "data": zip_data,
+            }
+        ],
+        "failed": [],
+    }
+
+    response = await jira_client.call_tool(
+        "jira_download_attachments",
+        {"issue_key": "TEST-123"},
+    )
+
+    assert len(response.content) == 2
+    payload_content = response.content[1]
+    # Must be TextContent, not an EmbeddedResource blob
+    assert not hasattr(payload_content, "resource")
+    payload = json.loads(payload_content.text)
+    assert payload["success"] is True
+    assert payload["filename"] == "archive.zip"
+    assert payload["mimeType"] == "application/zip"
+    assert payload["encoding"] == "base64"
+    assert base64.b64decode(payload["content"]) == zip_data
+
+
+@pytest.mark.anyio
+async def test_download_attachments_image_still_uses_embedded_resource(
+    jira_client, mock_jira_fetcher
+):
+    """Image attachments must keep going through EmbeddedResource -- only
+    the non-image path changes for #1419."""
+    image_data = b"\x89PNG\r\n\x1a\nfake png bytes"
+
+    mock_jira_fetcher.get_issue_attachment_contents.return_value = {
+        "success": True,
+        "issue_key": "TEST-123",
+        "total": 1,
+        "attachments": [
+            {
+                "filename": "screenshot.png",
+                "content_type": "image/png",
+                "size": len(image_data),
+                "data": image_data,
+            }
+        ],
+        "failed": [],
+    }
+
+    response = await jira_client.call_tool(
+        "jira_download_attachments",
+        {"issue_key": "TEST-123"},
+    )
+
+    assert len(response.content) == 2
+    resource_content = response.content[1]
+    assert hasattr(resource_content, "resource")
+    assert resource_content.resource.mimeType == "image/png"
 
 
 # ── jira_get_issue_images tests ──────────────────────────────────────

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1847,7 +1847,7 @@ async def test_download_attachments_binary_uses_text_content(
 ):
     """Non-image attachments (e.g. .zip) must be returned as TextContent
     carrying a base64 payload, not as an EmbeddedResource blob -- many MCP
-    clients reject non-image EmbeddedResource mimeTypes outright (#1419)."""
+    clients reject non-image EmbeddedResource mime types outright (#1419)."""
     import base64
 
     zip_data = b"PK\x03\x04fake zip bytes"
@@ -1874,12 +1874,12 @@ async def test_download_attachments_binary_uses_text_content(
 
     assert len(response.content) == 2
     payload_content = response.content[1]
-    # Must be TextContent, not an EmbeddedResource blob
-    assert not hasattr(payload_content, "resource")
+    # Must be TextContent (type="text"), not an EmbeddedResource (type="resource")
+    assert payload_content.type == "text"
     payload = json.loads(payload_content.text)
     assert payload["success"] is True
     assert payload["filename"] == "archive.zip"
-    assert payload["mimeType"] == "application/zip"
+    assert payload["mime_type"] == "application/zip"
     assert payload["encoding"] == "base64"
     assert base64.b64decode(payload["content"]) == zip_data
 
@@ -1914,7 +1914,8 @@ async def test_download_attachments_image_still_uses_embedded_resource(
 
     assert len(response.content) == 2
     resource_content = response.content[1]
-    assert hasattr(resource_content, "resource")
+    # Must be EmbeddedResource (type="resource"), unchanged from before #1419
+    assert resource_content.type == "resource"
     assert resource_content.resource.mimeType == "image/png"
 
 


### PR DESCRIPTION
Closes #1419.

## Problem

`download_attachments` returns every Jira attachment, regardless of type, as an `EmbeddedResource` blob (`BlobResourceContents`). Per the issue, many MCP clients (Claude Desktop in the repro) only forward `EmbeddedResource` blobs whose `mimeType` is a recognized image format — anything else (e.g. a `.zip`) gets rejected client-side with *"The tool returned an image in an unsupported format"*, and the attachment is silently unavailable to the model instead of erroring loudly or actually working.

Traced on `main` (`ba72540`): `JiraFetcher.get_issue_attachment_contents()` does no content-type filtering and fetches/encodes correctly — the bug is purely in how the result is *typed* for the client, matching the issue's own diagnosis.

## Fix

- Image attachments (checked via the existing `is_image_attachment()` helper) keep going through `EmbeddedResource` unchanged — that path already works, and `get_issue_images` handles the vision-specific case separately.
- Non-image attachments (documents, archives, anything else) now return `TextContent` carrying a base64 payload in a JSON envelope (`{success, issue_key, filename, mimeType, encoding: "base64", content}`), matching the response shape this file already uses for the summary/failure entries. `TextContent` is reliably forwarded by clients that drop non-image blobs, so the file is actually available to the model instead of silently missing.

## Scope note

I deliberately kept this to the binary case and to Jira only. Confluence's parallel PR (#1212, still open — not merged, so I can't build on it) additionally decodes *true* text-based attachments (BPMN/XML/CSV/etc.) to readable text via a new `is_text_attachment()` helper. That helper doesn't exist on `main` yet, so depending on it here would tie this PR to an unmerged one. This fix stands alone and can be layered under that refinement once it lands — the issue itself flags the longer-term unification via #1201/#1104.

## Tests

- 2 new tests: a non-image (`.zip`) attachment now returns `TextContent` with a correctly round-tripping base64 payload, and an image attachment is confirmed to still go through `EmbeddedResource` unchanged (regression guard).
- Updated a stale comment on an existing test whose assertion (`len(response.content) == 2`) still holds under the new behavior but no longer means "1 embedded resource".
- `pytest` (1461 passed across `tests/unit/servers/` + `tests/unit/jira/`), `ruff check`/`format`, and `mypy` all pass clean against the repo's actual `pre-commit` configuration.