### PR TITLE
fix(jira): convert ADF comment bodies to text in get_issue_comments (#1488)

### DIFF
--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -39,9 +39,19 @@ class CommentsMixin(JiraClient):
 
             processed_comments = []
             for comment in comments.get("comments", [])[:limit]:
+                # On Jira Cloud (REST API v3) comment bodies are returned as ADF
+                # (Atlassian Document Format) dicts. convert to plain text before
+                # passing to _clean_text -> clean_jira_text -> _process_mentions,
+                # which calls re.sub() and would otherwise raise TypeError on the
+                # dict. Mirrors the pattern used in add_comment / edit_comment
+                # above. Fixes #1488.
+                body_raw = comment.get("body", "")
+                body_text = (
+                    adf_to_text(body_raw) if isinstance(body_raw, dict) else body_raw
+                )
                 processed_comment = {
                     "id": comment.get("id"),
-                    "body": self._clean_text(comment.get("body", "")),
+                    "body": self._clean_text(body_text or ""),
                     "created": str(parse_date(comment.get("created"))),
                     "updated": str(parse_date(comment.get("updated"))),
                     "author": comment.get("author", {}).get("displayName", "Unknown"),

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -153,6 +153,57 @@ class TestCommentsMixin:
         with pytest.raises(Exception, match="Error getting comments"):
             comments_mixin.get_issue_comments("TEST-123")
 
+    def test_get_issue_comments_adf_body(self, comments_mixin):
+        """Regression test for #1488: Jira Cloud (REST API v3) returns
+        comment bodies as ADF dicts; get_issue_comments previously raised
+        TypeError from re.sub() in _process_mentions because the dict was
+        passed straight to _clean_text. adf_to_text() must be applied
+        first, matching the pattern in add_comment / edit_comment."""
+        comments_mixin.jira.issue_get_comments.return_value = {
+            "comments": [
+                {
+                    "id": "10001",
+                    "body": {
+                        "type": "doc",
+                        "version": 1,
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": "Hello from ADF",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "created": "2024-01-01T10:00:00.000+0000",
+                    "updated": "2024-01-01T11:00:00.000+0000",
+                    "author": {"displayName": "John Doe"},
+                },
+                {
+                    "id": "10002",
+                    # Plain string body must still work unchanged
+                    "body": "This is a plain text comment",
+                    "created": "2024-01-02T10:00:00.000+0000",
+                    "updated": "2024-01-02T11:00:00.000+0000",
+                    "author": {"displayName": "Jane Smith"},
+                },
+            ]
+        }
+
+        result = comments_mixin.get_issue_comments("TEST-123")
+
+        assert len(result) == 2
+        # ADF body converted to plain text and forwarded to _clean_text.
+        # The fixture's mock _clean_text is the identity function, so the
+        # plain-text extraction result is what comes back.
+        assert "Hello from ADF" in result[0]["body"]
+        assert "doc" not in result[0]["body"]
+        # Plain string body passes through adf_to_text unchanged.
+        assert result[1]["body"] == "This is a plain text comment"
+
     def test_add_comment_basic(self, comments_mixin):
         """Test add_comment with basic data (Cloud → ADF via v3 API)."""
         # Setup mock response for v3 API path


### PR DESCRIPTION
Fixes #1488

Jira Cloud (REST API v3) returns comment bodies as ADF (Atlassian Document Format) dicts, not plain strings. `get_issue_comments` in `jira/comments.py` passed the body straight to `_clean_text` → `clean_jira_text` → `_process_mentions`, which calls `re.sub()` and crashed with `TypeError` on the dict.

`adf_to_text()` was already imported in the module and is applied correctly in `add_comment` / `edit_comment`; mirror the same pattern in `get_issue_comments`. Plain-string bodies are unaffected (`isinstance` check passes through unchanged).

### Repro (pre-fix)

```
>>> mixin.get_issue_comments('PROJ-1')
TypeError: expected string or bytes-like object
```

### Verification

`uv run pytest tests/unit/` → 2579 passed, 5 skipped. New test `test_get_issue_comments_adf_body` exercises both an ADF dict body and a plain-string body, and asserts the ADF body is converted to plain text (no `doc` / paragraph structure leaks through to the caller) while the plain-string body passes through untouched.

Reported by @Troubladore on the community fork (https://github.com/Troubladore/mcp-atlassian/commit/981bebe).