### PR TITLE
fix(security): add format validation to AtlassianOpaqueTokenVerifier

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -787,7 +787,12 @@ def _build_auth_provider() -> HardenedOAuthProxy | None:
     allowed_client_redirect_uris = _get_allowed_redirect_uris()
     allowed_grant_types = _get_allowed_grant_types()
     require_consent = is_env_truthy("ATLASSIAN_OAUTH_REQUIRE_CONSENT", "true")
-    verifier = AtlassianOpaqueTokenVerifier(required_scopes=scopes)
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url=instance_url,
+        is_cloud=is_cloud,
+        cloud_id=os.getenv("ATLASSIAN_OAUTH_CLOUD_ID") if is_cloud else None,
+        required_scopes=scopes,
+    )
 
     return HardenedOAuthProxy(
         upstream_authorization_endpoint=upstream_authorize,

--- a/src/mcp_atlassian/utils/token_verifier.py
+++ b/src/mcp_atlassian/utils/token_verifier.py
@@ -1,35 +1,203 @@
-"""Token verifier for Atlassian opaque OAuth tokens.
+"""Token verifier for Atlassian OAuth tokens.
 
 FastMCP's OAuthProxy requires a TokenVerifier for loaded upstream access tokens.
-Atlassian OAuth tokens are opaque in many environments and there is no stable
-JWKS endpoint for verification, so we accept non-empty tokens and attach the
-required scopes.
+Atlassian tokens are opaque, so verification must be done via an upstream API
+call instead of local JWT/JWKS checks.
 """
 
 from __future__ import annotations
 
-import re
+import hashlib
+import logging
 import time
+from typing import Any
+from urllib.parse import urlparse
 
+import httpx
+from cachetools import TTLCache
 from fastmcp.server.auth.auth import AccessToken, TokenVerifier
+
+CLOUD_ACCESSIBLE_RESOURCES_URL = (
+    "https://api.atlassian.com/oauth/token/accessible-resources"
+)
+TOKEN_VALIDATION_TIMEOUT_SECONDS = 10.0
+TOKEN_CACHE_TTL_SECONDS = 300
+TOKEN_CACHE_MAX_SIZE = 1024
+NON_RESOURCE_SCOPES = frozenset({"offline_access"})
+DC_TOKEN_VALIDATION_PATHS = (
+    "/rest/api/2/myself",
+    "/rest/api/user/current",
+)
+
+logger = logging.getLogger("mcp-atlassian.oauth-proxy.token-verifier")
 
 
 class AtlassianOpaqueTokenVerifier(TokenVerifier):
-    """Accept opaque Atlassian tokens and wrap them in AccessToken."""
+    """Validate opaque Atlassian tokens with an upstream API call."""
+
+    def __init__(
+        self,
+        *,
+        instance_url: str | None = None,
+        is_cloud: bool = True,
+        cloud_id: str | None = None,
+        required_scopes: list[str] | None = None,
+    ) -> None:
+        super().__init__(required_scopes=required_scopes)
+        self.instance_url = instance_url.rstrip("/") if instance_url else None
+        self.is_cloud = is_cloud
+        self.cloud_id = cloud_id
+        self._token_cache: TTLCache[str, AccessToken] = TTLCache(
+            maxsize=TOKEN_CACHE_MAX_SIZE,
+            ttl=TOKEN_CACHE_TTL_SECONDS,
+        )
+
+    @staticmethod
+    def _cache_key(token: str) -> str:
+        """Return a non-secret cache key for an access token."""
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    async def _fetch_accessible_resources(self, token: str) -> list[dict[str, Any]]:
+        headers = {"Authorization": f"Bearer {token}"}
+        timeout = httpx.Timeout(TOKEN_VALIDATION_TIMEOUT_SECONDS)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(
+                CLOUD_ACCESSIBLE_RESOURCES_URL,
+                headers=headers,
+            )
+
+        if response.status_code != 200:
+            logger.warning(
+                "Token validation failed with status %s",
+                response.status_code,
+            )
+            return []
+
+        data = response.json()
+        if not isinstance(data, list):
+            logger.warning("Token validation returned non-list resources payload")
+            return []
+
+        return [resource for resource in data if isinstance(resource, dict)]
+
+    def _matches_cloud_instance(self, resource: dict[str, Any]) -> bool:
+        """Return whether a Cloud resource belongs to the configured instance."""
+        if self.cloud_id and resource.get("id") != self.cloud_id:
+            return False
+
+        if not self.instance_url:
+            return True
+
+        instance = urlparse(self.instance_url)
+        if (instance.hostname or "").lower() in {
+            "api.atlassian.com",
+            "auth.atlassian.com",
+        }:
+            return True
+
+        resource_url = resource.get("url")
+        if not isinstance(resource_url, str):
+            return False
+
+        candidate = urlparse(resource_url)
+        return (
+            candidate.scheme.lower(),
+            (candidate.hostname or "").lower(),
+            candidate.port,
+        ) == (
+            instance.scheme.lower(),
+            (instance.hostname or "").lower(),
+            instance.port,
+        )
+
+    @staticmethod
+    def _is_authenticated_dc_user(data: object) -> bool:
+        """Return whether a Data Center user response represents a real user."""
+        if not isinstance(data, dict):
+            return False
+        if str(data.get("type", "")).lower() == "anonymous":
+            return False
+        return any(
+            isinstance(data.get(field), str) and bool(data[field])
+            for field in ("accountId", "key", "name", "userKey", "username")
+        ) or str(data.get("type", "")).lower() in {"known", "user"}
+
+    async def _validate_dc_token(self, token: str) -> bool:
+        """Validate a token against an authenticated Data Center user endpoint."""
+        if not self.instance_url:
+            logger.warning("Data Center token validation requires an instance URL")
+            return False
+
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+        }
+        timeout = httpx.Timeout(TOKEN_VALIDATION_TIMEOUT_SECONDS)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            for path in DC_TOKEN_VALIDATION_PATHS:
+                response = await client.get(
+                    f"{self.instance_url}{path}", headers=headers
+                )
+                if response.status_code != 200:
+                    continue
+                if self._is_authenticated_dc_user(response.json()):
+                    return True
+
+        logger.warning("Token validation failed against Data Center user endpoints")
+        return False
+
+    async def _verify_cloud_token(self, token: str) -> set[str] | None:
+        """Validate a Cloud token and return its resource scopes."""
+        resources = await self._fetch_accessible_resources(token)
+        matching_resources = [
+            resource for resource in resources if self._matches_cloud_instance(resource)
+        ]
+        if not matching_resources:
+            return None
+
+        token_scopes: set[str] = set()
+        for resource in matching_resources:
+            scopes = resource.get("scopes", [])
+            if isinstance(scopes, list):
+                token_scopes.update(scope for scope in scopes if isinstance(scope, str))
+
+        required_scopes = set(self.required_scopes or [])
+        required_resource_scopes = required_scopes - NON_RESOURCE_SCOPES
+        if not required_resource_scopes.issubset(token_scopes):
+            missing = sorted(required_resource_scopes - token_scopes)
+            logger.warning("Token is missing required scopes: %s", missing)
+            return None
+
+        return token_scopes | (required_scopes & NON_RESOURCE_SCOPES)
 
     async def verify_token(self, token: str) -> AccessToken | None:  # noqa: D401
+        token = token.strip() if token else ""
         if not token:
             return None
 
-        # Atlassian tokens have specific format: base64-like, min 20 chars.
-        # Reject obviously fabricated tokens that don't match expected format.
-        if len(token) < 20 or not re.match(r"^[A-Za-z0-9._-]+$", token):
+        cache_key = self._cache_key(token)
+        cached_token = self._token_cache.get(cache_key)
+        if cached_token is not None:
+            return cached_token
+
+        try:
+            if self.is_cloud:
+                effective_scopes = await self._verify_cloud_token(token)
+                if effective_scopes is None:
+                    return None
+            else:
+                if not await self._validate_dc_token(token):
+                    return None
+                effective_scopes = set(self.required_scopes or [])
+        except (httpx.HTTPError, ValueError, TypeError) as exc:
+            logger.warning("Token validation request failed: %s", exc)
             return None
 
-        scopes = self.required_scopes or []
-        return AccessToken(
+        access_token = AccessToken(
             token=token,
             client_id="atlassian",
-            scopes=scopes,
-            expires_at=int(time.time()) + 86400 * 30,
+            scopes=sorted(effective_scopes),
+            expires_at=int(time.time()) + TOKEN_CACHE_TTL_SECONDS,
         )
+        self._token_cache[cache_key] = access_token
+        return access_token

--- a/src/mcp_atlassian/utils/token_verifier.py
+++ b/src/mcp_atlassian/utils/token_verifier.py
@@ -8,6 +8,7 @@ required scopes.
 
 from __future__ import annotations
 
+import re
 import time
 
 from fastmcp.server.auth.auth import AccessToken, TokenVerifier
@@ -18,6 +19,11 @@ class AtlassianOpaqueTokenVerifier(TokenVerifier):
 
     async def verify_token(self, token: str) -> AccessToken | None:  # noqa: D401
         if not token:
+            return None
+
+        # Atlassian tokens have specific format: base64-like, min 20 chars.
+        # Reject obviously fabricated tokens that don't match expected format.
+        if len(token) < 20 or not re.match(r"^[A-Za-z0-9._-]+$", token):
             return None
 
         scopes = self.required_scopes or []

--- a/src/mcp_atlassian/utils/token_verifier.py
+++ b/src/mcp_atlassian/utils/token_verifier.py
@@ -43,10 +43,18 @@ class AtlassianOpaqueTokenVerifier(TokenVerifier):
         cloud_id: str | None = None,
         required_scopes: list[str] | None = None,
     ) -> None:
+        """Initialize a verifier bound to one Atlassian instance.
+
+        Args:
+            instance_url: Atlassian Cloud or Data Center instance URL.
+            is_cloud: Whether the configured instance is Atlassian Cloud.
+            cloud_id: Optional Cloud resource ID to require during validation.
+            required_scopes: Scopes required by the OAuth proxy.
+        """
         super().__init__(required_scopes=required_scopes)
         self.instance_url = instance_url.rstrip("/") if instance_url else None
         self.is_cloud = is_cloud
-        self.cloud_id = cloud_id
+        self.cloud_id = cloud_id.strip() if cloud_id else None
         self._token_cache: TTLCache[str, AccessToken] = TTLCache(
             maxsize=TOKEN_CACHE_MAX_SIZE,
             ttl=TOKEN_CACHE_TTL_SECONDS,
@@ -56,6 +64,24 @@ class AtlassianOpaqueTokenVerifier(TokenVerifier):
     def _cache_key(token: str) -> str:
         """Return a non-secret cache key for an access token."""
         return hashlib.sha256(token.encode()).hexdigest()
+
+    @staticmethod
+    def _url_identity(value: str) -> tuple[str, str, int] | None:
+        """Return the scheme, hostname, and effective port for a URL."""
+        try:
+            parsed = urlparse(value)
+            scheme = parsed.scheme.lower()
+            hostname = (parsed.hostname or "").lower().rstrip(".")
+            port = parsed.port
+        except ValueError:
+            return None
+
+        if scheme not in {"http", "https"} or not hostname:
+            return None
+
+        if port is None:
+            port = 443 if scheme == "https" else 80
+        return scheme, hostname, port
 
     async def _fetch_accessible_resources(self, token: str) -> list[dict[str, Any]]:
         headers = {"Authorization": f"Bearer {token}"}
@@ -82,33 +108,31 @@ class AtlassianOpaqueTokenVerifier(TokenVerifier):
 
     def _matches_cloud_instance(self, resource: dict[str, Any]) -> bool:
         """Return whether a Cloud resource belongs to the configured instance."""
-        if self.cloud_id and resource.get("id") != self.cloud_id:
+        resource_id = resource.get("id")
+        resource_url = resource.get("url")
+        resource_scopes = resource.get("scopes")
+        if (
+            not isinstance(resource_id, str)
+            or not resource_id
+            or not isinstance(resource_url, str)
+            or not resource_url
+            or not isinstance(resource_scopes, list)
+            or any(not isinstance(scope, str) or not scope for scope in resource_scopes)
+        ):
             return False
+
+        if self.cloud_id:
+            return resource_id == self.cloud_id
 
         if not self.instance_url:
-            return True
-
-        instance = urlparse(self.instance_url)
-        if (instance.hostname or "").lower() in {
-            "api.atlassian.com",
-            "auth.atlassian.com",
-        }:
-            return True
-
-        resource_url = resource.get("url")
-        if not isinstance(resource_url, str):
             return False
 
-        candidate = urlparse(resource_url)
-        return (
-            candidate.scheme.lower(),
-            (candidate.hostname or "").lower(),
-            candidate.port,
-        ) == (
-            instance.scheme.lower(),
-            (instance.hostname or "").lower(),
-            instance.port,
-        )
+        instance_identity = self._url_identity(self.instance_url)
+        resource_identity = self._url_identity(resource_url)
+        if instance_identity is None or resource_identity is None:
+            return False
+
+        return resource_identity == instance_identity
 
     @staticmethod
     def _is_authenticated_dc_user(data: object) -> bool:
@@ -118,9 +142,9 @@ class AtlassianOpaqueTokenVerifier(TokenVerifier):
         if str(data.get("type", "")).lower() == "anonymous":
             return False
         return any(
-            isinstance(data.get(field), str) and bool(data[field])
+            isinstance(data.get(field), str) and bool(data[field].strip())
             for field in ("accountId", "key", "name", "userKey", "username")
-        ) or str(data.get("type", "")).lower() in {"known", "user"}
+        )
 
     async def _validate_dc_token(self, token: str) -> bool:
         """Validate a token against an authenticated Data Center user endpoint."""
@@ -140,7 +164,14 @@ class AtlassianOpaqueTokenVerifier(TokenVerifier):
                 )
                 if response.status_code != 200:
                     continue
-                if self._is_authenticated_dc_user(response.json()):
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    logger.warning(
+                        "Token validation returned malformed JSON from %s", path
+                    )
+                    continue
+                if self._is_authenticated_dc_user(response_data):
                     return True
 
         logger.warning("Token validation failed against Data Center user endpoints")

--- a/src/mcp_atlassian/utils/token_verifier.py
+++ b/src/mcp_atlassian/utils/token_verifier.py
@@ -121,15 +121,22 @@ class AtlassianOpaqueTokenVerifier(TokenVerifier):
         ):
             return False
 
-        if self.cloud_id:
-            return resource_id == self.cloud_id
-
-        if not self.instance_url:
+        if self.cloud_id and resource_id != self.cloud_id:
             return False
 
+        if not self.instance_url:
+            return bool(self.cloud_id)
+
         instance_identity = self._url_identity(self.instance_url)
+        if instance_identity is None:
+            return False
+
+        instance_hostname = instance_identity[1]
+        if instance_hostname in {"api.atlassian.com", "auth.atlassian.com"}:
+            return bool(self.cloud_id)
+
         resource_identity = self._url_identity(resource_url)
-        if instance_identity is None or resource_identity is None:
+        if resource_identity is None:
             return False
 
         return resource_identity == instance_identity

--- a/tests/e2e/cloud/test_oauth_token_verifier.py
+++ b/tests/e2e/cloud/test_oauth_token_verifier.py
@@ -1,0 +1,63 @@
+"""Cloud E2E coverage for upstream OAuth token verification."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from mcp_atlassian.utils.token_verifier import AtlassianOpaqueTokenVerifier
+
+from .conftest import CloudInstanceInfo
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+def _required_scopes() -> list[str]:
+    """Return the resource scopes configured for the OAuth proxy test."""
+    configured = os.environ.get("ATLASSIAN_OAUTH_SCOPE", "")
+    scopes = [scope for scope in configured.replace(",", " ").split() if scope]
+    return scopes or ["read:jira-work"]
+
+
+@pytest.fixture
+def cloud_oauth_verifier(
+    cloud_instance: CloudInstanceInfo,
+) -> AtlassianOpaqueTokenVerifier:
+    """Build the verifier bound to the configured Cloud site."""
+    assert cloud_instance.has_oauth(), (
+        "Cloud OAuth E2E requires CLOUD_E2E_OAUTH_ACCESS_TOKEN and "
+        "CLOUD_E2E_OAUTH_CLOUD_ID"
+    )
+    return AtlassianOpaqueTokenVerifier(
+        instance_url=cloud_instance.jira_url,
+        cloud_id=cloud_instance.oauth_cloud_id,
+        required_scopes=_required_scopes(),
+    )
+
+
+@pytest.mark.anyio
+async def test_cloud_oauth_token_is_verified_upstream(
+    cloud_instance: CloudInstanceInfo,
+    cloud_oauth_verifier: AtlassianOpaqueTokenVerifier,
+) -> None:
+    """Accept the configured live Cloud OAuth token with its granted scopes."""
+    accepted = await cloud_oauth_verifier.verify_token(
+        cloud_instance.oauth_access_token
+    )
+
+    assert accepted is not None, "Configured Cloud OAuth token was rejected"
+    assert accepted.token == cloud_instance.oauth_access_token
+    assert set(_required_scopes()).issubset(accepted.scopes)
+
+
+@pytest.mark.anyio
+async def test_cloud_oauth_token_rejects_format_valid_fabrication(
+    cloud_oauth_verifier: AtlassianOpaqueTokenVerifier,
+) -> None:
+    """Reject a fabricated token that passes superficial format checks."""
+    fabricated = f"invalid-{uuid.uuid4().hex}"
+    rejected = await cloud_oauth_verifier.verify_token(fabricated)
+
+    assert rejected is None, "Fabricated Cloud OAuth token was accepted"

--- a/tests/e2e/test_oauth_token_verifier_dc.py
+++ b/tests/e2e/test_oauth_token_verifier_dc.py
@@ -1,0 +1,41 @@
+"""Data Center E2E coverage for upstream OAuth token verification."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.utils.token_verifier import AtlassianOpaqueTokenVerifier
+
+from .conftest import DCInstanceInfo
+
+pytestmark = pytest.mark.dc_e2e
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("url_attribute", "token_attribute"),
+    (("jira_url", "jira_pat"), ("confluence_url", "confluence_pat")),
+    ids=("jira", "confluence"),
+)
+async def test_dc_oauth_token_verifier_accepts_live_pat_and_rejects_fabrication(
+    dc_instance: DCInstanceInfo,
+    url_attribute: str,
+    token_attribute: str,
+) -> None:
+    """Validate a fixture-created PAT and reject a fabricated bearer token."""
+    instance_url = getattr(dc_instance, url_attribute)
+    access_token = getattr(dc_instance, token_attribute)
+    assert access_token, f"No {token_attribute} was created for DC E2E"
+
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url=instance_url,
+        is_cloud=False,
+    )
+    accepted = await verifier.verify_token(access_token)
+    rejected = await verifier.verify_token(f"invalid-{uuid.uuid4().hex}")
+
+    assert accepted is not None, f"Valid {token_attribute} was rejected"
+    assert accepted.token == access_token
+    assert rejected is None, "Fabricated Data Center OAuth token was accepted"

--- a/tests/unit/servers/test_oauth_proxy_build.py
+++ b/tests/unit/servers/test_oauth_proxy_build.py
@@ -123,6 +123,8 @@ def test_build_auth_provider_uses_cloud_endpoints_for_atlassian_cloud(monkeypatc
         "audience": "api.atlassian.com",
         "prompt": "consent",
     }
+    assert provider._token_validator.is_cloud is True
+    assert provider._token_validator.instance_url == "https://acme.atlassian.net"
 
 
 def test_build_auth_provider_uses_dc_endpoints_for_datacenter_url(monkeypatch):
@@ -140,6 +142,8 @@ def test_build_auth_provider_uses_dc_endpoints_for_datacenter_url(monkeypatch):
         provider._upstream_token_endpoint
         == "https://jira.example.com/rest/oauth2/latest/token"
     )
+    assert provider._token_validator.is_cloud is False
+    assert provider._token_validator.instance_url == "https://jira.example.com"
 
 
 def test_build_auth_provider_infers_base_url_from_redirect_uri(monkeypatch):

--- a/tests/unit/utils/test_token_verifier.py
+++ b/tests/unit/utils/test_token_verifier.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 import pytest
 from fastmcp.server.auth.auth import AccessToken
 
@@ -12,12 +15,79 @@ from mcp_atlassian.utils.token_verifier import AtlassianOpaqueTokenVerifier
 async def test_verify_token_returns_fastmcp_access_token() -> None:
     verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
 
+    async def _resources(_token: str) -> list[dict]:
+        return [{"id": "cloud-1", "scopes": ["read:jira-work", "write:jira-work"]}]
+
+    verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
+
     token = await verifier.verify_token("opaque-token")
 
     assert isinstance(token, AccessToken)
     assert token is not None
     assert token.token == "opaque-token"
-    assert token.scopes == ["read:jira-work"]
+    assert "read:jira-work" in token.scopes
+
+
+@pytest.mark.anyio
+async def test_verify_token_caches_successful_validation() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
+    fetch_resources = AsyncMock(
+        return_value=[{"id": "cloud-1", "scopes": ["read:jira-work"]}]
+    )
+    verifier._fetch_accessible_resources = fetch_resources
+
+    first = await verifier.verify_token("opaque-token")
+    second = await verifier.verify_token("opaque-token")
+
+    assert first is second
+    assert "opaque-token" not in verifier._token_cache
+    fetch_resources.assert_awaited_once_with("opaque-token")
+
+    verifier._token_cache.expire(time=float("inf"))
+    third = await verifier.verify_token("opaque-token")
+
+    assert third is not None
+    assert fetch_resources.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_verify_token_accepts_offline_access_as_non_resource_scope() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        required_scopes=["read:jira-work", "offline_access"]
+    )
+
+    async def _resources(_token: str) -> list[dict]:
+        return [{"id": "cloud-1", "scopes": ["read:jira-work"]}]
+
+    verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert token is not None
+    assert token.scopes == ["offline_access", "read:jira-work"]
+
+
+@pytest.mark.anyio
+async def test_verify_token_rejects_resource_from_another_cloud_instance() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://expected.atlassian.net/wiki",
+        required_scopes=["read:confluence-content.all"],
+    )
+
+    async def _resources(_token: str) -> list[dict]:
+        return [
+            {
+                "id": "cloud-1",
+                "url": "https://other.atlassian.net",
+                "scopes": ["read:confluence-content.all"],
+            }
+        ]
+
+    verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert token is None
 
 
 @pytest.mark.anyio
@@ -27,3 +97,102 @@ async def test_verify_token_returns_none_for_empty_token() -> None:
     token = await verifier.verify_token("")
 
     assert token is None
+
+
+@pytest.mark.anyio
+async def test_verify_token_returns_none_when_required_scope_missing() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["write:jira-work"])
+
+    async def _resources(_token: str) -> list[dict]:
+        return [{"id": "cloud-1", "scopes": ["read:jira-work"]}]
+
+    verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert token is None
+
+
+@pytest.mark.anyio
+async def test_verify_token_returns_none_when_validation_fails() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
+
+    async def _raise(_token: str) -> list[dict]:
+        raise ValueError("validation failed")
+
+    verifier._fetch_accessible_resources = _raise  # type: ignore[method-assign]
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert token is None
+
+
+@pytest.mark.anyio
+async def test_verify_token_validates_against_data_center_instance() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://jira.example.com",
+        is_cloud=False,
+        required_scopes=["READ"],
+    )
+    validate_dc_token = AsyncMock(return_value=True)
+    verifier._validate_dc_token = validate_dc_token
+
+    token = await verifier.verify_token("dc-token")
+
+    assert token is not None
+    assert token.scopes == ["READ"]
+    validate_dc_token.assert_awaited_once_with("dc-token")
+
+
+@pytest.mark.anyio
+async def test_data_center_validation_tries_jira_then_confluence() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://confluence.example.com/confluence",
+        is_cloud=False,
+    )
+    jira_response = httpx.Response(404)
+    confluence_response = httpx.Response(
+        200,
+        json={"type": "known", "username": "alice"},
+    )
+    client = AsyncMock()
+    client.get.side_effect = [jira_response, confluence_response]
+    client_context = MagicMock()
+    client_context.__aenter__ = AsyncMock(return_value=client)
+    client_context.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "mcp_atlassian.utils.token_verifier.httpx.AsyncClient",
+        return_value=client_context,
+    ):
+        valid = await verifier._validate_dc_token("dc-token")
+
+    assert valid is True
+    assert [call.args[0] for call in client.get.await_args_list] == [
+        "https://confluence.example.com/confluence/rest/api/2/myself",
+        "https://confluence.example.com/confluence/rest/api/user/current",
+    ]
+
+
+@pytest.mark.anyio
+async def test_data_center_validation_rejects_anonymous_user() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://confluence.example.com/confluence",
+        is_cloud=False,
+    )
+    client = AsyncMock()
+    client.get.side_effect = [
+        httpx.Response(404),
+        httpx.Response(200, json={"type": "anonymous"}),
+    ]
+    client_context = MagicMock()
+    client_context.__aenter__ = AsyncMock(return_value=client)
+    client_context.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "mcp_atlassian.utils.token_verifier.httpx.AsyncClient",
+        return_value=client_context,
+    ):
+        valid = await verifier._validate_dc_token("invalid-token")
+
+    assert valid is False

--- a/tests/unit/utils/test_token_verifier.py
+++ b/tests/unit/utils/test_token_verifier.py
@@ -13,10 +13,19 @@ from mcp_atlassian.utils.token_verifier import AtlassianOpaqueTokenVerifier
 
 @pytest.mark.anyio
 async def test_verify_token_returns_fastmcp_access_token() -> None:
-    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://acme.atlassian.net",
+        required_scopes=["read:jira-work"],
+    )
 
     async def _resources(_token: str) -> list[dict]:
-        return [{"id": "cloud-1", "scopes": ["read:jira-work", "write:jira-work"]}]
+        return [
+            {
+                "id": "cloud-1",
+                "url": "https://acme.atlassian.net",
+                "scopes": ["read:jira-work", "write:jira-work"],
+            }
+        ]
 
     verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
 
@@ -30,9 +39,18 @@ async def test_verify_token_returns_fastmcp_access_token() -> None:
 
 @pytest.mark.anyio
 async def test_verify_token_caches_successful_validation() -> None:
-    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://acme.atlassian.net",
+        required_scopes=["read:jira-work"],
+    )
     fetch_resources = AsyncMock(
-        return_value=[{"id": "cloud-1", "scopes": ["read:jira-work"]}]
+        return_value=[
+            {
+                "id": "cloud-1",
+                "url": "https://acme.atlassian.net",
+                "scopes": ["read:jira-work"],
+            }
+        ]
     )
     verifier._fetch_accessible_resources = fetch_resources
 
@@ -51,13 +69,61 @@ async def test_verify_token_caches_successful_validation() -> None:
 
 
 @pytest.mark.anyio
+async def test_verify_token_rejects_unbound_cloud_resource() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
+
+    async def _resources(_token: str) -> list[dict]:
+        return [
+            {
+                "id": "cloud-1",
+                "url": "https://acme.atlassian.net",
+                "scopes": ["read:jira-work"],
+            }
+        ]
+
+    verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert token is None
+
+
+@pytest.mark.anyio
+async def test_verify_token_rejects_malformed_cloud_resource() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://acme.atlassian.net",
+        required_scopes=[],
+    )
+    fetch_resources = AsyncMock(
+        return_value=[
+            {
+                "id": "cloud-1",
+                "url": "https://acme.atlassian.net",
+            }
+        ]
+    )
+    verifier._fetch_accessible_resources = fetch_resources
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert token is None
+
+
+@pytest.mark.anyio
 async def test_verify_token_accepts_offline_access_as_non_resource_scope() -> None:
     verifier = AtlassianOpaqueTokenVerifier(
-        required_scopes=["read:jira-work", "offline_access"]
+        instance_url="https://acme.atlassian.net",
+        required_scopes=["read:jira-work", "offline_access"],
     )
 
     async def _resources(_token: str) -> list[dict]:
-        return [{"id": "cloud-1", "scopes": ["read:jira-work"]}]
+        return [
+            {
+                "id": "cloud-1",
+                "url": "https://acme.atlassian.net",
+                "scopes": ["read:jira-work"],
+            }
+        ]
 
     verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
 
@@ -101,10 +167,19 @@ async def test_verify_token_returns_none_for_empty_token() -> None:
 
 @pytest.mark.anyio
 async def test_verify_token_returns_none_when_required_scope_missing() -> None:
-    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["write:jira-work"])
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://acme.atlassian.net",
+        required_scopes=["write:jira-work"],
+    )
 
     async def _resources(_token: str) -> list[dict]:
-        return [{"id": "cloud-1", "scopes": ["read:jira-work"]}]
+        return [
+            {
+                "id": "cloud-1",
+                "url": "https://acme.atlassian.net",
+                "scopes": ["read:jira-work"],
+            }
+        ]
 
     verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
 
@@ -115,7 +190,10 @@ async def test_verify_token_returns_none_when_required_scope_missing() -> None:
 
 @pytest.mark.anyio
 async def test_verify_token_returns_none_when_validation_fails() -> None:
-    verifier = AtlassianOpaqueTokenVerifier(required_scopes=["read:jira-work"])
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://acme.atlassian.net",
+        required_scopes=["read:jira-work"],
+    )
 
     async def _raise(_token: str) -> list[dict]:
         raise ValueError("validation failed")
@@ -184,6 +262,30 @@ async def test_data_center_validation_rejects_anonymous_user() -> None:
     client.get.side_effect = [
         httpx.Response(404),
         httpx.Response(200, json={"type": "anonymous"}),
+    ]
+    client_context = MagicMock()
+    client_context.__aenter__ = AsyncMock(return_value=client)
+    client_context.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "mcp_atlassian.utils.token_verifier.httpx.AsyncClient",
+        return_value=client_context,
+    ):
+        valid = await verifier._validate_dc_token("invalid-token")
+
+    assert valid is False
+
+
+@pytest.mark.anyio
+async def test_data_center_validation_rejects_user_type_without_identity() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://confluence.example.com/confluence",
+        is_cloud=False,
+    )
+    client = AsyncMock()
+    client.get.side_effect = [
+        httpx.Response(404),
+        httpx.Response(200, json={"type": "known"}),
     ]
     client_context = MagicMock()
     client_context.__aenter__ = AsyncMock(return_value=client)

--- a/tests/unit/utils/test_token_verifier.py
+++ b/tests/unit/utils/test_token_verifier.py
@@ -157,6 +157,30 @@ async def test_verify_token_rejects_resource_from_another_cloud_instance() -> No
 
 
 @pytest.mark.anyio
+async def test_verify_token_rejects_cloud_id_from_another_cloud_instance() -> None:
+    verifier = AtlassianOpaqueTokenVerifier(
+        instance_url="https://expected.atlassian.net",
+        cloud_id="cloud-1",
+        required_scopes=["read:jira-work"],
+    )
+
+    async def _resources(_token: str) -> list[dict]:
+        return [
+            {
+                "id": "cloud-1",
+                "url": "https://other.atlassian.net",
+                "scopes": ["read:jira-work"],
+            }
+        ]
+
+    verifier._fetch_accessible_resources = _resources  # type: ignore[method-assign]
+
+    token = await verifier.verify_token("opaque-token")
+
+    assert token is None
+
+
+@pytest.mark.anyio
 async def test_verify_token_returns_none_for_empty_token() -> None:
     verifier = AtlassianOpaqueTokenVerifier(required_scopes=[])
 


### PR DESCRIPTION
## Summary

`AtlassianOpaqueTokenVerifier.verify_token()` accepted any non-empty string as a valid token without cryptographic verification, introspection, or format checking. When combined with the OAuth proxy (`ATLASSIAN_OAUTH_PROXY_ENABLE=true`), any client that can reach the MCP endpoint can authenticate with a fabricated token and access all Jira/Confluence tools.

## Impact

- Complete auth bypass when OAuth proxy is enabled
- Any non-empty string is accepted as valid authentication (e.g., `Bearer fake-token-123`)
- No way to distinguish legitimate tokens from fabricated ones

## Fix

Add minimum length (20 chars) and character format (`^[A-Za-z0-9._-]+$`) validation. Tokens that don't match Atlassian token format are rejected. This is a defense-in-depth check — full token introspection should be added when Atlassian provides a stable endpoint.

## Testing

- `verify_token("fake")` → returns `None` (too short)
- `verify_token("token with spaces!")` → returns `None` (invalid chars)
- `verify_token("aB3dEfGhIjKlMnOpQrStUv")` → returns `AccessToken` (valid format)

## Disclosure

Reported via GitHub Advisory (PVRA). The opaque token design is documented as intentional, but accepting arbitrary non-empty strings provides no authentication guarantee.