### PR TITLE
fix(security): close filter and SSRF follow-up gaps

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -145,7 +145,7 @@ class ConfluenceClient:
         self.confluence._session.hooks["response"].append(make_ssrf_redirect_hook())
         # Pin DNS resolution against rebinding: resolve+validate once and connect
         # to that address, closing the validate→reconnect TOCTOU. Preserves TLS SNI.
-        mount_ssrf_pinning(self.confluence._session)
+        mount_ssrf_pinning(self.confluence._session, transport_url)
 
         # Apply opt-in HTTP hardening after SSL setup and after the pinning
         # adapter is mounted: these wrappers patch send() in place on whatever

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -158,7 +158,7 @@ class JiraClient:
         self.jira._session.hooks["response"].append(make_ssrf_redirect_hook())
         # Pin DNS resolution against rebinding: resolve+validate once and connect
         # to that address, closing the validate→reconnect TOCTOU. Preserves TLS SNI.
-        mount_ssrf_pinning(self.jira._session)
+        mount_ssrf_pinning(self.jira._session, transport_url)
 
         # Apply opt-in HTTP hardening after SSL setup and after the pinning
         # adapter is mounted: these wrappers patch send() in place on whatever

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -39,10 +39,7 @@ class SearchMixin(JiraClient, IssueOperationsProto):
 
     def _and_projects_filter(self, jql: str, filter_to_use: str) -> str:
         """AND a single comma-separated project allowlist into ``jql``."""
-        # Split by commas, and escape backslashes before double-quotes to prevent
-        # JQL-injection bypass of the quoting below.
         projects = [p.strip() for p in filter_to_use.split(",")]
-        projects = [p.replace("\\", "\\\\").replace('"', '\\"') for p in projects]
 
         if len(projects) == 1:
             quoted = quote_jql_identifier_if_needed(projects[0])
@@ -51,6 +48,7 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             quoted_projects = [quote_jql_identifier_if_needed(p) for p in projects]
             projects_list = ", ".join(quoted_projects)
             project_query = f"project IN ({projects_list})"
+        grouped_project_query = f"({project_query})"
 
         if not jql:
             jql = project_query
@@ -65,9 +63,11 @@ class SearchMixin(JiraClient, IssueOperationsProto):
             if order_match:
                 order_clause = order_match.group(1)
                 jql_without_order = jql[: order_match.start()]
-                jql = f"({jql_without_order}) AND {project_query} {order_clause}"
+                jql = (
+                    f"({jql_without_order}) AND {grouped_project_query} {order_clause}"
+                )
             else:
-                jql = f"({jql}) AND {project_query}"
+                jql = f"({jql}) AND {grouped_project_query}"
 
         logger.info(f"Applied projects filter to query: {jql}")
         return jql

--- a/src/mcp_atlassian/jira/utils.py
+++ b/src/mcp_atlassian/jira/utils.py
@@ -37,12 +37,11 @@ def quote_jql_identifier_if_needed(identifier: str) -> str:
         needs_quoting = True
         logger.debug(f"Identifier '{identifier}' needs quoting (starts with digit).")
 
-    # Rule 3: Contains internal quotes or backslashes (always needs quoting+escaping)
-    elif '"' in identifier or "\\" in identifier:
+    # Rule 3: Only plain identifier characters are safe without quotes. Quoting
+    # everything else keeps whitespace and JQL operators inside one literal.
+    elif not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", identifier):
         needs_quoting = True
-        logger.debug(
-            f"Identifier '{identifier}' needs quoting (contains quotes/backslashes)."
-        )
+        logger.debug(f"Identifier '{identifier}' needs quoting (contains JQL syntax).")
 
     if needs_quoting:
         # Escape internal backslashes first, then double quotes

--- a/src/mcp_atlassian/utils/ssrf_adapter.py
+++ b/src/mcp_atlassian/utils/ssrf_adapter.py
@@ -21,6 +21,7 @@ caller-supplied URLs. The single-resolution pin still applies to every host.
 
 import os
 import socket
+from collections.abc import Iterable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -128,6 +129,19 @@ class _PinnedHTTPSConnectionPool(HTTPSConnectionPool):
 class SsrfPinningAdapter(HTTPAdapter):
     """A requests adapter that validates and pins DNS resolution for every call."""
 
+    def __init__(
+        self, *args: Any, trusted_urls: Iterable[str] = (), **kwargs: Any
+    ) -> None:
+        self._trusted_hosts: set[str] = set()
+        self._trust_urls(trusted_urls)
+        super().__init__(*args, **kwargs)
+
+    def _trust_urls(self, urls: Iterable[str]) -> None:
+        for url in urls:
+            hostname = urlparse(url).hostname
+            if hostname:
+                self._trusted_hosts.add(hostname.lower())
+
     def send(
         self,
         request: Any,
@@ -147,7 +161,7 @@ class SsrfPinningAdapter(HTTPAdapter):
         """
         hostname = urlparse(request.url or "").hostname or ""
         if proxies and not _hostname_matches_allowlist(
-            hostname, _operator_trusted_hosts()
+            hostname, [*_operator_trusted_hosts(), *self._trusted_hosts]
         ):
             proxies = {}
         return super().send(
@@ -172,11 +186,15 @@ class SsrfPinningAdapter(HTTPAdapter):
         }
 
 
-def mount_ssrf_pinning(session: Session) -> None:
+def mount_ssrf_pinning(session: Session, *trusted_urls: str) -> None:
     """Mount the SSRF DNS-pinning adapter for http/https on ``session``.
 
     Preserves the retry policy of any adapter already mounted (e.g. the one the
     Atlassian client configures), so pinning does not silently drop retries.
+
+    Args:
+        session: Requests session to protect.
+        trusted_urls: Operator-controlled transport URLs that may use proxies.
     """
     for scheme in ("https://", "http://"):
         existing = session.adapters.get(scheme)
@@ -187,3 +205,7 @@ def mount_ssrf_pinning(session: Session) -> None:
             else SsrfPinningAdapter()
         )
         session.mount(scheme, adapter)
+
+    for adapter in session.adapters.values():
+        if isinstance(adapter, SsrfPinningAdapter):
+            adapter._trust_urls(trusted_urls)

--- a/src/mcp_atlassian/utils/ssrf_adapter.py
+++ b/src/mcp_atlassian/utils/ssrf_adapter.py
@@ -128,6 +128,37 @@ class _PinnedHTTPSConnectionPool(HTTPSConnectionPool):
 class SsrfPinningAdapter(HTTPAdapter):
     """A requests adapter that validates and pins DNS resolution for every call."""
 
+    def send(
+        self,
+        request: Any,
+        stream: bool = False,
+        timeout: Any = None,
+        verify: Any = True,
+        cert: Any = None,
+        proxies: Any = None,
+    ) -> Any:
+        """Keep caller-controlled destinations on the pinned direct path.
+
+        An HTTP proxy resolves the target itself, outside this process, so merely
+        installing pinned connection pools on ``ProxyManager`` would only pin the
+        proxy host. Operator-configured service and allowlisted hosts may use a
+        deployment proxy; other destinations connect directly through this
+        adapter's validating pool.
+        """
+        hostname = urlparse(request.url or "").hostname or ""
+        if proxies and not _hostname_matches_allowlist(
+            hostname, _operator_trusted_hosts()
+        ):
+            proxies = {}
+        return super().send(
+            request,
+            stream=stream,
+            timeout=timeout,
+            verify=verify,
+            cert=cert,
+            proxies=proxies,
+        )
+
     def init_poolmanager(
         self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any
     ) -> None:

--- a/src/mcp_atlassian/utils/urls.py
+++ b/src/mcp_atlassian/utils/urls.py
@@ -6,7 +6,7 @@ import re
 import socket
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 
 def make_ssrf_redirect_hook() -> Callable[..., Any]:
@@ -18,7 +18,8 @@ def make_ssrf_redirect_hook() -> Callable[..., Any]:
 
     def hook(response: Any, **kwargs: Any) -> Any:
         if response.is_redirect:
-            error = validate_url_for_ssrf(response.headers.get("Location", ""))
+            redirect_url = urljoin(response.url, response.headers.get("Location", ""))
+            error = validate_url_for_ssrf(redirect_url)
             if error:
                 response.close()
                 raise ValueError(f"Redirect blocked (SSRF): {error}")

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -95,6 +95,7 @@ def test_base_session_has_ssrf_redirect_hook():
     # The hook must actually block a redirect to an internal/metadata host.
     internal_redirect = MagicMock()
     internal_redirect.is_redirect = True
+    internal_redirect.url = "https://test.atlassian.net/start"
     internal_redirect.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
     with pytest.raises(ValueError, match="SSRF"):
         for hook in hooks:

--- a/tests/unit/jira/test_jql_utils.py
+++ b/tests/unit/jira/test_jql_utils.py
@@ -29,9 +29,14 @@ class TestJQLQuoting:
             ("TEST", "TEST"),
             ("MYPROJECT", "MYPROJECT"),
             ("SCRUM", "SCRUM"),
+            ("MY-PROJECT", "MY-PROJECT"),
             # Starts with digit → quoted
             ("123P", '"123P"'),
             ("1ABC", '"1ABC"'),
+            # JQL syntax characters → quoted as a single literal
+            ("X OR project = OUTSIDE", '"X OR project = OUTSIDE"'),
+            ("X) OR project = OUTSIDE", '"X) OR project = OUTSIDE"'),
+            ("X=OUTSIDE", '"X=OUTSIDE"'),
             # Internal quote escaping
             ('my"key', '"my\\"key"'),
             # Internal backslash escaping
@@ -52,8 +57,12 @@ class TestJQLQuoting:
             "normal-TEST",
             "normal-MYPROJECT",
             "normal-SCRUM",
+            "normal-hyphenated",
             "digit-start-123P",
             "digit-start-1ABC",
+            "spaces-and-operator",
+            "parenthesis-and-operator",
+            "equals-operator",
             "internal-quote",
             "internal-backslash",
             "internal-backslash-and-quote",

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -291,7 +291,7 @@ class TestSearchMixin:
         # Test with single project filter (non-reserved keys are not quoted)
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
         search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project = TEST",
+            "(text ~ 'test') AND (project = TEST)",
             fields=ANY,
             start=0,
             limit=50,
@@ -303,7 +303,7 @@ class TestSearchMixin:
         # Test with multiple project filter
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="TEST,DEV")
         search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project IN (TEST, DEV)",
+            "(text ~ 'test') AND (project IN (TEST, DEV))",
             fields=ANY,
             start=0,
             limit=50,
@@ -338,7 +338,7 @@ class TestSearchMixin:
         # Test with config filter (non-reserved keys are not quoted)
         result = search_mixin.search_issues("text ~ 'test'")
         search_mixin.jira.jql.assert_called_with(
-            "(text ~ 'test') AND project IN (TEST, DEV)",
+            "(text ~ 'test') AND (project IN (TEST, DEV))",
             fields=ANY,
             start=0,
             limit=50,
@@ -351,7 +351,7 @@ class TestSearchMixin:
         # the config filter is still ANDed, it cannot be replaced.
         result = search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
         search_mixin.jira.jql.assert_called_with(
-            "((text ~ 'test') AND project IN (TEST, DEV)) AND project = OVERRIDE",
+            "((text ~ 'test') AND (project IN (TEST, DEV))) AND (project = OVERRIDE)",
             fields=ANY,
             start=0,
             limit=50,
@@ -365,7 +365,8 @@ class TestSearchMixin:
             "text ~ 'test'", projects_filter="OVER1,OVER2"
         )
         search_mixin.jira.jql.assert_called_with(
-            "((text ~ 'test') AND project IN (TEST, DEV)) AND project IN (OVER1, OVER2)",
+            "((text ~ 'test') AND (project IN (TEST, DEV))) "
+            "AND (project IN (OVER1, OVER2))",
             fields=ANY,
             start=0,
             limit=50,
@@ -680,7 +681,7 @@ class TestSearchMixin:
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST")
 
         # Assert: JQL verification
-        assert get_jql_from_call() == "(text ~ 'test') AND project = TEST"
+        assert get_jql_from_call() == "(text ~ 'test') AND (project = TEST)"
 
         # Reset mocks for next call
         search_mixin.jira.post.reset_mock()
@@ -689,7 +690,7 @@ class TestSearchMixin:
         # Act: Multiple projects filter
         search_mixin.search_issues("text ~ 'test'", projects_filter="TEST, DEV")
         # Assert: JQL verification
-        assert get_jql_from_call() == "(text ~ 'test') AND project IN (TEST, DEV)"
+        assert get_jql_from_call() == "(text ~ 'test') AND (project IN (TEST, DEV))"
 
         # Reset mocks for next call
         search_mixin.jira.post.reset_mock()
@@ -698,7 +699,7 @@ class TestSearchMixin:
         # Act: Call with both JQL and filter — the allowlist is always ANDed, so a
         # caller-supplied project clause cannot escape the configured filter.
         search_mixin.search_issues("project = OTHER", projects_filter="TEST")
-        assert get_jql_from_call() == "(project = OTHER) AND project = TEST"
+        assert get_jql_from_call() == "(project = OTHER) AND (project = TEST)"
 
     @pytest.mark.parametrize("is_cloud", [True, False])
     def test_search_issues_with_config_projects_filter_jql_construction(
@@ -724,7 +725,9 @@ class TestSearchMixin:
         # Act: Use config filter (non-reserved keys are not quoted)
         search_mixin.search_issues("text ~ 'test'")
         # Assert: JQL verification
-        assert get_jql_from_call() == "(text ~ 'test') AND project IN (CONF1, CONF2)"
+        assert get_jql_from_call() == (
+            "(text ~ 'test') AND (project IN (CONF1, CONF2))"
+        )
 
         # Reset mocks for next call
         search_mixin.jira.post.reset_mock()
@@ -734,7 +737,7 @@ class TestSearchMixin:
         # replace it, so the config filter is still ANDed (hard boundary).
         search_mixin.search_issues("text ~ 'test'", projects_filter="OVERRIDE")
         assert get_jql_from_call() == (
-            "((text ~ 'test') AND project IN (CONF1, CONF2)) AND project = OVERRIDE"
+            "((text ~ 'test') AND (project IN (CONF1, CONF2))) AND (project = OVERRIDE)"
         )
 
     @pytest.mark.parametrize("is_cloud", [True, False])
@@ -941,7 +944,7 @@ class TestSearchMixin:
         )
         assert (
             get_jql_from_call()
-            == '(assignee = "testuser") AND project = PROJ1 ORDER BY updated DESC'
+            == '(assignee = "testuser") AND (project = PROJ1) ORDER BY updated DESC'
         )
 
         # Reset mocks
@@ -953,8 +956,8 @@ class TestSearchMixin:
             'status = "Done" ORDER BY created ASC', projects_filter="PROJ1,PROJ2"
         )
         assert (
-            get_jql_from_call()
-            == '(status = "Done") AND project IN (PROJ1, PROJ2) ORDER BY created ASC'
+            get_jql_from_call() == '(status = "Done") AND (project IN (PROJ1, PROJ2)) '
+            "ORDER BY created ASC"
         )
 
         # Reset mocks
@@ -967,42 +970,37 @@ class TestSearchMixin:
         )
         assert (
             get_jql_from_call()
-            == "(priority = High) AND project = PROJ1 order by updated desc"
+            == "(priority = High) AND (project = PROJ1) order by updated desc"
         )
 
     # Tests for JQL injection prevention in projects filter (PR #949)
 
-    @pytest.mark.parametrize(
-        "input_value,expected",
-        [
-            ("normal", "normal"),
-            ('has"quote', 'has\\"quote'),
-            ("has\\backslash", "has\\\\backslash"),
-            ('has\\"both', 'has\\\\\\"both'),
-        ],
-        ids=[
-            "no-special-chars",
-            "double-quote-escaped",
-            "backslash-escaped",
-            "backslash-and-quote-escaped",
-        ],
-    )
-    def test_projects_filter_inline_escaping_logic(
+    @pytest.mark.parametrize("is_cloud", [True, False])
+    def test_projects_filter_cannot_inject_or_outside_config_allowlist(
         self,
-        input_value: str,
-        expected: str,
-    ):
-        """Regression: verify the inline escaping logic used in search_issues.
+        search_mixin: SearchMixin,
+        mock_issues_response: dict,
+        is_cloud: bool,
+    ) -> None:
+        """A caller filter must remain one literal inside the configured boundary."""
+        search_mixin.config.is_cloud = is_cloud
+        search_mixin.config.projects_filter = "ALLOWED"
+        search_mixin.config.url = "https://test.example.com"
+        search_mixin.jira.post = MagicMock(return_value=mock_issues_response)
+        search_mixin.jira.jql = MagicMock(return_value=mock_issues_response)
 
-        The projects filter escaping (search.py lines 67-69) applies:
-          1. Replace \\ with \\\\  (backslash first)
-          2. Replace " with \\"   (then double-quote)
+        search_mixin.search_issues(
+            "status = Open", projects_filter="X OR project = OUTSIDE"
+        )
 
-        This ordering is critical: reversing it would allow \\" bypass attacks.
-        """
-        # Reproduce the exact inline escaping logic from search.py
-        result = input_value.replace("\\", "\\\\").replace('"', '\\"')
-        assert result == expected
+        if is_cloud:
+            jql = search_mixin.jira.post.call_args.kwargs["json"]["jql"]
+        else:
+            jql = search_mixin.jira.jql.call_args.args[0]
+        assert jql == (
+            "((status = Open) AND (project = ALLOWED)) "
+            'AND (project = "X OR project = OUTSIDE")'
+        )
 
     @pytest.mark.parametrize(
         "malicious_filter",

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -342,6 +342,13 @@ def test_configure_rate_limit_shares_bucket_across_sessions(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("ATLASSIAN_REQUESTS_PER_SECOND", "5")
+    clock = [0.0]
+
+    def advance_clock(seconds: float) -> None:
+        clock[0] += seconds
+
+    monkeypatch.setattr("mcp_atlassian.utils.http.time.monotonic", lambda: clock[0])
+    monkeypatch.setattr("mcp_atlassian.utils.http.time.sleep", advance_clock)
 
     s1, s2 = Session(), Session()
     for sess in (s1, s2):
@@ -357,10 +364,8 @@ def test_configure_rate_limit_shares_bucket_across_sessions(
     s2.adapters["https://"].send(MagicMock())
     s2.adapters["https://"].send(MagicMock())
 
-    start = time.monotonic()
     s1.adapters["https://"].send(MagicMock())
-    elapsed = time.monotonic() - start
-    assert elapsed >= 0.1
+    assert clock[0] == pytest.approx(0.2)
 
 
 def _build_circuit_session(status_codes_iter):

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -352,6 +352,8 @@ def test_two_adapters_with_different_no_proxy_lists_stay_isolated(monkeypatch):
     later overwritten by the other client.
     """
     # Jira is configured first for jira.internal.
+    monkeypatch.setenv("JIRA_URL", "https://jira.internal")
+    monkeypatch.setenv("CONFLUENCE_URL", "https://confluence.internal")
     jira_adapter = NoProxyAdapter(no_proxy="jira.internal")
     # Confluence is configured later and overwrites the shared environment.
     confluence_adapter = NoProxyAdapter(no_proxy="confluence.internal")

--- a/tests/unit/utils/test_ssrf_adapter.py
+++ b/tests/unit/utils/test_ssrf_adapter.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 import requests
+from requests.adapters import HTTPAdapter
 
 from mcp_atlassian.utils.ssrf_adapter import (
     SsrfPinningAdapter,
@@ -59,6 +60,34 @@ def test_pinning_adapter_blocks_internal_through_real_stack(ip):
     ):
         with pytest.raises(requests.exceptions.ConnectionError, match="SSRF blocked"):
             session.get("https://rebind.attacker.test", timeout=5)
+
+
+@pytest.mark.security_regression
+def test_untrusted_target_bypasses_proxy_to_keep_dns_pinning():
+    """A proxy must not re-resolve a caller-controlled target outside the guard."""
+    adapter = SsrfPinningAdapter()
+    request = requests.Request("GET", "https://rebind.attacker.test").prepare()
+    proxies = {"https": "http://proxy.example.test:8080"}
+    response = requests.Response()
+
+    with patch.object(HTTPAdapter, "send", return_value=response) as send:
+        assert adapter.send(request, proxies=proxies) is response
+
+    assert send.call_args.kwargs["proxies"] == {}
+
+
+def test_operator_configured_target_keeps_proxy(monkeypatch):
+    """Operator-controlled service hosts may continue using deployment proxies."""
+    monkeypatch.setenv("JIRA_URL", "https://jira.internal")
+    adapter = SsrfPinningAdapter()
+    request = requests.Request("GET", "https://jira.internal/rest/api/2").prepare()
+    proxies = {"https": "http://proxy.example.test:8080"}
+    response = requests.Response()
+
+    with patch.object(HTTPAdapter, "send", return_value=response) as send:
+        assert adapter.send(request, proxies=proxies) is response
+
+    assert send.call_args.kwargs["proxies"] == proxies
 
 
 class _FakeConnectSock:

--- a/tests/unit/utils/test_ssrf_adapter.py
+++ b/tests/unit/utils/test_ssrf_adapter.py
@@ -17,6 +17,7 @@ from requests.adapters import HTTPAdapter
 from mcp_atlassian.utils.ssrf_adapter import (
     SsrfPinningAdapter,
     _pinned_create_connection,
+    mount_ssrf_pinning,
 )
 
 
@@ -81,6 +82,28 @@ def test_operator_configured_target_keeps_proxy(monkeypatch):
     monkeypatch.setenv("JIRA_URL", "https://jira.internal")
     adapter = SsrfPinningAdapter()
     request = requests.Request("GET", "https://jira.internal/rest/api/2").prepare()
+    proxies = {"https": "http://proxy.example.test:8080"}
+    response = requests.Response()
+
+    with patch.object(HTTPAdapter, "send", return_value=response) as send:
+        assert adapter.send(request, proxies=proxies) is response
+
+    assert send.call_args.kwargs["proxies"] == proxies
+
+
+@pytest.mark.security_regression
+def test_cloud_oauth_gateway_keeps_proxy_through_no_proxy_adapter(monkeypatch):
+    """The fixed Cloud OAuth transport remains proxyable after NO_PROXY handling."""
+    from mcp_atlassian.utils.ssl import NoProxyAdapter
+
+    for key in ("JIRA_URL", "CONFLUENCE_URL", "MCP_ALLOWED_URL_DOMAINS"):
+        monkeypatch.delenv(key, raising=False)
+    url = "https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/myself"
+    session = requests.Session()
+    session.mount("https://api.atlassian.com", NoProxyAdapter(no_proxy="localhost"))
+    mount_ssrf_pinning(session, url)
+    adapter = session.get_adapter(url)
+    request = requests.Request("GET", url).prepare()
     proxies = {"https": "http://proxy.example.test:8080"}
     response = requests.Response()
 

--- a/tests/unit/utils/test_urls.py
+++ b/tests/unit/utils/test_urls.py
@@ -5,12 +5,38 @@ import socket
 from unittest.mock import patch
 
 import pytest
+import requests
 
 from mcp_atlassian.utils.urls import (
     is_atlassian_cloud_url,
+    make_ssrf_redirect_hook,
     resolve_relative_url,
     validate_url_for_ssrf,
 )
+
+
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        ("/login", "https://jira.example.com/login"),
+        ("//cdn.example.com/file", "https://cdn.example.com/file"),
+    ],
+)
+def test_redirect_hook_resolves_location_before_validation(
+    location: str, expected: str
+) -> None:
+    """Relative and scheme-relative redirects are validated as absolute URLs."""
+    response = requests.Response()
+    response.status_code = 302
+    response.url = "https://jira.example.com/start"
+    response.headers["Location"] = location
+
+    with patch(
+        "mcp_atlassian.utils.urls.validate_url_for_ssrf", return_value=None
+    ) as validate:
+        assert make_ssrf_redirect_hook()(response) is response
+
+    validate.assert_called_once_with(expected)
 
 
 class TestResolveRelativeUrl:


### PR DESCRIPTION
## Summary

- quote and group Jira projects_filter clauses so caller input cannot escape the configured allowlist
- keep caller-controlled destinations off deployment proxies so DNS pinning remains effective
- preserve proxy routing for operator-configured transport URLs, including the Cloud OAuth api.atlassian.com gateway and NO_PROXY adapters
- resolve relative redirect locations before SSRF validation
- make the shared rate-limit bucket test deterministic across Python runners

## Compatibility note

Non-trusted destinations intentionally use the direct DNS-pinned path instead of a configured proxy. In proxy-only egress environments those destinations may be unreachable; operator-configured Jira, Confluence, allowlisted, and explicit client transport URLs continue to use configured proxies.

## Verification

- pre-commit (Ruff format/lint, mypy)
- local Python 3.12 unit suite: 3229 passed, 5 skipped
- GitHub lint, Docker build, Python 3.10-3.13: green
- Codex + Opus plan-review and final output-review: OKAY, no blocking findings
- release_validate.sh 8ac6bc0: unit 3229, DC 98, Cloud 87 passed