### PR TITLE
docs(docs): add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ Add to your Claude Desktop or Cursor MCP configuration:
 
 > **Server/Data Center users**: Use `JIRA_PERSONAL_TOKEN` instead of `JIRA_USERNAME` + `JIRA_API_TOKEN`. See [Authentication](https://mcp-atlassian.soomiles.com/docs/authentication) for details.
 
+#### Autohand Code
+
+Use the same `uvx` server with your Atlassian credentials:
+
+```bash
+autohand mcp add mcp-atlassian env \
+  JIRA_URL=https://your-company.atlassian.net \
+  JIRA_USERNAME=your.email@company.com \
+  JIRA_API_TOKEN=your_api_token \
+  CONFLUENCE_URL=https://your-company.atlassian.net/wiki \
+  CONFLUENCE_USERNAME=your.email@company.com \
+  CONFLUENCE_API_TOKEN=your_api_token \
+  uvx mcp-atlassian
+```
+
+Add `--scope project` after `add` to keep the configuration in the current
+project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current
+installation and CLI details.
+
 ### 3. Start Using
 
 Ask your AI assistant to:


### PR DESCRIPTION
## What changed

Adds an Autohand Code example to the Quick Start, reusing MCP Atlassian's existing `uvx mcp-atlassian` entry point and the same Jira and Confluence environment variables already shown for Claude Desktop and Cursor.

The setup also calls out the project-scoped option.

## Verification

- Checked the stdio command against the current Autohand Code MCP CLI
- `uv run pre-commit run --files README.md`
- `git diff --check`

This is a documentation-only change.
