### PR TITLE
fix(e2e): create Confluence DC PAT via native endpoint

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -240,8 +240,8 @@ def _create_jira_pat(info: DCInstanceInfo) -> Any:
 def _create_confluence_pat(info: DCInstanceInfo) -> Any:
     """Create a Confluence PAT via REST API."""
     resp = requests.post(
-        (f"{info.confluence_url}/rest/de.resolution.apitokenauth/1.0/user/token"),
-        json={"tokenName": "e2e-pytest"},
+        f"{info.confluence_url}/rest/pat/latest/tokens",
+        json={"name": "e2e-pytest", "expirationDuration": 90},
         auth=(info.admin_username, info.admin_password),
         timeout=30,
     )

--- a/tests/e2e/docker/create-pat.sh
+++ b/tests/e2e/docker/create-pat.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Create Personal Access Tokens (PATs) for Jira and Confluence DC.
 # Jira PAT: POST /rest/pat/latest/tokens (Jira 8.14+)
-# Confluence PAT: POST /rest/de.resolution.apitokenauth/1.0/user/token
+# Confluence PAT: POST /rest/pat/latest/tokens (Confluence 7.9+)
 # Usage: bash create-pat.sh
 
 set -euo pipefail
@@ -44,9 +44,10 @@ echo ""
 echo "=== Confluence: Create Personal Access Token ==="
 confluence_pat_response=$(curl -s -u "$AUTH" \
   -H "Content-Type: application/json" \
-  -X POST "${CONFLUENCE_BASE}/rest/de.resolution.apitokenauth/1.0/user/token" \
+  -X POST "${CONFLUENCE_BASE}/rest/pat/latest/tokens" \
   -d "{
-    \"tokenName\": \"${TOKEN_NAME}\"
+    \"name\": \"${TOKEN_NAME}\",
+    \"expirationDuration\": 90
   }")
 
 CONFLUENCE_PAT=$(echo "$confluence_pat_response" | python3 -c "


### PR DESCRIPTION
## Summary
- `_create_confluence_pat` and `create-pat.sh` called `/rest/de.resolution.apitokenauth/1.0/user/token`, which is a marketplace app endpoint and fails on vanilla Confluence DC.
- Switch to the native `/rest/pat/latest/tokens` endpoint (available since Confluence 7.9), using the same request shape as the existing Jira PAT helper (`name` + `expirationDuration`).

## Verification
- Verified against a vanilla Confluence 8.5.x DC instance: the marketplace endpoint 404s, the native endpoint returns a `rawToken` and the e2e suite runs green with the created PAT.