### PR TITLE
feat(confluence): add support for confluence page subtype

### DIFF
--- a/docs/_overrides/confluence_create_page.yaml
+++ b/docs/_overrides/confluence_create_page.yaml
@@ -1,4 +1,4 @@
 example: |
-  {"space_key": "DEV", "title": "Architecture Decision Record", "content": "## Context\n\nWe need to decide...", "parent_id": "98765432"}
+  {"space_key": "DEV", "title": "Architecture Decision Record", "content": "## Context\n\nWe need to decide...", "parent_id": "98765432", "subtype": "live"}
 tips: |
-  Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.
+  Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page. Set `subtype` to `live` on Confluence Cloud to create a Live Doc.

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -47,14 +47,15 @@ Create a new Confluence page.
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
 | `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at create time. |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
+| `subtype` | `string` | No | (Optional) Confluence page subtype. Use 'live' to create a Confluence Live Doc. Only supported for Confluence Cloud. |
 **Example:**
 
 ```json
-{"space_key": "DEV", "title": "Architecture Decision Record", "content": "## Context\n\nWe need to decide...", "parent_id": "98765432"}
+{"space_key": "DEV", "title": "Architecture Decision Record", "content": "## Context\n\nWe need to decide...", "parent_id": "98765432", "subtype": "live"}
 ```
 
 <Tip>
-Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page.
+Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page. Set `subtype` to `live` on Confluence Cloud to create a Live Doc.
 </Tip>
 
 

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -32,6 +32,20 @@ class PagesMixin(ConfluenceClient):
             )
         return None
 
+    def _cloud_v2_adapter(self) -> ConfluenceV2Adapter | None:
+        """Get a v2 API adapter for any Confluence Cloud auth mode."""
+        if not self.config.is_cloud:
+            return None
+
+        if self.config.auth_type == "oauth":
+            base_url = self.confluence.url
+        else:
+            base_url = self.config.url
+        return ConfluenceV2Adapter(
+            session=self.confluence._session,
+            base_url=base_url,
+        )
+
     @handle_auth_errors("Confluence API")
     def get_page_content(
         self, page_id: str, *, convert_to_markdown: bool = True
@@ -534,6 +548,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        subtype: str | None = None,
     ) -> ConfluencePage:
         """
         Create a new page in a Confluence space.
@@ -548,6 +563,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only)
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only)
+            subtype: Optional Confluence page subtype. Use "live" to create a Live Doc.
 
         Returns:
             ConfluencePage model containing the new page's data
@@ -568,19 +584,29 @@ class PagesMixin(ConfluenceClient):
                 final_body = body
                 representation = content_representation or "storage"
 
-            # Use v2 API for OAuth authentication, v1 API for token/basic auth
+            # Use v2 API for OAuth authentication and for Cloud page subtypes
+            # such as Live Docs. The v1 API/client does not expose subtype.
             v2_adapter = self._v2_adapter
+            if subtype:
+                v2_adapter = self._cloud_v2_adapter()
+                if not v2_adapter:
+                    raise ValueError(
+                        "Confluence page subtype is only supported for Confluence Cloud"
+                    )
             if v2_adapter:
                 logger.debug(
                     f"Using v2 API for OAuth authentication to create page '{title}'"
                 )
-                result = v2_adapter.create_page(
-                    space_key=space_key,
-                    title=title,
-                    body=final_body,
-                    parent_id=parent_id,
-                    representation=representation,
-                )
+                create_kwargs = {
+                    "space_key": space_key,
+                    "title": title,
+                    "body": final_body,
+                    "parent_id": parent_id,
+                    "representation": representation,
+                }
+                if subtype:
+                    create_kwargs["subtype"] = subtype
+                result = v2_adapter.create_page(**create_kwargs)
             else:
                 logger.debug(
                     f"Using v1 API for token/basic authentication to create page '{title}'"

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -79,6 +79,7 @@ class ConfluenceV2Adapter:
         parent_id: str | None = None,
         representation: str = "storage",
         status: str = "current",
+        subtype: str | None = None,
     ) -> dict[str, Any]:
         """Create a page using the v2 API.
 
@@ -89,6 +90,7 @@ class ConfluenceV2Adapter:
             parent_id: Optional parent page ID
             representation: Content representation format (default: "storage")
             status: Page status (default: "current")
+            subtype: Optional page subtype. Use "live" to create a Live Doc.
 
         Returns:
             The created page data from the API response
@@ -114,6 +116,8 @@ class ConfluenceV2Adapter:
             # Add parent if specified
             if parent_id:
                 data["parentId"] = parent_id
+            if subtype:
+                data["subtype"] = subtype
 
             # Make the v2 API call
             url = f"{self.base_url}/api/v2/pages"
@@ -431,6 +435,9 @@ class ConfluenceV2Adapter:
                     "representation": "storage",
                 }
             }
+
+        if "subtype" in v2_response:
+            v1_compatible["subtype"] = v2_response["subtype"]
 
         return v1_compatible
 

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -571,6 +571,16 @@ async def create_page(
             default=None,
         ),
     ] = None,
+    subtype: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Confluence page subtype. Use 'live' to create a "
+                "Confluence Live Doc. Only supported for Confluence Cloud."
+            ),
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Create a new Confluence page.
 
@@ -584,6 +594,7 @@ async def create_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        subtype: Optional page subtype. Use "live" to create a Confluence Live Doc.
 
     Returns:
         JSON string representing the created page object.
@@ -618,6 +629,7 @@ async def create_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        subtype=subtype,
     )
     result = page.to_simplified_dict()
     if not include_content:

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -301,6 +301,57 @@ class TestPagesMixin:
             assert result.title == title
             assert result.content == "Page content"
 
+    def test_create_page_with_live_subtype_uses_v2_for_cloud_basic_auth(
+        self, pages_mixin
+    ):
+        """Test creating a Live Doc uses the v2 API for Cloud basic auth."""
+        space_key = "PROJ"
+        title = "Live Doc Test Page"
+        body = "<p>Live content</p>"
+        parent_id = "987654321"
+
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceV2Adapter"
+        ) as mock_v2_adapter_class:
+            mock_v2_adapter = MagicMock()
+            mock_v2_adapter_class.return_value = mock_v2_adapter
+            mock_v2_adapter.create_page.return_value = {
+                "id": "live_123456789",
+                "title": title,
+                "subtype": "live",
+            }
+
+            with patch.object(
+                pages_mixin,
+                "get_page_content",
+                return_value=ConfluencePage(
+                    id="live_123456789",
+                    title=title,
+                    content="Live page content",
+                    space={"key": space_key, "name": "Project"},
+                ),
+            ):
+                result = pages_mixin.create_page(
+                    space_key,
+                    title,
+                    body,
+                    parent_id,
+                    is_markdown=False,
+                    subtype="live",
+                )
+
+                mock_v2_adapter.create_page.assert_called_once_with(
+                    space_key=space_key,
+                    title=title,
+                    body=body,
+                    parent_id=parent_id,
+                    representation="storage",
+                    subtype="live",
+                )
+                pages_mixin.confluence.create_page.assert_not_called()
+                assert isinstance(result, ConfluencePage)
+                assert result.id == "live_123456789"
+
     def test_create_page_error(self, pages_mixin):
         """Test error handling when creating a page."""
         # Arrange

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -112,6 +112,47 @@ class TestConfluenceV2Adapter:
         with pytest.raises(ValueError, match="Failed to get page '123456'"):
             v2_adapter.get_page("123456")
 
+    def test_create_page_with_live_subtype(self, v2_adapter, mock_session):
+        """Test creating a Live Doc page passes subtype to the v2 API."""
+        space_response = Mock()
+        space_response.json.return_value = {"results": [{"id": "space-123"}]}
+        create_response = Mock()
+        create_response.json.return_value = {
+            "id": "page-123",
+            "status": "current",
+            "title": "Live Agenda",
+            "spaceId": "space-123",
+            "subtype": "live",
+            "version": {"number": 1},
+        }
+        mock_session.get.return_value = space_response
+        mock_session.post.return_value = create_response
+
+        result = v2_adapter.create_page(
+            space_key="TEAM",
+            title="Live Agenda",
+            body="<p>Agenda</p>",
+            parent_id="parent-123",
+            subtype="live",
+        )
+
+        mock_session.post.assert_called_once_with(
+            "https://example.atlassian.net/wiki/api/v2/pages",
+            json={
+                "spaceId": "space-123",
+                "status": "current",
+                "title": "Live Agenda",
+                "body": {
+                    "representation": "storage",
+                    "value": "<p>Agenda</p>",
+                },
+                "parentId": "parent-123",
+                "subtype": "live",
+            },
+        )
+        assert result["id"] == "page-123"
+        assert result["subtype"] == "live"
+
     def test_get_page_with_expand_parameter(self, v2_adapter, mock_session):
         """Test that expand parameter is accepted but not used."""
         # Mock the v2 API response

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -641,6 +641,28 @@ async def test_create_page_with_string_parent_id(client, mock_confluence_fetcher
 
 
 @pytest.mark.anyio
+async def test_create_page_with_subtype(client, mock_confluence_fetcher):
+    """Test creating a page forwards the optional subtype argument."""
+    response = await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "Live Doc",
+            "content": "Test content",
+            "subtype": "live",
+        },
+    )
+
+    mock_confluence_fetcher.create_page.assert_called_once()
+    call_kwargs = mock_confluence_fetcher.create_page.call_args.kwargs
+    assert call_kwargs["subtype"] == "live"
+
+    result_data = json.loads(response.content[0].text)
+    assert result_data["message"] == "Page created successfully"
+    assert result_data["page"]["title"] == "Test Page Mock Title"
+
+
+@pytest.mark.anyio
 async def test_create_page_include_content(client, mock_confluence_fetcher):
     """Test create_page can include content when requested."""
     response = await client.call_tool(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Confluence Cloud supports different page subtypes e.g. live docs & pages (more details in https://community.developer.atlassian.com/t/rfc-83-live-docs-pages-in-confluence-cloud/88495). This can be set using `subtype` field from confluence api but it's currently missing from mcp-atlassian.

Add support for confluence cloud and this `subtype` field for pages api so the agent can decide the page subtype during page creation.

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Fixes: #

## Changes

<!-- Briefly list the key changes made. -->

- Add support for confluence cloud auth (`_cloud_v2_adapter`)
- Add support for passing in `subtype` field for pages

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: built and deployed the mcp with the change and confirm the mcp now allows different page creation types

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
