### PR TITLE
fix(jira): accept hyphens in the numeric segment of issue keys (#1389)

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -30,8 +30,11 @@ logger = logging.getLogger(__name__)
 # Regex patterns for Jira key validation.
 # Per Atlassian docs, Cloud project keys are 2-10 chars. Server/Data Center
 # allows longer keys (configurable). We accept any length to support both.
-# Underscores are also allowed to support non-standard project key formats
-ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+$"
+# Underscores are also allowed to support non-standard project key formats.
+# The numeric segment of an issue key may itself contain hyphens
+# (e.g. B7-214-68901) on some Jira Server/Data Center instances with
+# non-standard key configurations; see #1389.
+ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-[\d-]+$"
 PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+$"
 
 jira_mcp = FastMCP(

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2122,6 +2122,9 @@ def test_issue_key_pattern_validation():
     assert re.match(ISSUE_KEY_PATTERN, "ABCDEFGHIJ-99")
     assert re.match(ISSUE_KEY_PATTERN, "D_DEV-123")
     assert re.match(ISSUE_KEY_PATTERN, "MY_PROJECT-1")
+    # Valid issue keys with hyphens in the numeric segment (#1389)
+    assert re.match(ISSUE_KEY_PATTERN, "B7-214-68901")
+    assert re.match(ISSUE_KEY_PATTERN, "PRJ-1-2-3")
     # Invalid issue keys
     assert not re.match(ISSUE_KEY_PATTERN, "a-1")
     assert not re.match(ISSUE_KEY_PATTERN, "PROJ")


### PR DESCRIPTION
## What

ISSUE_KEY_PATTERN was `^[A-Z][A-Z0-9_]+-\d+$`, which rejects valid issue keys like `B7-214-68901` used by some Jira Server/Data Center instances with non-standard key configurations. Calls like `jira_get_issue(issue_key='B7-214-68901')` failed Pydantic validation even though the key is served by the instance at `/browse/B7-214-68901`.

## Fix

Broadened the numeric segment of the regex from `\d+` to `[\d-]+`. The character class now allows digits or hyphens in the post-project-key portion of the issue key.

```
-ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+$"
+ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-[\d-]+$"
```

## Behavior

The existing reject case `A-1-2` still fails because the regex requires at least one `[A-Z0-9_]` character between the leading project-key letter and the first hyphen — that constraint is preserved. The change is strictly additive: keys that already matched continue to match; keys that contain additional hyphens in the numeric segment now also match.

## Tests

Added two regression cases in `tests/unit/servers/test_jira_server.py::test_issue_key_pattern_validation`:

```
# Valid issue keys with hyphens in the numeric segment (#1389)
assert re.match(ISSUE_KEY_PATTERN, "B7-214-68901")
assert re.match(ISSUE_KEY_PATTERN, "PRJ-1-2-3")
```

Local test suite: `uv run pytest tests/unit/servers/test_jira_server.py` -> 133 passed (1 test_issue_key_pattern_validation + 132 others).

## Scope

Source + test. 2 files, 8 insertions / 2 deletions. Closes #1389.