### PR TITLE
fix(jira): stop JIRA_INTERNAL_ONLY_PROJECTS failing open on invisible characters

### DIFF
--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -29,7 +29,7 @@ from mcp_atlassian.utils.urls import make_ssrf_redirect_hook
 from mcp_atlassian.utils.user_agent import get_default_user_agent
 
 from ..models.jira.adf import markdown_to_adf
-from .config import JiraConfig
+from .config import JiraConfig, normalize_project_key
 
 # Configure logging
 logger = logging.getLogger("mcp-jira")
@@ -323,14 +323,18 @@ class JiraClient:
     def _project_key_from_issue_key(issue_key: str) -> str:
         """Extract the project key from an issue key (e.g. 'CC-123' -> 'CC').
 
-        Normalizes its own input (strips surrounding whitespace on the
+        Normalizes its own input the same way the configured keys are
+        normalized (surrounding whitespace and invisible characters, on the
         issue key AND on the extracted key) so that padded inputs like
         ' CC-1', '\\tCC-1' or 'CC -1' cannot slip past callers that
         compare the result against a set of clean project keys. A
         defense-in-depth check must not rely on the downstream API to
-        reject whitespace-padded keys.
+        reject whitespace-padded keys, and both sides of the comparison have
+        to normalize identically or the guard silently stops matching.
         """
-        return issue_key.strip().split("-", 1)[0].strip().upper()
+        return normalize_project_key(
+            normalize_project_key(issue_key).split("-", 1)[0]
+        )
 
     def _is_internal_only_project(self, issue_key: str) -> bool:
         """Check whether issue_key's project is in JIRA_INTERNAL_ONLY_PROJECTS.

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -20,27 +21,63 @@ from ..utils.proxy import get_proxy_settings_from_env
 from ..utils.urls import is_atlassian_cloud_url
 
 
+logger = logging.getLogger("mcp-atlassian.jira.config")
+
+_PROJECT_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+# str.strip() does not remove zero-width characters or a BOM, so a key pasted
+# from a browser or spreadsheet can carry one invisibly. That matters more here
+# than in most settings: an unmatched key silently leaves the project
+# unprotected, and this guard exists to keep automation off a customer-facing
+# portal, so it has to normalize them away rather than fail open.
+_INVISIBLE_CHARS = dict.fromkeys(
+    map(ord, "​‌‍⁠﻿")  # ZWSP, ZWNJ, ZWJ, word-joiner, BOM
+)
+
+
+def normalize_project_key(raw: str) -> str:
+    """Normalize a project key for internal-only comparisons."""
+    return raw.translate(_INVISIBLE_CHARS).strip().upper()
+
+
 def _parse_internal_only_projects(raw: str | None) -> frozenset[str]:
     """Parse JIRA_INTERNAL_ONLY_PROJECTS into a set of normalized project keys.
 
-    Tolerant of malformed input: extra whitespace, blank entries from
-    double/trailing commas, and mixed case are all normalized away. An
-    unset or empty value returns an empty set, which is the semantic
+    Tolerant of malformed input: extra whitespace, invisible characters, blank
+    entries from double/trailing commas, and mixed case are all normalized away.
+    An unset or empty value returns an empty set, which is the semantic
     "guard disabled" state used throughout the internal-only-projects
     feature — this keeps the feature strictly opt-in and a no-op for
     every other deployment of this server.
+
+    An entry that still does not look like a project key after normalization is
+    kept (it simply never matches) but logged as a warning: silently discarding
+    it would leave an operator believing a project is guarded when it is not.
 
     Args:
         raw: Raw comma-separated project keys from the environment
             (e.g. "CC" or "CC, HELP ,, support").
 
     Returns:
-        A frozenset of upper-cased, stripped project keys. Empty when
-        raw is None, empty, or contains only blank entries.
+        A frozenset of normalized project keys. Empty when raw is None,
+        empty, or contains only blank entries.
     """
     if not raw:
         return frozenset()
-    return frozenset(key.strip().upper() for key in raw.split(",") if key.strip())
+
+    keys = set()
+    for entry in raw.split(","):
+        key = normalize_project_key(entry)
+        if not key:
+            continue
+        if not _PROJECT_KEY_RE.match(key):
+            logger.warning(
+                "JIRA_INTERNAL_ONLY_PROJECTS entry %r is not a valid project key; "
+                "it will never match an issue, so that project is NOT guarded.",
+                entry,
+            )
+        keys.add(key)
+    return frozenset(keys)
 
 
 @dataclass

--- a/tests/e2e/cloud/test_jira_cloud_operations.py
+++ b/tests/e2e/cloud/test_jira_cloud_operations.py
@@ -437,6 +437,16 @@ class TestJiraCloudJSMComments:
                 issue_key, internal_id, "Cloud edited internal ServiceDesk comment"
             )
             assert edited["id"] == internal_id
+            # The edit itself goes through the core Jira API, so assert the
+            # comment is still internal afterwards: if that write ever dropped
+            # the ServiceDesk visibility property, the guard would have let the
+            # text through to the customer portal while the test still passed.
+            assert (
+                jira_fetcher._fetch_servicedesk_comment_is_public(
+                    issue_key, internal_id
+                )
+                is False
+            )
         finally:
             for comment_id in comment_ids:
                 _delete_cloud_comment(jira_fetcher, issue_key, comment_id)

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -422,6 +422,16 @@ class TestJiraDCJSMComments:
                 issue_key, internal_id, "DC edited internal ServiceDesk comment"
             )
             assert edited["id"] == internal_id
+            # The edit itself goes through the core Jira API, so assert the
+            # comment is still internal afterwards: if that write ever dropped
+            # the ServiceDesk visibility property, the guard would have let the
+            # text through to the customer portal while the test still passed.
+            assert (
+                jsm_jira_fetcher._fetch_servicedesk_comment_is_public(
+                    issue_key, internal_id
+                )
+                is False
+            )
         finally:
             for comment_id in comment_ids:
                 _delete_dc_comment(jsm_jira_fetcher, issue_key, comment_id)

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -1,5 +1,6 @@
 """Tests for the Jira config module."""
 
+import logging
 import os
 from unittest.mock import patch
 
@@ -272,6 +273,57 @@ def test_from_env_internal_only_projects_malformed_tolerated():
     ):
         config = JiraConfig.from_env()
         assert config.internal_only_projects == frozenset({"CC", "HELP", "SUPPORT"})
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "CC​",  # zero-width space
+        "﻿CC",  # BOM
+        "C‍C",  # zero-width joiner inside the key
+        "⁠CC‌",  # word-joiner + zero-width non-joiner
+    ],
+    ids=["zwsp", "bom", "zwj", "wj-zwnj"],
+)
+def test_from_env_internal_only_projects_strips_invisible_chars(raw):
+    """An invisible character must not silently leave the project unguarded.
+
+    str.strip() does not remove these, so a key pasted from a browser or
+    spreadsheet would never match its issues — and the guard would fail open
+    while the operator believed the project was protected.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_USERNAME": "test_username",
+            "JIRA_API_TOKEN": "test_token",
+            "JIRA_INTERNAL_ONLY_PROJECTS": raw,
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.internal_only_projects == frozenset({"CC"})
+
+
+def test_from_env_internal_only_projects_warns_on_invalid_key(caplog):
+    """An entry that cannot match any issue is surfaced, not silently dropped."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://test.atlassian.net",
+            "JIRA_USERNAME": "test_username",
+            "JIRA_API_TOKEN": "test_token",
+            "JIRA_INTERNAL_ONLY_PROJECTS": "CC,not a key!",
+        },
+        clear=True,
+    ):
+        with caplog.at_level(logging.WARNING):
+            config = JiraConfig.from_env()
+
+    assert "CC" in config.internal_only_projects
+    assert "not a key!" in caplog.text
+    assert "NOT guarded" in caplog.text
 
 
 def test_is_cloud_oauth_with_cloud_id():


### PR DESCRIPTION
Follow-up to #1478 (merged as 02de188), from an adversarial review of what shipped.

## The bug

`JIRA_INTERNAL_ONLY_PROJECTS` fails **open** on invisible characters. `str.strip()` does not remove zero-width characters or a BOM, so a key pasted from a browser or a spreadsheet can carry one:

```
"CC"          -> {'CC'}          guarded
"CC​"    -> {'CC​'}    NOT guarded  (silently)
"﻿CC"    -> {'﻿CC'}    NOT guarded  (silently)
```

The key then never matches its own issues, `_is_internal_only_project()` returns `False`, and the comment goes out **customer-visible** — while the operator believes the project is protected. There is no error and no warning.

For a setting whose entire job is keeping automation off a customer-facing portal, that is the wrong direction to fail.

## The fix

- Normalize zero-width characters and the BOM away, on **both** sides of the comparison — the configured keys *and* the project key extracted from an issue key. If only one side normalized, the guard would silently stop matching.
- **Warn** on an entry that still cannot match any issue after normalization, instead of dropping it silently. An operator who typos a key should find out from the logs, not from a customer.

## Also: the e2e tests weren't watching the edit path

`edit_comment` does its ServiceDesk visibility pre-check, but performs the actual write through the **core Jira API**. The tests only asserted the returned comment id — so if that write ever dropped the ServiceDesk internal-comment property, the text would reach the customer portal while the tests still passed.

Verified against a real JSM project that the property does survive the edit today, so this is a coverage gap rather than a live bug — but nothing was watching it. Both the Cloud and DC tests now re-assert `_fetch_servicedesk_comment_is_public(...) is False` after the edit.

## Verification

- unit: **3451 passed** (5 new)
- Cloud JSM e2e: **1 passed, 0 skipped** — real `service_desk` project
- DC JSM e2e: **1 passed, 0 skipped** — real Jira Service Management DC instance
- full DC e2e: **101 passed**, no regression
