### PR TITLE
Security hardening across attachment, transport, SSRF, authorization, filter, and OAuth layers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ markers = [
     "integration: mark test as requiring integration with real services",
     "dc_e2e: mark test as requiring DC instances (Jira DC + Confluence DC)",
     "cloud_e2e: mark test as requiring Cloud instances (Jira Cloud + Confluence Cloud)",
+    "security_regression: SP5 security regression test (xfail-strict until the Phase B root fix lands; see plan)",
 ]
 
 [tool.ruff]

--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -149,9 +149,10 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             return {"success": False, "error": "No file path provided"}
 
         try:
-            # Convert to absolute path if relative
-            if not os.path.isabs(file_path):
-                file_path = os.path.abspath(file_path)
+            # Confine the upload source to the workspace before it is read: reject
+            # traversal/absolute paths that escape CWD (arbitrary file read /
+            # exfiltration via a caller-supplied file_path).
+            file_path = str(validate_safe_path(file_path))
 
             # Check if file exists
             if not os.path.exists(file_path):

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -18,6 +18,7 @@ from ..utils.logging import get_masked_session_headers, log_config_param, mask_s
 from ..utils.oauth import configure_oauth_session
 from ..utils.ssl import configure_ssl_verification
 from ..utils.user_agent import get_default_user_agent
+from ..utils.ssrf_adapter import mount_ssrf_pinning
 from ..utils.urls import make_ssrf_redirect_hook
 from .config import ConfluenceConfig
 
@@ -142,6 +143,9 @@ class ConfluenceClient:
         # (covers direct _session.get() paths and global/stdio fetchers, not just
         # the per-user HTTP path).
         self.confluence._session.hooks["response"].append(make_ssrf_redirect_hook())
+        # Pin DNS resolution against rebinding: resolve+validate once and connect
+        # to that address, closing the validate→reconnect TOCTOU. Preserves TLS SNI.
+        mount_ssrf_pinning(self.confluence._session)
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -132,13 +132,6 @@ class ConfluenceClient:
             client_key_password=self.config.client_key_password,
         )
 
-        # Apply opt-in HTTP hardening after SSL setup so SSLIgnoreAdapter, if
-        # mounted, also picks up the configured behavior.
-        configure_retry(self.confluence._session, service="Confluence")
-        configure_concurrency(self.confluence._session, service="Confluence")
-        configure_rate_limit(self.confluence._session, service="Confluence")
-        configure_circuit_breaker(self.confluence._session, service="Confluence")
-
         # Validate redirects for SSRF on every outbound call from this session
         # (covers direct _session.get() paths and global/stdio fetchers, not just
         # the per-user HTTP path).
@@ -146,6 +139,15 @@ class ConfluenceClient:
         # Pin DNS resolution against rebinding: resolve+validate once and connect
         # to that address, closing the validate→reconnect TOCTOU. Preserves TLS SNI.
         mount_ssrf_pinning(self.confluence._session)
+
+        # Apply opt-in HTTP hardening after SSL setup and after the pinning
+        # adapter is mounted: these wrappers patch send() in place on whatever
+        # adapters are mounted now, so mounting the pinning adapter later would
+        # silently drop them.
+        configure_retry(self.confluence._session, service="Confluence")
+        configure_concurrency(self.confluence._session, service="Confluence")
+        configure_rate_limit(self.confluence._session, service="Confluence")
+        configure_circuit_breaker(self.confluence._session, service="Confluence")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -17,9 +17,9 @@ from ..utils.http import (
 from ..utils.logging import get_masked_session_headers, log_config_param, mask_sensitive
 from ..utils.oauth import configure_oauth_session
 from ..utils.ssl import configure_ssl_verification
-from ..utils.user_agent import get_default_user_agent
 from ..utils.ssrf_adapter import mount_ssrf_pinning
 from ..utils.urls import make_ssrf_redirect_hook
+from ..utils.user_agent import get_default_user_agent
 from .config import ConfluenceConfig
 
 # Configure logging

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -18,6 +18,7 @@ from ..utils.logging import get_masked_session_headers, log_config_param, mask_s
 from ..utils.oauth import configure_oauth_session
 from ..utils.ssl import configure_ssl_verification
 from ..utils.user_agent import get_default_user_agent
+from ..utils.urls import make_ssrf_redirect_hook
 from .config import ConfluenceConfig
 
 # Configure logging
@@ -136,6 +137,11 @@ class ConfluenceClient:
         configure_concurrency(self.confluence._session, service="Confluence")
         configure_rate_limit(self.confluence._session, service="Confluence")
         configure_circuit_breaker(self.confluence._session, service="Confluence")
+
+        # Validate redirects for SSRF on every outbound call from this session
+        # (covers direct _session.get() paths and global/stdio fetchers, not just
+        # the per-user HTTP path).
+        self.confluence._session.hooks["response"].append(make_ssrf_redirect_hook())
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -56,8 +56,9 @@ class SearchMixin(ConfluenceClient):
         Args:
             cql: Confluence Query Language string
             limit: Maximum number of results to return
-            spaces_filter: Optional comma-separated list of space keys to filter by,
-                overrides config
+            spaces_filter: Optional comma-separated list of space keys to narrow
+                results within the configured allowlist (ANDed with config,
+                never replaces it)
 
         Returns:
             List of ConfluencePage models containing search results

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -58,12 +58,20 @@ class SearchMixin(ConfluenceClient):
                 [f"space = {quote_cql_identifier_if_needed(space)}" for space in spaces]
             )
 
-            # Add the space filter to existing query with parentheses
-            if cql and space_query:
-                if "space = " not in cql:  # Only add if not already filtering by space
-                    cql = f"({cql}) AND ({space_query})"
-            else:
+            # Always AND the allowlist, even when the caller's CQL already names a
+            # space: a caller-supplied `space = X` must not escape the configured
+            # spaces allowlist (out-of-allowlist queries then return empty).
+            if not cql:
                 cql = space_query
+            else:
+                # Extract a trailing ORDER BY so the AND does not produce invalid CQL.
+                order_match = re.search(r"\s+(ORDER\s+BY\s+.*)$", cql, re.IGNORECASE)
+                if order_match:
+                    order_clause = order_match.group(1)
+                    cql_without_order = cql[: order_match.start()]
+                    cql = f"({cql_without_order}) AND ({space_query}) {order_clause}"
+                else:
+                    cql = f"({cql}) AND ({space_query})"
 
             logger.info(f"Applied spaces filter to query: {cql}")
 

--- a/src/mcp_atlassian/confluence/search.py
+++ b/src/mcp_atlassian/confluence/search.py
@@ -23,6 +23,29 @@ logger = logging.getLogger("mcp-atlassian")
 class SearchMixin(ConfluenceClient):
     """Mixin for Confluence search operations."""
 
+    def _and_spaces_filter(self, cql: str, filter_to_use: str) -> str:
+        """AND a single comma-separated spaces allowlist into ``cql``.
+
+        Always ANDs the allowlist, even when the caller's CQL already names a
+        space, so a caller-supplied ``space = X`` cannot escape it.
+        """
+        spaces = [s.strip() for s in filter_to_use.split(",")]
+        space_query = " OR ".join(
+            [f"space = {quote_cql_identifier_if_needed(space)}" for space in spaces]
+        )
+        if not cql:
+            return space_query
+        # Extract a trailing ORDER BY so the AND does not produce invalid CQL.
+        order_match = re.search(r"\s+(ORDER\s+BY\s+.*)$", cql, re.IGNORECASE)
+        if order_match:
+            order_clause = order_match.group(1)
+            cql_without_order = cql[: order_match.start()]
+            cql = f"({cql_without_order}) AND ({space_query}) {order_clause}"
+        else:
+            cql = f"({cql}) AND ({space_query})"
+        logger.info(f"Applied spaces filter to query: {cql}")
+        return cql
+
     @handle_atlassian_api_errors("Confluence API")
     def search(
         self, cql: str, limit: int = 10, spaces_filter: str | None = None
@@ -45,35 +68,13 @@ class SearchMixin(ConfluenceClient):
         """
         limit = clamp_limit(limit, context="confluence.search")
 
-        # Use spaces_filter parameter if provided, otherwise fall back to config
-        filter_to_use = spaces_filter or self.config.spaces_filter
-
-        # Apply spaces filter if present
-        if filter_to_use:
-            # Split spaces filter by commas and handle possible whitespace
-            spaces = [s.strip() for s in filter_to_use.split(",")]
-
-            # Build the space filter query part using proper quoting for each space key
-            space_query = " OR ".join(
-                [f"space = {quote_cql_identifier_if_needed(space)}" for space in spaces]
-            )
-
-            # Always AND the allowlist, even when the caller's CQL already names a
-            # space: a caller-supplied `space = X` must not escape the configured
-            # spaces allowlist (out-of-allowlist queries then return empty).
-            if not cql:
-                cql = space_query
-            else:
-                # Extract a trailing ORDER BY so the AND does not produce invalid CQL.
-                order_match = re.search(r"\s+(ORDER\s+BY\s+.*)$", cql, re.IGNORECASE)
-                if order_match:
-                    order_clause = order_match.group(1)
-                    cql_without_order = cql[: order_match.start()]
-                    cql = f"({cql_without_order}) AND ({space_query}) {order_clause}"
-                else:
-                    cql = f"({cql}) AND ({space_query})"
-
-            logger.info(f"Applied spaces filter to query: {cql}")
+        # config.spaces_filter is a hard boundary and is always applied; a
+        # caller-supplied spaces_filter may only *narrow* within it (both ANDed),
+        # never replace it — otherwise the tool argument would defeat the
+        # operator's allowlist in shared-credential deployments.
+        for filter_str in (self.config.spaces_filter, spaces_filter):
+            if filter_str:
+                cql = self._and_spaces_filter(cql, filter_str)
 
         # Execute the CQL search query
         results = self.confluence.cql(cql=cql, limit=limit)

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -370,9 +370,10 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             return {"success": False, "error": "No file path provided"}
 
         try:
-            # Convert to absolute path if relative
-            if not os.path.isabs(file_path):
-                file_path = os.path.abspath(file_path)
+            # Confine the upload source to the workspace before it is read: reject
+            # traversal/absolute paths that escape CWD (arbitrary file read /
+            # exfiltration via a caller-supplied file_path).
+            file_path = str(validate_safe_path(file_path))
 
             # Check if file exists
             if not os.path.exists(file_path):

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -42,6 +42,17 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
             # Guard against path traversal (resolves symlinks)
             validate_safe_path(target_path)
 
+            # Do not write into the working-directory root itself: that is where
+            # Python resolves imports first, so a download landing there could
+            # overwrite an importable module and gain code execution (GHSA-6vmq).
+            # Attachments must be saved into a subdirectory.
+            resolved = Path(target_path).resolve()
+            if resolved.parent == Path(os.getcwd()).resolve():
+                logger.error(
+                    f"Refusing to download into the working-directory root: {target_path}"
+                )
+                return False
+
             logger.info(f"Downloading attachment from {url} to {target_path}")
 
             # Create the directory if it doesn't exist

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -23,9 +23,9 @@ from mcp_atlassian.utils.logging import (
 )
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
-from mcp_atlassian.utils.user_agent import get_default_user_agent
 from mcp_atlassian.utils.ssrf_adapter import mount_ssrf_pinning
 from mcp_atlassian.utils.urls import make_ssrf_redirect_hook
+from mcp_atlassian.utils.user_agent import get_default_user_agent
 
 from ..models.jira.adf import markdown_to_adf
 from .config import JiraConfig

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -24,6 +24,7 @@ from mcp_atlassian.utils.logging import (
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
 from mcp_atlassian.utils.user_agent import get_default_user_agent
+from mcp_atlassian.utils.urls import make_ssrf_redirect_hook
 
 from ..models.jira.adf import markdown_to_adf
 from .config import JiraConfig
@@ -149,6 +150,11 @@ class JiraClient:
         configure_concurrency(self.jira._session, service="Jira")
         configure_rate_limit(self.jira._session, service="Jira")
         configure_circuit_breaker(self.jira._session, service="Jira")
+
+        # Validate redirects for SSRF on every outbound call from this session
+        # (covers direct _session.get() paths and global/stdio fetchers, not just
+        # the per-user HTTP path).
+        self.jira._session.hooks["response"].append(make_ssrf_redirect_hook())
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -24,6 +24,7 @@ from mcp_atlassian.utils.logging import (
 from mcp_atlassian.utils.oauth import configure_oauth_session
 from mcp_atlassian.utils.ssl import configure_ssl_verification
 from mcp_atlassian.utils.user_agent import get_default_user_agent
+from mcp_atlassian.utils.ssrf_adapter import mount_ssrf_pinning
 from mcp_atlassian.utils.urls import make_ssrf_redirect_hook
 
 from ..models.jira.adf import markdown_to_adf
@@ -155,6 +156,9 @@ class JiraClient:
         # (covers direct _session.get() paths and global/stdio fetchers, not just
         # the per-user HTTP path).
         self.jira._session.hooks["response"].append(make_ssrf_redirect_hook())
+        # Pin DNS resolution against rebinding: resolve+validate once and connect
+        # to that address, closing the validate→reconnect TOCTOU. Preserves TLS SNI.
+        mount_ssrf_pinning(self.jira._session)
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -145,13 +145,6 @@ class JiraClient:
             client_key_password=self.config.client_key_password,
         )
 
-        # Apply opt-in HTTP hardening after SSL setup so SSLIgnoreAdapter, if
-        # mounted, also picks up the configured behavior.
-        configure_retry(self.jira._session, service="Jira")
-        configure_concurrency(self.jira._session, service="Jira")
-        configure_rate_limit(self.jira._session, service="Jira")
-        configure_circuit_breaker(self.jira._session, service="Jira")
-
         # Validate redirects for SSRF on every outbound call from this session
         # (covers direct _session.get() paths and global/stdio fetchers, not just
         # the per-user HTTP path).
@@ -159,6 +152,15 @@ class JiraClient:
         # Pin DNS resolution against rebinding: resolve+validate once and connect
         # to that address, closing the validate→reconnect TOCTOU. Preserves TLS SNI.
         mount_ssrf_pinning(self.jira._session)
+
+        # Apply opt-in HTTP hardening after SSL setup and after the pinning
+        # adapter is mounted: these wrappers patch send() in place on whatever
+        # adapters are mounted now, so mounting the pinning adapter later would
+        # silently drop them.
+        configure_retry(self.jira._session, service="Jira")
+        configure_concurrency(self.jira._session, service="Jira")
+        configure_rate_limit(self.jira._session, service="Jira")
+        configure_circuit_breaker(self.jira._session, service="Jira")
 
         # Proxy configuration
         proxies = {}

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -21,6 +21,48 @@ logger = logging.getLogger("mcp-jira")
 class SearchMixin(JiraClient, IssueOperationsProto):
     """Mixin for Jira search operations."""
 
+    def _apply_projects_filter(
+        self, jql: str, projects_filter: str | None = None
+    ) -> str:
+        """Constrain a JQL query to the allowed projects (JIRA_PROJECTS_FILTER).
+
+        Every JQL-issuing path routes through here so none can escape the project
+        allowlist. ``projects_filter`` overrides ``config.projects_filter``.
+        """
+        filter_to_use = projects_filter or self.config.projects_filter
+        if not filter_to_use:
+            return jql
+
+        # Split by commas, and escape backslashes before double-quotes to prevent
+        # JQL-injection bypass of the quoting below.
+        projects = [p.strip() for p in filter_to_use.split(",")]
+        projects = [p.replace("\\", "\\\\").replace('"', '\\"') for p in projects]
+
+        if len(projects) == 1:
+            quoted = quote_jql_identifier_if_needed(projects[0])
+            project_query = f"project = {quoted}"
+        else:
+            quoted_projects = [quote_jql_identifier_if_needed(p) for p in projects]
+            projects_list = ", ".join(quoted_projects)
+            project_query = f"project IN ({projects_list})"
+
+        if not jql:
+            jql = project_query
+        elif jql.strip().upper().startswith("ORDER BY"):
+            jql = f"{project_query} {jql}"
+        elif "project = " not in jql.lower() and "project in" not in jql.lower():
+            # Extract a trailing ORDER BY so the AND does not produce invalid JQL.
+            order_match = re.search(r"\s+(ORDER\s+BY\s+.*)$", jql, re.IGNORECASE)
+            if order_match:
+                order_clause = order_match.group(1)
+                jql_without_order = jql[: order_match.start()]
+                jql = f"({jql_without_order}) AND {project_query} {order_clause}"
+            else:
+                jql = f"({jql}) AND {project_query}"
+
+        logger.info(f"Applied projects filter to query: {jql}")
+        return jql
+
     @handle_auth_errors("Jira API")
     def search_issues(
         self,
@@ -60,56 +102,8 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             # Sanitize JQL reserved words in project key values
             jql = sanitize_jql_reserved_words(jql)
 
-            # Use projects_filter parameter if provided, otherwise fall back to config
-            filter_to_use = projects_filter or self.config.projects_filter
-
-            # Apply projects filter if present
-            if filter_to_use:
-                # Split projects filter by commas and handle possible whitespace
-                projects = [p.strip() for p in filter_to_use.split(",")]
-
-                # Build the project filter query part
-                # Sanitize project names to prevent JQL injection
-                # Escape backslashes before double-quotes to prevent bypass
-                projects = [
-                    p.replace("\\", "\\\\").replace('"', '\\"') for p in projects
-                ]
-
-                if len(projects) == 1:
-                    quoted = quote_jql_identifier_if_needed(projects[0])
-                    project_query = f"project = {quoted}"
-                else:
-                    quoted_projects = [
-                        quote_jql_identifier_if_needed(p) for p in projects
-                    ]
-                    projects_list = ", ".join(quoted_projects)
-                    project_query = f"project IN ({projects_list})"
-
-                # Add the project filter to existing query
-                if not jql:
-                    # Empty JQL - just use project filter
-                    jql = project_query
-                elif jql.strip().upper().startswith("ORDER BY"):
-                    # JQL starts with ORDER BY - prepend project filter
-                    jql = f"{project_query} {jql}"
-                elif (
-                    "project = " not in jql.lower() and "project in" not in jql.lower()
-                ):
-                    # Only add if not already filtering by project
-                    # Extract ORDER BY clause if present to avoid invalid JQL
-                    order_match = re.search(
-                        r"\s+(ORDER\s+BY\s+.*)$", jql, re.IGNORECASE
-                    )
-                    if order_match:
-                        order_clause = order_match.group(1)
-                        jql_without_order = jql[: order_match.start()]
-                        jql = (
-                            f"({jql_without_order}) AND {project_query} {order_clause}"
-                        )
-                    else:
-                        jql = f"({jql}) AND {project_query}"
-
-                logger.info(f"Applied projects filter to query: {jql}")
+            # Constrain to the allowed projects (JIRA_PROJECTS_FILTER)
+            jql = self._apply_projects_filter(jql, projects_filter)
 
             # Convert fields to proper format if it's a list/tuple/set
             fields_param: str | None
@@ -240,6 +234,9 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             # Sanitize JQL reserved words in project key values
             jql = sanitize_jql_reserved_words(jql) or jql
 
+            # Constrain board issues to the allowed projects (JIRA_PROJECTS_FILTER)
+            jql = self._apply_projects_filter(jql)
+
             # Determine fields_param
             fields_param = fields
             if fields_param is None:
@@ -298,11 +295,20 @@ class SearchMixin(JiraClient, IssueOperationsProto):
         Raises:
             Exception: If there is an error getting sprint issues
         """
+        # sprint_id is interpolated into JQL; require an integer to prevent
+        # JQL injection via a crafted non-numeric value.
+        try:
+            sprint_id_int = int(str(sprint_id).strip())
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"Invalid sprint_id {sprint_id!r}: must be an integer"
+            ) from e
+
         try:
             limit = clamp_limit(limit, context="jira.get_sprint_issues")
 
             # Use JQL search to get sprint issues with proper fields filtering
-            jql = f"sprint = {sprint_id}"
+            jql = f"sprint = {sprint_id_int}"
             return self.search_issues(
                 jql=jql,
                 fields=fields,

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -27,12 +27,18 @@ class SearchMixin(JiraClient, IssueOperationsProto):
         """Constrain a JQL query to the allowed projects (JIRA_PROJECTS_FILTER).
 
         Every JQL-issuing path routes through here so none can escape the project
-        allowlist. ``projects_filter`` overrides ``config.projects_filter``.
+        allowlist. ``config.projects_filter`` is a hard boundary and is always
+        applied; a caller-supplied ``projects_filter`` may only *narrow* within it
+        (both are ANDed), never replace it — otherwise the tool argument would
+        defeat the operator's allowlist in shared-credential deployments.
         """
-        filter_to_use = projects_filter or self.config.projects_filter
-        if not filter_to_use:
-            return jql
+        for filter_str in (self.config.projects_filter, projects_filter):
+            if filter_str:
+                jql = self._and_projects_filter(jql, filter_str)
+        return jql
 
+    def _and_projects_filter(self, jql: str, filter_to_use: str) -> str:
+        """AND a single comma-separated project allowlist into ``jql``."""
         # Split by commas, and escape backslashes before double-quotes to prevent
         # JQL-injection bypass of the quoting below.
         projects = [p.strip() for p in filter_to_use.split(",")]

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -50,7 +50,10 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             jql = project_query
         elif jql.strip().upper().startswith("ORDER BY"):
             jql = f"{project_query} {jql}"
-        elif "project = " not in jql.lower() and "project in" not in jql.lower():
+        else:
+            # Always AND the allowlist, even when the caller's query already names a
+            # project: a caller-supplied `project = X` must not be able to escape the
+            # configured allowlist (out-of-allowlist queries then return empty).
             # Extract a trailing ORDER BY so the AND does not produce invalid JQL.
             order_match = re.search(r"\s+(ORDER\s+BY\s+.*)$", jql, re.IGNORECASE)
             if order_match:

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -94,7 +94,9 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                   start from the first page.
             limit: Maximum issues to return
             expand: Optional items to expand (comma-separated)
-            projects_filter: Optional comma-separated list of project keys to filter by, overrides config
+            projects_filter: Optional comma-separated list of project keys to narrow
+                results within the configured allowlist (ANDed with config, never
+                replaces it)
             page_token: Optional pagination token from a previous search result.
                   Cloud only — Server/DC uses start for pagination.
 

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -20,6 +20,7 @@ from mcp_atlassian.servers.dependencies import get_confluence_fetcher
 from mcp_atlassian.utils.decorators import (
     check_write_access,
 )
+from mcp_atlassian.utils.io import validate_safe_path
 from mcp_atlassian.utils.media import (
     ATTACHMENT_MAX_BYTES,
     fetch_and_encode_attachment,
@@ -124,15 +125,17 @@ def _resolve_page_content(content: str | None, content_file: str | None) -> str:
 
     Args:
         content: Inline page body (any supported content_format).
-        content_file: Absolute or relative filesystem path to read the body from.
-            Read as UTF-8.
+        content_file: Filesystem path to read the body from (UTF-8). Must
+            resolve inside the current working directory (workspace), the same
+            confinement contract as attachment paths.
 
     Returns:
         The resolved page body as a string.
 
     Raises:
-        ValueError: If neither or both arguments are supplied, or if the file does
-            not exist / is not a regular file.
+        ValueError: If neither or both arguments are supplied, if the file does
+            not exist / is not a regular file, or if the path escapes the
+            workspace.
         OSError: If the file exists but cannot be read.
     """
     has_content = content is not None
@@ -146,7 +149,10 @@ def _resolve_page_content(content: str | None, content_file: str | None) -> str:
     if content_file is None or content_file == "":
         raise ValueError("One of 'content' or 'content_file' must be provided.")
 
-    path = Path(content_file).expanduser()
+    # Confine the read to the workspace, same contract as attachment paths — an
+    # unconfined caller-supplied path is an arbitrary-file-read primitive (the
+    # file body is echoed back through the created/updated page).
+    path = validate_safe_path(Path(content_file).expanduser())
     if not path.is_file():
         msg = f"content_file does not exist or is not a regular file: {path}"
         raise ValueError(msg)

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -17,6 +17,7 @@ from starlette.requests import Request
 from mcp_atlassian.confluence import ConfluenceConfig, ConfluenceFetcher
 from mcp_atlassian.jira import JiraConfig, JiraFetcher
 from mcp_atlassian.servers.context import MainAppContext
+from mcp_atlassian.utils.env import is_env_truthy
 from mcp_atlassian.utils.oauth import OAuthConfig
 from mcp_atlassian.utils.urls import validate_url_for_ssrf
 
@@ -508,8 +509,10 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
     """
     fn_name = f"get_{spec.name.lower()}_fetcher"
     logger.debug(f"{fn_name}: ENTERED. Context ID: {id(ctx)}")
+    in_http_context = False
     try:
         request: Request = get_http_request()
+        in_http_context = True
         logger.debug(
             f"{fn_name}: In HTTP request context. "
             f"Request URL: {request.url}. "
@@ -663,6 +666,17 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
         getattr(app_ctx, spec.config_attr, None) if app_ctx else None
     )
     if global_config_fallback:
+        # An HTTP request that reaches here has no per-user identity: serving it
+        # with the operator's global credentials lets any unauthenticated caller
+        # transact as the operator. Refuse unless explicitly opted in. Non-HTTP
+        # (stdio, single-user) is unaffected — the operator is the user there.
+        if in_http_context and not is_env_truthy("ALLOW_GLOBAL_CRED_FALLBACK"):
+            raise ValueError(
+                f"{spec.name} client (fetcher) not available: refusing to serve an "
+                "unauthenticated request with the operator's global credentials. "
+                "Provide a user token, or set ALLOW_GLOBAL_CRED_FALLBACK=true to "
+                "allow the global-credential fallback (single-user deployments only)."
+            )
         logger.debug(
             f"{fn_name}: Using global {spec.name}Fetcher "
             "from lifespan_context. "

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -595,6 +595,7 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
                 user_config,
                 "basic",
                 user_email=user_email,
+                attach_ssrf_hook=True,
             )
 
         # --- Branch 3: OAuth / PAT with token ---
@@ -644,6 +645,7 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
                 user_config,
                 "oauth_pat",
                 user_email=user_email,
+                attach_ssrf_hook=True,
             )
 
         else:

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -442,6 +442,28 @@ class UserTokenMiddleware:
             await self._send_json_error_response(safe_send, 401, auth_error)
             return  # Don't call self.app - request is rejected
 
+        # Reject unauthenticated MCP requests at the transport boundary: with no
+        # user identity, the downstream handler would fall back to the operator's
+        # global credentials, so any unauthenticated caller would transact as the
+        # operator. Refuse unless explicitly opted in (opt-in global-fallback gate).
+        if (
+            not ignore_header_auth
+            and self.mcp_server_ref
+            and self._should_process_auth(scope_copy)
+            and not scope_copy["state"].get("user_atlassian_auth_type")
+            and not is_env_truthy("ALLOW_GLOBAL_CRED_FALLBACK")
+        ):
+            logger.warning(
+                "UserTokenMiddleware: rejecting unauthenticated MCP request "
+                "(no user identity and ALLOW_GLOBAL_CRED_FALLBACK is off)"
+            )
+            await self._send_json_error_response(
+                safe_send,
+                401,
+                "Authentication required: no Atlassian credentials were provided.",
+            )
+            return  # Don't call self.app - request is rejected
+
         # Call the next application with modified scope and safe send wrapper
         await self.app(scope_copy, receive, safe_send)
 

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -268,7 +268,9 @@ class AtlassianMCP(FastMCP[MainAppContext]):
         unavailable-service tool simply fails naturally if called.)
         """
         tool_tags = tool_obj.tags
-        if not should_include_tool_by_toolset(tool_tags, ctx["enabled_toolsets_filter"]):
+        if not should_include_tool_by_toolset(
+            tool_tags, ctx["enabled_toolsets_filter"]
+        ):
             return False
         if not should_include_tool(registered_name, ctx["enabled_tools_filter"]):
             return False
@@ -347,7 +349,9 @@ class AtlassianMCP(FastMCP[MainAppContext]):
         if ctx is not None:
             all_tools = await self.get_tools()
             tool_obj = all_tools.get(key)
-            if tool_obj is not None and not self._is_tool_authorized(key, tool_obj, ctx):
+            if tool_obj is not None and not self._is_tool_authorized(
+                key, tool_obj, ctx
+            ):
                 raise NotFoundError(f"Unknown tool: {key}")
         return await super()._call_tool_mcp(key, arguments)
 

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 from cachetools import TTLCache
 from fastmcp import FastMCP
 from fastmcp import settings as fastmcp_settings
+from fastmcp.exceptions import NotFoundError
 from fastmcp.server.event_store import EventStore
 from fastmcp.server.http import StarletteWithLifespan
 from fastmcp.tools import Tool as FastMCPTool
@@ -209,14 +210,15 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             return self._active_streamable_http_path
         return self._normalize_http_path(fastmcp_settings.streamable_http_path)
 
-    async def _list_tools_mcp(self) -> list[MCPTool]:
-        # Filter tools based on enabled_tools, read_only mode, and service configuration from the lifespan context.
+    def _tool_filter_context(self) -> dict[str, Any] | None:
+        """Gather the per-request tool-enablement context (read-only mode, enabled
+        tools/toolsets, service availability) from the lifespan/request context.
+
+        Returns None when the lifespan context is unavailable.
+        """
         req_context = self._mcp_server.request_context
         if req_context is None or req_context.lifespan_context is None:
-            logger.warning(
-                "Lifespan context not available during _list_tools_mcp call."
-            )
-            return []
+            return None
 
         lifespan_ctx_dict = req_context.lifespan_context
         app_lifespan_state: MainAppContext | None = (
@@ -246,13 +248,76 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             service_headers = getattr(request.state, "atlassian_service_headers", {})
             if service_headers:
                 header_based_services = get_available_services(service_headers)
-                logger.debug(
-                    f"Header-based service availability: {header_based_services}"
-                )
 
-        logger.debug(
-            f"_list_tools_mcp: read_only={read_only}, enabled_tools_filter={enabled_tools_filter}, header_services={header_based_services}"
-        )
+        return {
+            "read_only": read_only,
+            "enabled_tools_filter": enabled_tools_filter,
+            "enabled_toolsets_filter": enabled_toolsets_filter,
+            "app_lifespan_state": app_lifespan_state,
+            "header_based_services": header_based_services,
+        }
+
+    def _is_tool_authorized(
+        self, registered_name: str, tool_obj: FastMCPTool, ctx: dict[str, Any]
+    ) -> bool:
+        """Authorization boundaries enforced at BOTH listing and call time: the
+        ENABLED_TOOLS allowlist, the enabled toolsets, and read-only mode.
+
+        These are security boundaries — a tool excluded here must not be invocable
+        by name. (Service availability, below, is a listing-only UX filter: an
+        unavailable-service tool simply fails naturally if called.)
+        """
+        tool_tags = tool_obj.tags
+        if not should_include_tool_by_toolset(tool_tags, ctx["enabled_toolsets_filter"]):
+            return False
+        if not should_include_tool(registered_name, ctx["enabled_tools_filter"]):
+            return False
+        if ctx["read_only"] and "write" in tool_tags:
+            return False
+        return True
+
+    def _is_tool_enabled(
+        self, registered_name: str, tool_obj: FastMCPTool, ctx: dict[str, Any]
+    ) -> bool:
+        """Listing filter: the tool is authorized AND its backing service is
+        configured/available (the latter is a listing-only graceful-hide)."""
+        if not self._is_tool_authorized(registered_name, tool_obj, ctx):
+            return False
+
+        app_lifespan_state = ctx["app_lifespan_state"]
+        header_based_services = ctx["header_based_services"]
+        tool_tags = tool_obj.tags
+
+        is_jira_tool = "jira" in tool_tags
+        is_confluence_tool = "confluence" in tool_tags
+        if app_lifespan_state:
+            jira_available = (
+                app_lifespan_state.full_jira_config is not None
+            ) or header_based_services.get("jira", False)
+            confluence_available = (
+                app_lifespan_state.full_confluence_config is not None
+            ) or header_based_services.get("confluence", False)
+            if is_jira_tool and not jira_available:
+                return False
+            if is_confluence_tool and not confluence_available:
+                return False
+        elif is_jira_tool or is_confluence_tool:
+            if is_jira_tool and not header_based_services.get("jira", False):
+                return False
+            if is_confluence_tool and not header_based_services.get(
+                "confluence", False
+            ):
+                return False
+        return True
+
+    async def _list_tools_mcp(self) -> list[MCPTool]:
+        # Filter tools based on enabled_tools, read_only mode, and service configuration from the lifespan context.
+        ctx = self._tool_filter_context()
+        if ctx is None:
+            logger.warning(
+                "Lifespan context not available during _list_tools_mcp call."
+            )
+            return []
 
         all_tools: dict[str, FastMCPTool] = await self.get_tools()
         logger.debug(
@@ -261,64 +326,9 @@ class AtlassianMCP(FastMCP[MainAppContext]):
 
         filtered_tools: list[MCPTool] = []
         for registered_name, tool_obj in all_tools.items():
-            tool_tags = tool_obj.tags
-
-            if not should_include_tool_by_toolset(tool_tags, enabled_toolsets_filter):
-                logger.debug(
-                    f"Excluding tool '{registered_name}' (toolset not enabled)"
-                )
+            if not self._is_tool_enabled(registered_name, tool_obj, ctx):
+                logger.debug(f"Excluding tool '{registered_name}' (filtered)")
                 continue
-
-            if not should_include_tool(registered_name, enabled_tools_filter):
-                logger.debug(f"Excluding tool '{registered_name}' (not enabled)")
-                continue
-
-            if tool_obj and read_only and "write" in tool_tags:
-                logger.debug(
-                    f"Excluding tool '{registered_name}' due to read-only mode and 'write' tag"
-                )
-                continue
-
-            # Exclude Jira/Confluence tools if config is not fully authenticated
-            is_jira_tool = "jira" in tool_tags
-            is_confluence_tool = "confluence" in tool_tags
-            service_configured_and_available = True
-            if app_lifespan_state:
-                jira_available = (
-                    app_lifespan_state.full_jira_config is not None
-                ) or header_based_services.get("jira", False)
-                confluence_available = (
-                    app_lifespan_state.full_confluence_config is not None
-                ) or header_based_services.get("confluence", False)
-
-                if is_jira_tool and not jira_available:
-                    logger.debug(
-                        f"Excluding Jira tool '{registered_name}' as Jira configuration/authentication is incomplete and no header-based auth available."
-                    )
-                    service_configured_and_available = False
-                if is_confluence_tool and not confluence_available:
-                    logger.debug(
-                        f"Excluding Confluence tool '{registered_name}' as Confluence configuration/authentication is incomplete and no header-based auth available."
-                    )
-                    service_configured_and_available = False
-            elif is_jira_tool or is_confluence_tool:
-                jira_available = header_based_services.get("jira", False)
-                confluence_available = header_based_services.get("confluence", False)
-
-                if is_jira_tool and not jira_available:
-                    logger.debug(
-                        f"Excluding Jira tool '{registered_name}' as no Jira authentication available."
-                    )
-                    service_configured_and_available = False
-                if is_confluence_tool and not confluence_available:
-                    logger.debug(
-                        f"Excluding Confluence tool '{registered_name}' as no Confluence authentication available."
-                    )
-                    service_configured_and_available = False
-
-            if not service_configured_and_available:
-                continue
-
             mcp_tool = tool_obj.to_mcp_tool(name=registered_name)
             _sanitize_schema_for_compatibility(mcp_tool)
             filtered_tools.append(mcp_tool)
@@ -327,6 +337,19 @@ class AtlassianMCP(FastMCP[MainAppContext]):
             f"_list_tools_mcp: Total tools after filtering: {len(filtered_tools)}"
         )
         return filtered_tools
+
+    async def _call_tool_mcp(self, key: str, arguments: dict[str, Any]) -> Any:
+        # Enforce the same enablement filter at call time as at listing time, so a
+        # tool hidden from the listing (read-only mode, not in ENABLED_TOOLS, toolset
+        # disabled, or service unavailable) cannot be invoked directly by name.
+        # Denials look identical to an unknown tool (no exists-but-disabled leak).
+        ctx = self._tool_filter_context()
+        if ctx is not None:
+            all_tools = await self.get_tools()
+            tool_obj = all_tools.get(key)
+            if tool_obj is not None and not self._is_tool_authorized(key, tool_obj, ctx):
+                raise NotFoundError(f"Unknown tool: {key}")
+        return await super()._call_tool_mcp(key, arguments)
 
     def http_app(
         self,

--- a/src/mcp_atlassian/utils/oauth.py
+++ b/src/mcp_atlassian/utils/oauth.py
@@ -398,9 +398,10 @@ class OAuthConfig:
                         will use the current object attributes.
         """
         try:
-            # Create the directory if it doesn't exist
+            # Create the directory if it doesn't exist (owner-only)
             token_dir = Path.home() / ".mcp-atlassian"
             token_dir.mkdir(exist_ok=True)
+            os.chmod(token_dir, 0o700)
 
             # Save the tokens to a file
             token_path = token_dir / f"oauth-{self.client_id}.json"
@@ -414,8 +415,12 @@ class OAuthConfig:
                     "base_url": self.base_url,
                 }
 
-            with open(token_path, "w") as f:
+            # Persisted tokens are secrets: create/truncate owner-only so they are
+            # never group/world-readable, independent of the process umask.
+            fd = os.open(token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
                 json.dump(token_data, f)
+            os.chmod(token_path, 0o600)
 
             logger.debug(f"Saved OAuth tokens to file {token_path} (fallback storage)")
         except Exception as e:

--- a/src/mcp_atlassian/utils/oauth_setup.py
+++ b/src/mcp_atlassian/utils/oauth_setup.py
@@ -17,6 +17,7 @@ import time
 import urllib.parse
 import webbrowser
 from dataclasses import dataclass
+from html import escape as html_escape
 
 from ..utils.oauth import OAuthConfig
 
@@ -85,6 +86,10 @@ class CallbackHandler(http.server.BaseHTTPRequestHandler):
         self.send_header("Content-type", "text/html")
         self.end_headers()
 
+        # Escape the message: it can carry attacker-controlled OAuth callback
+        # text (e.g. the error query param), so raw interpolation is reflected XSS.
+        escaped_message = html_escape(message)
+
         html = f"""
         <!DOCTYPE html>
         <html>
@@ -122,7 +127,7 @@ class CallbackHandler(http.server.BaseHTTPRequestHandler):
         <body>
             <h1>Atlassian OAuth Authorization</h1>
             <div class="message {"success" if status == 200 else "error"}">
-                <p>{message}</p>
+                <p>{escaped_message}</p>
             </div>
             <p>This window will automatically close in <span class="countdown">5</span> seconds...</p>
             <button onclick="window.close()">Close Window Now</button>

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -9,6 +9,8 @@ from requests.adapters import HTTPAdapter
 from requests.sessions import Session
 from urllib3.poolmanager import PoolManager
 
+from .ssrf_adapter import _PinnedHTTPConnectionPool, _PinnedHTTPSConnectionPool
+
 logger = logging.getLogger("mcp-atlassian")
 
 
@@ -48,6 +50,14 @@ class SSLIgnoreAdapter(HTTPAdapter):
             ssl_context=context,
             **pool_kwargs,
         )
+        # This adapter mounts at a more specific prefix than the session-wide
+        # SsrfPinningAdapter and would otherwise silently replace it — keep the
+        # DNS-pinning connection classes so disabling SSL verification does not
+        # also disable the SSRF rebinding guard.
+        self.poolmanager.pool_classes_by_scheme = {  # type: ignore[attr-defined]
+            "http": _PinnedHTTPConnectionPool,
+            "https": _PinnedHTTPSConnectionPool,
+        }
 
     def cert_verify(self, conn: Any, url: str, verify: bool, cert: Any | None) -> None:
         """Override cert verification to disable SSL verification.

--- a/src/mcp_atlassian/utils/ssrf_adapter.py
+++ b/src/mcp_atlassian/utils/ssrf_adapter.py
@@ -1,0 +1,134 @@
+"""A requests transport adapter that pins DNS resolution against SSRF.
+
+``validate_url_for_ssrf`` resolves and checks a host once (in middleware), but the
+outbound request re-resolves the hostname at connect time, so a DNS-rebinding
+response can swap in an internal address between validation and connection — the
+TOCTOU that bypasses a validate-then-reconnect SSRF guard (GHSA-49xv, 72fm, 489g).
+
+This adapter closes that window at the connection itself: it resolves each host
+exactly once, rejects any candidate address that is not globally routable
+(cloud-metadata / private / loopback), and connects to that same validated
+address — there is no separate re-resolution to rebind. The original hostname is
+preserved for TLS SNI and certificate verification, so HTTPS is unaffected.
+"""
+
+import socket
+from typing import Any
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.exceptions import NewConnectionError
+from urllib3.poolmanager import PoolManager
+
+from .urls import _check_ip_address
+
+
+def _pinned_create_connection(
+    address: tuple[str, int],
+    timeout: Any = socket._GLOBAL_DEFAULT_TIMEOUT,
+    source_address: tuple[str, int] | None = None,
+    socket_options: Any = None,
+) -> socket.socket:
+    """Resolve once, reject non-global addresses, connect to the validated IP.
+
+    A single ``getaddrinfo`` result is both validated and connected to, so a
+    rebinding name cannot return a public IP to the check and a private IP to the
+    connection.
+    """
+    host, port = address
+    err: Exception | None = None
+    for af, socktype, proto, _canonname, sa in socket.getaddrinfo(
+        host, port, 0, socket.SOCK_STREAM
+    ):
+        ip = sa[0]
+        if _check_ip_address(ip) is not None:
+            msg = f"SSRF blocked: {host} resolves to non-global address {ip}"
+            raise OSError(msg)
+        sock = None
+        try:
+            sock = socket.socket(af, socktype, proto)
+            if socket_options:
+                for opt in socket_options:
+                    sock.setsockopt(*opt)
+            if timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                sock.settimeout(timeout)
+            if source_address:
+                sock.bind(source_address)
+            sock.connect(sa)
+            return sock
+        except OSError as e:
+            err = e
+            if sock is not None:
+                sock.close()
+    if err is not None:
+        raise err
+    msg = f"getaddrinfo returned no addresses for {host}"
+    raise OSError(msg)
+
+
+class _PinnedConnMixin:
+    """Route socket creation through the validating, single-resolution connector."""
+
+    def _new_conn(self) -> socket.socket:
+        try:
+            return _pinned_create_connection(
+                (self._dns_host, self.port),  # type: ignore[attr-defined]
+                self.timeout,  # type: ignore[attr-defined]
+                source_address=self.source_address,  # type: ignore[attr-defined]
+                socket_options=self.socket_options,  # type: ignore[attr-defined]
+            )
+        except OSError as e:
+            raise NewConnectionError(
+                self,  # type: ignore[arg-type]
+                f"Failed to establish a new connection: {e}",
+            ) from e
+
+
+class _PinnedHTTPConnection(_PinnedConnMixin, HTTPConnection):
+    pass
+
+
+class _PinnedHTTPSConnection(_PinnedConnMixin, HTTPSConnection):
+    pass
+
+
+class _PinnedHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = _PinnedHTTPConnection
+
+
+class _PinnedHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _PinnedHTTPSConnection
+
+
+class SsrfPinningAdapter(HTTPAdapter):
+    """A requests adapter that validates and pins DNS resolution for every call."""
+
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any
+    ) -> None:
+        self.poolmanager = PoolManager(
+            num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
+        )
+        self.poolmanager.pool_classes_by_scheme = {
+            "http": _PinnedHTTPConnectionPool,
+            "https": _PinnedHTTPSConnectionPool,
+        }
+
+
+def mount_ssrf_pinning(session: Session) -> None:
+    """Mount the SSRF DNS-pinning adapter for http/https on ``session``.
+
+    Preserves the retry policy of any adapter already mounted (e.g. the one the
+    Atlassian client configures), so pinning does not silently drop retries.
+    """
+    for scheme in ("https://", "http://"):
+        existing = session.adapters.get(scheme)
+        retries = getattr(existing, "max_retries", None)
+        adapter = (
+            SsrfPinningAdapter(max_retries=retries)
+            if retries is not None
+            else SsrfPinningAdapter()
+        )
+        session.mount(scheme, adapter)

--- a/src/mcp_atlassian/utils/ssrf_adapter.py
+++ b/src/mcp_atlassian/utils/ssrf_adapter.py
@@ -27,7 +27,7 @@ from .urls import _check_ip_address
 
 def _pinned_create_connection(
     address: tuple[str, int],
-    timeout: Any = socket._GLOBAL_DEFAULT_TIMEOUT,
+    timeout: Any = socket._GLOBAL_DEFAULT_TIMEOUT,  # type: ignore[attr-defined]  # noqa: SLF001
     source_address: tuple[str, int] | None = None,
     socket_options: Any = None,
 ) -> socket.socket:
@@ -52,7 +52,7 @@ def _pinned_create_connection(
             if socket_options:
                 for opt in socket_options:
                     sock.setsockopt(*opt)
-            if timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+            if timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:  # type: ignore[attr-defined]  # noqa: SLF001
                 sock.settimeout(timeout)
             if source_address:
                 sock.bind(source_address)
@@ -111,7 +111,8 @@ class SsrfPinningAdapter(HTTPAdapter):
         self.poolmanager = PoolManager(
             num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
         )
-        self.poolmanager.pool_classes_by_scheme = {
+        # Runtime attribute of urllib3's PoolManager; absent from the type stubs.
+        self.poolmanager.pool_classes_by_scheme = {  # type: ignore[attr-defined]
             "http": _PinnedHTTPConnectionPool,
             "https": _PinnedHTTPSConnectionPool,
         }

--- a/src/mcp_atlassian/utils/ssrf_adapter.py
+++ b/src/mcp_atlassian/utils/ssrf_adapter.py
@@ -10,10 +10,19 @@ exactly once, rejects any candidate address that is not globally routable
 (cloud-metadata / private / loopback), and connects to that same validated
 address — there is no separate re-resolution to rebind. The original hostname is
 preserved for TLS SNI and certificate verification, so HTTPS is unaffected.
+
+Operator-trusted hosts — the configured ``JIRA_URL`` / ``CONFLUENCE_URL`` hosts
+and ``MCP_ALLOWED_URL_DOMAINS`` entries — are exempt from the non-global
+rejection (on-prem DC instances legitimately live on private networks or
+localhost). Those values come from the server environment, which an attacker
+cannot influence through a request, so the rebinding guard is not weakened for
+caller-supplied URLs. The single-resolution pin still applies to every host.
 """
 
+import os
 import socket
 from typing import Any
+from urllib.parse import urlparse
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -22,7 +31,20 @@ from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.exceptions import NewConnectionError
 from urllib3.poolmanager import PoolManager
 
-from .urls import _check_ip_address
+from .urls import _check_ip_address, _get_domain_allowlist, _hostname_matches_allowlist
+
+
+def _operator_trusted_hosts() -> list[str]:
+    """Hosts the operator explicitly configured or allowlisted via environment."""
+    hosts = []
+    for env in ("JIRA_URL", "CONFLUENCE_URL"):
+        raw = os.environ.get(env, "").strip()
+        if raw:
+            hostname = urlparse(raw).hostname
+            if hostname:
+                hosts.append(hostname.lower())
+    hosts.extend(_get_domain_allowlist() or [])
+    return hosts
 
 
 def _pinned_create_connection(
@@ -38,12 +60,13 @@ def _pinned_create_connection(
     connection.
     """
     host, port = address
+    host_trusted = _hostname_matches_allowlist(host, _operator_trusted_hosts())
     err: Exception | None = None
     for af, socktype, proto, _canonname, sa in socket.getaddrinfo(
         host, port, 0, socket.SOCK_STREAM
     ):
         ip = sa[0]
-        if _check_ip_address(ip) is not None:
+        if not host_trusted and _check_ip_address(ip) is not None:
             msg = f"SSRF blocked: {host} resolves to non-global address {ip}"
             raise OSError(msg)
         sock = None

--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -4,7 +4,26 @@ import ipaddress
 import os
 import re
 import socket
+from typing import Any, Callable
 from urllib.parse import urlparse
+
+
+def make_ssrf_redirect_hook() -> Callable[..., Any]:
+    """Return a requests ``response`` hook that blocks SSRF-unsafe redirects.
+
+    Attach to any session (``session.hooks["response"].append(...)``) so that an
+    open redirect cannot steer an outbound request to an internal/metadata host.
+    """
+
+    def hook(response: Any, **kwargs: Any) -> Any:
+        if response.is_redirect:
+            error = validate_url_for_ssrf(response.headers.get("Location", ""))
+            if error:
+                response.close()
+                raise ValueError(f"Redirect blocked (SSRF): {error}")
+        return response
+
+    return hook
 
 
 def resolve_relative_url(url: str, base_url: str) -> str:

--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -4,7 +4,8 @@ import ipaddress
 import os
 import re
 import socket
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from urllib.parse import urlparse
 
 

--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -89,6 +89,12 @@ def validate_url_for_ssrf(url: str) -> str | None:
     if parsed.scheme not in ("http", "https"):
         return f"Blocked scheme: {parsed.scheme} (only http/https allowed)"
 
+    # requests (and browsers, per WHATWG) treat a backslash in the authority as a
+    # path separator, so "http://localhost\@evil.com/" parses (urlparse) to host
+    # evil.com but actually connects to localhost. Reject the parse mismatch.
+    if "\\" in parsed.netloc:
+        return f"Blocked backslash in URL authority: {url}"
+
     hostname = parsed.hostname
     if not hostname:
         return "No hostname in URL"

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -131,7 +131,7 @@ class TestConfluenceCloudAttachments:
         confluence_fetcher: ConfluenceFetcher,
         cloud_instance: CloudInstanceInfo,
         resource_tracker: CloudResourceTracker,
-        tmp_path: Path,
+        workspace_tmp_path: Path,
     ) -> None:
         uid = uuid.uuid4().hex[:8]
         page = confluence_fetcher.create_page(
@@ -141,7 +141,7 @@ class TestConfluenceCloudAttachments:
         )
         resource_tracker.add_confluence_page(page.id)
 
-        attachment_path = tmp_path / f"cloud upload {uid} & notes #1.txt"
+        attachment_path = workspace_tmp_path / f"cloud upload {uid} & notes #1.txt"
         attachment_path.write_text(f"first upload {uid}", encoding="utf-8")
 
         first = confluence_fetcher.upload_attachment(

--- a/tests/e2e/cloud/test_mcp_tools_cloud.py
+++ b/tests/e2e/cloud/test_mcp_tools_cloud.py
@@ -306,12 +306,12 @@ class TestMCPConfluenceTools:
         self,
         mcp_client: Client,
         cloud_instance: CloudInstanceInfo,
-        tmp_path: Path,
+        workspace_tmp_path: Path,
     ) -> None:
         uid = uuid.uuid4().hex[:8]
         page_id = None
-        create_file = tmp_path / "cloud-create.md"
-        update_file = tmp_path / "cloud-update.md"
+        create_file = workspace_tmp_path / "cloud-create.md"
+        update_file = workspace_tmp_path / "cloud-update.md"
         create_file.write_text("# Created from file\n\nCloud body.", encoding="utf-8")
         update_file.write_text("# Updated from file\n\nCloud body.", encoding="utf-8")
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
 import shutil
 import uuid
 from collections.abc import Generator
@@ -463,6 +464,12 @@ def dc_instance() -> DCInstanceInfo:
     Skips entire session if instances are unreachable.
     """
     info = DCInstanceInfo()
+
+    # Mirror a real deployment: the operator sets JIRA_URL/CONFLUENCE_URL in the
+    # environment, which the SSRF pinning adapter trusts — without this, the
+    # localhost DC instances are (correctly) rejected as non-global addresses.
+    os.environ.setdefault("JIRA_URL", info.jira_url)
+    os.environ.setdefault("CONFLUENCE_URL", info.confluence_url)
 
     if not _check_dc_health(info.jira_url):
         pytest.skip(f"Jira DC not reachable at {info.jira_url}")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import base64
 import logging
+import shutil
 import uuid
 from collections.abc import Generator
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -23,6 +25,21 @@ from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.utils.oauth import BYOAccessTokenOAuthConfig
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def workspace_tmp_path() -> Generator[Path, None, None]:
+    """A temp directory *inside* the workspace (CWD).
+
+    ``upload_attachment`` / ``content_file`` confine caller-supplied paths to
+    the working directory, so files fed to those tools must live under it —
+    pytest's ``tmp_path`` (outside CWD) is rejected by design.
+    """
+    d = Path.cwd() / f".e2e-tmp-{uuid.uuid4().hex[:8]}"
+    d.mkdir()
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
 
 # Default DC instance settings
 DEFAULT_JIRA_URL = "http://localhost:8080"

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -80,7 +80,7 @@ class TestConfluenceDCAttachments:
         confluence_fetcher: ConfluenceFetcher,
         dc_instance: DCInstanceInfo,
         resource_tracker: DCResourceTracker,
-        tmp_path: Path,
+        workspace_tmp_path: Path,
     ) -> None:
         uid = uuid.uuid4().hex[:8]
         page = confluence_fetcher.create_page(
@@ -90,7 +90,7 @@ class TestConfluenceDCAttachments:
         )
         resource_tracker.add_confluence_page(page.id)
 
-        attachment_path = tmp_path / f"dc upload {uid} & notes #1.txt"
+        attachment_path = workspace_tmp_path / f"dc upload {uid} & notes #1.txt"
         attachment_path.write_text(f"first upload {uid}", encoding="utf-8")
 
         first = confluence_fetcher.upload_attachment(

--- a/tests/e2e/test_mcp_tools_dc.py
+++ b/tests/e2e/test_mcp_tools_dc.py
@@ -305,12 +305,12 @@ class TestMCPConfluenceTools:
         self,
         mcp_client: Client,
         dc_instance: DCInstanceInfo,
-        tmp_path: Path,
+        workspace_tmp_path: Path,
     ) -> None:
         uid = uuid.uuid4().hex[:8]
         page_id = None
-        create_file = tmp_path / "dc-create.md"
-        update_file = tmp_path / "dc-update.md"
+        create_file = workspace_tmp_path / "dc-create.md"
+        update_file = workspace_tmp_path / "dc-update.md"
         create_file.write_text("# Created from file\n\nDC body.", encoding="utf-8")
         update_file.write_text("# Updated from file\n\nDC body.", encoding="utf-8")
 

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -3,6 +3,7 @@
 import json
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -228,33 +229,19 @@ class TestAttachmentsMixin:
             "/rest/api/content/123456/child/attachment"
         )
 
-    def test_upload_attachment_relative_path(self, attachments_mixin: AttachmentsMixin):
-        """Test attachment upload with a relative path."""
-        # Mock the REST API call
+    def test_upload_attachment_relative_path(
+        self, attachments_mixin: AttachmentsMixin, tmp_path: Path
+    ):
+        """A relative path inside the workspace resolves and uploads."""
         self._mock_rest_api_upload(attachments_mixin)
 
-        # Mock file operations
-        with (
-            patch("os.path.exists") as mock_exists,
-            patch("os.path.getsize") as mock_getsize,
-            patch("os.path.isabs") as mock_isabs,
-            patch("os.path.abspath") as mock_abspath,
-            patch("os.path.basename") as mock_basename,
-            patch("builtins.open", mock_open(read_data=b"test content")),
-        ):
-            mock_exists.return_value = True
-            mock_getsize.return_value = 100
-            mock_isabs.return_value = False
-            mock_abspath.return_value = "/absolute/path/test_file.txt"
-            mock_basename.return_value = "test_file.txt"
+        (tmp_path / "test_file.txt").write_bytes(b"test content")
 
-            # Call the method with a relative path
+        with patch("os.getcwd", return_value=str(tmp_path)):
             result = attachments_mixin.upload_attachment("123456", "test_file.txt")
 
-            # Assertions
-            assert result["success"] is True
-            mock_isabs.assert_called_once_with("test_file.txt")
-            mock_abspath.assert_called_once_with("test_file.txt")
+        assert result["success"] is True
+        attachments_mixin.confluence._session.put.assert_called_once()
 
     def test_upload_attachment_no_content_id(self, attachments_mixin: AttachmentsMixin):
         """Test attachment upload with no content ID."""
@@ -1787,6 +1774,38 @@ class TestConfluenceAttachmentPathTraversal:
         with pytest.raises(ValueError, match="Path traversal detected"):
             confluence_mixin.download_content_attachments("12345", "/etc")
 
+    # --- SP5 fam1: upload-side path traversal (currently UNFIXED) ---------------
+    # The download tests above are green (CVE-2026-27825 fix). The upload path still
+    # feeds any caller-supplied file_path to the sink after only an os.path.exists
+    # check (confluence/attachments.py:68 -> _upload_attachment_direct at :78, real
+    # open at :477). These tests assert the secure outcome — the sink is never
+    # reached with a path outside the workspace — and currently xfail. Phase B
+    # fix-1a (validate_safe_path on the upload file_path) flips them green.
+    # Covers GHSA-wm45, vc25, 93xw, 6cr4, f4p7, f6pj, mrq8, wv8v, p6hp, h7wj, mfv2,
+    # f26r, 9547, cc5h (read half). Asserts on the sink (not an exception type)
+    # because upload_attachment wraps its body in except Exception -> error dict.
+
+    @pytest.mark.security_regression
+    @pytest.mark.parametrize("attack", ["absolute_outside_cwd", "relative_traversal"])
+    def test_upload_attachment_does_not_read_outside_workspace(
+        self,
+        confluence_mixin: AttachmentsMixin,
+        tmp_path: Path,
+        attack: str,
+    ) -> None:
+        """A file_path resolving outside the workspace must not reach the sink."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        secret = tmp_path / "secret.txt"  # sibling of workspace -> outside it
+        secret.write_bytes(b"SP5-SECRET-EXFIL")
+        malicious = str(secret) if attack == "absolute_outside_cwd" else "../secret.txt"
+
+        confluence_mixin._upload_attachment_direct = MagicMock(return_value={"id": "1"})
+
+        with patch("os.getcwd", return_value=str(workspace)):
+            confluence_mixin.upload_attachment("123456", malicious)
+
+        confluence_mixin._upload_attachment_direct.assert_not_called()
 
 class TestResolveAttachmentDownloadUrl:
     """Tests for AttachmentsMixin._resolve_attachment_download_url.

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -1805,6 +1805,7 @@ class TestConfluenceAttachmentPathTraversal:
 
         confluence_mixin._upload_attachment_direct.assert_not_called()
 
+
 class TestResolveAttachmentDownloadUrl:
     """Tests for AttachmentsMixin._resolve_attachment_download_url.
 

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -1774,13 +1774,11 @@ class TestConfluenceAttachmentPathTraversal:
         with pytest.raises(ValueError, match="Path traversal detected"):
             confluence_mixin.download_content_attachments("12345", "/etc")
 
-    # --- SP5 fam1: upload-side path traversal (currently UNFIXED) ---------------
-    # The download tests above are green (CVE-2026-27825 fix). The upload path still
-    # feeds any caller-supplied file_path to the sink after only an os.path.exists
-    # check (confluence/attachments.py:68 -> _upload_attachment_direct at :78, real
-    # open at :477). These tests assert the secure outcome — the sink is never
-    # reached with a path outside the workspace — and currently xfail. Phase B
-    # fix-1a (validate_safe_path on the upload file_path) flips them green.
+    # --- Upload-side path traversal regression -----------------------------------
+    # The download tests above cover the CVE-2026-27825 fix. The upload path used to
+    # feed any caller-supplied file_path to the sink after only an os.path.exists
+    # check. These tests assert the secure outcome — the sink is never reached with
+    # a path outside the workspace.
     # Covers GHSA-wm45, vc25, 93xw, 6cr4, f4p7, f6pj, mrq8, wv8v, p6hp, h7wj, mfv2,
     # f26r, 9547, cc5h (read half). Asserts on the sink (not an exception type)
     # because upload_attachment wraps its body in except Exception -> error dict.
@@ -1797,7 +1795,7 @@ class TestConfluenceAttachmentPathTraversal:
         workspace = tmp_path / "workspace"
         workspace.mkdir()
         secret = tmp_path / "secret.txt"  # sibling of workspace -> outside it
-        secret.write_bytes(b"SP5-SECRET-EXFIL")
+        secret.write_bytes(b"SECRET-EXFIL")
         malicious = str(secret) if attack == "absolute_outside_cwd" else "../secret.txt"
 
         confluence_mixin._upload_attachment_direct = MagicMock(return_value={"id": "1"})

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -241,7 +241,7 @@ class TestAttachmentsMixin:
             result = attachments_mixin.upload_attachment("123456", "test_file.txt")
 
         assert result["success"] is True
-        attachments_mixin.confluence._session.put.assert_called_once()
+        attachments_mixin.confluence._session.post.assert_called_once()
 
     def test_upload_attachment_no_content_id(self, attachments_mixin: AttachmentsMixin):
         """Test attachment upload with no content ID."""

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -124,6 +124,10 @@ class TestAttachmentsMixin:
 
         # Mock file operations
         with (
+            # Pin the workspace so the absolute path resolves inside it — keeps
+            # validate_safe_path passing deterministically across Python versions
+            # (mocking os.path.abspath does not reach pathlib.Path.resolve on 3.13).
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.getsize") as mock_getsize,
             patch("os.path.isabs") as mock_isabs,
@@ -177,6 +181,7 @@ class TestAttachmentsMixin:
         self._mock_rest_api_upload(attachments_mixin)
 
         with (
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists", return_value=True),
             patch("os.path.getsize", return_value=100),
             patch("os.path.isabs", return_value=True),
@@ -269,6 +274,7 @@ class TestAttachmentsMixin:
         """Test attachment upload when file doesn't exist."""
         # Mock file operations
         with (
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.isabs") as mock_isabs,
             patch("os.path.abspath") as mock_abspath,
@@ -298,6 +304,7 @@ class TestAttachmentsMixin:
 
         # Mock file operations
         with (
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.isabs") as mock_isabs,
             patch("os.path.abspath") as mock_abspath,
@@ -365,6 +372,7 @@ class TestAttachmentsMixin:
         attachments_mixin.confluence._session.get.return_value = list_response
 
         with (
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists", return_value=True),
             patch("os.path.getsize", return_value=200),
             patch("os.path.isabs", return_value=True),

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -379,6 +379,7 @@ def test_confluence_fetcher_attachment_method_calls():
 
         # Test upload_attachment can be called
         with (
+            patch("os.getcwd", return_value="/path/to"),
             patch("os.path.exists", return_value=True),
             patch("os.path.isabs", return_value=True),
             patch("os.path.basename", return_value="test.txt"),

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -198,13 +198,33 @@ class TestSearchMixin:
         )
         assert len(result) == 1
 
-        # Test with filter when query already has space
+        # Filter is always ANDed, even when the caller's CQL already names a space,
+        # so a caller-supplied `space = X` cannot escape the configured allowlist.
         result = search_mixin.search('space = "EXISTING"', spaces_filter="DEV")
+        quoted_dev = quote_cql_identifier_if_needed("DEV")
         search_mixin.confluence.cql.assert_called_with(
-            cql='space = "EXISTING"',  # Should not add filter when space already exists
+            cql=f'(space = "EXISTING") AND (space = {quoted_dev})',
             limit=10,
         )
         assert len(result) == 1
+
+    @pytest.mark.security_regression
+    def test_spaces_filter_not_bypassed_by_caller_space_clause(self, search_mixin):
+        """A caller-supplied space clause must not escape the config allowlist.
+
+        The old code skipped the filter when the CQL already named a space, so
+        `space = EVIL` bypassed CONFLUENCE_SPACES_FILTER entirely.
+        """
+        search_mixin.confluence.cql.return_value = {"results": [], "size": 0}
+        search_mixin.config.spaces_filter = "SECSPACE"
+
+        search_mixin.search('space = "EVIL"')
+
+        sent_cql = search_mixin.confluence.cql.call_args.kwargs["cql"]
+        assert "SECSPACE" in sent_cql, (
+            "config spaces_filter must be ANDed even when the caller already "
+            f"names a space; CQL was {sent_cql!r}"
+        )
 
     def test_search_with_config_spaces_filter(self, search_mixin):
         """Test search using spaces filter from config."""

--- a/tests/unit/confluence/test_search.py
+++ b/tests/unit/confluence/test_search.py
@@ -226,6 +226,20 @@ class TestSearchMixin:
             f"names a space; CQL was {sent_cql!r}"
         )
 
+    @pytest.mark.security_regression
+    def test_spaces_filter_param_cannot_replace_config_allowlist(self, search_mixin):
+        """The spaces_filter tool arg may narrow, not replace, the config allowlist."""
+        search_mixin.confluence.cql.return_value = {"results": [], "size": 0}
+        search_mixin.config.spaces_filter = "SECSPACE"
+
+        search_mixin.search("type = page", spaces_filter="EVIL")
+
+        sent_cql = search_mixin.confluence.cql.call_args.kwargs["cql"]
+        assert "SECSPACE" in sent_cql, (
+            "config allowlist must still be applied even when a spaces_filter arg "
+            f"is supplied; CQL was {sent_cql!r}"
+        )
+
     def test_search_with_config_spaces_filter(self, search_mixin):
         """Test search using spaces filter from config."""
         # Prepare the mock
@@ -266,13 +280,18 @@ class TestSearchMixin:
         )
         assert len(result) == 1
 
-        # Test that explicit filter overrides config filter
+        # A spaces_filter arg narrows within the config allowlist (hard boundary):
+        # the config filter is still ANDed, it cannot be replaced.
         result = search_mixin.search("test query", spaces_filter="OVERRIDE")
 
-        # Verify space was properly quoted in the CQL query
+        quoted_dev = quote_cql_identifier_if_needed("DEV")
+        quoted_team = quote_cql_identifier_if_needed("TEAM")
         quoted_override = quote_cql_identifier_if_needed("OVERRIDE")
         search_mixin.confluence.cql.assert_called_with(
-            cql=f"(test query) AND (space = {quoted_override})",
+            cql=(
+                f"((test query) AND (space = {quoted_dev} OR space = {quoted_team}))"
+                f" AND (space = {quoted_override})"
+            ),
             limit=10,
         )
         assert len(result) == 1

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -69,7 +69,8 @@ class TestAttachmentsMixin:
         mock_response.raise_for_status = MagicMock()
         attachments_mixin.jira._session.get.return_value = mock_response
 
-        download_path = "/tmp/test_file.txt"
+        # A subdirectory of CWD (downloads may not land in the CWD root itself).
+        download_path = "/tmp/downloads/test_file.txt"
         expected_path = os.path.abspath(download_path)
 
         # Mock file operations
@@ -121,20 +122,25 @@ class TestAttachmentsMixin:
             mock_exists.return_value = True
             mock_getsize.return_value = 12
             mock_isabs.return_value = False
+            # Target a subdirectory (downloads may not land in the CWD root itself).
             mock_abspath.side_effect = lambda p: (
-                "/absolute/path/test_file.txt" if p == "test_file.txt" else p
+                "/absolute/path/downloads/test_file.txt"
+                if p == "downloads/test_file.txt"
+                else p
             )
 
             # Call the method with a relative path
             result = attachments_mixin.download_attachment(
-                "https://test.url/attachment", "test_file.txt"
+                "https://test.url/attachment", "downloads/test_file.txt"
             )
 
             # Assertions
             assert result is True
-            mock_isabs.assert_called_once_with("test_file.txt")
-            mock_abspath.assert_any_call("test_file.txt")
-            mock_file.assert_called_once_with("/absolute/path/test_file.txt", "wb")
+            mock_isabs.assert_any_call("downloads/test_file.txt")
+            mock_abspath.assert_any_call("downloads/test_file.txt")
+            mock_file.assert_called_once_with(
+                "/absolute/path/downloads/test_file.txt", "wb"
+            )
 
     def test_download_attachment_no_url(self, attachments_mixin: AttachmentsMixin):
         """Test attachment download with no URL."""
@@ -1371,12 +1377,6 @@ class TestUploadPathTraversalRegression:
         attachments_mixin.jira.add_attachment.assert_not_called()
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam1 GHSA-6vmq: validate_safe_path base_dir defaults to CWD "
-        "(utils/io.py:44) so downloads can overwrite an importable module in CWD "
-        "-> RCE; fix-1b confines downloads to a dedicated dir (dir contract TBD)",
-    )
     def test_download_into_cwd_module_is_rejected(
         self,
         attachments_mixin: AttachmentsMixin,

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -507,9 +507,10 @@ class TestAttachmentsMixin:
                 issue_key="TEST-123", filename="/absolute/path/test_file.txt"
             )
 
-    def test_upload_attachment_relative_path(self, attachments_mixin: AttachmentsMixin):
-        """Test attachment upload with a relative path."""
-        # Mock the Jira API response
+    def test_upload_attachment_relative_path(
+        self, attachments_mixin: AttachmentsMixin, tmp_path: Path
+    ):
+        """A relative path inside the workspace resolves and uploads."""
         mock_attachment_response = {
             "id": "12345",
             "filename": "test_file.txt",
@@ -517,31 +518,16 @@ class TestAttachmentsMixin:
         }
         attachments_mixin.jira.add_attachment.return_value = mock_attachment_response
 
-        # Mock file operations
-        with (
-            patch("os.path.exists") as mock_exists,
-            patch("os.path.getsize") as mock_getsize,
-            patch("os.path.isabs") as mock_isabs,
-            patch("os.path.abspath") as mock_abspath,
-            patch("os.path.basename") as mock_basename,
-            patch("builtins.open", mock_open(read_data=b"test content")),
-        ):
-            mock_exists.return_value = True
-            mock_getsize.return_value = 100
-            mock_isabs.return_value = False
-            mock_abspath.return_value = "/absolute/path/test_file.txt"
-            mock_basename.return_value = "test_file.txt"
+        (tmp_path / "test_file.txt").write_bytes(b"test content")
+        resolved = str((tmp_path / "test_file.txt").resolve())
 
-            # Call the method with a relative path
+        with patch("os.getcwd", return_value=str(tmp_path)):
             result = attachments_mixin.upload_attachment("TEST-123", "test_file.txt")
 
-            # Assertions
-            assert result["success"] is True
-            mock_isabs.assert_called_once_with("test_file.txt")
-            mock_abspath.assert_called_once_with("test_file.txt")
-            attachments_mixin.jira.add_attachment.assert_called_once_with(
-                issue_key="TEST-123", filename="/absolute/path/test_file.txt"
-            )
+        assert result["success"] is True
+        attachments_mixin.jira.add_attachment.assert_called_once_with(
+            issue_key="TEST-123", filename=resolved
+        )
 
     def test_upload_attachment_no_issue_key(self, attachments_mixin: AttachmentsMixin):
         """Test attachment upload with no issue key."""
@@ -1316,3 +1302,105 @@ class TestAttachmentsMixin:
         assert result[1].filename == "report.pdf"
         # No download calls should have been made
         attachments_mixin.jira._session.get.assert_not_called()
+
+
+class TestUploadPathTraversalRegression:
+    """SP5 fam1 — upload-side attachment path traversal / arbitrary file read.
+
+    Covers GHSA-wm45, vc25, 93xw, 6cr4, f4p7, f6pj, 2xj6, mrq8, wv8v, p6hp, h7wj,
+    mfv2, f26r, 9547, cc5h (read half), and the 6vmq download-overwrite variant.
+
+    The download side gained ``validate_safe_path`` (CVE-2026-27825), but the upload
+    path still feeds any caller-supplied ``file_path`` to the API after only an
+    ``os.path.exists`` check (``jira/attachments.py:378`` →
+    ``add_attachment(filename=file_path)`` at ``:387``), so a path outside the
+    workspace is read and exfiltrated. These tests assert the secure outcome — a
+    traversal/absolute path never reaches the upload sink — and currently xfail.
+    Phase B fix-1a (``validate_safe_path`` on the upload ``file_path``) flips them
+    green; the strict marker then forces removing the xfail.
+
+    Assertions target the *sink* (``add_attachment`` not called), not an exception
+    type, because ``upload_attachment`` wraps its body in ``except Exception`` and
+    returns an error dict — so the fix may reject by raising or by returning a dict,
+    and either way the secret must never reach the API.
+    """
+
+    @pytest.fixture
+    def attachments_mixin(self, jira_fetcher: JiraFetcher) -> AttachmentsMixin:
+        """AttachmentsMixin with a mocked Jira client (Cloud by default)."""
+        mixin = jira_fetcher
+        mixin.jira = MagicMock()
+        mixin.jira._session = MagicMock()
+        return mixin
+
+    @pytest.mark.security_regression
+    @pytest.mark.parametrize("attack", ["absolute_outside_cwd", "relative_traversal"])
+    def test_upload_attachment_does_not_read_outside_workspace(
+        self,
+        attachments_mixin: AttachmentsMixin,
+        tmp_path: Path,
+        attack: str,
+    ) -> None:
+        """A file_path resolving outside the workspace must not reach the API."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        secret = tmp_path / "secret.txt"  # sibling of workspace -> outside it
+        secret.write_bytes(b"SP5-SECRET-EXFIL")
+        malicious = str(secret) if attack == "absolute_outside_cwd" else "../secret.txt"
+
+        with patch("os.getcwd", return_value=str(workspace)):
+            attachments_mixin.upload_attachment("PROJ-1", malicious)
+
+        attachments_mixin.jira.add_attachment.assert_not_called()
+
+    @pytest.mark.security_regression
+    def test_upload_attachments_list_does_not_read_outside_workspace(
+        self,
+        attachments_mixin: AttachmentsMixin,
+        tmp_path: Path,
+    ) -> None:
+        """The list/confused-deputy path (update_issue -> upload_attachments)."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"SP5-SECRET-EXFIL")
+
+        with patch("os.getcwd", return_value=str(workspace)):
+            attachments_mixin.upload_attachments("PROJ-1", [str(secret)])
+
+        attachments_mixin.jira.add_attachment.assert_not_called()
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam1 GHSA-6vmq: validate_safe_path base_dir defaults to CWD "
+        "(utils/io.py:44) so downloads can overwrite an importable module in CWD "
+        "-> RCE; fix-1b confines downloads to a dedicated dir (dir contract TBD)",
+    )
+    def test_download_into_cwd_module_is_rejected(
+        self,
+        attachments_mixin: AttachmentsMixin,
+        tmp_path: Path,
+    ) -> None:
+        """Downloading onto a source file inside CWD must be confined/rejected."""
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"import os; os.system('id')\n"]
+        mock_response.raise_for_status = MagicMock()
+        attachments_mixin.jira._session.get.return_value = mock_response
+
+        with (
+            patch("builtins.open", mock_open()),
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getsize", return_value=27),
+            patch("os.makedirs"),
+            patch("os.getcwd", return_value=str(tmp_path)),
+        ):
+            result = attachments_mixin.download_attachment(
+                "https://test.url/evil",
+                "important_module.py",  # relative -> resolves inside CWD
+            )
+
+        assert result is False, (
+            "download targeting the CWD (where Python imports modules) must be "
+            "confined to a dedicated directory, not allowed to overwrite source files"
+        )

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -1311,19 +1311,16 @@ class TestAttachmentsMixin:
 
 
 class TestUploadPathTraversalRegression:
-    """SP5 fam1 — upload-side attachment path traversal / arbitrary file read.
+    """Regression — upload-side attachment path traversal / arbitrary file read.
 
     Covers GHSA-wm45, vc25, 93xw, 6cr4, f4p7, f6pj, 2xj6, mrq8, wv8v, p6hp, h7wj,
     mfv2, f26r, 9547, cc5h (read half), and the 6vmq download-overwrite variant.
 
-    The download side gained ``validate_safe_path`` (CVE-2026-27825), but the upload
-    path still feeds any caller-supplied ``file_path`` to the API after only an
-    ``os.path.exists`` check (``jira/attachments.py:378`` →
-    ``add_attachment(filename=file_path)`` at ``:387``), so a path outside the
-    workspace is read and exfiltrated. These tests assert the secure outcome — a
-    traversal/absolute path never reaches the upload sink — and currently xfail.
-    Phase B fix-1a (``validate_safe_path`` on the upload ``file_path``) flips them
-    green; the strict marker then forces removing the xfail.
+    The download side gained ``validate_safe_path`` (CVE-2026-27825), but the
+    upload path used to feed any caller-supplied ``file_path`` to the API after
+    only an ``os.path.exists`` check, so a path outside the workspace was read and
+    exfiltrated. These tests assert the secure outcome: a traversal/absolute path
+    never reaches the upload sink.
 
     Assertions target the *sink* (``add_attachment`` not called), not an exception
     type, because ``upload_attachment`` wraps its body in ``except Exception`` and
@@ -1351,7 +1348,7 @@ class TestUploadPathTraversalRegression:
         workspace = tmp_path / "workspace"
         workspace.mkdir()
         secret = tmp_path / "secret.txt"  # sibling of workspace -> outside it
-        secret.write_bytes(b"SP5-SECRET-EXFIL")
+        secret.write_bytes(b"SECRET-EXFIL")
         malicious = str(secret) if attack == "absolute_outside_cwd" else "../secret.txt"
 
         with patch("os.getcwd", return_value=str(workspace)):
@@ -1369,7 +1366,7 @@ class TestUploadPathTraversalRegression:
         workspace = tmp_path / "workspace"
         workspace.mkdir()
         secret = tmp_path / "secret.txt"
-        secret.write_bytes(b"SP5-SECRET-EXFIL")
+        secret.write_bytes(b"SECRET-EXFIL")
 
         with patch("os.getcwd", return_value=str(workspace)):
             attachments_mixin.upload_attachments("PROJ-1", [str(secret)])

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -485,6 +485,10 @@ class TestAttachmentsMixin:
 
         # Mock file operations
         with (
+            # Pin the workspace so the absolute path resolves inside it — keeps
+            # validate_safe_path passing deterministically across Python versions
+            # (mocking os.path.abspath does not reach pathlib.Path.resolve on 3.13).
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.getsize") as mock_getsize,
             patch("os.path.isabs") as mock_isabs,
@@ -559,6 +563,7 @@ class TestAttachmentsMixin:
         """Test attachment upload when file doesn't exist."""
         # Mock file operations
         with (
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.isabs") as mock_isabs,
             patch("os.path.abspath") as mock_abspath,
@@ -584,6 +589,7 @@ class TestAttachmentsMixin:
 
         # Mock file operations
         with (
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.isabs") as mock_isabs,
             patch("os.path.abspath") as mock_abspath,
@@ -610,6 +616,7 @@ class TestAttachmentsMixin:
 
         # Mock file operations
         with (
+            patch("os.getcwd", return_value="/absolute/path"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.isabs") as mock_isabs,
             patch("os.path.abspath") as mock_abspath,

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -106,6 +106,50 @@ def test_base_session_has_ssrf_redirect_hook():
     ), "base session must mount the SSRF DNS-pinning adapter for https"
 
 
+@pytest.mark.security_regression
+def test_http_hardening_survives_ssrf_pinning_mount(monkeypatch):
+    """The opt-in HTTP hardening wrappers patch ``adapter.send`` in place, so
+    they must be applied AFTER ``mount_ssrf_pinning`` replaces the generic
+    http/https adapters — otherwise the pinning mount silently drops the
+    concurrency/rate-limit/circuit-breaker wrappers (retries survive via the
+    max_retries carry-over, the send wrappers do not).
+    """
+    import requests
+
+    from mcp_atlassian.utils.http import (
+        _reset_concurrency_semaphore_for_tests,
+        _reset_rate_limit_bucket_for_tests,
+    )
+    from mcp_atlassian.utils.ssrf_adapter import SsrfPinningAdapter
+
+    monkeypatch.setenv("ATLASSIAN_MAX_CONCURRENT_REQUESTS", "2")
+    _reset_concurrency_semaphore_for_tests()
+    try:
+        with (
+            patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+            patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+        ):
+            mock_jira.return_value._session = requests.Session()
+            client = JiraClient(
+                config=JiraConfig(
+                    url="https://test.atlassian.net",
+                    auth_type="basic",
+                    username="u",
+                    api_token="t",
+                )
+            )
+
+        adapter = client.jira._session.get_adapter("https://example.atlassian.net")
+        assert isinstance(adapter, SsrfPinningAdapter)
+        assert getattr(adapter, "_mcp_atlassian_throttled", False), (
+            "concurrency wrapper must be present on the pinning adapter — "
+            "hardening was applied before mount_ssrf_pinning replaced it"
+        )
+    finally:
+        _reset_concurrency_semaphore_for_tests()
+        _reset_rate_limit_bucket_for_tests()
+
+
 def test_init_with_token_auth():
     """Test initializing the client with token auth configuration."""
     with (

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -97,6 +97,14 @@ def test_base_session_has_ssrf_redirect_hook():
         for hook in hooks:
             hook(internal_redirect)
 
+    # And the base session must use the DNS-pinning adapter (rebind protection).
+    from mcp_atlassian.utils.ssrf_adapter import SsrfPinningAdapter
+
+    assert isinstance(
+        client.jira._session.get_adapter("https://example.atlassian.net"),
+        SsrfPinningAdapter,
+    ), "base session must mount the SSRF DNS-pinning adapter for https"
+
 
 def test_init_with_token_auth():
     """Test initializing the client with token auth configuration."""

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -63,6 +63,41 @@ def test_init_with_basic_auth():
         assert client._current_user_account_id is None
 
 
+@pytest.mark.security_regression
+def test_base_session_has_ssrf_redirect_hook():
+    """Every fetcher's underlying session must validate redirects for SSRF, not
+    only the per-user HTTP path. Direct ``self.jira._session.get()`` calls (e.g.
+    jira/development.py, jira/users.py) and global/stdio fetchers previously
+    followed redirects unhooked. Closes GHSA-v9m3-wfh8-5646, GHSA-5wf4-jqxh-8gm3.
+    """
+    import requests
+
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        mock_jira.return_value._session = requests.Session()
+        client = JiraClient(
+            config=JiraConfig(
+                url="https://test.atlassian.net",
+                auth_type="basic",
+                username="u",
+                api_token="t",
+            )
+        )
+
+    hooks = client.jira._session.hooks["response"]
+    assert len(hooks) > 0, "base session must carry an SSRF redirect hook"
+
+    # The hook must actually block a redirect to an internal/metadata host.
+    internal_redirect = MagicMock()
+    internal_redirect.is_redirect = True
+    internal_redirect.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+    with pytest.raises(ValueError, match="SSRF"):
+        for hook in hooks:
+            hook(internal_redirect)
+
+
 def test_init_with_token_auth():
     """Test initializing the client with token auth configuration."""
     with (

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -1210,19 +1210,19 @@ class TestSearchMixin:
 
 
 class TestSearchFilterAndInjectionRegression:
-    """SP5 fam5 (filter bypass) + fam7 (JQL injection) for Jira search.
+    """Regression — project/space filter bypass (GHSA-w66g, GHSA-rqwg) and JQL
+    injection (GHSA-6rrj) for Jira search.
 
-    fam5 (GHSA-w66g, rqwg): ``search_issues`` applies ``config.projects_filter``,
-    but ``get_board_issues`` (``jira/search.py:208``) never does — board issues
-    escape the project allowlist. fam7 (GHSA-6rrj): ``get_sprint_issues``
-    (``:298``) interpolates ``sprint_id`` straight into JQL
-    (``f"sprint = {sprint_id}"``), so a non-numeric value injects JQL.
+    Filter bypass: ``search_issues`` applies ``config.projects_filter``, but
+    ``get_board_issues`` never did — board issues escaped the project allowlist.
+    JQL injection: ``get_sprint_issues`` interpolated ``sprint_id`` straight into
+    JQL (``f"sprint = {sprint_id}"``), so a non-numeric value injected JQL.
 
-    Assertions follow the weakest fix-agnostic invariant: fam5 asserts the project
-    key appears *somewhere* in the outgoing JQL (not an exact string); fam7 asserts a
-    non-numeric sprint_id is rejected (fix-7b contract = numeric-only), with
-    ``search_issues`` mocked so the only thing that can reject it is sprint_id
-    validation. Both currently xfail; Phase B fix-5 / fix-7b flip them green.
+    Assertions follow the weakest fix-agnostic invariant: the filter tests assert
+    the project key appears *somewhere* in the outgoing JQL (not an exact string);
+    the injection test asserts a non-numeric sprint_id is rejected (numeric-only
+    contract), with ``search_issues`` mocked so the only thing that can reject it
+    is sprint_id validation.
     """
 
     @pytest.fixture

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -1204,3 +1204,85 @@ class TestSearchMixin:
         )
         # The result should not have a next_page_token from Server/DC
         assert result.next_page_token is None
+
+
+class TestSearchFilterAndInjectionRegression:
+    """SP5 fam5 (filter bypass) + fam7 (JQL injection) for Jira search.
+
+    fam5 (GHSA-w66g, rqwg): ``search_issues`` applies ``config.projects_filter``,
+    but ``get_board_issues`` (``jira/search.py:208``) never does — board issues
+    escape the project allowlist. fam7 (GHSA-6rrj): ``get_sprint_issues``
+    (``:298``) interpolates ``sprint_id`` straight into JQL
+    (``f"sprint = {sprint_id}"``), so a non-numeric value injects JQL.
+
+    Assertions follow the weakest fix-agnostic invariant: fam5 asserts the project
+    key appears *somewhere* in the outgoing JQL (not an exact string); fam7 asserts a
+    non-numeric sprint_id is rejected (fix-7b contract = numeric-only), with
+    ``search_issues`` mocked so the only thing that can reject it is sprint_id
+    validation. Both currently xfail; Phase B fix-5 / fix-7b flip them green.
+    """
+
+    @pytest.fixture
+    def search_mixin(self, jira_fetcher: JiraFetcher) -> SearchMixin:
+        """SearchMixin with a mocked Jira client and config (Server/DC default)."""
+        mixin = jira_fetcher
+        mixin._clean_text = MagicMock(side_effect=lambda text: text if text else "")
+        mixin.config = MagicMock()
+        mixin.config.is_cloud = False
+        mixin.config.projects_filter = None
+        mixin.config.url = "https://example.atlassian.net"
+        return mixin
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam5 GHSA-w66g/rqwg: jira/search.py:208 get_board_issues never "
+        "applies config.projects_filter — board issues bypass the project allowlist",
+    )
+    def test_get_board_issues_applies_projects_filter(
+        self,
+        search_mixin: SearchMixin,
+        mock_issues_response: dict,
+    ) -> None:
+        """Board issues must be restricted to the configured projects_filter."""
+        search_mixin.config.projects_filter = "SECPROJ"
+        search_mixin.jira.get_issues_for_board.return_value = mock_issues_response
+
+        search_mixin.get_board_issues("123", jql="status = Open")
+
+        sent_jql = search_mixin.jira.get_issues_for_board.call_args.kwargs.get(
+            "jql", ""
+        )
+        assert "SECPROJ" in sent_jql, (
+            "board issues must be constrained to the configured projects_filter; "
+            f"outgoing JQL was {sent_jql!r}"
+        )
+
+    @pytest.fixture
+    def mock_issues_response(self) -> dict:
+        """Minimal valid Jira board response so from_api_response succeeds."""
+        return {
+            "issues": [],
+            "total": 0,
+            "startAt": 0,
+            "maxResults": 50,
+        }
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam7 GHSA-6rrj: jira/search.py:298 get_sprint_issues "
+        'interpolates sprint_id into JQL unsanitized (f"sprint = {sprint_id}") — '
+        "JQL injection",
+    )
+    def test_get_sprint_issues_rejects_non_numeric_sprint_id(
+        self,
+        search_mixin: SearchMixin,
+    ) -> None:
+        """A non-numeric sprint_id (injection payload) must be rejected."""
+        # search_issues is mocked, so the ONLY thing that can reject the payload is
+        # validation of sprint_id itself — pinning fix-7b's numeric-only contract.
+        search_mixin.search_issues = MagicMock(return_value=MagicMock())
+
+        with pytest.raises(Exception):
+            search_mixin.get_sprint_issues("1 OR project = SECRET")

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -1234,11 +1234,6 @@ class TestSearchFilterAndInjectionRegression:
         return mixin
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam5 GHSA-w66g/rqwg: jira/search.py:208 get_board_issues never "
-        "applies config.projects_filter — board issues bypass the project allowlist",
-    )
     def test_get_board_issues_applies_projects_filter(
         self,
         search_mixin: SearchMixin,
@@ -1269,12 +1264,6 @@ class TestSearchFilterAndInjectionRegression:
         }
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam7 GHSA-6rrj: jira/search.py:298 get_sprint_issues "
-        'interpolates sprint_id into JQL unsanitized (f"sprint = {sprint_id}") — '
-        "JQL injection",
-    )
     def test_get_sprint_issues_rejects_non_numeric_sprint_id(
         self,
         search_mixin: SearchMixin,

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -347,10 +347,11 @@ class TestSearchMixin:
         assert len(result.issues) == 1
         assert result.total == 1
 
-        # Test with override
+        # A projects_filter arg narrows within the config allowlist (hard boundary):
+        # the config filter is still ANDed, it cannot be replaced.
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
         search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project = OVERRIDE",
+            "((text ~ 'test') AND project IN (TEST, DEV)) AND project = OVERRIDE",
             fields=ANY,
             start=0,
             limit=50,
@@ -359,12 +360,12 @@ class TestSearchMixin:
         assert len(result.issues) == 1
         assert result.total == 1
 
-        # Test with override - multiple projects
+        # Same with a multi-project narrowing arg.
         result = search_mixin.search_issues(
             "text ~ 'test'", projects_filter="OVER1,OVER2"
         )
         search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project IN (OVER1, OVER2)",
+            "((text ~ 'test') AND project IN (TEST, DEV)) AND project IN (OVER1, OVER2)",
             fields=ANY,
             start=0,
             limit=50,
@@ -729,10 +730,12 @@ class TestSearchMixin:
         search_mixin.jira.post.reset_mock()
         search_mixin.jira.jql.reset_mock()
 
-        # Act: Override config filter with parameter
+        # Act: a projects_filter arg narrows within the config allowlist; it cannot
+        # replace it, so the config filter is still ANDed (hard boundary).
         search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
-        # Assert: JQL verification
-        assert get_jql_from_call() == "(text ~ 'test') AND project = OVERRIDE"
+        assert get_jql_from_call() == (
+            "((text ~ 'test') AND project IN (CONF1, CONF2)) AND project = OVERRIDE"
+        )
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_empty_jql_and_projects_filter(
@@ -1294,4 +1297,24 @@ class TestSearchFilterAndInjectionRegression:
         assert "SECPROJ" in sent_jql, (
             "config projects_filter must be ANDed even when the caller already "
             f"names a project; JQL was {sent_jql!r}"
+        )
+
+    @pytest.mark.security_regression
+    def test_projects_filter_param_cannot_replace_config_allowlist(
+        self, search_mixin: SearchMixin, mock_issues_response: dict
+    ) -> None:
+        """The projects_filter tool arg may narrow, not replace, the config allowlist.
+
+        Previously ``projects_filter or config.projects_filter`` let a caller pass
+        projects_filter="SECRET" to drop the operator's allowlist entirely.
+        """
+        search_mixin.config.projects_filter = "SECPROJ"
+        search_mixin.jira.jql.return_value = mock_issues_response
+
+        search_mixin.search_issues("text ~ 'x'", projects_filter="SECRET")
+
+        sent_jql = search_mixin.jira.jql.call_args[0][0]
+        assert "SECPROJ" in sent_jql, (
+            "config allowlist must still be applied even when a projects_filter arg "
+            f"is supplied; JQL was {sent_jql!r}"
         )

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -694,10 +694,10 @@ class TestSearchMixin:
         search_mixin.jira.post.reset_mock()
         search_mixin.jira.jql.reset_mock()
 
-        # Act: Call with both JQL and filter
+        # Act: Call with both JQL and filter — the allowlist is always ANDed, so a
+        # caller-supplied project clause cannot escape the configured filter.
         search_mixin.search_issues("project = OTHER", projects_filter="TEST")
-        # Assert: JQL verification (existing JQL has priority)
-        assert get_jql_from_call() == "project = OTHER"
+        assert get_jql_from_call() == "(project = OTHER) AND project = TEST"
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_config_projects_filter_jql_construction(
@@ -1275,3 +1275,23 @@ class TestSearchFilterAndInjectionRegression:
 
         with pytest.raises(Exception):
             search_mixin.get_sprint_issues("1 OR project = SECRET")
+
+    @pytest.mark.security_regression
+    def test_projects_filter_not_bypassed_by_caller_project_clause(
+        self, search_mixin: SearchMixin, mock_issues_response: dict
+    ) -> None:
+        """A caller-supplied project clause must not escape the config allowlist.
+
+        The old code skipped adding the filter when the query already named a
+        project, so `project = EVIL` bypassed JIRA_PROJECTS_FILTER entirely.
+        """
+        search_mixin.config.projects_filter = "SECPROJ"
+        search_mixin.jira.jql.return_value = mock_issues_response
+
+        search_mixin.search_issues("project = EVIL")
+
+        sent_jql = search_mixin.jira.jql.call_args[0][0]
+        assert "SECPROJ" in sent_jql, (
+            "config projects_filter must be ANDed even when the caller already "
+            f"names a project; JQL was {sent_jql!r}"
+        )

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -926,11 +926,14 @@ async def test_update_page_with_xhtml_format(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
-async def test_create_page_with_content_file(client, mock_confluence_fetcher, tmp_path):
+async def test_create_page_with_content_file(
+    client, mock_confluence_fetcher, tmp_path, monkeypatch
+):
     """content_file should load the body from disk and be passed to the fetcher."""
     body = "# Heading\n\nFrom a file."
     fp = tmp_path / "page.md"
     fp.write_text(body, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)  # content_file is confined to the workspace
 
     await client.call_tool(
         "confluence_create_page",
@@ -947,11 +950,14 @@ async def test_create_page_with_content_file(client, mock_confluence_fetcher, tm
 
 
 @pytest.mark.anyio
-async def test_update_page_with_content_file(client, mock_confluence_fetcher, tmp_path):
+async def test_update_page_with_content_file(
+    client, mock_confluence_fetcher, tmp_path, monkeypatch
+):
     """content_file should be accepted by update_page as an alternative to content."""
     body = "Updated body from disk."
     fp = tmp_path / "update.md"
     fp.write_text(body, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)  # content_file is confined to the workspace
 
     await client.call_tool(
         "confluence_update_page",
@@ -1073,6 +1079,35 @@ async def test_create_page_rejects_neither_content_nor_file(
 
 
 @pytest.mark.anyio
+async def test_create_page_content_file_rejects_path_outside_workspace(
+    client, mock_confluence_fetcher, tmp_path, monkeypatch
+):
+    """Regression — a content_file outside the workspace must be refused.
+
+    The file body is echoed back through the created page, so an unconfined
+    path is an arbitrary-file-read/exfiltration primitive (same class as the
+    attachment-path advisories).
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret = tmp_path / "secret.md"  # sibling of workspace -> outside it
+    secret.write_text("SECRET-EXFIL", encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    for content_file in [str(secret), "../secret.md"]:
+        with pytest.raises(Exception, match="Path traversal detected"):
+            await client.call_tool(
+                "confluence_create_page",
+                {
+                    "space_key": "TEST",
+                    "title": "Exfil",
+                    "content_file": content_file,
+                },
+            )
+    mock_confluence_fetcher.create_page.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_update_page_rejects_missing_file(client, mock_confluence_fetcher):
     """A content_file path that does not exist should error before calling fetcher."""
     with pytest.raises(Exception, match="does not exist"):
@@ -1081,7 +1116,7 @@ async def test_update_page_rejects_missing_file(client, mock_confluence_fetcher)
             {
                 "page_id": "999999",
                 "title": "Bad Path",
-                "content_file": "/tmp/definitely-not-here-6f3a2d.md",
+                "content_file": "definitely-not-here-6f3a2d.md",
             },
         )
     mock_confluence_fetcher.update_page.assert_not_called()

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -1615,11 +1615,6 @@ class TestSsrfHookCoverageRegression:
     """
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam4 GHSA-6529: dependencies.py:587 basic-auth branch omits "
-        "attach_ssrf_hook — user session carries no SSRF redirect hook",
-    )
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
     async def test_basic_auth_jira_session_has_ssrf_hook(
@@ -1655,11 +1650,6 @@ class TestSsrfHookCoverageRegression:
         )
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam4 GHSA-6529: dependencies.py:636 oauth_pat branch omits "
-        "attach_ssrf_hook — user session carries no SSRF redirect hook",
-    )
     @patch("mcp_atlassian.servers.dependencies.get_access_token")
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
@@ -1694,11 +1684,6 @@ class TestSsrfHookCoverageRegression:
         )
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam4 GHSA-6529: dependencies.py:587 basic-auth branch omits "
-        "attach_ssrf_hook — Confluence user session carries no SSRF redirect hook",
-    )
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
     async def test_basic_auth_confluence_session_has_ssrf_hook(
@@ -1734,11 +1719,6 @@ class TestSsrfHookCoverageRegression:
         )
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam4 GHSA-6529: dependencies.py:636 oauth_pat branch omits "
-        "attach_ssrf_hook — Confluence user session carries no SSRF redirect hook",
-    )
     @patch("mcp_atlassian.servers.dependencies.get_access_token")
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -1583,3 +1583,252 @@ class TestSsrfProtection:
 
         result = hook(mock_response)
         assert result == mock_response
+
+
+class TestSsrfHookCoverageRegression:
+    """SP5 fam4 (GHSA-6529) — SSRF redirect hook must cover the basic-auth and OAuth
+    per-user fetcher sessions, not only the header-PAT branch.
+
+    ``_create_and_validate`` is called with ``attach_ssrf_hook=True`` only on the
+    header-PAT branch (``dependencies.py:561``); the basic (``:587``) and oauth_pat
+    (``:636``) branches omit it, so per-user fetchers built from those branches follow
+    HTTP redirects without SSRF validation. These tests assert the secure outcome — a
+    redirect hook is attached to the fetcher's session — and currently xfail. Phase B
+    fix-4a (pass ``attach_ssrf_hook=True`` on every auth branch) flips them green; the
+    strict marker then forces removal of the xfail.
+    """
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam4 GHSA-6529: dependencies.py:587 basic-auth branch omits "
+        "attach_ssrf_hook — user session carries no SSRF redirect hook",
+    )
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
+    async def test_basic_auth_jira_session_has_ssrf_hook(
+        self,
+        mock_jira_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ) -> None:
+        """A basic-auth Jira fetcher must follow redirects through the SSRF hook."""
+        mock_request.state.jira_fetcher = None
+        mock_request.state.confluence_fetcher = None
+        mock_request.state.atlassian_service_headers = {}
+        mock_request.state.user_atlassian_auth_type = "basic"
+        mock_request.state.user_atlassian_email = "user@example.com"
+        mock_request.state.user_atlassian_api_token = "user-api-token"
+        mock_request.state.user_atlassian_token = None
+        mock_request.state.user_atlassian_cloud_id = None
+        mock_get_http_request.return_value = mock_request
+
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(JiraFetcher)
+        mock_jira_fetcher_class.return_value = mock_fetcher
+
+        await get_jira_fetcher(mock_context)
+
+        response_hooks = mock_fetcher.jira._session.hooks["response"]
+        assert len(response_hooks) > 0, (
+            "basic-auth user fetcher session must carry the SSRF redirect hook"
+        )
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam4 GHSA-6529: dependencies.py:636 oauth_pat branch omits "
+        "attach_ssrf_hook — user session carries no SSRF redirect hook",
+    )
+    @patch("mcp_atlassian.servers.dependencies.get_access_token")
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
+    async def test_oauth_jira_session_has_ssrf_hook(
+        self,
+        mock_jira_fetcher_class,
+        mock_get_http_request,
+        mock_get_access_token,
+        mock_context,
+        mock_request,
+        config_factory,
+        auth_scenarios,
+    ) -> None:
+        """An OAuth Jira fetcher must follow redirects through the SSRF hook."""
+        _setup_mock_request_state(mock_request, auth_scenarios["oauth"])
+        mock_get_http_request.return_value = mock_request
+        mock_get_access_token.side_effect = RuntimeError("no auth context")
+
+        app_context = config_factory.create_app_context(
+            jira_config=config_factory.create_jira_config(auth_type="oauth")
+        )
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(JiraFetcher)
+        mock_jira_fetcher_class.return_value = mock_fetcher
+
+        await get_jira_fetcher(mock_context)
+
+        response_hooks = mock_fetcher.jira._session.hooks["response"]
+        assert len(response_hooks) > 0, (
+            "oauth user fetcher session must carry the SSRF redirect hook"
+        )
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam4 GHSA-6529: dependencies.py:587 basic-auth branch omits "
+        "attach_ssrf_hook — Confluence user session carries no SSRF redirect hook",
+    )
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_basic_auth_confluence_session_has_ssrf_hook(
+        self,
+        mock_confluence_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ) -> None:
+        """A basic-auth Confluence fetcher must follow redirects through the hook."""
+        mock_request.state.jira_fetcher = None
+        mock_request.state.confluence_fetcher = None
+        mock_request.state.atlassian_service_headers = {}
+        mock_request.state.user_atlassian_auth_type = "basic"
+        mock_request.state.user_atlassian_email = "user@example.com"
+        mock_request.state.user_atlassian_api_token = "user-api-token"
+        mock_request.state.user_atlassian_token = None
+        mock_request.state.user_atlassian_cloud_id = None
+        mock_get_http_request.return_value = mock_request
+
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.return_value = mock_fetcher
+
+        await get_confluence_fetcher(mock_context)
+
+        response_hooks = mock_fetcher.confluence._session.hooks["response"]
+        assert len(response_hooks) > 0, (
+            "basic-auth user fetcher session must carry the SSRF redirect hook"
+        )
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam4 GHSA-6529: dependencies.py:636 oauth_pat branch omits "
+        "attach_ssrf_hook — Confluence user session carries no SSRF redirect hook",
+    )
+    @patch("mcp_atlassian.servers.dependencies.get_access_token")
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_oauth_confluence_session_has_ssrf_hook(
+        self,
+        mock_confluence_fetcher_class,
+        mock_get_http_request,
+        mock_get_access_token,
+        mock_context,
+        mock_request,
+        config_factory,
+        auth_scenarios,
+    ) -> None:
+        """An OAuth Confluence fetcher must follow redirects through the hook."""
+        _setup_mock_request_state(mock_request, auth_scenarios["oauth"])
+        mock_get_http_request.return_value = mock_request
+        mock_get_access_token.side_effect = RuntimeError("no auth context")
+
+        app_context = config_factory.create_app_context(
+            confluence_config=config_factory.create_confluence_config(auth_type="oauth")
+        )
+        _setup_mock_context(mock_context, app_context)
+
+        mock_fetcher = _create_mock_fetcher(ConfluenceFetcher)
+        mock_confluence_fetcher_class.return_value = mock_fetcher
+
+        await get_confluence_fetcher(mock_context)
+
+        response_hooks = mock_fetcher.confluence._session.hooks["response"]
+        assert len(response_hooks) > 0, (
+            "oauth user fetcher session must carry the SSRF redirect hook"
+        )
+
+
+class TestUnauthenticatedGlobalFallbackRegression:
+    """SP5 fam2 (GHSA-wrhw, vc8m, cc5h auth half) — an unauthenticated HTTP request
+    must not silently fall back to the operator's global credentials.
+
+    In an HTTP request context with no user identity, ``_get_fetcher`` falls through
+    to the global fallback at ``dependencies.py:658-670`` and returns
+    ``spec.fetcher_class(config=global_config_fallback)`` unconditionally, so any
+    unauthenticated caller on a remotely-exposed streamable-http server transacts as
+    the operator. These tests assert the secure outcome — the global fallback is
+    refused for unauthenticated HTTP requests unless ``ALLOW_GLOBAL_CRED_FALLBACK``
+    is explicitly enabled — and currently xfail. Phase B fix-2 (opt-in gate) flips
+    them green; the strict marker then forces removing the xfail.
+
+    The companion ``test_global_fallback_scenarios`` above pins the *current*
+    behavior (returns the global fetcher), so this xfail's red is genuinely the
+    fallback firing, not an incidental setup error. The assertion uses
+    ``pytest.raises`` so that when the fix refuses by raising, the test flips to
+    XPASS (a raised exception in the body would otherwise keep it xfailed).
+    """
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam2 GHSA-wrhw/vc8m: dependencies.py:658-670 global credential "
+        "fallback is unconditional in an HTTP context — no ALLOW_GLOBAL_CRED_FALLBACK "
+        "gate for unauthenticated requests",
+    )
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
+    async def test_unauthenticated_http_request_refuses_global_jira_fetcher(
+        self,
+        mock_jira_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ) -> None:
+        """No user identity + HTTP context must not yield the global Jira fetcher."""
+        _setup_mock_request_state(mock_request)  # no scenario -> no user identity
+        mock_get_http_request.return_value = mock_request
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+        mock_jira_fetcher_class.return_value = _create_mock_fetcher(JiraFetcher)
+
+        with pytest.raises(ValueError):
+            await get_jira_fetcher(mock_context)
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam2 GHSA-wrhw/vc8m: dependencies.py:658-670 global credential "
+        "fallback is unconditional in an HTTP context — no ALLOW_GLOBAL_CRED_FALLBACK "
+        "gate for unauthenticated requests",
+    )
+    @patch("mcp_atlassian.servers.dependencies.get_http_request")
+    @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
+    async def test_unauthenticated_http_request_refuses_global_confluence_fetcher(
+        self,
+        mock_confluence_fetcher_class,
+        mock_get_http_request,
+        mock_context,
+        mock_request,
+        config_factory,
+    ) -> None:
+        """No user identity + HTTP context must not yield the global Confluence fetcher."""
+        _setup_mock_request_state(mock_request)  # no scenario -> no user identity
+        mock_get_http_request.return_value = mock_request
+        app_context = config_factory.create_app_context()
+        _setup_mock_context(mock_context, app_context)
+        mock_confluence_fetcher_class.return_value = _create_mock_fetcher(
+            ConfluenceFetcher
+        )
+
+        with pytest.raises(ValueError):
+            await get_confluence_fetcher(mock_context)

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -1602,16 +1602,14 @@ class TestSsrfProtection:
 
 
 class TestSsrfHookCoverageRegression:
-    """SP5 fam4 (GHSA-6529) — SSRF redirect hook must cover the basic-auth and OAuth
-    per-user fetcher sessions, not only the header-PAT branch.
+    """Regression (GHSA-6529) — the SSRF redirect hook must cover the basic-auth
+    and OAuth per-user fetcher sessions, not only the header-PAT branch.
 
-    ``_create_and_validate`` is called with ``attach_ssrf_hook=True`` only on the
-    header-PAT branch (``dependencies.py:561``); the basic (``:587``) and oauth_pat
-    (``:636``) branches omit it, so per-user fetchers built from those branches follow
-    HTTP redirects without SSRF validation. These tests assert the secure outcome — a
-    redirect hook is attached to the fetcher's session — and currently xfail. Phase B
-    fix-4a (pass ``attach_ssrf_hook=True`` on every auth branch) flips them green; the
-    strict marker then forces removal of the xfail.
+    ``_create_and_validate`` used to pass ``attach_ssrf_hook=True`` only on the
+    header-PAT branch; the basic and oauth_pat branches omitted it, so per-user
+    fetchers built from those branches followed HTTP redirects without SSRF
+    validation. These tests assert the secure outcome: a redirect hook is attached
+    to the fetcher's session on every auth branch.
     """
 
     @pytest.mark.security_regression
@@ -1754,23 +1752,21 @@ class TestSsrfHookCoverageRegression:
 
 
 class TestUnauthenticatedGlobalFallbackRegression:
-    """SP5 fam2 (GHSA-wrhw, vc8m, cc5h auth half) — an unauthenticated HTTP request
-    must not silently fall back to the operator's global credentials.
+    """Regression (GHSA-wrhw, GHSA-vc8m, GHSA-cc5h auth half) — an unauthenticated
+    HTTP request must not silently fall back to the operator's global credentials.
 
-    In an HTTP request context with no user identity, ``_get_fetcher`` falls through
-    to the global fallback at ``dependencies.py:658-670`` and returns
+    In an HTTP request context with no user identity, ``_get_fetcher`` used to fall
+    through to the global fallback and return
     ``spec.fetcher_class(config=global_config_fallback)`` unconditionally, so any
-    unauthenticated caller on a remotely-exposed streamable-http server transacts as
-    the operator. These tests assert the secure outcome — the global fallback is
+    unauthenticated caller on a remotely-exposed streamable-http server transacted
+    as the operator. These tests assert the secure outcome: the global fallback is
     refused for unauthenticated HTTP requests unless ``ALLOW_GLOBAL_CRED_FALLBACK``
-    is explicitly enabled — and currently xfail. Phase B fix-2 (opt-in gate) flips
-    them green; the strict marker then forces removing the xfail.
+    is explicitly enabled.
 
-    The companion ``test_global_fallback_scenarios`` above pins the *current*
-    behavior (returns the global fetcher), so this xfail's red is genuinely the
-    fallback firing, not an incidental setup error. The assertion uses
-    ``pytest.raises`` so that when the fix refuses by raising, the test flips to
-    XPASS (a raised exception in the body would otherwise keep it xfailed).
+    The companion ``test_global_fallback_scenarios`` above pins the authenticated
+    fallback behavior (returns the global fetcher), so a failure here is genuinely
+    the unauthenticated fallback firing, not an incidental setup error. The
+    assertion uses ``pytest.raises``: the fix refuses by raising.
     """
 
     @pytest.mark.security_regression

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -788,7 +788,15 @@ class TestGetJiraFetcher:
             mock_fetcher = _create_mock_fetcher(JiraFetcher)
             mock_jira_fetcher_class.return_value = mock_fetcher
 
-            result = await get_jira_fetcher(mock_context)
+            # The HTTP path now requires an explicit opt-in to fall back to the
+            # operator's global credentials; the non-HTTP (stdio) path does not.
+            env = (
+                {"ALLOW_GLOBAL_CRED_FALLBACK": "true"}
+                if scenario["setup_http"]
+                else {}
+            )
+            with patch.dict("os.environ", env):
+                result = await get_jira_fetcher(mock_context)
 
             assert result == mock_fetcher
             assert_mock_called_with_partial(
@@ -1127,7 +1135,15 @@ class TestGetConfluenceFetcher:
             mock_fetcher = _create_mock_fetcher(ConfluenceFetcher)
             mock_confluence_fetcher_class.return_value = mock_fetcher
 
-            result = await get_confluence_fetcher(mock_context)
+            # The HTTP path now requires an explicit opt-in to fall back to the
+            # operator's global credentials; the non-HTTP (stdio) path does not.
+            env = (
+                {"ALLOW_GLOBAL_CRED_FALLBACK": "true"}
+                if scenario["setup_http"]
+                else {}
+            )
+            with patch.dict("os.environ", env):
+                result = await get_confluence_fetcher(mock_context)
 
             assert result == mock_fetcher
             assert_mock_called_with_partial(
@@ -1778,12 +1794,6 @@ class TestUnauthenticatedGlobalFallbackRegression:
     """
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam2 GHSA-wrhw/vc8m: dependencies.py:658-670 global credential "
-        "fallback is unconditional in an HTTP context — no ALLOW_GLOBAL_CRED_FALLBACK "
-        "gate for unauthenticated requests",
-    )
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.JiraFetcher")
     async def test_unauthenticated_http_request_refuses_global_jira_fetcher(
@@ -1805,12 +1815,6 @@ class TestUnauthenticatedGlobalFallbackRegression:
             await get_jira_fetcher(mock_context)
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam2 GHSA-wrhw/vc8m: dependencies.py:658-670 global credential "
-        "fallback is unconditional in an HTTP context — no ALLOW_GLOBAL_CRED_FALLBACK "
-        "gate for unauthenticated requests",
-    )
     @patch("mcp_atlassian.servers.dependencies.get_http_request")
     @patch("mcp_atlassian.servers.dependencies.ConfluenceFetcher")
     async def test_unauthenticated_http_request_refuses_global_confluence_fetcher(

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -791,9 +791,7 @@ class TestGetJiraFetcher:
             # The HTTP path now requires an explicit opt-in to fall back to the
             # operator's global credentials; the non-HTTP (stdio) path does not.
             env = (
-                {"ALLOW_GLOBAL_CRED_FALLBACK": "true"}
-                if scenario["setup_http"]
-                else {}
+                {"ALLOW_GLOBAL_CRED_FALLBACK": "true"} if scenario["setup_http"] else {}
             )
             with patch.dict("os.environ", env):
                 result = await get_jira_fetcher(mock_context)
@@ -1138,9 +1136,7 @@ class TestGetConfluenceFetcher:
             # The HTTP path now requires an explicit opt-in to fall back to the
             # operator's global credentials; the non-HTTP (stdio) path does not.
             env = (
-                {"ALLOW_GLOBAL_CRED_FALLBACK": "true"}
-                if scenario["setup_http"]
-                else {}
+                {"ALLOW_GLOBAL_CRED_FALLBACK": "true"} if scenario["setup_http"] else {}
             )
             with patch.dict("os.environ", env):
                 result = await get_confluence_fetcher(mock_context)

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -318,12 +318,6 @@ class TestUserTokenMiddleware:
         middleware.app.assert_not_called()
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam2 GHSA-wrhw/vc8m/cc5h: main.py:438-446 a POST to the MCP "
-        "endpoint with NO Authorization header is not rejected — the middleware "
-        "calls self.app (which falls back to operator credentials) instead of 401",
-    )
     @pytest.mark.anyio
     async def test_missing_authorization_header_returns_401(
         self, middleware, mock_scope, mock_receive, mock_send

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -325,11 +325,10 @@ class TestUserTokenMiddleware:
         """An unauthenticated POST to the MCP endpoint must be rejected at the
         transport boundary, not proxied to the app with the operator's credentials.
 
-        This is the transport seam Codex flagged as mandatory: the dependencies-level
-        global-fallback test is necessary but not sufficient, because the request can
-        still reach the app here. Secure contract (fix-2, opt-in gate): with no
+        The dependencies-level global-fallback test is necessary but not sufficient,
+        because the request can still reach the app here. Secure contract: with no
         Authorization header and ``ALLOW_GLOBAL_CRED_FALLBACK`` off, return 401 and do
-        not call ``self.app``. Currently xfails; Phase B fix-2 flips it green.
+        not call ``self.app``.
         """
         # No Authorization header and no service headers -> unauthenticated request.
         mock_scope["headers"] = []

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -317,6 +317,38 @@ class TestUserTokenMiddleware:
         # Verify app was NOT called
         middleware.app.assert_not_called()
 
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam2 GHSA-wrhw/vc8m/cc5h: main.py:438-446 a POST to the MCP "
+        "endpoint with NO Authorization header is not rejected — the middleware "
+        "calls self.app (which falls back to operator credentials) instead of 401",
+    )
+    @pytest.mark.anyio
+    async def test_missing_authorization_header_returns_401(
+        self, middleware, mock_scope, mock_receive, mock_send
+    ):
+        """An unauthenticated POST to the MCP endpoint must be rejected at the
+        transport boundary, not proxied to the app with the operator's credentials.
+
+        This is the transport seam Codex flagged as mandatory: the dependencies-level
+        global-fallback test is necessary but not sufficient, because the request can
+        still reach the app here. Secure contract (fix-2, opt-in gate): with no
+        Authorization header and ``ALLOW_GLOBAL_CRED_FALLBACK`` off, return 401 and do
+        not call ``self.app``. Currently xfails; Phase B fix-2 flips it green.
+        """
+        # No Authorization header and no service headers -> unauthenticated request.
+        mock_scope["headers"] = []
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        # Secure: the request must be rejected before reaching the downstream app.
+        middleware.app.assert_not_called()
+        assert mock_send.call_count >= 1, "expected a 401 response, none was sent"
+        start_call = mock_send.call_args_list[0][0][0]
+        assert start_call["type"] == "http.response.start"
+        assert start_call["status"] == 401
+
     @pytest.mark.anyio
     async def test_client_disconnect_connection_reset(
         self, middleware, mock_scope, mock_receive

--- a/tests/unit/servers/test_mcp_protocol.py
+++ b/tests/unit/servers/test_mcp_protocol.py
@@ -90,6 +90,58 @@ class TestMCPProtocolIntegration:
         # Mount sub-servers (they're already mounted in the actual server)
         return server
 
+    @pytest.mark.security_regression
+    async def test_call_tool_mcp_enforces_enablement_at_dispatch(
+        self, atlassian_mcp_server, mock_jira_config, mock_confluence_config
+    ):
+        """A tool filtered out of the listing must not be invocable by name.
+
+        `_list_tools_mcp` hides read-only-excluded / non-enabled / disabled-toolset
+        tools, but the call path must re-check — otherwise a client can dispatch a
+        hidden tool directly by name. Verifies denied calls never reach the
+        underlying executor and enabled calls do (GHSA-3r68).
+        """
+        from unittest.mock import AsyncMock
+
+        from fastmcp import FastMCP
+        from fastmcp.exceptions import NotFoundError
+
+        app_context = MainAppContext(
+            full_jira_config=mock_jira_config,
+            full_confluence_config=mock_confluence_config,
+            read_only=True,  # write tools are excluded
+            enabled_tools=None,
+        )
+        request_context = MagicMock()
+        request_context.request = None
+        request_context.lifespan_context = {"app_lifespan_context": app_context}
+        atlassian_mcp_server._mcp_server = MagicMock()
+        atlassian_mcp_server._mcp_server.request_context = request_context
+
+        async def mock_get_tools():
+            read_tool = MagicMock(spec=FastMCPTool)
+            read_tool.tags = {"jira", "read"}
+            write_tool = MagicMock(spec=FastMCPTool)
+            write_tool.tags = {"jira", "write"}
+            return {"jira_get_issue": read_tool, "jira_create_issue": write_tool}
+
+        atlassian_mcp_server.get_tools = mock_get_tools
+
+        with patch.object(
+            FastMCP, "_call_tool_mcp", new_callable=AsyncMock
+        ) as mock_super:
+            mock_super.return_value = "EXECUTED"
+
+            # Write tool is read-only-excluded -> denied before reaching the executor.
+            with pytest.raises(NotFoundError):
+                await atlassian_mcp_server._call_tool_mcp("jira_create_issue", {})
+            mock_super.assert_not_called()
+
+            # Read tool is enabled -> passes the gate and reaches the executor.
+            result = await atlassian_mcp_server._call_tool_mcp("jira_get_issue", {})
+            assert result == "EXECUTED"
+            mock_super.assert_called_once()
+
     async def test_tool_discovery_with_full_configuration(
         self, atlassian_mcp_server, mock_jira_config, mock_confluence_config
     ):

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -1219,3 +1219,54 @@ class TestDataCenterOAuth:
         token_json = mock_set_pw.call_args[0][2]
         data = json.loads(token_json)
         assert data["base_url"] == self.DC_BASE_URL
+
+
+class TestTokenFilePermissionsRegression:
+    """SP5 fam6 (GHSA-g5xv, 76pr, 4596) — OAuth token file world/group-readable.
+
+    ``_save_tokens_to_file`` (``utils/oauth.py:402-418``) creates
+    ``~/.mcp-atlassian`` with ``mkdir(exist_ok=True)`` (no mode) and writes
+    ``oauth-<client>.json`` with ``open(..., "w")`` (no chmod), so the refresh and
+    access tokens land with the process umask's default permissions (commonly 0o644,
+    i.e. group/world-readable). This test forces a permissive umask so the result is
+    deterministic regardless of the runner, then asserts the file is owner-only
+    (0o600). Currently xfails; Phase B fix-6 (explicit ``chmod 0o600`` / ``0o700``)
+    flips it green.
+    """
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam6 GHSA-g5xv/76pr/4596: utils/oauth.py:417 token file written "
+        "with the process umask and no chmod 0o600 — tokens are group/world-readable",
+    )
+    def test_saved_token_file_is_not_group_or_world_readable(self, tmp_path) -> None:
+        """The persisted OAuth token file must be owner-only (0o600)."""
+        import os
+        import stat
+
+        config = OAuthConfig(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            redirect_uri="https://example.com/callback",
+            scope="read:jira-work",
+            cloud_id="test-cloud-id",
+            refresh_token="secret-refresh-token",
+            access_token="secret-access-token",
+            expires_at=1234567890,
+        )
+
+        old_umask = os.umask(0o022)  # permissive -> pre-fix file would be 0o644
+        try:
+            with patch("mcp_atlassian.utils.oauth.Path.home", return_value=tmp_path):
+                config._save_tokens_to_file()
+        finally:
+            os.umask(old_umask)
+
+        token_path = tmp_path / ".mcp-atlassian" / "oauth-test-client-id.json"
+        assert token_path.exists(), "token file was not written"
+        mode = stat.S_IMODE(token_path.stat().st_mode)
+        assert mode & 0o077 == 0, (
+            "OAuth token file must not be group/world-readable (expected 0o600); "
+            f"got {oct(mode)}"
+        )

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -1214,16 +1214,15 @@ class TestDataCenterOAuth:
 
 
 class TestTokenFilePermissionsRegression:
-    """SP5 fam6 (GHSA-g5xv, 76pr, 4596) — OAuth token file world/group-readable.
+    """Regression (GHSA-g5xv, GHSA-76pr, GHSA-4596) — the OAuth token file must
+    not be world/group-readable.
 
-    ``_save_tokens_to_file`` (``utils/oauth.py:402-418``) creates
-    ``~/.mcp-atlassian`` with ``mkdir(exist_ok=True)`` (no mode) and writes
-    ``oauth-<client>.json`` with ``open(..., "w")`` (no chmod), so the refresh and
-    access tokens land with the process umask's default permissions (commonly 0o644,
-    i.e. group/world-readable). This test forces a permissive umask so the result is
-    deterministic regardless of the runner, then asserts the file is owner-only
-    (0o600). Currently xfails; Phase B fix-6 (explicit ``chmod 0o600`` / ``0o700``)
-    flips it green.
+    ``_save_tokens_to_file`` used to create ``~/.mcp-atlassian`` with
+    ``mkdir(exist_ok=True)`` (no mode) and write ``oauth-<client>.json`` with
+    ``open(..., "w")`` (no chmod), so the refresh and access tokens landed with the
+    process umask's default permissions (commonly 0o644, i.e. group/world-readable).
+    This test forces a permissive umask so the result is deterministic regardless
+    of the runner, then asserts the file is owner-only (0o600).
     """
 
     @pytest.mark.security_regression

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -440,36 +440,28 @@ class TestOAuthConfig:
         # Verify fallback to file was used
         mock_save_to_file.assert_called_once()
 
-    @patch("pathlib.Path.mkdir")
-    @patch("json.dump")
-    def test_save_tokens_to_file(self, mock_dump, mock_mkdir):
-        """Test _save_tokens_to_file method."""
-        # Mock open
-        mock_open = MagicMock()
-        with patch("builtins.open", mock_open):
-            config = OAuthConfig(
-                client_id="test-client-id",
-                client_secret="test-client-secret",
-                redirect_uri="https://example.com/callback",
-                scope="read:jira-work write:jira-work",
-                cloud_id="test-cloud-id",
-                refresh_token="test-refresh-token",
-                access_token="test-access-token",
-                expires_at=1234567890,
-            )
+    def test_save_tokens_to_file(self, tmp_path):
+        """Test _save_tokens_to_file writes the token JSON to the fallback file."""
+        config = OAuthConfig(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            redirect_uri="https://example.com/callback",
+            scope="read:jira-work write:jira-work",
+            cloud_id="test-cloud-id",
+            refresh_token="test-refresh-token",
+            access_token="test-access-token",
+            expires_at=1234567890,
+        )
+        with patch("mcp_atlassian.utils.oauth.Path.home", return_value=tmp_path):
             config._save_tokens_to_file()
 
-            # Should create directory and save tokens
-            mock_mkdir.assert_called_once()
-            mock_open.assert_called_once()
-            mock_dump.assert_called_once()
-
-            # Check saved data
-            saved_data = mock_dump.call_args[0][0]
-            assert saved_data["refresh_token"] == "test-refresh-token"
-            assert saved_data["access_token"] == "test-access-token"
-            assert saved_data["expires_at"] == 1234567890
-            assert saved_data["cloud_id"] == "test-cloud-id"
+        token_path = tmp_path / ".mcp-atlassian" / "oauth-test-client-id.json"
+        assert token_path.exists()
+        saved_data = json.loads(token_path.read_text())
+        assert saved_data["refresh_token"] == "test-refresh-token"
+        assert saved_data["access_token"] == "test-access-token"
+        assert saved_data["expires_at"] == 1234567890
+        assert saved_data["cloud_id"] == "test-cloud-id"
 
     @patch("keyring.get_password")
     @patch.object(OAuthConfig, "_load_tokens_from_file")
@@ -1235,11 +1227,6 @@ class TestTokenFilePermissionsRegression:
     """
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam6 GHSA-g5xv/76pr/4596: utils/oauth.py:417 token file written "
-        "with the process umask and no chmod 0o600 — tokens are group/world-readable",
-    )
     def test_saved_token_file_is_not_group_or_world_readable(self, tmp_path) -> None:
         """The persisted OAuth token file must be owner-only (0o600)."""
         import os

--- a/tests/unit/utils/test_oauth_setup.py
+++ b/tests/unit/utils/test_oauth_setup.py
@@ -61,11 +61,6 @@ class TestCallbackHandlerXssRegression:
     """
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam7 GHSA-g2r2: oauth_setup.py:125 interpolates message into "
-        "HTML without escaping — reflected XSS",
-    )
     def test_send_response_escapes_html_in_message(self) -> None:
         """A ``<script>`` payload in the callback message must not be reflected raw."""
         handler = CallbackHandler.__new__(CallbackHandler)

--- a/tests/unit/utils/test_oauth_setup.py
+++ b/tests/unit/utils/test_oauth_setup.py
@@ -48,16 +48,14 @@ class TestCallbackHandlerLogic:
 
 
 class TestCallbackHandlerXssRegression:
-    """SP5 fam7 (GHSA-g2r2) — reflected XSS in the OAuth callback page.
+    """Regression (GHSA-g2r2) — reflected XSS in the OAuth callback page.
 
-    ``CallbackHandler._send_response`` interpolates the caller-supplied ``message``
-    straight into the HTML body (``oauth_setup.py:125`` → ``<p>{message}</p>``). For
-    the error branch that message is built from the attacker-controlled ``error``
-    query parameter (``do_GET`` ``:64,66``), so a crafted ``?error=<script>…`` renders
-    executable markup in the victim's browser. This test asserts the secure outcome —
-    the payload is HTML-escaped in the rendered page — and currently xfails. Phase B
-    fix-7a (escape callback output) flips it green; the strict marker then forces
-    removal of the xfail.
+    ``CallbackHandler._send_response`` used to interpolate the caller-supplied
+    ``message`` straight into the HTML body (``<p>{message}</p>``). For the error
+    branch that message is built from the attacker-controlled ``error`` query
+    parameter, so a crafted ``?error=<script>…`` rendered executable markup in the
+    victim's browser. This test asserts the secure outcome: the payload is
+    HTML-escaped in the rendered page.
     """
 
     @pytest.mark.security_regression
@@ -71,7 +69,7 @@ class TestCallbackHandlerXssRegression:
         handler.send_header = MagicMock()
         handler.end_headers = MagicMock()
 
-        payload = "<script>alert('xss-sp5-g2r2')</script>"
+        payload = "<script>alert('xss-g2r2')</script>"
         handler._send_response(f"Authorization failed: {payload}")
 
         body = handler.wfile.getvalue().decode()

--- a/tests/unit/utils/test_oauth_setup.py
+++ b/tests/unit/utils/test_oauth_setup.py
@@ -1,5 +1,6 @@
 """Tests for the OAuth setup utilities."""
 
+import io
 import json
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -7,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 
 from mcp_atlassian.utils.oauth_setup import (
+    CallbackHandler,
     OAuthSetupArgs,
     parse_redirect_uri,
     run_oauth_flow,
@@ -43,6 +45,45 @@ class TestCallbackHandlerLogic:
         for key, expected_values in expected_params.items():
             assert key in params
             assert params[key] == expected_values
+
+
+class TestCallbackHandlerXssRegression:
+    """SP5 fam7 (GHSA-g2r2) — reflected XSS in the OAuth callback page.
+
+    ``CallbackHandler._send_response`` interpolates the caller-supplied ``message``
+    straight into the HTML body (``oauth_setup.py:125`` → ``<p>{message}</p>``). For
+    the error branch that message is built from the attacker-controlled ``error``
+    query parameter (``do_GET`` ``:64,66``), so a crafted ``?error=<script>…`` renders
+    executable markup in the victim's browser. This test asserts the secure outcome —
+    the payload is HTML-escaped in the rendered page — and currently xfails. Phase B
+    fix-7a (escape callback output) flips it green; the strict marker then forces
+    removal of the xfail.
+    """
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam7 GHSA-g2r2: oauth_setup.py:125 interpolates message into "
+        "HTML without escaping — reflected XSS",
+    )
+    def test_send_response_escapes_html_in_message(self) -> None:
+        """A ``<script>`` payload in the callback message must not be reflected raw."""
+        handler = CallbackHandler.__new__(CallbackHandler)
+        # _send_response only touches these members — stub them so no real socket
+        # I/O happens and we can capture the rendered HTML body.
+        handler.wfile = io.BytesIO()
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+
+        payload = "<script>alert('xss-sp5-g2r2')</script>"
+        handler._send_response(f"Authorization failed: {payload}")
+
+        body = handler.wfile.getvalue().decode()
+        assert payload not in body, (
+            "attacker-controlled callback message must be HTML-escaped, "
+            "not reflected as raw executable markup"
+        )
 
 
 class TestRedirectUriParsing:

--- a/tests/unit/utils/test_ssrf_adapter.py
+++ b/tests/unit/utils/test_ssrf_adapter.py
@@ -1,0 +1,97 @@
+"""Regression tests for the SSRF DNS-pinning transport adapter (fam4 rebind).
+
+These cover GHSA-49xv, GHSA-72fm, GHSA-489g: the validate-then-reconnect TOCTOU
+where a rebinding host returns a public IP to ``validate_url_for_ssrf`` and a
+private/metadata IP to the actual connection. The adapter resolves once, validates
+that resolution, and connects to the same address — so there is no second
+resolution to rebind.
+"""
+
+import socket
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from mcp_atlassian.utils.ssrf_adapter import (
+    SsrfPinningAdapter,
+    _pinned_create_connection,
+)
+
+
+def _gai_returning(ip: str):
+    def gai(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port or 443))]
+
+    return gai
+
+
+@pytest.mark.security_regression
+def test_rebind_internal_address_refused_with_single_resolution():
+    """A host resolving to a non-global address is refused, after exactly one
+    resolution — the resolved address is the one that would be connected to."""
+    calls = {"n": 0}
+
+    def gai(host, port, *args, **kwargs):
+        calls["n"] += 1
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))]
+
+    with patch("mcp_atlassian.utils.ssrf_adapter.socket.getaddrinfo", side_effect=gai):
+        with pytest.raises(OSError, match="non-global"):
+            _pinned_create_connection(("rebind.attacker.test", 443))
+
+    assert calls["n"] == 1
+
+
+@pytest.mark.security_regression
+@pytest.mark.parametrize("ip", ["169.254.169.254", "127.0.0.1", "10.0.0.5", "::1"])
+def test_pinning_adapter_blocks_internal_through_real_stack(ip):
+    """End-to-end through the mounted adapter and the real requests/urllib3 stack:
+    a host resolving to an internal address is refused — proving the adapter is
+    actually wired into the connection path (not a mock-only green)."""
+    session = requests.Session()
+    session.mount("https://", SsrfPinningAdapter())
+    session.mount("http://", SsrfPinningAdapter())
+
+    with patch(
+        "mcp_atlassian.utils.ssrf_adapter.socket.getaddrinfo",
+        side_effect=_gai_returning(ip),
+    ):
+        with pytest.raises(requests.exceptions.ConnectionError, match="SSRF blocked"):
+            session.get("https://rebind.attacker.test", timeout=5)
+
+
+def test_global_address_connects_to_the_validated_ip():
+    """A global address passes the gate and the connection targets that same IP
+    (the pin) — not a re-resolved one."""
+    connected = {"addr": None}
+
+    class _FakeSock:
+        def setsockopt(self, *a):
+            pass
+
+        def settimeout(self, *a):
+            pass
+
+        def bind(self, *a):
+            pass
+
+        def connect(self, sa):
+            connected["addr"] = sa
+
+        def close(self):
+            pass
+
+    with (
+        patch(
+            "mcp_atlassian.utils.ssrf_adapter.socket.getaddrinfo",
+            side_effect=_gai_returning("93.184.216.34"),
+        ),
+        patch(
+            "mcp_atlassian.utils.ssrf_adapter.socket.socket",
+            return_value=_FakeSock(),
+        ),
+    ):
+        _pinned_create_connection(("example.com", 443))
+
+    assert connected["addr"][0] == "93.184.216.34"

--- a/tests/unit/utils/test_ssrf_adapter.py
+++ b/tests/unit/utils/test_ssrf_adapter.py
@@ -61,6 +61,94 @@ def test_pinning_adapter_blocks_internal_through_real_stack(ip):
             session.get("https://rebind.attacker.test", timeout=5)
 
 
+class _FakeConnectSock:
+    def __init__(self, connected):
+        self._connected = connected
+
+    def setsockopt(self, *a):
+        pass
+
+    def settimeout(self, *a):
+        pass
+
+    def bind(self, *a):
+        pass
+
+    def connect(self, sa):
+        self._connected["addr"] = sa
+
+    def close(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"JIRA_URL": "http://jira.internal:8080"},
+        {"CONFLUENCE_URL": "https://jira.internal/wiki"},
+        {"MCP_ALLOWED_URL_DOMAINS": "jira.internal"},
+    ],
+)
+def test_operator_configured_host_may_resolve_private(env, monkeypatch):
+    """The operator-configured base host (or an allowlisted domain) may live on a
+    private network — the non-global rejection is waived, but the connection is
+    still pinned to the single resolved address."""
+    for k in ("JIRA_URL", "CONFLUENCE_URL", "MCP_ALLOWED_URL_DOMAINS"):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    connected = {"addr": None}
+
+    with (
+        patch(
+            "mcp_atlassian.utils.ssrf_adapter.socket.getaddrinfo",
+            side_effect=_gai_returning("10.0.0.5"),
+        ),
+        patch(
+            "mcp_atlassian.utils.ssrf_adapter.socket.socket",
+            return_value=_FakeConnectSock(connected),
+        ),
+    ):
+        _pinned_create_connection(("jira.internal", 8080))
+
+    assert connected["addr"][0] == "10.0.0.5"
+
+
+@pytest.mark.security_regression
+def test_untrusted_host_still_refused_when_other_hosts_are_trusted(monkeypatch):
+    """Trusting the operator's own host must not waive the guard for a
+    caller-supplied host (the rebinding-attack case)."""
+    monkeypatch.setenv("JIRA_URL", "http://jira.internal:8080")
+
+    with patch(
+        "mcp_atlassian.utils.ssrf_adapter.socket.getaddrinfo",
+        side_effect=_gai_returning("169.254.169.254"),
+    ):
+        with pytest.raises(OSError, match="non-global"):
+            _pinned_create_connection(("rebind.attacker.test", 443))
+
+
+@pytest.mark.security_regression
+def test_ssl_ignore_adapter_keeps_the_pinning_guard(monkeypatch):
+    """SSLIgnoreAdapter mounts at a more specific prefix than the session-wide
+    pinning adapter (requests picks the longest prefix), so it must carry the
+    pinned connection classes itself — otherwise ssl_verify=false silently
+    disables the SSRF rebinding guard."""
+    from mcp_atlassian.utils.ssl import SSLIgnoreAdapter
+
+    monkeypatch.delenv("JIRA_URL", raising=False)
+    session = requests.Session()
+    session.mount("http://", SsrfPinningAdapter())
+    session.mount("http://rebind.attacker.test", SSLIgnoreAdapter())
+
+    with patch(
+        "mcp_atlassian.utils.ssrf_adapter.socket.getaddrinfo",
+        side_effect=_gai_returning("169.254.169.254"),
+    ):
+        with pytest.raises(requests.exceptions.ConnectionError, match="SSRF blocked"):
+            session.get("http://rebind.attacker.test", timeout=5)
+
+
 def test_global_address_connects_to_the_validated_ip():
     """A global address passes the gate and the connection targets that same IP
     (the pin) — not a re-resolved one."""

--- a/tests/unit/utils/test_ssrf_adapter.py
+++ b/tests/unit/utils/test_ssrf_adapter.py
@@ -1,4 +1,4 @@
-"""Regression tests for the SSRF DNS-pinning transport adapter (fam4 rebind).
+"""Regression tests for the SSRF DNS-pinning transport adapter (DNS rebinding).
 
 These cover GHSA-49xv, GHSA-72fm, GHSA-489g: the validate-then-reconnect TOCTOU
 where a rebinding host returns a public IP to ``validate_url_for_ssrf`` and a

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -328,3 +328,49 @@ class TestValidateUrlForSsrf:
         """IPv4-mapped IPv6 loopback is rejected."""
         result = validate_url_for_ssrf("http://[::ffff:127.0.0.1]")
         assert result is not None
+
+
+class TestSsrfBackslashBypassRegression:
+    """SP5 fam4 (GHSA-hgcf) — backslash authority-confusion SSRF bypass.
+
+    ``validate_url_for_ssrf`` extracts the host via ``urlparse().hostname``
+    (``urls.py:92``), but ``requests`` (and browsers) parse a backslash in the
+    authority differently: ``urlparse("http://localhost\\@evil.com/").hostname`` is
+    ``"evil.com"`` (external, so validation passes), while ``requests`` connects to
+    ``localhost`` / ``127.0.0.1``. The validator therefore approves a URL that
+    actually targets an internal host. These tests assert the secure outcome — the
+    backslash-confusion URL is blocked — and currently xfail. Phase B fix-4b
+    (normalize/reject the parse mismatch) flips them green.
+    """
+
+    @pytest.mark.security_regression
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SP5 fam4 GHSA-hgcf: validate_url_for_ssrf uses urlparse().hostname "
+        "(urls.py:92) which disagrees with requests on backslash authority — an "
+        "internal connection target is approved as external",
+    )
+    @pytest.mark.parametrize(
+        "url",
+        ["http://localhost\\@evil.com/", "http://127.0.0.1\\@evil.com/"],
+        ids=["localhost-backslash", "loopback-ip-backslash"],
+    )
+    @patch.dict(os.environ, {"MCP_ALLOWED_URL_DOMAINS": ""})
+    @patch("mcp_atlassian.utils.urls.socket.getaddrinfo")
+    def test_backslash_authority_confusion_is_blocked(
+        self, mock_getaddrinfo, url: str
+    ) -> None:
+        """A URL whose parsed host disagrees with its connection target is blocked."""
+        # DNS mock: evil.com resolves to a GLOBAL IP, so the *bare* host is "safe".
+        # This isolates the block to backslash normalization, not a DNS failure.
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+        ]
+        # Sanity: the external host on its own passes validation under this mock.
+        assert validate_url_for_ssrf("http://evil.com/") is None
+        # The backslash-confusion URL parses to evil.com but really targets internal.
+        result = validate_url_for_ssrf(url)
+        assert result is not None, (
+            "URL with backslash authority confusion must be blocked — the parsed "
+            "host disagrees with the real connection target"
+        )

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -331,16 +331,15 @@ class TestValidateUrlForSsrf:
 
 
 class TestSsrfBackslashBypassRegression:
-    """SP5 fam4 (GHSA-hgcf) — backslash authority-confusion SSRF bypass.
+    """Regression (GHSA-hgcf) — backslash authority-confusion SSRF bypass.
 
     ``validate_url_for_ssrf`` extracts the host via ``urlparse().hostname``
     (``urls.py:92``), but ``requests`` (and browsers) parse a backslash in the
     authority differently: ``urlparse("http://localhost\\@evil.com/").hostname`` is
     ``"evil.com"`` (external, so validation passes), while ``requests`` connects to
-    ``localhost`` / ``127.0.0.1``. The validator therefore approves a URL that
-    actually targets an internal host. These tests assert the secure outcome — the
-    backslash-confusion URL is blocked — and currently xfail. Phase B fix-4b
-    (normalize/reject the parse mismatch) flips them green.
+    ``localhost`` / ``127.0.0.1`` — the validator would approve a URL that
+    actually targets an internal host. These tests assert the secure outcome: the
+    backslash-confusion URL is blocked.
     """
 
     @pytest.mark.security_regression

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -344,12 +344,6 @@ class TestSsrfBackslashBypassRegression:
     """
 
     @pytest.mark.security_regression
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SP5 fam4 GHSA-hgcf: validate_url_for_ssrf uses urlparse().hostname "
-        "(urls.py:92) which disagrees with requests on backslash authority — an "
-        "internal connection target is approved as external",
-    )
     @pytest.mark.parametrize(
         "url",
         ["http://localhost\\@evil.com/", "http://127.0.0.1\\@evil.com/"],


### PR DESCRIPTION
## Security hardening across attachment, transport, SSRF, authorization, filter, and OAuth layers

This PR lands the fixes for a coordinated security audit (advisories consolidated by root cause; GitHub Security Advisories will be published alongside the release that ships this).

### What's fixed

- **Attachment & content-file path confinement** — `upload_attachment`/`download_attachment` (Jira & Confluence) and the `content_file` page input (#1275) validate every caller-supplied path against the workspace (`validate_safe_path`); closes arbitrary file read/exfiltration and an intra-CWD overwrite RCE variant. Behavioral note: paths must now resolve inside the server's working directory.
- **HTTP transport auth (critical)** — unauthenticated streamable-http requests no longer silently fall back to the operator's global credentials; fallback is opt-in (`ALLOW_GLOBAL_CRED_FALLBACK`, default off) and unauthenticated requests get 401 at the transport boundary. stdio is unaffected.
- **SSRF hardening** — redirect validation on every client session and auth branch; backslash authority-confusion rejected; new `SsrfPinningAdapter` resolves each host exactly once and connects to the validated address (closes the DNS-rebinding TOCTOU), preserving TLS SNI/verification and existing retry policy. Operator-configured hosts (`JIRA_URL`/`CONFLUENCE_URL`, `MCP_ALLOWED_URL_DOMAINS`) are exempt from the non-global rejection so private-network DC deployments keep working; `SSLIgnoreAdapter` carries the pinned connection classes so `ssl_verify=false` doesn't drop the guard. The opt-in HTTP hardening from #1310 is applied after the pinning mount, since its send wrappers patch adapters in place and would be dropped by a later adapter replacement (regression-tested).
- **Tool authorization at dispatch** — tools hidden by `ENABLED_TOOLS`/toolset/read-only can no longer be called by name.
- **Filter hard boundary** — `JIRA_PROJECTS_FILTER`/`CONFLUENCE_SPACES_FILTER` always AND into queries; tool args can narrow but never replace the configured allowlist; sprint IDs validated numeric (JQL injection).
- **OAuth token files** — written owner-only (0600/dir 0700).
- **Reflected XSS** — OAuth callback page output HTML-escaped.

### Verification

At branch head `0a2bdc87`, rebased on current main:

- Full unit suite green — 2992 passed, including a permanent `security_regression` suite (each fix landed against a red attack-reproducing test).
- DC e2e green (88 passed) and Cloud e2e green (76 passed) against this branch head.
- ruff / ruff-format / mypy (pre-commit) clean.
