### PR TITLE
feat(confluence): expose version author and date in page responses

### DIFF
--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -285,6 +285,10 @@ class ConfluencePage(ApiModel, TimestampMixin):
         # Add version information if available
         if self.version:
             result["version"] = self.version.number
+            if self.version.by:
+                result["version_author"] = self.version.by.display_name
+            if self.version.when:
+                result["version_date"] = self.format_timestamp(self.version.when)
 
         # Add attachments if available
         result["attachments"] = [

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -288,7 +288,9 @@ class ConfluencePage(ApiModel, TimestampMixin):
             if self.version.by:
                 result["version_author"] = self.version.by.display_name
             if self.version.when:
-                result["version_date"] = self.format_timestamp(self.version.when)
+                # Raw ISO 8601, unlike created/updated: the timezone offset is
+                # what makes this usable for activity tracking (see #1375)
+                result["version_date"] = self.version.when
 
         # Add attachments if available
         result["attachments"] = [

--- a/tests/unit/models/test_confluence_page_model.py
+++ b/tests/unit/models/test_confluence_page_model.py
@@ -123,20 +123,6 @@ class TestConfluencePage:
         # URL should be included
         assert "url" in simplified
 
-    def test_subtype_is_preserved_in_simplified_dict(self):
-        """Test that Cloud page subtypes survive model conversion."""
-        page = ConfluencePage.from_api_response(
-            {
-                "id": "live-123",
-                "title": "Live Doc",
-                "type": "page",
-                "subtype": "live",
-            }
-        )
-
-        assert page.subtype == "live"
-        assert page.to_simplified_dict()["subtype"] == "live"
-
     def test_to_simplified_dict_includes_version_author_and_date(
         self, confluence_page_data
     ):
@@ -160,6 +146,20 @@ class TestConfluencePage:
         assert simplified["version"] == 3
         assert "version_author" not in simplified
         assert "version_date" not in simplified
+
+    def test_subtype_is_preserved_in_simplified_dict(self):
+        """Test that Cloud page subtypes survive model conversion."""
+        page = ConfluencePage.from_api_response(
+            {
+                "id": "live-123",
+                "title": "Live Doc",
+                "type": "page",
+                "subtype": "live",
+            }
+        )
+
+        assert page.subtype == "live"
+        assert page.to_simplified_dict()["subtype"] == "live"
 
     def test_from_api_response_with_expandable_space(self):
         """Test creating a ConfluencePage from data with space info in _expandable."""

--- a/tests/unit/models/test_confluence_page_model.py
+++ b/tests/unit/models/test_confluence_page_model.py
@@ -140,14 +140,14 @@ class TestConfluencePage:
     def test_to_simplified_dict_includes_version_author_and_date(
         self, confluence_page_data
     ):
-        """Test that version author and timestamp are surfaced."""
+        """Test that version author and ISO 8601 timestamp are surfaced."""
         page = ConfluencePage.from_api_response(confluence_page_data)
 
         simplified = page.to_simplified_dict()
 
         assert simplified["version"] == 1
         assert simplified["version_author"] == "Example User (Unlicensed)"
-        assert simplified["version_date"] == "2024-01-01 09:00:00"
+        assert simplified["version_date"] == "2024-01-01T09:00:00.000Z"
 
     def test_to_simplified_dict_omits_version_details_when_absent(self):
         """Test that version author and date are omitted when unavailable."""

--- a/tests/unit/models/test_confluence_page_model.py
+++ b/tests/unit/models/test_confluence_page_model.py
@@ -137,6 +137,30 @@ class TestConfluencePage:
         assert page.subtype == "live"
         assert page.to_simplified_dict()["subtype"] == "live"
 
+    def test_to_simplified_dict_includes_version_author_and_date(
+        self, confluence_page_data
+    ):
+        """Test that version author and timestamp are surfaced."""
+        page = ConfluencePage.from_api_response(confluence_page_data)
+
+        simplified = page.to_simplified_dict()
+
+        assert simplified["version"] == 1
+        assert simplified["version_author"] == "Example User (Unlicensed)"
+        assert simplified["version_date"] == "2024-01-01 09:00:00"
+
+    def test_to_simplified_dict_omits_version_details_when_absent(self):
+        """Test that version author and date are omitted when unavailable."""
+        page = ConfluencePage.from_api_response(
+            {"id": "123456", "title": "No Version Details", "version": {"number": 3}}
+        )
+
+        simplified = page.to_simplified_dict()
+
+        assert simplified["version"] == 3
+        assert "version_author" not in simplified
+        assert "version_date" not in simplified
+
     def test_from_api_response_with_expandable_space(self):
         """Test creating a ConfluencePage from data with space info in _expandable."""
         page_data = {


### PR DESCRIPTION
## Description

`ConfluenceVersion` already parses `by` (author) and `when` (timestamp) from the API response — the existing test suite even asserts on `page.version.by.display_name` and `page.version.when`. But `ConfluencePage.to_simplified_dict()` collapsed the whole version object down to a bare integer:

```python
if self.version:
    result["version"] = self.version.number   # by / when discarded here
```

The data already reaches the model, but is discarded when serializing the simplified response — so there is no way to answer "who last edited this page, and when" through `confluence_get_page` or `confluence_get_page_history`.

This adds `version_author` and `version_date` to the response, using the field names proposed in #1375.

Fixes: #1375 (request 1 — request 2 was fixed separately by #1117 and #1480, both shipped in v0.23.0, so this PR addresses the remaining part of #1375)

## Changes

- `to_simplified_dict()` now emits `version_author` (display name) and `version_date` when the underlying data is present
- `version` remains an `int`, so existing clients are unaffected — this is additive, not a breaking change
- Both new keys are omitted entirely when `version.by` / `version.when` are absent, consistent with how `author` and `space` are handled

No `expand` changes are needed: `get_page_content()` and `get_page_history()` already request `version` from the API, which already includes `by` and `when`. That means `confluence_get_page_history` picks this up for free.

### Note on the timestamp format

`version_date` carries the raw ISO 8601 value from the API instead of going through the `format_timestamp()` helper used by `created` and `updated`. I kept the raw API value here to match the issue requirements:

- #1375's use case is activity tracking ("which pages did user X edit in April?"), which needs machine-comparable timestamps with an unambiguous offset — exactly what the API's ISO 8601 value provides.
- `format_timestamp()` (since #1236) localizes to the server's OS timezone for human display. That remains appropriate for `created`/`updated`, but it's less suitable for a comparison key, since the value would depend on where the MCP server happens to run.
- `version_date` is a new key with no existing clients, so it can adopt the issue's requested format without breaking anyone. `created` and `updated` are left as they were.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: verified against a real Confluence Server/DC instance (the environment in #1375), where `confluence_get_page` previously returned `version: 6` with no author or date

Two tests added to `tests/unit/models/test_confluence_page_model.py`:

- `test_to_simplified_dict_includes_version_author_and_date` — asserts both keys are populated from the existing `confluence_page_data` fixture
- `test_to_simplified_dict_omits_version_details_when_absent` — asserts neither key appears when the API returns only `version.number`

Rebased onto current `main` (post-v0.23.0). After the rebase:

```
uv run pytest tests/unit/models/ tests/unit/confluence/ -q
797 passed, 5 skipped
```

`pre-commit run` (ruff, ruff-format, mypy) passes on both changed files.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).
