### PR TITLE
fix(servers): add items schema to set_page_restrictions list parameters (#1455)

### DIFF
--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -2875,6 +2875,7 @@ async def set_page_restrictions(
                 "allowed to view the page. Empty list = unrestricted."
             ),
             default=None,
+            json_schema_extra={"items": {"type": "string"}},
         ),
     ] = None,
     read_groups: Annotated[
@@ -2882,6 +2883,7 @@ async def set_page_restrictions(
         Field(
             description="(Optional) Group names allowed to view the page.",
             default=None,
+            json_schema_extra={"items": {"type": "string"}},
         ),
     ] = None,
     edit_users: Annotated[
@@ -2892,6 +2894,7 @@ async def set_page_restrictions(
                 "allowed to edit the page."
             ),
             default=None,
+            json_schema_extra={"items": {"type": "string"}},
         ),
     ] = None,
     edit_groups: Annotated[
@@ -2899,6 +2902,7 @@ async def set_page_restrictions(
         Field(
             description="(Optional) Group names allowed to edit the page.",
             default=None,
+            json_schema_extra={"items": {"type": "string"}},
         ),
     ] = None,
 ) -> str:

--- a/tests/unit/servers/test_schema_compatibility.py
+++ b/tests/unit/servers/test_schema_compatibility.py
@@ -399,9 +399,8 @@ class TestSetPageRestrictionsArraySchema:
         prop = properties[param_name]
         assert "items" in prop, (
             f"Parameter {param_name!r} is missing required 'items' field "
-            f"(regression of issue #1455 — VS Code Agent mode cannot start)"
+            f"(regression of issue #1455: VS Code Agent mode cannot start)"
         )
         assert prop["items"] == {"type": "string"}, (
-            f"Parameter {param_name!r} has unexpected 'items' schema: "
-            f"{prop['items']!r}"
+            f"Parameter {param_name!r} has unexpected 'items' schema: {prop['items']!r}"
         )

--- a/tests/unit/servers/test_schema_compatibility.py
+++ b/tests/unit/servers/test_schema_compatibility.py
@@ -354,3 +354,54 @@ class TestNarrowedParameterRegression:
         csv = "./file1.pdf, ./file2.png"
         result = [p.strip() for p in csv.split(",") if p.strip()]
         assert result == ["./file1.pdf", "./file2.png"]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for set_page_restrictions array-parameter schema (issue #1455)
+# ---------------------------------------------------------------------------
+
+
+class TestSetPageRestrictionsArraySchema:
+    """Regression: VS Code Agent mode rejects tools whose array-typed parameters
+    lack an ``items`` definition in the JSON schema (issue #1455).
+
+    These tests guard the fix in
+    ``src.mcp_atlassian.servers.confluence.set_page_restrictions`` which
+    adds ``json_schema_extra={"items": {"type": "string"}}`` to each of the
+    four list parameters (read_users, read_groups, edit_users, edit_groups).
+    """
+
+    TOOL_NAME = "confluence_set_page_restrictions"
+    LIST_PARAM_NAMES = ("read_users", "read_groups", "edit_users", "edit_groups")
+
+    def test_tool_present(self, all_tool_schemas: dict[str, dict]) -> None:
+        """The tool must be discoverable in the main MCP server."""
+        assert self.TOOL_NAME in all_tool_schemas, (
+            f"Tool {self.TOOL_NAME!r} is missing from the registered tools"
+        )
+
+    @pytest.mark.parametrize("param_name", LIST_PARAM_NAMES)
+    def test_list_param_has_items_definition(
+        self, param_name: str, all_tool_schemas: dict[str, dict]
+    ) -> None:
+        """Each list-typed parameter must declare an ``items`` schema.
+
+        VS Code's MCP tool validator refuses to register a tool whose array
+        parameter is missing ``items`` (``tool parameters array type must
+        have items``).  Without this, the entire ``confluence_set_page_restrictions``
+        tool is rejected and VS Code cannot enter Agent mode.
+        """
+        schema = all_tool_schemas[self.TOOL_NAME]
+        properties = schema.get("properties", {})
+        assert param_name in properties, (
+            f"Parameter {param_name!r} is missing from the tool schema"
+        )
+        prop = properties[param_name]
+        assert "items" in prop, (
+            f"Parameter {param_name!r} is missing required 'items' field "
+            f"(regression of issue #1455 — VS Code Agent mode cannot start)"
+        )
+        assert prop["items"] == {"type": "string"}, (
+            f"Parameter {param_name!r} has unexpected 'items' schema: "
+            f"{prop['items']!r}"
+        )


### PR DESCRIPTION
## Summary

VS Code Agent mode rejects the `confluence_set_page_restrictions` tool with `"tool parameters array type must have items"` because the four list-typed parameters (`read_users`, `read_groups`, `edit_users`, `edit_groups`) are declared as `list[str] | None` with `default=None` and Pydantic v2 omits the required `items` field from the generated JSON schema. This blocks VS Code from activating Agent mode entirely for users on `mcp-atlassian>=0.22.0`.

Fix: add `json_schema_extra={"items": {"type": "string"}}` to each of the four `Field` definitions so the generated schema includes a valid `items` declaration. Behavior is unchanged — the implementation in `confluence/restrictions.py` already treats `None` and `[]` identically via `read_users = read_users or []`.

## Changes

- `src/mcp_atlassian/servers/confluence.py` (4 lines): add `json_schema_extra={"items": {"type": "string"}}` to each of the four `Field()` definitions for `read_users`, `read_groups`, `edit_users`, `edit_groups` in `set_page_restrictions` (line ~2870-2903).
- `tests/unit/servers/test_schema_compatibility.py` (51 lines): new `TestSetPageRestrictionsArraySchema` class with 5 regression tests asserting the tool is present and that each of the four list parameters includes `items: {"type": "string"}` in the generated inputSchema.

## Verification

- The 4 list-param tests fail on the unpatched code (confirming the bug) and pass after the fix.
- All 514 tests in `test_schema_compatibility.py` and all 74 tests in `test_confluence_server.py` pass.
- The fix is purely additive on the schema — no behavioral change for callers that pass `None`, `[]`, or a populated list.

## Fixes

Closes #1455