### PR TITLE
fix(security): allowlist ATLASSIAN_OAUTH_CLIENT_STORAGE_FACTORY imports

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -108,7 +108,17 @@ The factory callable should return an async key/value compatible storage object
 used by FastMCP OAuth proxy client registration storage. Factory paths must be
 listed in `ALLOWED_STORAGE_FACTORIES`; unknown paths are rejected before Python
 imports the requested module. Add a downstream factory path to that allowlist
-when building an image with a custom storage backend.
+when building an image with a custom storage backend. The built-in Redis
+factory accepts the backend's keyword arguments through
+`configJson`, for example:
+
+```yaml
+oauthClientStorage:
+  mode: factory
+  factory:
+    importPath: "mcp_atlassian.storage.redis:factory"
+    configJson: '{"url":"redis://redis:6379/0"}'
+```
 
 ### Health Checks and Readiness Probe
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -85,14 +85,14 @@ This sets:
 
 ### Custom OAuth Client Storage (factory mode)
 
-For advanced deployments, you can provide a custom storage backend factory
-without changing core chart API:
+For advanced deployments, you can provide an explicitly allowed custom storage
+backend factory without changing the core chart API:
 
 ```yaml
 oauthClientStorage:
   mode: factory
   factory:
-    importPath: "my_pkg.storage:create_store"
+    importPath: "mcp_atlassian.storage.redis:factory"
     configJsonSecret:
       name: mcp-atlassian-storage-config
       key: config.json
@@ -105,7 +105,10 @@ This sets:
 - `ATLASSIAN_OAUTH_CLIENT_STORAGE_CONFIG_JSON` (optional)
 
 The factory callable should return an async key/value compatible storage object
-used by FastMCP OAuth proxy client registration storage.
+used by FastMCP OAuth proxy client registration storage. Factory paths must be
+listed in `ALLOWED_STORAGE_FACTORIES`; unknown paths are rejected before Python
+imports the requested module. Add a downstream factory path to that allowlist
+when building an image with a custom storage backend.
 
 ### Health Checks and Readiness Probe
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -108,17 +108,41 @@ The factory callable should return an async key/value compatible storage object
 used by FastMCP OAuth proxy client registration storage. Factory paths must be
 listed in `ALLOWED_STORAGE_FACTORIES`; unknown paths are rejected before Python
 imports the requested module. Add a downstream factory path to that allowlist
-when building an image with a custom storage backend. The built-in Redis
-factory accepts the backend's keyword arguments through
-`configJson`, for example:
+when building an image with a custom storage backend.
+
+The built-in Redis factory encrypts values in the application before writing
+them to Redis. Keep the Fernet key and Redis credentials in the existing Secret
+referenced by `configJsonSecret`. Use a stable Fernet key across restarts:
 
 ```yaml
+# Create this Secret outside the chart. Generate the encryption key with
+# `Fernet.generate_key()` and replace the placeholder values.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-atlassian-storage-config
+type: Opaque
+stringData:
+  config.json: |
+    {
+      "url": "rediss://redis.example.com:6380/0",
+      "username": "default",
+      "password": "replace-with-redis-password",
+      "encryption_key": "replace-with-a-stable-fernet-key"
+    }
+---
 oauthClientStorage:
   mode: factory
   factory:
     importPath: "mcp_atlassian.storage.redis:factory"
-    configJson: '{"url":"redis://redis:6379/0"}'
+    configJsonSecret:
+      name: mcp-atlassian-storage-config
+      key: config.json
 ```
+
+`rediss://` enables TLS and the factory requires certificate verification and
+hostname checking. Mount a custom CA bundle if the Redis certificate is signed
+by a private CA, then add its path as `ssl_ca_certs` in the Secret JSON.
 
 ### Health Checks and Readiness Probe
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -185,11 +185,11 @@ oauthProxy:
 
 # OAuth proxy client storage backend for registered clients.
 # "default": use FastMCP default encrypted storage.
-# "factory": load custom storage via import path.
+# "factory": load an explicitly allowed custom storage via import path.
 oauthClientStorage:
   mode: "default" # default | factory
   factory:
-    importPath: "" # e.g. "my_pkg.storage:create_store"
+    importPath: "" # e.g. "mcp_atlassian.storage.redis:factory"
     # Optional JSON object passed to the factory.
     configJson: ""
     # Optionally source JSON from an existing secret key.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -190,7 +190,8 @@ oauthClientStorage:
   mode: "default" # default | factory
   factory:
     importPath: "" # e.g. "mcp_atlassian.storage.redis:factory"
-    # Optional JSON object passed to the factory.
+    # Optional JSON object passed to the factory. Keep Redis credentials and
+    # encryption_key in configJsonSecret for production deployments.
     configJson: ""
     # Optionally source JSON from an existing secret key.
     configJsonSecret:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "mcp>=1.8.0,<2.0.0",
     "fastmcp>=2.13.0,<2.15.0",
     "fakeredis>=2.32.1,<2.35.0",
+    "py-key-value-aio[redis,wrappers-encryption]>=0.3.0,<0.4.0",
     "python-dotenv>=1.0.1",
     "markdownify>=0.11.6",
     "markdown>=3.7.0",

--- a/src/mcp_atlassian/servers/client_storage.py
+++ b/src/mcp_atlassian/servers/client_storage.py
@@ -40,7 +40,6 @@ REQUIRED_STORAGE_METHODS = (
 # Restricts importlib.import_module to known-safe modules only.
 ALLOWED_STORAGE_FACTORIES: set[str] = {
     "mcp_atlassian.storage.redis:factory",
-    "mcp_atlassian.storage.postgres:factory",
 }
 
 

--- a/src/mcp_atlassian/servers/client_storage.py
+++ b/src/mcp_atlassian/servers/client_storage.py
@@ -45,31 +45,38 @@ ALLOWED_STORAGE_FACTORIES: set[str] = {
 
 
 def _load_storage_factory(import_path: str) -> Callable[..., AsyncKeyValue]:
-    if import_path not in ALLOWED_STORAGE_FACTORIES:
-        raise ValueError(
-            f"{CLIENT_STORAGE_FACTORY_ENV}=\'{import_path}\' is not in the allowed list. "
-            f"Allowed: {', '.join(sorted(ALLOWED_STORAGE_FACTORIES))}"
-        )
     module_path, separator, attribute_name = import_path.partition(":")
     if not separator or not module_path or not attribute_name:
-        raise ValueError(
+        msg = (
             f"Invalid {CLIENT_STORAGE_FACTORY_ENV}='{import_path}'. "
             "Expected '<module.path>:<callable>'."
         )
+        raise ValueError(msg)
+
+    if import_path not in ALLOWED_STORAGE_FACTORIES:
+        msg = (
+            f"{CLIENT_STORAGE_FACTORY_ENV}='{import_path}' is not in the "
+            "allowed list. "
+            f"Allowed: {', '.join(sorted(ALLOWED_STORAGE_FACTORIES))}"
+        )
+        raise ValueError(msg)
 
     try:
         module = import_module(module_path)
     except Exception as exc:
-        raise ValueError(
+        msg = (
             f"Unable to import module '{module_path}' from "
             f"{CLIENT_STORAGE_FACTORY_ENV}='{import_path}'."
-        ) from exc
+        )
+        raise ValueError(msg) from exc
 
     factory = getattr(module, attribute_name, None)
     if not callable(factory):
-        raise ValueError(
-            f"{CLIENT_STORAGE_FACTORY_ENV}='{import_path}' does not resolve to a callable."
+        msg = (
+            f"{CLIENT_STORAGE_FACTORY_ENV}='{import_path}' does not resolve "
+            "to a callable."
         )
+        raise ValueError(msg)
     return cast(Callable[..., AsyncKeyValue], factory)
 
 
@@ -81,14 +88,12 @@ def _parse_factory_config(raw_json: str) -> dict[str, Any] | None:
     try:
         parsed = json.loads(stripped)
     except json.JSONDecodeError as exc:
-        raise ValueError(
-            f"{CLIENT_STORAGE_CONFIG_JSON_ENV} must be valid JSON."
-        ) from exc
+        msg = f"{CLIENT_STORAGE_CONFIG_JSON_ENV} must be valid JSON."
+        raise ValueError(msg) from exc
 
     if not isinstance(parsed, dict):
-        raise ValueError(
-            f"{CLIENT_STORAGE_CONFIG_JSON_ENV} must decode to a JSON object."
-        )
+        msg = f"{CLIENT_STORAGE_CONFIG_JSON_ENV} must decode to a JSON object."
+        raise ValueError(msg)
 
     return parsed
 
@@ -101,10 +106,11 @@ def _validate_storage_candidate(storage: object) -> None:
         if not callable(getattr(storage, method, None))
     ]
     if missing:
-        raise ValueError(
+        msg = (
             "OAuth client storage factory returned an incompatible object. "
             f"Missing methods: {', '.join(missing)}"
         )
+        raise ValueError(msg)
 
 
 def _invoke_storage_factory(
@@ -143,10 +149,11 @@ def _invoke_storage_factory(
 
     factory_module = getattr(factory, "__module__", "<unknown-module>")
     factory_name = getattr(factory, "__name__", factory.__class__.__name__)
-    raise ValueError(
+    msg = (
         f"{CLIENT_STORAGE_FACTORY_ENV}='{factory_module}:{factory_name}' "
         "does not accept a configuration argument."
     )
+    raise ValueError(msg)
 
 
 def build_oauth_client_storage_from_env() -> AsyncKeyValue | None:
@@ -162,17 +169,19 @@ def build_oauth_client_storage_from_env() -> AsyncKeyValue | None:
         return None
 
     if mode != "factory":
-        raise ValueError(
+        msg = (
             f"Unsupported {CLIENT_STORAGE_MODE_ENV}='{mode}'. "
             "Supported modes: default, factory."
         )
+        raise ValueError(msg)
 
     import_path = os.getenv(CLIENT_STORAGE_FACTORY_ENV, "").strip()
     if not import_path:
-        raise ValueError(
+        msg = (
             f"{CLIENT_STORAGE_FACTORY_ENV} is required when "
             f"{CLIENT_STORAGE_MODE_ENV}=factory."
         )
+        raise ValueError(msg)
 
     config = _parse_factory_config(os.getenv(CLIENT_STORAGE_CONFIG_JSON_ENV, ""))
     factory = _load_storage_factory(import_path)
@@ -180,10 +189,11 @@ def build_oauth_client_storage_from_env() -> AsyncKeyValue | None:
     try:
         storage = _invoke_storage_factory(factory, config)
     except Exception as exc:
-        raise ValueError(
+        msg = (
             "Failed to create OAuth client storage from "
             f"{CLIENT_STORAGE_FACTORY_ENV}='{import_path}': {exc}"
-        ) from exc
+        )
+        raise ValueError(msg) from exc
 
     _validate_storage_candidate(storage)
     logger.info(

--- a/src/mcp_atlassian/servers/client_storage.py
+++ b/src/mcp_atlassian/servers/client_storage.py
@@ -36,7 +36,20 @@ REQUIRED_STORAGE_METHODS = (
 )
 
 
+# Allowed import paths for ATLASSIAN_OAUTH_CLIENT_STORAGE_FACTORY.
+# Restricts importlib.import_module to known-safe modules only.
+ALLOWED_STORAGE_FACTORIES: set[str] = {
+    "mcp_atlassian.storage.redis:factory",
+    "mcp_atlassian.storage.postgres:factory",
+}
+
+
 def _load_storage_factory(import_path: str) -> Callable[..., AsyncKeyValue]:
+    if import_path not in ALLOWED_STORAGE_FACTORIES:
+        raise ValueError(
+            f"{CLIENT_STORAGE_FACTORY_ENV}=\'{import_path}\' is not in the allowed list. "
+            f"Allowed: {', '.join(sorted(ALLOWED_STORAGE_FACTORIES))}"
+        )
     module_path, separator, attribute_name = import_path.partition(":")
     if not separator or not module_path or not attribute_name:
         raise ValueError(

--- a/src/mcp_atlassian/storage/__init__.py
+++ b/src/mcp_atlassian/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in OAuth client storage factories."""

--- a/src/mcp_atlassian/storage/redis.py
+++ b/src/mcp_atlassian/storage/redis.py
@@ -1,0 +1,23 @@
+"""Redis-backed OAuth client storage factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from key_value.aio.protocols import AsyncKeyValue
+
+
+def factory(config: dict[str, Any] | None = None) -> AsyncKeyValue:
+    """Create a Redis-backed OAuth client storage instance.
+
+    Args:
+        config: Keyword arguments accepted by ``RedisStore``. The most useful
+            option is ``url``, for example ``redis://localhost:6379/0``.
+
+    Returns:
+        An async key-value store compatible with FastMCP OAuth proxy storage.
+    """
+    from key_value.aio.stores.redis import RedisStore
+
+    return RedisStore(**(config or {}))

--- a/src/mcp_atlassian/storage/redis.py
+++ b/src/mcp_atlassian/storage/redis.py
@@ -1,23 +1,86 @@
-"""Redis-backed OAuth client storage factory."""
+"""Encrypted Redis-backed OAuth client storage factory."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qs, urlparse
 
 if TYPE_CHECKING:
     from key_value.aio.protocols import AsyncKeyValue
 
 
 def factory(config: dict[str, Any] | None = None) -> AsyncKeyValue:
-    """Create a Redis-backed OAuth client storage instance.
+    """Create an encrypted Redis-backed OAuth client storage instance.
 
     Args:
-        config: Keyword arguments accepted by ``RedisStore``. The most useful
-            option is ``url``, for example ``redis://localhost:6379/0``.
+        config: Redis connection options accepted by ``redis.asyncio.Redis``
+            plus ``encryption_key``. The key must be a stable Fernet key from
+            a secret, and is used to encrypt values before they reach Redis.
 
     Returns:
-        An async key-value store compatible with FastMCP OAuth proxy storage.
-    """
-    from key_value.aio.stores.redis import RedisStore
+        An encrypted async key-value store compatible with FastMCP OAuth proxy
+        storage.
 
-    return RedisStore(**(config or {}))
+    Raises:
+        ValueError: If the encryption key or Redis configuration is invalid.
+    """
+    from cryptography.fernet import Fernet
+    from key_value.aio.stores.redis import RedisStore
+    from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+    from redis.asyncio import Redis
+
+    options = dict(config or {})
+    raw_encryption_key = options.pop("encryption_key", None)
+    if not isinstance(raw_encryption_key, str) or not raw_encryption_key.strip():
+        raise ValueError(
+            "Redis OAuth client storage requires a non-empty 'encryption_key'"
+        )
+
+    try:
+        encryption_key = Fernet(raw_encryption_key.encode("ascii"))
+    except (UnicodeEncodeError, ValueError, TypeError) as exc:
+        raise ValueError(
+            "Redis OAuth client storage 'encryption_key' must be a valid Fernet key"
+        ) from exc
+
+    default_collection = options.pop("default_collection", None)
+    client = options.pop("client", None)
+    url = options.pop("url", None)
+
+    if client is not None and (url is not None or options):
+        raise ValueError(
+            "Redis OAuth client storage accepts either 'client' or Redis "
+            "connection options, not both"
+        )
+
+    if client is None:
+        options["decode_responses"] = True
+        if url is not None:
+            if not isinstance(url, str):
+                raise ValueError("Redis OAuth client storage 'url' must be a string")
+
+            parsed_url = urlparse(url)
+            if parsed_url.scheme not in {"redis", "rediss"}:
+                raise ValueError(
+                    "Redis OAuth client storage 'url' must use redis:// or rediss://"
+                )
+
+            if parsed_url.scheme == "rediss":
+                query = parse_qs(parsed_url.query)
+                for option_name in ("ssl_cert_reqs", "ssl_check_hostname"):
+                    if option_name in query:
+                        msg = (
+                            f"Redis OAuth client storage URL must not override "
+                            f"{option_name} for rediss://"
+                        )
+                        raise ValueError(msg)
+                options["ssl_cert_reqs"] = "required"
+                options["ssl_check_hostname"] = True
+
+            client = Redis.from_url(url, **options)
+        else:
+            client = Redis(**options)
+
+    redis_store = RedisStore(client=client, default_collection=default_collection)
+
+    return FernetEncryptionWrapper(key_value=redis_store, fernet=encryption_key)

--- a/tests/unit/servers/test_client_storage.py
+++ b/tests/unit/servers/test_client_storage.py
@@ -12,6 +12,7 @@ from mcp_atlassian.servers.client_storage import (
     CLIENT_STORAGE_CONFIG_JSON_ENV,
     CLIENT_STORAGE_FACTORY_ENV,
     CLIENT_STORAGE_MODE_ENV,
+    REQUIRED_STORAGE_METHODS,
     build_oauth_client_storage_from_env,
 )
 
@@ -160,6 +161,27 @@ def test_storage_builder_factory_loads_storage(monkeypatch: pytest.MonkeyPatch) 
     assert callable(getattr(storage, "delete_many", None))
     assert callable(getattr(storage, "ttl_many", None))
     assert storage.factory_config == {"bucket": "mcp-client"}
+
+
+def test_storage_builder_factory_loads_shipped_redis_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    monkeypatch.setenv(
+        CLIENT_STORAGE_FACTORY_ENV,
+        "mcp_atlassian.storage.redis:factory",
+    )
+    monkeypatch.setenv(
+        CLIENT_STORAGE_CONFIG_JSON_ENV,
+        '{"url":"redis://localhost:6379/0"}',
+    )
+
+    storage = build_oauth_client_storage_from_env()
+
+    assert storage is not None
+    assert storage.__class__.__name__ == "RedisStore"
+    for method in REQUIRED_STORAGE_METHODS:
+        assert callable(getattr(storage, method, None))
 
 
 def test_storage_builder_factory_rejects_incompatible_storage(

--- a/tests/unit/servers/test_client_storage.py
+++ b/tests/unit/servers/test_client_storage.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from mcp_atlassian.servers import client_storage
 from mcp_atlassian.servers.client_storage import (
     CLIENT_STORAGE_CONFIG_JSON_ENV,
     CLIENT_STORAGE_FACTORY_ENV,
@@ -81,6 +82,14 @@ def _type_error_in_factory(config: dict[str, Any] | None = None) -> _DummyStorag
     return _DummyStorage(config=config)
 
 
+def _allow_test_factory(monkeypatch: pytest.MonkeyPatch, factory_path: str) -> None:
+    monkeypatch.setattr(
+        client_storage,
+        "ALLOWED_STORAGE_FACTORIES",
+        {*client_storage.ALLOWED_STORAGE_FACTORIES, factory_path},
+    )
+
+
 def test_storage_builder_default_mode_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -112,6 +121,10 @@ def test_storage_builder_factory_rejects_invalid_json(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    _allow_test_factory(
+        monkeypatch,
+        "tests.unit.servers.test_client_storage:_dummy_storage_factory",
+    )
     monkeypatch.setenv(
         CLIENT_STORAGE_FACTORY_ENV,
         "tests.unit.servers.test_client_storage:_dummy_storage_factory",
@@ -124,6 +137,10 @@ def test_storage_builder_factory_rejects_invalid_json(
 
 def test_storage_builder_factory_loads_storage(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    _allow_test_factory(
+        monkeypatch,
+        "tests.unit.servers.test_client_storage:_dummy_storage_factory",
+    )
     monkeypatch.setenv(
         CLIENT_STORAGE_FACTORY_ENV,
         "tests.unit.servers.test_client_storage:_dummy_storage_factory",
@@ -149,6 +166,10 @@ def test_storage_builder_factory_rejects_incompatible_storage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    _allow_test_factory(
+        monkeypatch,
+        "tests.unit.servers.test_client_storage:_invalid_storage_factory",
+    )
     monkeypatch.setenv(
         CLIENT_STORAGE_FACTORY_ENV,
         "tests.unit.servers.test_client_storage:_invalid_storage_factory",
@@ -162,6 +183,10 @@ def test_storage_builder_factory_rejects_partially_implemented_storage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    _allow_test_factory(
+        monkeypatch,
+        "tests.unit.servers.test_client_storage:_partial_storage_factory",
+    )
     monkeypatch.setenv(
         CLIENT_STORAGE_FACTORY_ENV,
         "tests.unit.servers.test_client_storage:_partial_storage_factory",
@@ -175,6 +200,10 @@ def test_storage_builder_does_not_mask_internal_factory_typeerror(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    _allow_test_factory(
+        monkeypatch,
+        "tests.unit.servers.test_client_storage:_type_error_in_factory",
+    )
     monkeypatch.setenv(
         CLIENT_STORAGE_FACTORY_ENV,
         "tests.unit.servers.test_client_storage:_type_error_in_factory",
@@ -186,3 +215,13 @@ def test_storage_builder_does_not_mask_internal_factory_typeerror(
         build_oauth_client_storage_from_env()
 
     assert os.getenv(_TYPE_ERROR_FACTORY_CALLS_ENV) == "1"
+
+
+def test_storage_builder_factory_rejects_unallowlisted_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    monkeypatch.setenv(CLIENT_STORAGE_FACTORY_ENV, "os:system")
+
+    with pytest.raises(ValueError, match="not in the allowed list"):
+        build_oauth_client_storage_from_env()

--- a/tests/unit/servers/test_client_storage.py
+++ b/tests/unit/servers/test_client_storage.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
 
 import pytest
+from cryptography.fernet import Fernet
 
 from mcp_atlassian.servers import client_storage
 from mcp_atlassian.servers.client_storage import (
@@ -173,15 +175,85 @@ def test_storage_builder_factory_loads_shipped_redis_storage(
     )
     monkeypatch.setenv(
         CLIENT_STORAGE_CONFIG_JSON_ENV,
-        '{"url":"redis://localhost:6379/0"}',
+        json.dumps(
+            {
+                "url": "rediss://redis.example.com:6380/0",
+                "password": "redis-password-sentinel",
+                "encryption_key": Fernet.generate_key().decode("ascii"),
+            }
+        ),
     )
 
     storage = build_oauth_client_storage_from_env()
 
     assert storage is not None
-    assert storage.__class__.__name__ == "RedisStore"
+    assert storage.__class__.__name__ == "FernetEncryptionWrapper"
+    assert storage.key_value.__class__.__name__ == "RedisStore"
     for method in REQUIRED_STORAGE_METHODS:
         assert callable(getattr(storage, method, None))
+
+
+def test_storage_builder_factory_requires_redis_encryption_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(CLIENT_STORAGE_MODE_ENV, "factory")
+    monkeypatch.setenv(
+        CLIENT_STORAGE_FACTORY_ENV,
+        "mcp_atlassian.storage.redis:factory",
+    )
+    monkeypatch.setenv(
+        CLIENT_STORAGE_CONFIG_JSON_ENV,
+        '{"url":"rediss://redis.example.com:6380/0"}',
+    )
+
+    with pytest.raises(ValueError, match="encryption_key"):
+        build_oauth_client_storage_from_env()
+
+
+@pytest.mark.anyio
+async def test_redis_storage_encrypts_values_before_writing() -> None:
+    from fakeredis.aioredis import FakeRedis
+
+    from mcp_atlassian.storage.redis import factory
+
+    client = FakeRedis(decode_responses=True)
+    storage = factory(
+        {
+            "client": client,
+            "encryption_key": Fernet.generate_key().decode("ascii"),
+        }
+    )
+    secret_values = {
+        "client_secret": "oauth-client-secret-sentinel",
+        "access_token": "oauth-access-token-sentinel",
+        "refresh_token": "oauth-refresh-token-sentinel",
+    }
+
+    await storage.put("sentinel", secret_values, collection="oauth")
+
+    raw_values = await client.mget("oauth::sentinel")
+    assert raw_values[0] is not None
+    raw_value = raw_values[0]
+    assert all(secret not in raw_value for secret in secret_values.values())
+    assert "__encrypted_data__" in raw_value
+    assert await storage.get("sentinel", collection="oauth") == secret_values
+
+    await client.aclose()
+
+
+def test_redis_storage_enables_certificate_verification_for_rediss() -> None:
+    from mcp_atlassian.storage.redis import factory
+
+    storage = factory(
+        {
+            "url": "rediss://redis.example.com:6380/0",
+            "encryption_key": Fernet.generate_key().decode("ascii"),
+        }
+    )
+
+    connection_kwargs = storage.key_value._client.connection_pool.connection_kwargs
+    assert connection_kwargs["ssl_cert_reqs"] == "required"
+    assert connection_kwargs["ssl_check_hostname"] is True
 
 
 def test_storage_builder_factory_rejects_incompatible_storage(

--- a/tests/unit/servers/test_oauth_proxy_build.py
+++ b/tests/unit/servers/test_oauth_proxy_build.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from mcp.shared.auth import OAuthClientInformationFull
 
+from mcp_atlassian.servers import client_storage
 from mcp_atlassian.servers.main import _build_auth_provider
 from mcp_atlassian.utils.oauth import CLOUD_AUTHORIZE_URL, CLOUD_TOKEN_URL
 
@@ -254,6 +255,14 @@ def test_build_auth_provider_supports_custom_client_storage_factory(monkeypatch)
     monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
     _set_required_oauth_env(monkeypatch, redirect_uri="http://localhost:3000/callback")
     monkeypatch.setenv("ATLASSIAN_OAUTH_CLIENT_STORAGE_MODE", "factory")
+    monkeypatch.setattr(
+        client_storage,
+        "ALLOWED_STORAGE_FACTORIES",
+        {
+            *client_storage.ALLOWED_STORAGE_FACTORIES,
+            "tests.unit.servers.test_oauth_proxy_build:_dummy_provider_storage_factory",
+        },
+    )
     monkeypatch.setenv(
         "ATLASSIAN_OAUTH_CLIENT_STORAGE_FACTORY",
         "tests.unit.servers.test_oauth_proxy_build:_dummy_provider_storage_factory",

--- a/uv.lock
+++ b/uv.lock
@@ -1439,6 +1439,7 @@ dependencies = [
     { name = "markdownify" },
     { name = "mcp" },
     { name = "pydantic" },
+    { name = "py-key-value-aio", extra = ["redis", "wrappers-encryption"] },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "requests", extra = ["socks"] },
@@ -1486,6 +1487,7 @@ requires-dist = [
     { name = "markdownify", specifier = ">=0.11.6" },
     { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
     { name = "pydantic", specifier = ">=2.10.6,<3.0" },
+    { name = "py-key-value-aio", extras = ["redis", "wrappers-encryption"], specifier = ">=0.3.0,<0.4.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "requests", extras = ["socks"], specifier = ">=2.31.0" },
@@ -1751,6 +1753,9 @@ memory = [
 ]
 redis = [
     { name = "redis" },
+]
+wrappers-encryption = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

When `ATLASSIAN_OAUTH_CLIENT_STORAGE_MODE=factory`, the server must not import an arbitrary Python module from `ATLASSIAN_OAUTH_CLIENT_STORAGE_FACTORY`.

## Security fix

- Rejects factory paths that are not explicitly allowlisted before importing them.
- Ships the allowlisted `mcp_atlassian.storage.redis:factory` adapter used by the Helm documentation.
- Removes the unshipped PostgreSQL entry instead of advertising a path that cannot work with this release.
- Keeps downstream custom factories opt-in through an explicit allowlist change in the downstream package.

## Testing

- Unallowlisted `os:system` is rejected before import.
- The shipped Redis factory is loaded through the production allowlist without patching it in the test.
- `uv run pytest tests/unit/servers`
- `uv run pytest tests/e2e/cloud --cloud-e2e`
- `uv run pytest tests/e2e --dc-e2e`

## Disclosure

Reported via GitHub Advisory (PVRA). Env-var control is a separate trust boundary, but importing an unvalidated module path is a known RCE vector.