### PR TITLE
test: make rate-limit throttle test deterministic

### DIFF
--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -316,7 +316,7 @@ def test_configure_rate_limit_disabled_by_default():
 
 
 def test_configure_rate_limit_throttles_requests(monkeypatch: pytest.MonkeyPatch):
-    """At 10 rps, 5 sends after the burst should take >= ~0.4s."""
+    """At 10 rps (burst 10), 15 sends must take >= 0.5s from the first send."""
     monkeypatch.setenv("ATLASSIAN_REQUESTS_PER_SECOND", "10")
 
     session = Session()
@@ -326,15 +326,16 @@ def test_configure_rate_limit_throttles_requests(monkeypatch: pytest.MonkeyPatch
     configure_rate_limit(session, service="Test")
 
     adapter = session.adapters["https://"]
-    for _ in range(10):
-        adapter.send(MagicMock())  # drain burst
-
+    # Timer covers all 15 sends: the bucket holds 10 tokens, so the last 5
+    # must wait for refill at 10/s — a >= 0.5s lower bound a slow runner can
+    # only lengthen. (Timing only the post-drain sends was flaky: tokens
+    # refilled during a slow drain loop, shrinking the measured wait.)
     start = time.monotonic()
-    for _ in range(5):
+    for _ in range(15):
         adapter.send(MagicMock())
     elapsed = time.monotonic() - start
 
-    assert elapsed >= 0.35, f"expected throttling >= 0.35s, got {elapsed:.3f}s"
+    assert elapsed >= 0.45, f"expected throttling >= 0.45s, got {elapsed:.3f}s"
 
 
 def test_configure_rate_limit_shares_bucket_across_sessions(


### PR DESCRIPTION
## Why

`test_configure_rate_limit_throttles_requests` is flaky on slow CI runners — it failed on the Python 3.10 job of #1211 (`expected throttling >= 0.35s, got 0.303s`) on a PR that doesn't touch rate-limit code at all.

The test drains the 10-token burst first and only then starts the timer for 5 more sends. On a slow shared runner the drain loop itself takes long enough for the bucket to refill, which *shrinks* the measured wait below the threshold — an inverted flake where slower machines fail.

## Fix

Start the timer before all 15 sends. With a 10-token bucket refilling at 10 rps, the 15th send cannot complete before 0.5s from the first — a deterministic lower bound that machine slowness can only lengthen, never shorten. Asserted at 0.45s for float margin.

Test-only change; no production code touched.

## Verify

`uv run pytest tests/unit/utils/test_http.py -q` → 23 passed locally.