### PR TITLE
fix(confluence): use POST for attachment upload on Confluence Server/Data Center

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -575,12 +575,25 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             if minor_edit is not None:
                 data["minorEdit"] = str(minor_edit).lower()
 
-            # Use PUT to support creating new versions of existing attachments
-            # PUT will create a new attachment if it doesn't exist, OR create a new
-            # version if an attachment with the same filename already exists
-            response = self.confluence._session.put(
-                url, headers=headers, files=files, data=data
-            )
+            # HTTP method differs by deployment (see #1163 / #1202):
+            #   * Confluence Cloud accepts PUT on the collection endpoint, which
+            #     creates the attachment, or a new version if the filename exists.
+            #   * Confluence Server/Data Center rejects PUT here with
+            #     405 Method Not Allowed and requires POST (POST also creates a new
+            #     version when the filename already exists on Server/DC).
+            # Official REST API docs:
+            #   Cloud (PUT create-or-update + POST):
+            #     https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content---attachments/
+            #   Server/Data Center (POST only; PUT on collection -> 405):
+            #     https://developer.atlassian.com/server/confluence/rest/v1010/api-group-attachments/
+            if self.config.is_cloud:
+                response = self.confluence._session.put(
+                    url, headers=headers, files=files, data=data
+                )
+            else:
+                response = self.confluence._session.post(
+                    url, headers=headers, files=files, data=data
+                )
             response.raise_for_status()
 
             # Parse response

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -105,13 +105,14 @@ class TestAttachmentsMixin:
 
         mock_response = Mock()
         if raise_error:
-            # Changed from .post to .put to match implementation
+            # Mock both verbs: Cloud uses PUT, Server/DC uses POST.
             attachments_mixin.confluence._session.put.side_effect = raise_error
+            attachments_mixin.confluence._session.post.side_effect = raise_error
         else:
             mock_response.json.return_value = response_data
             mock_response.raise_for_status.return_value = None
-            # Changed from .post to .put to match implementation
             attachments_mixin.confluence._session.put.return_value = mock_response
+            attachments_mixin.confluence._session.post.return_value = mock_response
 
         return mock_response
 
@@ -171,7 +172,8 @@ class TestAttachmentsMixin:
         """Run an upload with the given config URL and return the request URL.
 
         Sets ``config.url`` (which drives ``is_cloud``), performs an upload with
-        all file I/O mocked, and returns the URL passed to ``session.put``.
+        all file I/O mocked, and returns the URL passed to the upload request
+        (PUT on Cloud, POST on Server/DC).
         """
         attachments_mixin.config.url = config_url
         self._mock_rest_api_upload(attachments_mixin)
@@ -188,7 +190,9 @@ class TestAttachmentsMixin:
                 "123456", "/absolute/path/test_file.txt"
             )
 
-        return attachments_mixin.confluence._session.put.call_args[0][0]
+        session = attachments_mixin.confluence._session
+        verb = session.put if attachments_mixin.config.is_cloud else session.post
+        return verb.call_args[0][0]
 
     def test_upload_attachment_cloud_adds_wiki_prefix(
         self, attachments_mixin: AttachmentsMixin
@@ -228,6 +232,52 @@ class TestAttachmentsMixin:
             url == "https://confluence.example.com"
             "/rest/api/content/123456/child/attachment"
         )
+
+    def test_upload_attachment_cloud_uses_put(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Cloud uses HTTP PUT (create-or-new-version) on the attachment endpoint."""
+        attachments_mixin.config.url = "https://test.atlassian.net/wiki"
+        self._mock_rest_api_upload(attachments_mixin)
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getsize", return_value=100),
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.abspath", return_value="/absolute/path/test_file.txt"),
+            patch("os.path.basename", return_value="test_file.txt"),
+            patch("builtins.open", mock_open(read_data=b"test content")),
+        ):
+            result = attachments_mixin.upload_attachment(
+                "123456", "/absolute/path/test_file.txt"
+            )
+
+        assert result["success"] is True
+        attachments_mixin.confluence._session.put.assert_called_once()
+        attachments_mixin.confluence._session.post.assert_not_called()
+
+    def test_upload_attachment_server_dc_uses_post(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Server/DC must use HTTP POST - DC returns 405 for PUT (see #1163)."""
+        attachments_mixin.config.url = "https://confluence.example.com"
+        self._mock_rest_api_upload(attachments_mixin)
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getsize", return_value=100),
+            patch("os.path.isabs", return_value=True),
+            patch("os.path.abspath", return_value="/absolute/path/test_file.txt"),
+            patch("os.path.basename", return_value="test_file.txt"),
+            patch("builtins.open", mock_open(read_data=b"test content")),
+        ):
+            result = attachments_mixin.upload_attachment(
+                "123456", "/absolute/path/test_file.txt"
+            )
+
+        assert result["success"] is True
+        attachments_mixin.confluence._session.post.assert_called_once()
+        attachments_mixin.confluence._session.put.assert_not_called()
 
     def test_upload_attachment_relative_path(self, attachments_mixin: AttachmentsMixin):
         """Test attachment upload with a relative path."""


### PR DESCRIPTION
## Description

`confluence_upload_attachment` / `confluence_upload_attachments` always fail on Confluence **Server/Data Center**, while `get_page` / `update_page` work fine.

Root cause: the direct upload call in `_upload_attachment_direct` uses **PUT** on `/rest/api/content/{id}/child/attachment`. 
Data Center rejects PUT on that collection endpoint with **405 Method Not Allowed** — it only accepts **POST**.
Confluence Cloud keeps PUT because it provides create-or-update (new version on existing filename), which is not available on Server/DC.

Fixes: #1163

Refs (official REST API docs):
- Cloud (PUT create-or-update + POST): https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content---attachments/
- Server/Data Center (POST only): https://developer.atlassian.com/server/confluence/rest/v1010/api-group-attachments/

## Changes

- Branch the upload HTTP method by deployment: `config.is_cloud` → **PUT** (Cloud), else **POST** (Server/DC).
- Add explanatory comment + official doc links at the call site.
- Add unit tests asserting Cloud uses PUT and Server/DC uses POST.

## Testing

- [x] Unit tests added/updated (`tests/unit/confluence/test_attachments.py`: `test_upload_attachment_cloud_uses_put`, `test_upload_attachment_server_dc_uses_post`; updated DC URL test to POST)
- [x] Integration tests passed
- [x] Manual checks performed: `uploaded PNG attachments to a real Confluence Data Center instance (PAT auth) — previously "success: false", now succeeds`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed) — n/a (code comment + doc links added)