### PR TITLE
jira-browse-url

### DIFF
--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -74,6 +74,7 @@ class JiraIssue(ApiModel, TimestampMixin):
     attachments: list[JiraAttachment] = Field(default_factory=list)
     timetracking: JiraTimetracking | None = None
     url: str | None = None
+    browse_url: str | None = None
     epic_key: str | None = None
     epic_name: str | None = None
     fix_versions: list[str] = Field(default_factory=list)
@@ -239,6 +240,14 @@ class JiraIssue(ApiModel, TimestampMixin):
             return fields[custom_field_id]
 
         return None
+
+    @staticmethod
+    def _build_browse_url(base_url: Any, key: str) -> str | None:
+        if not isinstance(base_url, str) or not base_url.strip():
+            return None
+        if key == JIRA_DEFAULT_KEY:
+            return None
+        return f"{base_url.strip().rstrip('/')}/browse/{key}"
 
     @classmethod
     def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "JiraIssue":
@@ -412,6 +421,7 @@ class JiraIssue(ApiModel, TimestampMixin):
 
         # URL
         url = data.get("self")  # API URL for the issue
+        browse_url = cls._build_browse_url(kwargs.get("base_url"), key)
 
         # Try to find epic fields (varies by Jira instance)
         epic_key = None
@@ -476,6 +486,7 @@ class JiraIssue(ApiModel, TimestampMixin):
             attachments=attachments,
             timetracking=timetracking,
             url=url,
+            browse_url=browse_url,
             epic_key=epic_key,
             epic_name=epic_name,
             fix_versions=fix_versions,
@@ -507,6 +518,9 @@ class JiraIssue(ApiModel, TimestampMixin):
         # Add URL if available and requested
         if self.url and should_include_field("url"):
             result["url"] = self.url
+
+        if self.browse_url:
+            result["browse_url"] = self.browse_url
 
         # Add description if available and requested
         if self.description and should_include_field("description"):

--- a/src/mcp_atlassian/models/jira/search.py
+++ b/src/mcp_atlassian/models/jira/search.py
@@ -50,12 +50,15 @@ class JiraSearchResult(ApiModel):
         issues = []
         issues_data = data.get("issues", [])
         if isinstance(issues_data, list):
+            base_url = kwargs.get("base_url")
             for issue_data in issues_data:
                 if issue_data:
                     requested_fields = kwargs.get("requested_fields")
                     issues.append(
                         JiraIssue.from_api_response(
-                            issue_data, requested_fields=requested_fields
+                            issue_data,
+                            base_url=base_url,
+                            requested_fields=requested_fields,
                         )
                     )
 

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -255,6 +255,30 @@ class TestJiraIssue:
         assert issue.security is None
         assert issue.worklog is None
 
+    def test_from_api_response_builds_browse_url(self, jira_issue_data):
+        """Test creating a browser URL from the configured Jira base URL."""
+        issue = JiraIssue.from_api_response(
+            jira_issue_data,
+            base_url="https://example.atlassian.net/",
+            requested_fields="summary",
+        )
+        simplified = issue.to_simplified_dict()
+
+        assert issue.url == "https://example.atlassian.net/rest/api/2/issue/12345"
+        assert issue.browse_url == "https://example.atlassian.net/browse/PROJ-123"
+        assert (
+            simplified["browse_url"]
+            == "https://example.atlassian.net/browse/PROJ-123"
+        )
+        assert "url" not in simplified
+
+    def test_from_api_response_omits_browse_url_without_base_url(self, jira_issue_data):
+        """Test browser URL is absent when no Jira base URL is provided."""
+        issue = JiraIssue.from_api_response(jira_issue_data)
+
+        assert issue.browse_url is None
+        assert "browse_url" not in issue.to_simplified_dict()
+
     def test_to_simplified_dict(self, jira_issue_data):
         """Test converting a JiraIssue to a simplified dictionary."""
         issue = JiraIssue.from_api_response(jira_issue_data)

--- a/tests/unit/models/test_jira_search_model.py
+++ b/tests/unit/models/test_jira_search_model.py
@@ -84,6 +84,21 @@ class TestJiraSearchResult:
         assert "created" in issue
         assert "updated" in issue
 
+    def test_to_simplified_dict_includes_issue_browse_url(self, jira_search_data):
+        """Test search results include browser URLs for returned issues."""
+        search_result = JiraSearchResult.from_api_response(
+            jira_search_data,
+            base_url="https://example.atlassian.net/",
+        )
+        simplified = search_result.to_simplified_dict()
+
+        issue = simplified["issues"][0]
+        assert issue["key"] == "PROJ-123"
+        assert (
+            issue["browse_url"]
+            == "https://example.atlassian.net/browse/PROJ-123"
+        )
+
     def test_to_simplified_dict_empty_result(self):
         """Test converting an empty JiraSearchResult to a simplified dictionary."""
         search_result = JiraSearchResult()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

Adds new browse_url field to jira item and search returns, which allows markdown renderer
to display clickable links that can open the jira ticket in browser.

Fixes: #

## Changes

Changes to src/mcp_atlassian/models/jira/issue.py and search.py to add browse_url field and generate it from base_url.
Added browse_url to Jira issue model output as a browser-friendly issue link, e.g. /browse/PROJECT-123.
Preserved existing url behavior unchanged; it still points to Jira’s REST self endpoint.
Passed Jira base_url through search result parsing so issues returned from search can include browse_url.
Included browse_url in simplified issue output when available.
Added unit coverage for direct issue parsing and Jira search result parsing.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
