### PR TITLE
fix(confluence): persist reply body in confluence_reply_to_comment

### DIFF
--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -17,12 +17,12 @@ class CommentsMixin(ConfluenceClient):
 
     @property
     def _v2_adapter(self) -> ConfluenceV2Adapter | None:
-        """Get v2 API adapter for OAuth authentication.
+        """Get v2 API adapter for Confluence Cloud OAuth/PAT authentication.
 
         Returns:
-            ConfluenceV2Adapter instance if OAuth is configured, None otherwise
+            ConfluenceV2Adapter instance when Cloud auth supports v2, else None
         """
-        if self.config.auth_type == "oauth" and self.config.is_cloud:
+        if self.config.is_cloud and self.config.auth_type in ("oauth", "pat"):
             return ConfluenceV2Adapter(
                 session=self.confluence._session, base_url=self.confluence.url
             )
@@ -172,13 +172,18 @@ class CommentsMixin(ConfluenceClient):
                 )
                 space_key = ""
             else:
-                # v1 API: POST /rest/api/content/ with container type "comment"
+                # v1 API: attach the reply to the page and link the parent via ancestors.
+                # Using container.type="comment" creates empty comment stubs on Cloud/DC.
+                page_id = self._resolve_page_id_for_parent_comment(comment_id)
+                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
+                space_key = page.get("space", {}).get("key", "")
                 data: dict[str, Any] = {
                     "type": "comment",
                     "container": {
-                        "id": comment_id,
-                        "type": "comment",
+                        "id": page_id,
+                        "type": "page",
                     },
+                    "ancestors": [{"id": comment_id}],
                     "body": {
                         "storage": {
                             "value": content,
@@ -187,7 +192,6 @@ class CommentsMixin(ConfluenceClient):
                     },
                 }
                 response = self.confluence.post("rest/api/content/", data=data)
-                space_key = ""
 
             if not response:
                 logger.error("Failed to reply to comment: empty response")
@@ -206,6 +210,26 @@ class CommentsMixin(ConfluenceClient):
             logger.debug("Full exception details for comment reply:", exc_info=True)
             return None
 
+    def _resolve_page_id_for_parent_comment(self, comment_id: str) -> str:
+        """Resolve the page ID that owns a comment thread parent."""
+        parent = self.confluence.get_page_by_id(
+            page_id=comment_id, expand="container,ancestors"
+        )
+        container = parent.get("container", {})
+        if container.get("type") == "page" and container.get("id"):
+            return str(container["id"])
+
+        ancestors = parent.get("ancestors") or []
+        for ancestor in reversed(ancestors):
+            if ancestor.get("type") == "page" and ancestor.get("id"):
+                return str(ancestor["id"])
+
+        if ancestors and ancestors[-1].get("id"):
+            return str(ancestors[-1]["id"])
+
+        msg = f"Could not resolve page for parent comment {comment_id}"
+        raise ValueError(msg)
+
     def _process_comment_response(
         self, response: dict[str, Any], space_key: str
     ) -> ConfluenceComment:
@@ -218,8 +242,13 @@ class CommentsMixin(ConfluenceClient):
         Returns:
             Processed ConfluenceComment instance
         """
+        body = response.get("body", {})
+        body_html = body.get("view", {}).get("value", "")
+        if not body_html:
+            body_html = body.get("storage", {}).get("value", "")
+
         _, processed_markdown = self.preprocessor.process_html_content(
-            response.get("body", {}).get("view", {}).get("value", ""),
+            body_html,
             space_key=space_key,
             confluence_client=self.confluence,
         )

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -172,8 +172,8 @@ class CommentsMixin(ConfluenceClient):
                 )
                 space_key = ""
             else:
-                # v1 API: attach the reply to the page and link the parent via ancestors.
-                # Using container.type="comment" creates empty comment stubs on Cloud/DC.
+                # v1 API: attach reply to page; parent via ancestors.
+                # container.type="comment" creates empty stubs on Cloud/DC.
                 page_id = self._resolve_page_id_for_parent_comment(comment_id)
                 page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
                 space_key = page.get("space", {}).get("key", "")

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -484,13 +484,36 @@ class ConfluenceV2Adapter:
             result = response.json()
             logger.debug("Successfully created footer comment with v2 API")
 
-            return self._convert_v2_comment_to_v1_format(result)
+            converted = self._convert_v2_comment_to_v1_format(result)
+            if not converted.get("body", {}).get("view", {}).get("value"):
+                comment_id = result.get("id")
+                if comment_id:
+                    refreshed = self.get_footer_comment(str(comment_id))
+                    if refreshed:
+                        converted = self._convert_v2_comment_to_v1_format(refreshed)
+
+            return converted
 
         except Exception as e:
             if isinstance(e, ValueError | HTTPError):
                 raise
             logger.error(f"Error creating footer comment: {e}")
             raise ValueError(f"Failed to create footer comment: {e}") from e
+
+    def get_footer_comment(self, comment_id: str) -> dict[str, Any] | None:
+        """Fetch a footer comment, including body content."""
+        try:
+            url = f"{self.base_url}/api/v2/footer-comments/{comment_id}"
+            response = self.session.get(url, params={"body-format": "storage"})
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.debug(
+                "Failed to refresh footer comment %s after create: %s",
+                comment_id,
+                e,
+            )
+            return None
 
     def _convert_v2_comment_to_v1_format(
         self, v2_response: dict[str, Any]

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -507,7 +507,7 @@ class ConfluenceV2Adapter:
             response = self.session.get(url, params={"body-format": "storage"})
             response.raise_for_status()
             return response.json()
-        except Exception as e:
+        except requests.RequestException as e:
             logger.debug(
                 "Failed to refresh footer comment %s after create: %s",
                 comment_id,

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -300,7 +300,9 @@ class TestReplyToComment:
         assert result.parent_comment_id == "456789123"
         comments_mixin.confluence.post.assert_called_once()
         call_args = comments_mixin.confluence.post.call_args
-        payload = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs["data"]
+        payload = (
+            call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs["data"]
+        )
         assert payload["container"] == {"id": "12345", "type": "page"}
         assert payload["ancestors"] == [{"id": "456789123"}]
 

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -276,7 +276,14 @@ class TestReplyToComment:
 
     def test_reply_to_comment_v1_success(self, comments_mixin):
         """T1: reply_to_comment v1 success - parent_comment_id set."""
-        # Mock the POST call for v1 API
+        comments_mixin.confluence.get_page_by_id.side_effect = [
+            {
+                "id": "456789123",
+                "container": {"id": "12345", "type": "page"},
+                "ancestors": [],
+            },
+            {"id": "12345", "space": {"key": "TEST"}},
+        ]
         comments_mixin.confluence.post.return_value = MOCK_COMMENT_REPLY_V1_RESPONSE
         # Mock preprocessor
         comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
@@ -292,6 +299,10 @@ class TestReplyToComment:
         assert result is not None
         assert result.parent_comment_id == "456789123"
         comments_mixin.confluence.post.assert_called_once()
+        call_args = comments_mixin.confluence.post.call_args
+        payload = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs["data"]
+        assert payload["container"] == {"id": "12345", "type": "page"}
+        assert payload["ancestors"] == [{"id": "456789123"}]
 
     def test_reply_to_comment_v2_oauth_success(self, comments_mixin):
         """T2: reply_to_comment v2/OAuth routes through v2_adapter."""
@@ -341,6 +352,14 @@ class TestReplyToComment:
 
     def test_reply_with_html_content(self, comments_mixin):
         """T3: Reply with HTML content skips markdown conversion."""
+        comments_mixin.confluence.get_page_by_id.side_effect = [
+            {
+                "id": "456789123",
+                "container": {"id": "12345", "type": "page"},
+                "ancestors": [],
+            },
+            {"id": "12345", "space": {"key": "TEST"}},
+        ]
         comments_mixin.confluence.post.return_value = MOCK_COMMENT_REPLY_V1_RESPONSE
         comments_mixin.preprocessor.process_html_content.return_value = (
             "<p>HTML reply</p>",
@@ -354,6 +373,11 @@ class TestReplyToComment:
 
     def test_reply_network_error(self, comments_mixin):
         """T4: Network error returns None."""
+        comments_mixin.confluence.get_page_by_id.return_value = {
+            "id": "456789123",
+            "container": {"id": "12345", "type": "page"},
+            "ancestors": [],
+        }
         comments_mixin.confluence.post.side_effect = requests.RequestException(
             "Connection error"
         )
@@ -367,6 +391,14 @@ class TestReplyToComment:
 
     def test_reply_empty_response(self, comments_mixin):
         """T5: Empty API response returns None."""
+        comments_mixin.confluence.get_page_by_id.side_effect = [
+            {
+                "id": "456789123",
+                "container": {"id": "12345", "type": "page"},
+                "ancestors": [],
+            },
+            {"id": "12345", "space": {"key": "TEST"}},
+        ]
         comments_mixin.confluence.post.return_value = None
         comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
             "<p>Test</p>"

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -254,6 +254,47 @@ class TestConfluenceV2AdapterComments:
         assert result["body"]["view"]["value"] == "<p>Reply content</p>"
         assert result["extensions"]["location"] == "footer"
 
+    def test_create_footer_comment_reply_refreshes_missing_body(
+        self, v2_adapter, mock_session
+    ):
+        """Create reply re-fetches comment body when POST response omits it."""
+        create_response = Mock()
+        create_response.status_code = 200
+        create_response.json.return_value = {
+            "id": "222333444",
+            "status": "current",
+            "title": "Re: Comment",
+            "parentCommentId": "456789123",
+            "version": {"number": 1},
+            "_links": {},
+        }
+        refresh_response = Mock()
+        refresh_response.status_code = 200
+        refresh_response.json.return_value = {
+            "id": "222333444",
+            "status": "current",
+            "title": "Re: Comment",
+            "parentCommentId": "456789123",
+            "body": {
+                "storage": {
+                    "value": "<p>Reply content</p>",
+                    "representation": "storage",
+                },
+            },
+            "version": {"number": 1},
+            "_links": {},
+        }
+        mock_session.post.return_value = create_response
+        mock_session.get.return_value = refresh_response
+
+        result = v2_adapter.create_footer_comment(
+            parent_comment_id="456789123",
+            body="<p>Reply content</p>",
+        )
+
+        mock_session.get.assert_called_once()
+        assert result["body"]["view"]["value"] == "<p>Reply content</p>"
+
     def test_create_footer_comment_top_level(self, v2_adapter, mock_session):
         """Create top-level comment with pageId sends correct payload."""
         mock_response = Mock()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Fixes #1409

`confluence_reply_to_comment` reported success but created replies with empty bodies. The v1 reply path posted with `container.type="comment"`, which Confluence accepts but does not persist body content reliably. This change uses the documented page container + `ancestors` payload, routes Cloud PAT through the v2 footer-comments API, and refreshes v2 create responses when body content is omitted.

## Changes

- Resolve the parent comment's page and post v1 replies with `container.type="page"` plus `ancestors=[parent]`
- Enable the v2 adapter for Cloud PAT as well as OAuth in comment operations
- Re-fetch created v2 footer comments when POST responses omit body content
- Fall back to `body.storage.value` when `body.view` is missing in comment responses

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [ ] Manual checks performed: not run (no Confluence credentials in CI agent)

Commands run:
- `uv run pytest tests/unit/confluence/test_comments.py tests/unit/confluence/test_v2_adapter.py -q` → 40 passed

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).