### PR TITLE
fix(security): use ipaddress for private IP detection in is_atlassian_cloud_url()

### DIFF
--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -41,15 +41,17 @@ def is_atlassian_cloud_url(url: str) -> bool:
     parsed_url = urlparse(url)
     hostname = parsed_url.hostname or ""
 
-    # Check for localhost or IP address
-    if (
-        hostname == "localhost"
-        or re.match(r"^127\.", hostname)
-        or re.match(r"^192\.168\.", hostname)
-        or re.match(r"^10\.", hostname)
-        or re.match(r"^172\.(1[6-9]|2[0-9]|3[0-1])\.", hostname)
-    ):
+    # Check for localhost or IP address (including IPv6-mapped)
+    if hostname == "localhost":
         return False
+    try:
+        addr = ipaddress.ip_address(hostname)
+        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+            addr = addr.ipv4_mapped
+        if not addr.is_global:
+            return False
+    except ValueError:
+        pass  # Not an IP literal, continue with domain checks
 
     # The standard check for Atlassian cloud domains
     # Use endswith() to prevent URL validation bypass via substring matching


### PR DESCRIPTION
## Summary

`is_atlassian_cloud_url()` used regex matching (`re.match(r"^127\.", hostname)`, etc.) to detect private IPv4 addresses. IPv6-mapped IPv4 addresses like `::ffff:127.0.0.1` bypass all regex checks because they don't start with `127.`, `192.168.`, `10.`, or `172.`.

While `validate_url_for_ssrf()` correctly uses `ipaddress.ip_address()` (which handles IPv6-mapped addresses), `is_atlassian_cloud_url()` is used independently for Cloud/DC routing decisions.

## Impact

A URL with an IPv6-mapped private IP (e.g., `http://[::ffff:127.0.0.1]:8080/`) is incorrectly classified as Data Center (not Cloud, not private), causing the server to make API requests to localhost/internal hosts.

## Fix

Replace regex-based private IP detection with `ipaddress.ip_address()`, consistent with `validate_url_for_ssrf()`. IPv6-mapped addresses are unwrapped to their IPv4 equivalent before the `is_global` check.

## Testing

- `is_atlassian_cloud_url("http://[::ffff:127.0.0.1]:8080/")` → returns `False` (private)
- `is_atlassian_cloud_url("http://[::ffff:192.168.1.1]/")` → returns `False` (private)
- `is_atlassian_cloud_url("https://company.atlassian.net")` → returns `True` (cloud)

## Disclosure

Reported via GitHub Advisory (PVRA). Companion to AGNT-001 — both address SSRF attack surface in URL handling.