### PR TITLE
fix(security): set restrictive permissions (0600) on OAuth token fallback file

### DIFF
--- a/src/mcp_atlassian/utils/oauth.py
+++ b/src/mcp_atlassian/utils/oauth.py
@@ -414,7 +414,7 @@ class OAuthConfig:
                     "base_url": self.base_url,
                 }
 
-            with open(token_path, "w") as f:
+            with open(token_path, "w", opener=lambda path, flags: os.open(path, flags, 0o600)) as f:
                 json.dump(token_data, f)
 
             logger.debug(f"Saved OAuth tokens to file {token_path} (fallback storage)")


### PR DESCRIPTION
## Summary

When the system keyring is unavailable, `OAuthConfig._save_tokens_to_file()` writes OAuth tokens (access_token, refresh_token) to a plaintext JSON file at `~/.mcp-atlassian/oauth-{client_id}.json` with default permissions (typically 0644 on Unix), making tokens readable by any local user.

On systems without keyring (headless servers, containers), this becomes the primary storage mechanism.

## Impact

- OAuth token exposure to local users
- Full API access with stolen tokens
- Refresh token allows persistent access even after access token expiry

## Fix

Use `os.open` with mode `0o600` as the file opener, so the fallback file is created owner-read/write only. This matches the permission model used by SSH key files and other credential stores.

## Testing

- Create token file on system without keyring
- Verify `stat -c %a ~/.mcp-atlassian/oauth-*.json` returns `600`
- Verify token file is still readable by the owning process

## Disclosure

Reported via GitHub Advisory (PVRA). Plaintext fallback is a known tradeoff when keyring is unavailable, but default world-readable permissions unnecessarily expose credentials.