### PR TITLE
fix(security): validate JIRA_URL/CONFLUENCE_URL for SSRF on startup

### DIFF
--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -11,7 +11,7 @@ from ..utils.oauth import (
     OAuthConfig,
     get_oauth_config_from_env,
 )
-from ..utils.urls import is_atlassian_cloud_url
+from ..utils.urls import is_atlassian_cloud_url, validate_url_for_ssrf
 
 
 @dataclass
@@ -98,6 +98,10 @@ class ConfluenceConfig:
             ValueError: If any required environment variable is missing
         """
         url = os.getenv("CONFLUENCE_URL")
+        if url:
+            ssrf_error = validate_url_for_ssrf(url)
+            if ssrf_error:
+                raise ValueError(f"CONFLUENCE_URL failed SSRF validation: {ssrf_error}")
         if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
             error_msg = (
                 "Missing required CONFLUENCE_URL environment variable. "

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -11,7 +11,7 @@ from ..utils.oauth import (
     OAuthConfig,
     get_oauth_config_from_env,
 )
-from ..utils.urls import is_atlassian_cloud_url
+from ..utils.urls import is_atlassian_cloud_url, validate_url_for_ssrf
 
 
 @dataclass
@@ -166,6 +166,10 @@ class JiraConfig:
             ValueError: If required environment variables are missing or invalid
         """
         url = os.getenv("JIRA_URL")
+        if url:
+            ssrf_error = validate_url_for_ssrf(url)
+            if ssrf_error:
+                raise ValueError(f"JIRA_URL failed SSRF validation: {ssrf_error}")
         if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
             error_msg = (
                 "Missing required JIRA_URL environment variable. "


### PR DESCRIPTION
## Summary

`JIRA_URL` and `CONFLUENCE_URL` environment variables were consumed directly by `JiraConfig.from_env()` and `ConfluenceConfig.from_env()` without passing through `validate_url_for_ssrf()`. While `UserTokenMiddleware` validates header-provided URLs (`X-Atlassian-Jira-Url`, `X-Atlassian-Confluence-Url`), the env-var configuration path had no SSRF validation.

## Impact

An attacker who can set environment variables (container misconfiguration, CI/CD injection, shared hosting) can set `JIRA_URL` or `CONFLUENCE_URL` to an internal network address (e.g., `http://169.254.169.254/latest/meta-data/`), causing the server to make API requests to internal resources and leak cloud credentials through MCP tool responses.

## Fix

Add `validate_url_for_ssrf()` call in both `JiraConfig.from_env()` and `ConfluenceConfig.from_env()`, so that env-configured URLs are validated the same way as header-provided ones. Invalid URLs raise `ValueError` at startup with a clear error message.

## Testing

- Set `JIRA_URL=http://127.0.0.1:8080/` → startup fails with SSRF validation error
- Set `JIRA_URL=http://169.254.169.254/` → startup fails with SSRF validation error
- Set `JIRA_URL=https://company.atlassian.net` → startup succeeds (valid Atlassian Cloud URL)

## Disclosure

Reported via GitHub Advisory (PVRA). This is a defense-in-depth fix — env-var control is a separate trust boundary, but SSRF validation should be consistent across all URL input paths.