### PR TITLE
fix(confluence): expand content metadata in CQL search results

### DIFF
--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -64,8 +64,14 @@ class SearchMixin(ConfluenceClient):
 
             logger.info(f"Applied spaces filter to query: {cql}")
 
-        # Execute the CQL search query
-        results = self.confluence.cql(cql=cql, limit=limit)
+        # Execute the CQL search query. Expand content.history and
+        # content.version so each result carries created/updated/author and
+        # version metadata; on the /rest/api/search endpoint these nested
+        # properties require the "content." prefix (a bare "history,version"
+        # is silently ignored).
+        results = self.confluence.cql(
+            cql=cql, limit=limit, expand="content.history,content.version"
+        )
 
         # Convert the response to a search result model
         search_result = ConfluenceSearchResult.from_api_response(

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -59,13 +59,78 @@ class TestSearchMixin:
         result = search_mixin.search("test query")
 
         # Verify API call
-        search_mixin.confluence.cql.assert_called_once_with(cql="test query", limit=10)
+        search_mixin.confluence.cql.assert_called_once_with(
+            cql="test query", limit=10, expand="content.history,content.version"
+        )
 
         # Verify result
         assert len(result) == 1
         assert result[0].id == "123456789"
         assert result[0].title == "Test Page"
         assert result[0].content == "Processed content"
+
+    def test_search_expands_content_metadata(self, search_mixin):
+        """Search results should carry created/updated/author and version metadata.
+
+        Regression guard: on the ``/rest/api/search`` endpoint these live under
+        the nested ``content`` object, so the query must expand
+        ``content.history`` and ``content.version``. Without it every result's
+        ``created``/``updated``/``author`` comes back empty.
+        """
+        search_mixin.confluence.cql.return_value = {
+            "results": [
+                {
+                    "content": {
+                        "id": "123456789",
+                        "title": "Test Page",
+                        "type": "page",
+                        "space": {"key": "SPACE", "name": "Test Space"},
+                        "history": {
+                            "createdDate": "2026-07-07T17:56:30.079+08:00",
+                            "createdBy": {"displayName": "Alice Author"},
+                        },
+                        "version": {
+                            "number": 3,
+                            "when": "2026-07-09T17:22:07.533+08:00",
+                            "by": {"displayName": "Bob Editor"},
+                        },
+                    },
+                    "excerpt": "Test content excerpt",
+                    "url": "https://confluence.example.com/pages/123456789",
+                }
+            ]
+        }
+        search_mixin.preprocessor.process_html_content.return_value = (
+            "<p>Processed HTML</p>",
+            "Processed content",
+        )
+
+        result = search_mixin.search("test query")
+
+        # The nested content properties must be requested with the
+        # "content." prefix, otherwise /rest/api/search ignores them.
+        search_mixin.confluence.cql.assert_called_once_with(
+            cql="test query", limit=10, expand="content.history,content.version"
+        )
+
+        assert len(result) == 1
+        page = result[0]
+        assert page.created == "2026-07-07T17:56:30.079+08:00"
+        # No history.lastUpdated in the payload, so updated falls back to the
+        # version timestamp.
+        assert page.updated == "2026-07-09T17:22:07.533+08:00"
+        assert page.author is not None
+        assert page.author.display_name == "Alice Author"
+        assert page.version is not None
+        assert page.version.number == 3
+        assert page.version.by is not None
+        assert page.version.by.display_name == "Bob Editor"
+
+        simplified = page.to_simplified_dict()
+        assert simplified["created"]
+        assert simplified["updated"]
+        assert simplified["author"] == "Alice Author"
+        assert simplified["version"] == 3
 
     def test_search_with_empty_results(self, search_mixin):
         """Test handling of empty search results."""
@@ -183,6 +248,7 @@ class TestSearchMixin:
         search_mixin.confluence.cql.assert_called_with(
             cql=f"(test query) AND (space = {quoted_dev})",
             limit=10,
+            expand="content.history,content.version",
         )
         assert len(result) == 1
 
@@ -195,6 +261,7 @@ class TestSearchMixin:
         search_mixin.confluence.cql.assert_called_with(
             cql=f"(test query) AND (space = {quoted_dev} OR space = {quoted_team})",
             limit=10,
+            expand="content.history,content.version",
         )
         assert len(result) == 1
 
@@ -203,6 +270,7 @@ class TestSearchMixin:
         search_mixin.confluence.cql.assert_called_with(
             cql='space = "EXISTING"',  # Should not add filter when space already exists
             limit=10,
+            expand="content.history,content.version",
         )
         assert len(result) == 1
 
@@ -243,6 +311,7 @@ class TestSearchMixin:
         search_mixin.confluence.cql.assert_called_with(
             cql=f"(test query) AND (space = {quoted_dev} OR space = {quoted_team})",
             limit=10,
+            expand="content.history,content.version",
         )
         assert len(result) == 1
 
@@ -254,6 +323,7 @@ class TestSearchMixin:
         search_mixin.confluence.cql.assert_called_with(
             cql=f"(test query) AND (space = {quoted_override})",
             limit=10,
+            expand="content.history,content.version",
         )
         assert len(result) == 1
 


### PR DESCRIPTION
## Summary

`confluence_search` returned every result with empty `created` / `updated` / `author`. `SearchMixin.search()` called `cql()` without an `expand`, so `GET /rest/api/search` never returned the history/version data that `ConfluencePage.from_api_response()` parses.

This expands `content.history,content.version` on the CQL query. On `/rest/api/search` the page is nested under a `content` object, so the expand keys need the `content.` prefix — a bare `history,version` is **silently ignored** (verified against a live Confluence Server/DC 8.x instance; only the prefixed form populates the fields). Same fix in spirit as expanding `history` for `get_page`.

## Changes

- `src/mcp_atlassian/confluence/search.py`: add `expand="content.history,content.version"` to the `cql()` call.
- `tests/unit/confluence/test_search.py`: update the existing `cql` call assertions and add `test_search_expands_content_metadata`, which asserts `created`/`updated`/`author`/`version` flow through to the returned pages.

## Trade-off

CQL searches often return many results, so expanding history/version makes each result heavier (`get_page`, being a single page, has no such cost). I kept it always-on because "search results should carry basic metadata" matches user expectations and mirrors what `get_page` already returns. Happy to make it opt-in via a parameter if you'd prefer.

## Independent of #1445

This is orthogonal to #1445 (which adds `version_author` / `version_date` to `to_simplified_dict`). This PR is based on `main` and does not depend on it; once #1445 merges, those two fields will additionally flow into search results through the same `content.version` expand.

## Testing

- `uv run pytest tests/unit/confluence/test_search.py tests/unit/models/ -q` → **301 passed, 5 skipped**
- `uv run pre-commit run --files src/mcp_atlassian/confluence/search.py tests/unit/confluence/test_search.py` → all hooks pass (ruff, ruff-format, mypy)
- End-to-end against a live Confluence Server/DC 8.x: `confluence_search` results now include `created`/`updated`/`author` that were previously empty.

Closes #1446