### PR TITLE
docs: sync generated tool reference and counts with registered tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,10 +227,10 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # Keywords: "all" (all toolsets), "default" (core toolsets only)
 # Core toolsets: jira_issues, jira_fields, jira_comments, jira_transitions,
 #   confluence_pages, confluence_comments
-# Example: TOOLSETS=default                      # Only core tools (~23 tools)
+# Example: TOOLSETS=default                      # Only core tools (~35 tools)
 # Example: TOOLSETS=default,jira_agile           # Core + agile tools
-# Example: TOOLSETS=all                          # All 23 toolsets (93 tools)
-# If unset, all toolsets are enabled (93 tools). Set TOOLSETS=all explicitly to
+# Example: TOOLSETS=all                          # All 24 toolsets (98 tools)
+# If unset, all toolsets are enabled (98 tools). Set TOOLSETS=all explicitly to
 # preserve this behavior — in v0.22.0, the default will change to core toolsets only.
 # Unknown names are silently ignored; if ALL names are unknown, no tools are enabled (fail-closed).
 #TOOLSETS=

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**93 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**98 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs.json
+++ b/docs.json
@@ -3,7 +3,7 @@
   "theme": "mint",
   "name": "MCP Atlassian",
   "metadata": {
-    "og:description": "MCP server for Atlassian Jira and Confluence — all 93 tools enabled by default"
+    "og:description": "MCP server for Atlassian Jira and Confluence — all 98 tools enabled by default"
   },
   "seo": {
     "indexHiddenPages": false

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -299,7 +299,7 @@ Toolsets provide group-level tool control. Instead of listing individual tool na
 enable entire groups of related tools at once using the `TOOLSETS` environment variable.
 
 ```bash
-# Restrict to core tools only (~23 tools across 6 core toolsets)
+# Restrict to core tools only (~35 tools across 6 core toolsets)
 TOOLSETS=default
 
 # Core tools plus agile boards/sprints

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 96 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 98 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **96 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **98 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -63,45 +63,46 @@ MCP Atlassian provides **96 tools** for interacting with Jira and Confluence. To
 
 Toolsets group related tools for easier management via `TOOLSETS` env var or `--toolsets` flag.
 
-**Jira Toolsets (15):**
+**Jira Toolsets (16):**
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
-| `jira_issues` | Yes | `jira_get_issue`, `jira_search`, `jira_get_project_issues`, `jira_create_issue`, `jira_update_issue`, `jira_delete_issue`, `jira_move_issue`, `jira_batch_create_issues`, `jira_batch_get_changelogs` |
+| `jira_issues` | Yes | `jira_get_issue`, `jira_search`, `jira_get_project_issues`, `jira_create_issue`, `jira_batch_create_issues`, `jira_batch_get_changelogs`, `jira_update_issue`, `jira_assign_issue`, `jira_delete_issue`, `jira_move_issue` |
 | `jira_fields` | Yes | `jira_search_fields`, `jira_get_field_options` |
 | `jira_comments` | Yes | `jira_add_comment`, `jira_edit_comment` |
 | `jira_transitions` | Yes | `jira_get_transitions`, `jira_transition_issue` |
-| `jira_projects` | No | `jira_get_all_projects`, `jira_get_project_versions`, `jira_get_project_components`, `jira_create_version`, `jira_batch_create_versions`, `jira_update_version` |
-| `jira_agile` | No | `jira_get_agile_boards`, `jira_get_board_issues`, `jira_get_sprints_from_board`, `jira_get_sprint_issues`, `jira_create_sprint`, `jira_update_sprint`, `jira_add_issues_to_sprint` |
+| `jira_projects` | No | `jira_get_project_issue_types`, `jira_get_create_fields`, `jira_get_project_versions`, `jira_get_project_components`, `jira_get_all_projects`, `jira_search_projects`, `jira_get_project_fields`, `jira_create_version`, `jira_batch_create_versions`, `jira_update_version` |
+| `jira_agile` | No | `jira_get_agile_boards`, `jira_get_board_issues`, `jira_get_sprints_from_board`, `jira_get_sprint_issues`, `jira_create_sprint`, `jira_update_sprint`, `jira_add_issues_to_sprint`, `jira_move_issues_to_backlog` |
 | `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_create_remote_issue_link`, `jira_remove_issue_link` |
 | `jira_worklog` | No | `jira_get_worklog`, `jira_add_worklog` |
 | `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images` |
-| `jira_users` | No | `jira_get_user_profile` |
+| `jira_users` | No | `jira_get_user_profile`, `jira_search_assignable_users` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
 | `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues`, `jira_get_request_types`, `jira_get_request_type_fields`, `jira_create_customer_request` |
 | `jira_forms` | No | `jira_get_issue_proforma_forms`, `jira_get_proforma_form_details`, `jira_update_proforma_form_answers` |
 | `jira_metrics` | No | `jira_get_issue_dates`, `jira_get_issue_sla` |
 | `jira_development` | No | `jira_get_issue_development_info`, `jira_get_issues_development_info` |
+| `jira_project_analysis` | No | `jira_get_project_epic_hierarchy`, `jira_get_cross_project_dependencies` |
 
 **Confluence Toolsets (8):**
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
-| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_space_page_tree`, `confluence_get_page_history`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_copy_page`, `confluence_get_page_restrictions`, `confluence_set_page_restrictions`, `confluence_get_page_diff` |
-| `confluence_comments` | Yes | `confluence_get_comments`, `confluence_add_comment`, `confluence_reply_to_comment` |
+| `confluence_pages` | Yes | `confluence_search`, `confluence_get_page`, `confluence_get_page_children`, `confluence_get_space_page_tree`, `confluence_create_page`, `confluence_update_page`, `confluence_update_page_section`, `confluence_delete_page`, `confluence_move_page`, `confluence_get_page_history`, `confluence_get_page_diff`, `confluence_get_page_restrictions`, `confluence_set_page_restrictions`, `confluence_copy_page` |
+| `confluence_comments` | Yes | `confluence_get_comments`, `confluence_add_comment`, `confluence_reply_to_comment`, `confluence_get_inline_comments`, `confluence_add_inline_comment` |
 | `confluence_labels` | No | `confluence_get_labels`, `confluence_add_label` |
 | `confluence_users` | No | `confluence_search_user` |
 | `confluence_analytics` | No | `confluence_get_page_views` |
 | `confluence_attachments` | No | `confluence_upload_attachment`, `confluence_upload_attachments`, `confluence_get_attachments`, `confluence_download_attachment`, `confluence_download_content_attachments`, `confluence_delete_attachment`, `confluence_get_page_images` |
-| `confluence_permissions` | No | `confluence_check_content_permissions`, `confluence_get_space_permissions` |
 | `confluence_templates` | No | `confluence_list_page_templates`, `confluence_get_page_template`, `confluence_create_page_from_template` |
+| `confluence_permissions` | No | `confluence_check_content_permissions`, `confluence_get_space_permissions` |
 
 ```bash
 # All toolsets are enabled when TOOLSETS is not set.
 # To restrict to core toolsets plus specific extras:
 TOOLSETS=default,jira_agile,jira_attachments
 
-# Enable all toolsets (96 tools)
+# Enable all toolsets (98 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/confluence-attachments.mdx
+++ b/docs/tools/confluence-attachments.mdx
@@ -14,25 +14,20 @@ Upload an attachment to Confluence content (page or blog post).
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content_id` | `string` | Yes | The ID of the Confluence content (page or blog post) to attach the file to. Page IDs can be found in the page URL or by using the search/get_page tools. Example: '123456789' |
-| `file_path` | `string` | No | Full path to the file to upload. Can be absolute (e.g., '/home/user/document.pdf' or 'C:\Users\name\file.docx') or relative to the current working directory (e.g., './uploads/document.pdf'). Requires the MCP server to be able to read the path. Provide exactly one of `file_path` or `content_base64`. |
-| `content_base64` | `string` | No | Base64-encoded file content to upload directly, without the server reading from disk. Use this for remote or containerized MCP servers. Provide exactly one of `file_path` or `content_base64`. |
-| `filename` | `string` | No | Attachment filename, including extension. Required when using `content_base64`; ignored when using `file_path`. |
+| `file_path` | `string` | No | Full path to the file to upload. Can be absolute (e.g., '/home/user/document.pdf' or 'C:\Users\name\file.docx') or relative to the current working directory (e.g., './uploads/document.pdf'). If a file with the same name already exists, a new version will be created. Requires the server to be able to read the path; for remote or containerized servers use 'content_base64' instead. Provide either 'file_path' or 'content_base64', not both. |
+| `content_base64` | `string` | No | (Optional) Base64-encoded file content to upload directly, without the server reading from disk. Use this when the server cannot access host file paths (e.g. a remote or containerized MCP server). Requires 'filename'. Provide either 'file_path' or 'content_base64', not both. |
+| `filename` | `string` | No | (Optional) Attachment filename, including extension (e.g. 'report.pdf'). Required when using 'content_base64'; it determines the attachment title and file type. Ignored when 'file_path' is used. |
 | `comment` | `string` | No | (Optional) A comment describing this attachment or version. Visible in the attachment history. Example: 'Updated Q4 2024 figures' |
 | `minor_edit` | `boolean` | No | (Optional) Whether this is a minor edit. If true, watchers are not notified. Default is false. |
 **Example:**
 
 ```json
-{"content_id": "12345678", "file_path": "/path/to/diagram.png", "comment": "Updated architecture diagram"}
-```
-
-```json
-{"content_id": "12345678", "content_base64": "SGVsbG8=", "filename": "hello.txt"}
+{"page_id": "12345678", "file_path": "/path/to/diagram.png", "comment": "Updated architecture diagram"}
 ```
 
 <Tip>
 Supports any file type. If an attachment with the same name exists, it's updated (new version created).
 </Tip>
-
 
 ---
 
@@ -76,19 +71,15 @@ List all attachments for a Confluence content item (page or blog post).
 Use `media_type="application/octet-stream"` for binary files (Confluence returns this for most files including images). Use `filename` parameter for specific files.
 </Tip>
 
-
 <Warning>
 Confluence API returns generic MIME types — use the `mediaTypeDescription` field for human-readable type info.
 </Warning>
-
 
 ---
 
 ### Download Attachment
 
 Download an attachment from Confluence as an embedded resource.
-
-<Note>On Confluence Cloud, attachment downloads automatically use the v1 REST endpoint (the legacy `/download/` link was removed and returns 401 for API/scoped tokens). Override with `CONFLUENCE_ATTACHMENT_DOWNLOAD_USE_V1`.</Note>
 
 **Parameters:**
 
@@ -127,8 +118,6 @@ Permanently delete an attachment from Confluence.
 ### Get Page Images
 
 Get all images attached to a Confluence page as inline image content.
-
-<Note>On Confluence Cloud, images are fetched via the v1 REST endpoint automatically (the legacy `/download/` link was removed and returns 401 for API/scoped tokens). Override with `CONFLUENCE_ATTACHMENT_DOWNLOAD_USE_V1`.</Note>
 
 **Parameters:**
 

--- a/docs/tools/confluence-comments.mdx
+++ b/docs/tools/confluence-comments.mdx
@@ -25,6 +25,17 @@ Add a comment to a Confluence page.
 Supports Markdown formatting. Comments are added to the page's comment section.
 </Tip>
 
+---
+
+### Get Comments
+
+Get comments for a specific Confluence page.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | `string` | Yes | Confluence page ID (numeric ID, can be parsed from URL, e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' -> '123456789') |
 
 ---
 
@@ -41,28 +52,35 @@ Reply to an existing comment thread on a Confluence page.
 | `comment_id` | `string` | Yes | The ID of the parent comment to reply to |
 | `body` | `string` | Yes | The reply content in Markdown format |
 
-**Example:**
-
-```json
-{"comment_id": "67890", "body": "Thanks for the feedback! I've updated the section."}
-```
-
-<Tip>
-Get comment IDs from `confluence_get_comments`. Replies are threaded under the parent comment.
-</Tip>
-
-
 ---
 
-### Get Comments
+### Get Inline Comments
 
-Get comments for a specific Confluence page.
+Get all inline comments for a Confluence page.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `page_id` | `string` | Yes | Confluence page ID (numeric ID, can be parsed from URL, e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' -> '123456789') |
+| `page_id` | `string` | Yes | The ID of the page to get inline comments from |
+
+---
+
+### Add Inline Comment
+
+Add an inline comment anchored to a text selection on a page.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | `string` | Yes | The ID of the page to add the inline comment to |
+| `body` | `string` | Yes | The comment content in Markdown format |
+| `text_selection` | `string` | Yes | The exact text on the page to anchor the inline comment to. Must match text that exists in the page content. |
+| `text_selection_match_count` | `integer` | No | Total number of times the selected text appears on the page. Defaults to 1. |
+| `text_selection_match_index` | `integer` | No | Zero-based index of which occurrence of the text to anchor to. Defaults to 0 (first occurrence). |
 
 ---
 
@@ -113,10 +131,8 @@ Get view statistics for a Confluence page.
 Useful for identifying popular or stale content. Available periods depend on your Confluence analytics configuration.
 </Tip>
 
-
 <Warning>
 Analytics features may require additional permissions on Server/DC.
 </Warning>
-
 
 ---

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -11,7 +11,7 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `page_id` | `string` | No | Confluence page ID, full page URL, or tiny link (for example, `https://example.atlassian.net/wiki/x/N4CIO`). Provide this OR both `title` and `space_key`. If `page_id` is provided, `title` and `space_key` are ignored. |
+| `page_id` | `string` | No | Confluence page ID, full page URL, or tiny link. For example: '123456789', 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', or 'https://example.atlassian.net/wiki/x/N4CIO'. Provide this OR both 'title' and 'space_key'. If page_id is provided, title and space_key will be ignored. |
 | `title` | `string` | No | The exact title of the Confluence page. Use this with 'space_key' if 'page_id' is not known. |
 | `space_key` | `string` | No | The key of the Confluence space where the page resides (e.g., 'DEV', 'TEAM'). Required if using 'title'. |
 | `include_metadata` | `boolean` | No | Whether to include page metadata such as creation date, last update, version, and labels. |
@@ -25,7 +25,6 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 <Tip>
 Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date.
 </Tip>
-
 
 ---
 
@@ -41,16 +40,16 @@ Create a new Confluence page.
 |-----------|------|----------|-------------|
 | `space_key` | `string` | Yes | The key of the space to create the page in (usually a short uppercase code like 'DEV', 'TEAM', or 'DOC') |
 | `title` | `string` | Yes | The title of the page |
-| `content` | `string` | No* | The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, storage format, or XHTML storage format |
-| `content_file` | `string` | No* | Absolute or relative filesystem path to read the page body from (UTF-8). Mutually exclusive with `content`. |
+| `content` | `string` | No | The content of the page. Format depends on content_format parameter. Can be Markdown (default), wiki markup, storage format, or XHTML storage format. Either 'content' or 'content_file' must be provided, but not both. |
 | `parent_id` | `string` | No | (Optional) parent page ID. If provided, this page will be created as a child of the specified page |
-| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' for Confluence XHTML storage format. Wiki format uses Confluence wiki markup syntax |
+| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' when providing Confluence XHTML storage format (same as 'storage'). Wiki format uses Confluence wiki markup syntax |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
-| `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at create time. |
+| `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at create time |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
+| `content_file` | `string` | No | (Optional) Absolute or relative filesystem path to read the page body from (UTF-8). Use this instead of 'content' when the body is too large to pass comfortably as a tool argument. Mutually exclusive with 'content'. |
+| `page_width` | `string` | No | (Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (Confluence default). |
+| `table_layout` | `string` | No | (Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'. |
 | `subtype` | `string` | No | (Optional) Confluence page subtype. Use 'live' to create a Confluence Live Doc. Only supported for Confluence Cloud. |
-| `page_width` | `string` | No | Page layout width. Options: 'full-width', 'default'. |
-| `table_layout` | `string` | No | Table width preset for Markdown tables. Options: 'full-width', 'wide', 'default'. |
 **Example:**
 
 ```json
@@ -60,9 +59,6 @@ Create a new Confluence page.
 <Tip>
 Use Markdown for content — it's auto-converted to Confluence storage format. Specify `parent_id` to create as a child page. Set `subtype` to `live` on Confluence Cloud to create a Live Doc.
 </Tip>
-
-<Note>Exactly one of `content` or `content_file` must be provided.</Note>
-
 
 ---
 
@@ -78,17 +74,17 @@ Update an existing Confluence page.
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | The ID of the page to update |
 | `title` | `string` | Yes | The new title of the page |
-| `content` | `string` | No* | The new content of the page. Format depends on content_format parameter |
-| `content_file` | `string` | No* | Absolute or relative filesystem path to read the new page body from (UTF-8). Mutually exclusive with `content`. |
+| `content` | `string` | No | The new content of the page. Format depends on content_format parameter and may be Markdown (default), wiki markup, storage format, or XHTML storage format. Either 'content' or 'content_file' must be provided, but not both. |
 | `is_minor_edit` | `boolean` | No | Whether this is a minor edit |
 | `version_comment` | `string` | No | Optional comment for this version |
 | `parent_id` | `string` | No | Optional the new parent page ID |
-| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' for Confluence XHTML storage format. Wiki format uses Confluence wiki markup syntax |
+| `content_format` | `string` | No | (Optional) The format of the content parameter. Options: 'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use 'xhtml' when providing Confluence XHTML storage format (same as 'storage'). Wiki format uses Confluence wiki markup syntax |
 | `enable_heading_anchors` | `boolean` | No | (Optional) Whether to enable automatic heading anchor generation. Only applies when content_format is 'markdown' |
-| `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at update time. |
+| `include_content` | `boolean` | No | (Optional) Whether to include page content in the response. Defaults to false since callers already have the content at update time |
 | `emoji` | `string` | No | (Optional) Page title emoji (icon shown in navigation). Can be any emoji character like '📝', '🚀', '📚'. Set to null/None to remove. |
-| `page_width` | `string` | No | Page layout width. Options: 'full-width', 'default'. Use an empty string to reset to default. |
-| `table_layout` | `string` | No | Table width preset for Markdown tables. Options: 'full-width', 'wide', 'default'. |
+| `content_file` | `string` | No | (Optional) Absolute or relative filesystem path to read the new page body from (UTF-8). Use this instead of 'content' when the body is too large to pass comfortably as a tool argument. Mutually exclusive with 'content'. |
+| `page_width` | `string` | No | (Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (preserve existing). |
+| `table_layout` | `string` | No | (Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'. |
 **Example:**
 
 ```json
@@ -98,43 +94,6 @@ Update an existing Confluence page.
 <Tip>
 Set `is_minor_edit: true` to skip notification emails. The page version is auto-incremented.
 </Tip>
-
-<Note>Exactly one of `content` or `content_file` must be provided.</Note>
-
-
----
-
-### Update Page Section
-
-Update a single section of a Confluence page without affecting the rest.
-
-<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `page_id` | `string` | Yes | The ID of the page to update |
-| `heading_text` | `string` | Yes | Exact text of the heading that starts the section to replace. Matching is case-sensitive. Use `confluence_get_page` with `convert_to_markdown=false` to inspect exact heading text when unsure. |
-| `new_content` | `string` | Yes | Replacement content for the section body. Do not include the heading itself — only the body beneath it. Format is controlled by `content_format`. |
-| `content_format` | `string` | No | Format of `new_content`. Options: `'markdown'` (default) or `'storage'` (raw Confluence storage XML). Use `'storage'` to insert macros or elements that markdown cannot express. |
-| `is_minor_edit` | `boolean` | No | Whether this is a minor edit |
-| `version_comment` | `string` | No | Optional comment for this version |
-
-**Example:**
-
-```json
-{"page_id": "12345678", "heading_text": "Weekly Update", "new_content": "- Shipped v2.1\n- Started v2.2 planning", "version_comment": "Weekly sync"}
-```
-
-<Tip>
-Use this instead of `confluence_update_page` when the page contains macros, layouts, task lists, or other Confluence-specific elements you don't want to lose. The tool fetches the page as raw storage XML, surgically replaces only the target section, and writes the full XML back — so everything outside the section is preserved exactly.
-</Tip>
-
-<Warning>
-`heading_text` must match the heading exactly as it appears in Confluence (case-sensitive, no surrounding emoji — emoji in headings are stripped automatically). If the heading is not found, a `ValueError` is raised.
-</Warning>
-
 
 ---
 
@@ -170,6 +129,19 @@ Get child pages and folders of a specific Confluence page.
 
 ---
 
+### Get Space Page Tree
+
+Get page hierarchy for a Confluence space as a flat list.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `space_key` | `string` | Yes | Space key |
+| `limit` | `integer` | No | Max pages to fetch |
+
+---
+
 ### Get Page History
 
 Get a historical version of a specific Confluence page.
@@ -184,6 +156,25 @@ Get a historical version of a specific Confluence page.
 
 ---
 
+### Update Page Section
+
+Update a single section of a Confluence page without affecting the rest.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `page_id` | `string` | Yes | The ID of the page to update |
+| `heading_text` | `string` | Yes | Exact text of the heading that starts the section to replace. Matching is case-sensitive. Use confluence_get_page with convert_to_markdown=false to inspect exact heading text when unsure. |
+| `new_content` | `string` | Yes | Replacement content for the section body. Do NOT include the heading itself — only the body beneath it. Format is controlled by content_format. |
+| `content_format` | `string` | No | (Optional) Format of new_content. Options: 'markdown' (default) or 'storage' (raw Confluence storage XML). Use 'storage' to insert macros or elements that markdown cannot express. |
+| `is_minor_edit` | `boolean` | No | Whether this is a minor edit |
+| `version_comment` | `string` | No | Optional comment for this version |
+
+---
+
 ### Move Page
 
 Move a Confluence page to a new parent or space.
@@ -195,24 +186,9 @@ Move a Confluence page to a new parent or space.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | ID of the page to move |
-| `target_parent_id` | `string` | No* | Target parent page ID. If omitted with `target_space_key`, moves to space root. |
-| `target_space_key` | `string` | No* | Target space key for cross-space moves |
+| `target_parent_id` | `string` | No | Target parent page ID. If omitted with target_space_key, moves to space root. |
+| `target_space_key` | `string` | No | Target space key for cross-space moves |
 | `position` | `string` | No | Position: 'append' (default, move as child of target), 'above' (move before target as sibling), or 'below' (move after target as sibling) |
-
-**Example:**
-
-```json
-{"page_id": "12345678", "target_parent_id": "98765432"}
-```
-
-<Warning>
-At least one of `target_parent_id` or `target_space_key` must be provided.
-</Warning>
-
-<Tip>
-Use `target_space_key` to move pages between spaces. Omit `target_parent_id` with a space key to move to the space root.
-</Tip>
-
 
 ---
 
@@ -227,16 +203,10 @@ Copy a Confluence page to a new location.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `source_page_id` | `string` | Yes | The ID of the page to copy |
-| `destination_space_key` | `string` | Yes | Space key for the new page |
-| `new_title` | `string` | Yes | Title for the copied page |
-| `destination_parent_id` | `string` | No | Parent page ID in the destination space. Omit to copy to the space root. |
-| `copy_attachments` | `boolean` | No | Whether to copy attachments. Supported on Confluence Cloud. |
-
-**Example:**
-
-```json
-{"source_page_id": "12345678", "destination_space_key": "DOCS", "new_title": "Copied Runbook", "destination_parent_id": "98765432"}
-```
+| `destination_space_key` | `string` | Yes | Space key for the new page (e.g. 'DEV', 'TEAM') |
+| `new_title` | `string` | Yes | Title for the new copied page |
+| `destination_parent_id` | `string` | No | (Optional) Parent page ID in the destination space. When omitted the page is created at the space root. |
+| `copy_attachments` | `boolean` | No | (Optional) Whether to copy attachments to the new page. Defaults to true. Only supported on Confluence Cloud. |
 
 ---
 
@@ -254,7 +224,7 @@ Get view and edit restrictions for a Confluence page.
 
 ### Set Page Restrictions
 
-Replace view and edit restrictions for a Confluence page.
+Set view and edit restrictions on a Confluence page.
 
 <Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 
@@ -263,16 +233,14 @@ Replace view and edit restrictions for a Confluence page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | The ID of the page to restrict |
-| `read_users` | `array` | No | Account IDs (Cloud) or usernames (Server/DC) allowed to view the page |
-| `read_groups` | `array` | No | Group names allowed to view the page |
-| `edit_users` | `array` | No | Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page |
-| `edit_groups` | `array` | No | Group names allowed to edit the page |
-
-<Warning>Omitting all restriction lists or passing empty lists removes all page restrictions.</Warning>
+| `read_users` | `array` | No | (Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to view the page. Empty list = unrestricted. |
+| `read_groups` | `array` | No | (Optional) Group names allowed to view the page. |
+| `edit_users` | `array` | No | (Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page. |
+| `edit_groups` | `array` | No | (Optional) Group names allowed to edit the page. |
 
 ---
 
-### Get Page Diff
+### Get Page Version Diff
 
 Get a unified diff between two versions of a Confluence page.
 
@@ -281,18 +249,7 @@ Get a unified diff between two versions of a Confluence page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | Confluence page ID (numeric ID, can be found in the page URL). For example, in 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', the page ID is '123456789'. |
-| `from_version` | `integer` | Yes | Source version number (>=1) |
-| `to_version` | `integer` | Yes | Target version number (>=1) |
-
-**Example:**
-
-```json
-{"page_id": "12345678", "from_version": 1, "to_version": 3}
-```
-
-<Tip>
-Use `confluence_get_page_history` to discover available version numbers. The diff is in unified format, showing additions and removals between versions.
-</Tip>
-
+| `from_version` | `integer` | Yes | Source version number |
+| `to_version` | `integer` | Yes | Target version number |
 
 ---

--- a/docs/tools/confluence-permissions.mdx
+++ b/docs/tools/confluence-permissions.mdx
@@ -3,43 +3,31 @@ title: "Confluence Permissions"
 description: "Inspect content and space permissions"
 ---
 
-<Note>These tools are only available for Confluence Cloud. Server/Data Center uses different permission APIs.</Note>
-
 ### Check Content Permissions
 
-Check whether a user or group can perform an operation on Confluence content.
+Check whether a user or group can perform an operation on specific content.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `content_id` | `string` | Yes | Confluence content ID, such as a page, blog post, comment, or attachment ID. |
-| `user_identifier` | `string` | Yes | Account ID for `subject_type="user"` or group ID for `subject_type="group"`. |
-| `operation` | `string` | Yes | Operation to check, such as `read`, `update`, or `delete`. |
-| `subject_type` | `string` | No | Subject type to check. Defaults to `user`; use `group` for group checks. |
-
-**Example:**
-
-```json
-{"content_id": "12345678", "user_identifier": "5b10a2844c20165700ede21g", "operation": "read"}
-```
+| `content_id` | `string` | Yes | Confluence content ID (page, blog post, comment, or attachment). Example: '123456789' |
+| `user_identifier` | `string` | Yes | Account ID of the user (for subject_type='user') or group ID (for subject_type='group'). Example user account ID: '5b10a2844c20165700ede21g' |
+| `operation` | `string` | Yes | The operation to check. Common values: 'read', 'update', 'delete', 'export', 'purge', 'administer', 'create_or_delete_from_view'. |
+| `subject_type` | `string` | No | Whether the subject is a 'user' or a 'group'. Defaults to 'user'. |
 
 ---
 
 ### Get Space Permissions
 
-List permission assignments for a Confluence space.
+List all permission assignments for a Confluence space.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `space_id` | `string` | Yes | Numeric Confluence space ID. This is the internal space ID, not the space key. |
+| `space_id` | `string` | Yes | Numeric ID of the Confluence space. This is the internal space ID, not the space key. Example: '98304'. You can find the space ID from the Confluence REST API (GET /wiki/api/v2/spaces) or from the space URL. |
 | `limit` | `integer` | No | Maximum number of permission entries to return. Defaults to 25. |
-| `cursor` | `string` | No | Pagination cursor from a previous response. |
+| `cursor` | `string` | No | Optional pagination cursor from a previous response. |
 
-**Example:**
-
-```json
-{"space_id": "98304", "limit": 50}
-```
+---

--- a/docs/tools/confluence-search.mdx
+++ b/docs/tools/confluence-search.mdx
@@ -24,17 +24,15 @@ Search Confluence content using simple terms or CQL.
 Supports both CQL queries and simple text search. Simple text uses `siteSearch` by default with automatic fallback to `text` search.
 </Tip>
 
-
 <Warning>
 CQL syntax may differ slightly between Cloud and Server/DC. Personal spaces use `space="~username"` (quoted).
 </Warning>
-
 
 ---
 
 ### Search User
 
-Search Confluence users using CQL.
+Search Confluence users using CQL (Cloud) or group member API (Server/DC).
 
 **Parameters:**
 
@@ -43,9 +41,5 @@ Search Confluence users using CQL.
 | `query` | `string` | Yes | Search query - a CQL query string for user search. Examples of CQL: - Basic user lookup by full name: 'user.fullname ~ "First Last"' Note: Special identifiers need proper quoting in CQL: personal space keys (e.g., "~username"), reserved words, numeric IDs, and identifiers with special characters. |
 | `limit` | `integer` | No | Maximum number of results (1-50) |
 | `group_name` | `string` | No | Group to search within on Server/DC instances (default: 'confluence-users'). Ignored on Cloud. |
-
-<Tip>
-On Server/DC, user search falls back to group member enumeration. Use `group_name` to search within a specific group if the default 'confluence-users' doesn't include all users.
-</Tip>
 
 ---

--- a/docs/tools/confluence-templates.mdx
+++ b/docs/tools/confluence-templates.mdx
@@ -3,8 +3,6 @@ title: "Confluence Templates"
 description: "List page templates and create pages from them"
 ---
 
-<Note>These tools are only available for Confluence Cloud. Server/Data Center does not expose the template REST API.</Note>
-
 ### List Page Templates
 
 List Confluence page content templates.
@@ -20,7 +18,7 @@ List Confluence page content templates.
 
 ### Get Page Template
 
-Get a Confluence page template by ID, including its storage-format body.
+Get a Cloud page template by ID, including its storage-format body.
 
 **Parameters:**
 
@@ -32,7 +30,7 @@ Get a Confluence page template by ID, including its storage-format body.
 
 ### Create Page from Template
 
-Create a new Confluence page pre-populated with a template's body.
+Create a new Cloud page pre-populated with a template's body.
 
 <Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 

--- a/docs/tools/jira-agile.mdx
+++ b/docs/tools/jira-agile.mdx
@@ -26,7 +26,6 @@ Get jira agile boards by name, project key, or type.
 Supports fuzzy search by board name. Combine with `project_key` to narrow results.
 </Tip>
 
-
 ---
 
 ### Get Board Issues
@@ -83,7 +82,6 @@ Get jira issues from sprint.
 Get the sprint ID from `jira_get_sprints_from_board` first.
 </Tip>
 
-
 ---
 
 ### Create Sprint
@@ -136,15 +134,18 @@ Add issues to a Jira sprint.
 | `sprint_id` | `string` | Yes | Sprint ID to add issues to |
 | `issue_keys` | `string` | Yes | Comma-separated issue keys (e.g., 'PROJ-1,PROJ-2') |
 
-**Example:**
+---
 
-```json
-{"sprint_id": "42", "issue_keys": "PROJ-1,PROJ-2,PROJ-3"}
-```
+### Move Issues to Backlog
 
-<Tip>
-Get sprint IDs from `jira_get_sprints_from_board`. Issue keys are validated server-side — invalid keys will cause an error.
-</Tip>
+Move issues to the backlog, removing them from any sprint.
 
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_keys` | `string` | Yes | Comma-separated issue keys (e.g., 'PROJ-1,PROJ-2') |
 
 ---

--- a/docs/tools/jira-attachments.mdx
+++ b/docs/tools/jira-attachments.mdx
@@ -22,7 +22,6 @@ Download attachments from a Jira issue.
 Downloads all attachments from the issue. Files larger than 50MB are skipped. Returns base64-encoded content.
 </Tip>
 
-
 ---
 
 ### Get Issue Images

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -15,7 +15,8 @@ Add a comment to a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `body` | `string` | Yes | Comment text in Markdown format |
-| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
+| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
+| `public` | `boolean` | No | (Optional) For JSM/Service Desk issues only. Set to true for customer-visible comment, false for internal agent-only comment. Posted via the ServiceDesk API as a raw string; Jira Cloud renders it server-side and stores ADF (markdown observed to render on Cloud, without the client-side markdown-to-ADF guarantees of the regular comment path). Cannot be combined with visibility. If the issue's project is listed in JIRA_INTERNAL_ONLY_PROJECTS, only public=false is accepted — public=true or omitting this field is rejected. |
 **Example:**
 
 ```json
@@ -23,12 +24,8 @@ Add a comment to a Jira issue.
 ```
 
 <Tip>
-Supports Markdown formatting. On Jira Cloud, mention users with
-`[~accountid:ACCOUNT_ID]` or `@[Display Name](accountid:ACCOUNT_ID)`.
-Use `visibility` parameter for restricted comments (e.g., service desk
-internal notes).
+Supports Markdown formatting. Use `visibility` parameter for restricted comments (e.g., service desk internal notes).
 </Tip>
-
 
 ---
 
@@ -45,7 +42,7 @@ Edit an existing comment on a Jira issue.
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `comment_id` | `string` | Yes | The ID of the comment to edit |
 | `body` | `string` | Yes | Updated comment text in Markdown format |
-| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
+| `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
 
 ---
 
@@ -101,11 +98,9 @@ Get changelogs for multiple Jira issues (Cloud only).
 Efficient for tracking field changes across multiple issues at once. Returns change history for each issue.
 </Tip>
 
-
 <Warning>
 Only available on Jira Cloud.
 </Warning>
-
 
 ---
 
@@ -118,5 +113,63 @@ Retrieve profile information for a specific Jira user.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `user_identifier` | `string` | Yes | Identifier for the user (e.g., email address 'user@example.com', username 'johndoe', account ID 'accountid:...', or key for Server/DC). |
+
+---
+
+### Search Assignable Users
+
+Search Jira users assignable in a given project or issue.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | `string` | Yes | Free-form text to search Jira users by: display name, username, or email substring (e.g. 'Smith', 'jane.doe', 'doe@example.com'). Server-side match is case-insensitive and partial. |
+| `project_key` | `string` | No | Project key to scope the search to (e.g. 'DT'). Required if issue_key is not given. |
+| `issue_key` | `string` | No | Issue key to scope the search to (e.g. 'DT-779'). Required if project_key is not given. |
+| `limit` | `integer` | No | Maximum number of users to return (default 20). |
+
+---
+
+### Get Issue Watchers
+
+Get the list of watchers for a Jira issue.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123') |
+
+---
+
+### Add Issue Watcher
+
+Add a user as a watcher to a Jira issue.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123') |
+| `user_identifier` | `string` | Yes | User to add as watcher. For Jira Cloud, use the account ID. For Jira Server/DC, use the username. |
+
+---
+
+### Remove Issue Watcher
+
+Remove a user from watching a Jira issue.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123') |
+| `username` | `string` | No | Username to remove (for Jira Server/DC). |
+| `account_id` | `string` | No | Account ID to remove (for Jira Cloud). |
 
 ---

--- a/docs/tools/jira-forms-metrics.mdx
+++ b/docs/tools/jira-forms-metrics.mdx
@@ -80,7 +80,6 @@ Calculate SLA metrics for a Jira issue.
 Configure SLA calculation via `JIRA_SLA_*` environment variables. Set `JIRA_SLA_WORKING_HOURS_ONLY=true` for business hours only.
 </Tip>
 
-
 ---
 
 ### Get Issue Development Info
@@ -92,7 +91,7 @@ Get development information (PRs, commits, branches) linked to a Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123') |
-| `application_type` | `string` | No | (Optional) Case-sensitive application type. Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'githube' (GitHub Enterprise Server), 'GitLab'. If omitted, available types are discovered automatically. |
+| `application_type` | `string` | No | (Optional) Filter by application type (case-sensitive). Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'githube' (GitHub Enterprise Server), 'GitLab'. If omitted, types are discovered automatically. |
 | `data_type` | `string` | No | (Optional) Filter by data type. Examples: 'pullrequest', 'branch', 'repository' |
 
 ---
@@ -106,7 +105,7 @@ Get development information for multiple Jira issues.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_keys` | `string` | Yes | Comma-separated list of Jira issue keys (e.g., 'PROJ-123,PROJ-456') |
-| `application_type` | `string` | No | (Optional) Case-sensitive application type. Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'githube' (GitHub Enterprise Server), 'GitLab'. If omitted, available types are discovered automatically. |
+| `application_type` | `string` | No | (Optional) Filter by application type (case-sensitive). Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'githube' (GitHub Enterprise Server), 'GitLab'. If omitted, types are discovered automatically. |
 | `data_type` | `string` | No | (Optional) Filter by data type. Examples: 'pullrequest', 'branch', 'repository' |
 
 ---

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Jira Issues"
-description: "Create, read, update, move, delete, and transition Jira issues"
+description: "Create, read, update, delete, and transition Jira issues"
 ---
 
 ### Get Issue
 
-Get details of a specific Jira issue including its Epic links and relationship information.
+Get details of a specific Jira issue.
 
 **Parameters:**
 
@@ -17,28 +17,21 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
-| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response. Supported values: `all`, `remote_links`, `transitions`, `watchers`, `changelog`, `comments`, `worklogs`. |
-| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
+| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response, avoiding extra tool calls. Supported: all, remote_links, transitions, watchers, changelog, comments, worklogs |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The 'names' expansion is added automatically. Standard fields are unaffected. |
 **Example:**
 
 ```json
-{"issue_key": "PROJ-123", "fields": "summary,status,assignee", "comment_limit": 5, "include": "remote_links,transitions"}
+{"issue_key": "PROJ-123", "fields": "summary,status,assignee", "comment_limit": 5}
 ```
 
 <Tip>
-Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content. Use `include: "all"` to inline common enrichments that otherwise require separate tool calls.
+Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
 </Tip>
-
-<Tip>
-Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
-If a display name conflicts with another output key, that custom field keeps its raw ID so no value is lost.
-</Tip>
-
 
 <Warning>
 Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
 </Warning>
-
 
 ---
 
@@ -56,9 +49,9 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 | `summary` | `string` | Yes | Summary/title of the issue |
 | `issue_type` | `string` | Yes | Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). The available types depend on your project configuration. For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields. |
 | `assignee` | `string` | No | (Optional) Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...') |
-| `description` | `string` | No | Issue description in Markdown format. On Jira Cloud, use `{expand:Title}...{expand}` for a collapsible section. |
+| `description` | `string` | No | Issue description in Markdown format. On Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API') |
-| `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: `{"priority": {"name": "High"}}` - Add labels: `{"labels": ["frontend", "urgent"]}` - Link to parent (for any issue type): `{"parent": "PROJ-123"}` - Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}` - Set Fix Version/s: `{"fixVersions": [{"id": "10020"}]}` - Custom fields: `{"customfield_10010": "value"}` |
+| `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: `{"priority": {"name": "High"}`} - Add labels: `{"labels": ["frontend", "urgent"]}` - Link to parent (for any issue type): `{"parent": "PROJ-123"}` - Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}` - Set Fix Version/s: `{"fixVersions": [{"id": "10020"}]`} - Custom fields: `{"customfield_10010": "value"}` |
 **Example:**
 
 ```json
@@ -66,19 +59,12 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 ```
 
 <Tip>
-Use Markdown in the description - it's automatically converted to ADF (Cloud)
-or wiki markup (Server/DC). On Jira Cloud, mention users with
-`[~accountid:ACCOUNT_ID]` or `@[Display Name](accountid:ACCOUNT_ID)`.
-Use `{expand:Title}` and `{expand}` around content to create a collapsible
-section on Jira Cloud.
-For epics, provide `epic_name` parameter.
+Use Markdown in the description — it's automatically converted to ADF (Cloud) or wiki markup (Server/DC). For epics, provide `epic_name` parameter.
 </Tip>
-
 
 <Warning>
 Cloud uses ADF format internally (auto-converted from Markdown). Server/DC uses wiki markup.
 </Warning>
-
 
 ---
 
@@ -93,11 +79,11 @@ Update an existing Jira issue including changing status, adding Epic links, upda
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format; on Jira Cloud, use `{expand:Title}...{expand}` for a collapsible section. Example: `'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}'` |
+| `fields` | `string` | Yes | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format; on Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. Example: '`{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}`' |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}`. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names (e.g., 'Frontend,API') |
 | `attachments` | `string` | No | (Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt'] |
-| `return_fields` | `string` | No | (Optional) Controls which fields of the updated issue are returned, to reduce response size and token usage. Defaults to `*all` (the complete issue). To save tokens, pass a comma-separated list of just the field(s) you care about (e.g., 'summary,duedate'), or a single light field for a minimal confirmation. The issue 'key' is always returned regardless. |
+| `return_fields` | `string` | No | (Optional) Controls which fields of the updated issue are returned, to reduce response size and token usage. Defaults to '*all' (the complete issue, which can be very large). TOKEN-SAVING TIP: after an update you usually do NOT need the whole issue back. Pass a comma-separated list of just the field(s) you care about (e.g., 'summary,duedate'), or a single light field such as 'status' for a minimal confirmation - this can cut the response by thousands of tokens. The issue 'key' is always returned regardless. If you later need other fields, fetch them on demand with jira_get_issue (which also supports field filtering). Use '*all' only when you genuinely need the full updated issue. |
 **Example:**
 
 ```json
@@ -105,14 +91,8 @@ Update an existing Jira issue including changing status, adding Epic links, upda
 ```
 
 <Tip>
-Save response tokens: after an update you rarely need the whole issue back. Set `return_fields` to only the field(s) you changed (e.g., `return_fields: "duedate"`) — this can cut thousands of tokens. Use `*all` only when you need the full updated issue.
-</Tip>
-
-
-<Tip>
 Use `additional_fields` as a JSON string for any field not covered by explicit parameters. Find field IDs with `jira_search_fields`.
 </Tip>
-
 
 ---
 
@@ -130,28 +110,33 @@ Delete an existing Jira issue.
 
 ---
 
-### Move Issue
+### Assign Issue
 
-Move a Jira Cloud issue to a different project.
+Assign a Jira issue to a user using the dedicated assignment endpoint.
 
 <Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 
-<Warning>
-This tool is only available for Jira Cloud. The target project must support the issue's current type. Jira may assign a new issue key in the target project.
-</Warning>
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
+| `assignee` | `string` | No | User identifier to assign (email, display name, or account ID), or a JSON object string from jira_search_assignable_users. Pass null or empty string to unassign the issue. |
+
+---
+
+### Move Issue to Project
+
+Move a Jira issue to a different project (Jira Cloud only).
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key to move (e.g., 'PROJ-123') |
-| `target_project_key` | `string` | Yes | Target project key (e.g., 'OTHERPROJ') |
-
-**Example:**
-
-```json
-{"issue_key": "PROJ-123", "target_project_key": "OTHERPROJ"}
-```
+| `target_project_key` | `string` | Yes | Key of the target project (e.g., 'OTHERPROJ'). The issue will keep its current issue type and may receive a new key in the target project. |
 
 ---
 
@@ -165,7 +150,7 @@ Create multiple Jira issues in a batch.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: `[{"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}, {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}]` |
+| `issues` | `string` | Yes | JSON array of issue objects. Each object should contain: - project_key (required): The project key (e.g., 'PROJ') - summary (required): Issue summary/title - issue_type (required): Type of issue (e.g., 'Task', 'Bug') - description (optional): Issue description in Markdown format - assignee (optional): Assignee username or email - components (optional): Array of component names Example: [ `{"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"}`, `{"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}` ] |
 | `validate_only` | `boolean` | No | If true, only validates the issues without creating them |
 
 ---
@@ -182,8 +167,8 @@ Transition a Jira issue to a new status.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `transition_id` | `string` | Yes | ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31' |
-| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: `'{"resolution": {"name": "Fixed"}}'` |
-| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. |
+| `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '`{"resolution": {"name": "Fixed"}`}' |
+| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be customer-visible on JSM and cannot be forced internal): transition without a comment, then post an internal note with jira_add_comment(public=false). |
 **Example:**
 
 ```json
@@ -193,7 +178,6 @@ Transition a Jira issue to a new status.
 <Tip>
 Use `jira_get_transitions` first to see available transitions for the current issue state.
 </Tip>
-
 
 ---
 

--- a/docs/tools/jira-links-versions.mdx
+++ b/docs/tools/jira-links-versions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jira Links & Versions"
-description: "Issue links, epic links, remote links, project versions, and components"
+description: "Issue links, epic links, remote links, versions, components, and cross-project and epic hierarchy analysis"
 ---
 
 ### Get Link Types
@@ -28,8 +28,8 @@ Create a link between two Jira issues.
 | `link_type` | `string` | Yes | The type of link to create (e.g., 'Duplicate', 'Blocks', 'Relates to') |
 | `inward_issue_key` | `string` | Yes | The key of the inward issue (e.g., 'PROJ-123', 'ACV2-642') |
 | `outward_issue_key` | `string` | Yes | The key of the outward issue (e.g., 'PROJ-456') |
-| `comment` | `string` | No | (Optional) Comment to add to the link |
-| `comment_visibility` | `string` | No | (Optional) Visibility settings for the comment as JSON string (e.g. `'{"type":"group","value":"jira-users"}'`) |
+| `comment` | `string` | No | (Optional) Comment to add to the link. Rejected when either linked issue belongs to a project listed in JIRA_INTERNAL_ONLY_PROJECTS (a link comment may be customer-visible on JSM and cannot be forced internal): create the link without a comment, then post an internal note with jira_add_comment(public=false) on the relevant issue. |
+| `comment_visibility` | `string` | No | (Optional) Visibility settings for the comment as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
 
 ---
 
@@ -134,7 +134,7 @@ Batch create multiple versions in a Jira project.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `project_key` | `string` | Yes | Jira project key (e.g., 'PROJ', 'ACV2') |
-| `versions` | `string` | Yes | JSON array of version objects. Each object should contain: - name (required): Name of the version - startDate (optional): Start date (YYYY-MM-DD) - releaseDate (optional): Release date (YYYY-MM-DD) - description (optional): Description of the version Example: `[{"name": "v1.0", "startDate": "2025-01-01", "releaseDate": "2025-02-01", "description": "First release"}, {"name": "v2.0"}]` |
+| `versions` | `string` | Yes | JSON array of version objects. Each object should contain: - name (required): Name of the version - startDate (optional): Start date (YYYY-MM-DD) - releaseDate (optional): Release date (YYYY-MM-DD) - description (optional): Description of the version Example: [ `{"name": "v1.0", "startDate": "2025-01-01", "releaseDate": "2025-02-01", "description": "First release"}`, `{"name": "v2.0"}` ] |
 
 ---
 
@@ -148,12 +148,38 @@ Update an existing fix version in a Jira project.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `version_id` | `string` | Yes | Numeric ID of the version to update (e.g., '10001') |
+| `version_id` | `string` | Yes | Numeric ID of the version to update (e.g. '10001') |
 | `name` | `string` | No | New name for the version |
 | `description` | `string` | No | New description for the version |
 | `start_date` | `string` | No | New start date (YYYY-MM-DD) |
 | `release_date` | `string` | No | New release date (YYYY-MM-DD) |
 | `archived` | `boolean` | No | Set archived flag (true to archive) |
 | `released` | `boolean` | No | Set released flag (true to mark released) |
+
+---
+
+### Get Project Epic Hierarchy
+
+Group a project's epics under their cross-project parent issues.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_key` | `string` | Yes | Jira project key (e.g., 'PROJ') |
+| `max_epics` | `integer` | No | Maximum number of epics to fetch (1-500) |
+
+---
+
+### Get Cross-Project Dependencies
+
+Find all cross-project issue links for a project.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_key` | `string` | Yes | Jira project key (e.g., 'PROJ') |
+| `max_issues` | `integer` | No | Maximum issues to scan for links (1-500) |
 
 ---

--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -17,8 +17,8 @@ Search Jira issues using JQL (Jira Query Language).
 | `start_at` | `integer` | No | Starting index for pagination (0-based) |
 | `projects_filter` | `string` | No | (Optional) Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided. |
 | `expand` | `string` | No | (Optional) fields to expand. Examples: 'renderedFields', 'transitions', 'changelog' |
-| `page_token` | `string` | No | Pagination token from a previous search result. Cloud only — Server/DC uses `start_at` for pagination. |
-| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
+| `page_token` | `string` | No | (Optional) Pagination token from a previous search result. Cloud only — Server/DC uses start_at for pagination. |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The 'names' expansion is added automatically. Standard fields are unaffected. |
 **Example:**
 
 ```json
@@ -29,20 +29,9 @@ Search Jira issues using JQL (Jira Query Language).
 Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
 </Tip>
 
-<Tip>
-Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
-If a display name conflicts with another output key, that custom field keeps its raw ID so no value is lost.
-</Tip>
-
-
 <Warning>
 Some JQL functions (e.g., `issueHistory()`) are Cloud-only.
 </Warning>
-
-<Tip>
-Cloud supports cursor-based pagination via `page_token` for deterministic results across large datasets. The token is returned in the `next_page_token` field of search results.
-</Tip>
-
 
 ---
 
@@ -67,7 +56,6 @@ Search Jira fields by keyword with fuzzy match.
 Use this to discover custom field IDs before using them in `jira_create_issue` or `jira_update_issue`.
 </Tip>
 
-
 ---
 
 ### Get Field Options
@@ -86,57 +74,55 @@ Get allowed option values for a custom field.
 | `return_limit` | `integer` | No | Maximum number of results to return (applied after filtering). |
 | `values_only` | `boolean` | No | If true, return only value strings in a compact JSON format instead of full option objects. |
 
-**Example:**
-
-```json
-{"field_id": "customfield_10001", "contains": "high", "return_limit": 5, "values_only": true}
-```
-
-<Tip>
-Use `contains` to filter large option lists (e.g., hundreds of values). Combine with `values_only: true` for a compact response.
-</Tip>
-
 ---
 
 ### Get Project Issue Types
 
-List the issue types that can be created in a Jira project.
+Get available issue types for a Jira project.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `project_key` | `string` | Yes | Jira project key (for example, `PROJ`) |
-
-The response includes each type's ID, name, description, subtask flag, and
-untranslated name when Jira provides one.
-
-**Example:**
-
-```json
-{"project_key": "PROJ"}
-```
+| `project_key` | `string` | Yes | Jira project key (e.g., 'PROJ', 'JTEST') |
 
 ---
 
 ### Get Create Fields
 
-List the fields available when creating one issue type in a Jira project.
+Get fields available for creating an issue of a specific type.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `project_key` | `string` | Yes | Jira project key (for example, `PROJ`) |
-| `issue_type_id` | `string` | Yes | Issue type ID returned by `jira_get_project_issue_types` |
+| `project_key` | `string` | Yes | Jira project key (e.g., 'PROJ', 'JTEST') |
+| `issue_type_id` | `string` | Yes | The issue type ID (from get_project_issue_types). Example: '10002' for Task. |
 
-Each field includes its ID, name, required flag, and schema. Use
-`jira_get_field_options` to retrieve allowed values for a field.
+---
 
-**Example:**
+### Get Project Fields
 
-```json
-{"project_key": "PROJ", "issue_type_id": "10002"}
-```
+Get the fields available on issues of a project (the create schema),
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project_key` | `string` | Yes | The project key, e.g. 'PROJ'. |
+
+---
+
+### Search Projects
+
+Search for Jira projects by name or key prefix.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | `string` | Yes | Name or key prefix to search for |
+| `max_results` | `integer` | No | Maximum number of results to return |
+| `current_project_ids` | `string` | No | Comma-separated list of project IDs to exclude from results |
 
 ---

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -6,16 +6,17 @@ tool metadata, then renders per-category MDX pages via a Jinja2 template.
 
 Usage:
     python scripts/generate_tool_docs.py           # generate docs/tools/*.mdx
-    python scripts/generate_tool_docs.py --check   # verify all tools are mapped
+    python scripts/generate_tool_docs.py --check   # verify mappings and counts
 
 CI usage:
-    python scripts/generate_tool_docs.py --check   # exits 1 if any tool is undocumented
+    python scripts/generate_tool_docs.py --check   # exits 1 on mapping/count drift
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -84,6 +85,8 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
         "jira_create_version",
         "jira_batch_create_versions",
         "jira_update_version",
+        "jira_get_project_epic_hierarchy",
+        "jira_get_cross_project_dependencies",
     ],
     "jira-attachments": [
         "jira_download_attachments",
@@ -175,7 +178,8 @@ CATEGORY_META: dict[str, dict[str, str]] = {
     "jira-links-versions": {
         "title": "Jira Links & Versions",
         "description": (
-            "Issue links, epic links, remote links, versions, and components"
+            "Issue links, epic links, remote links, versions, components, and "
+            "cross-project and epic hierarchy analysis"
         ),
     },
     "jira-attachments": {
@@ -261,6 +265,29 @@ class ToolDoc:
     is_write: bool
     parameters: list[ToolParam] = field(default_factory=list)
     override: ToolOverride | None = None
+
+
+@dataclass(frozen=True)
+class ToolCounts:
+    """Registered tool and toolset counts used in generated documentation."""
+
+    total_tools: int
+    jira_tools: int
+    confluence_tools: int
+    core_tools: int
+    total_toolsets: int
+    jira_toolsets: int
+    confluence_toolsets: int
+    core_toolsets: int
+
+
+@dataclass
+class ToolsetDoc:
+    """A registered toolset and its introspected tools."""
+
+    name: str
+    core: bool
+    tools: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +453,58 @@ def build_tool_docs(
     return category_docs
 
 
+def get_tool_counts(tools: dict[str, dict[str, Any]]) -> ToolCounts:
+    """Calculate tool and toolset counts from their live registries."""
+    from mcp_atlassian.utils.toolsets import (
+        ALL_TOOLSETS,
+        CONFLUENCE_TOOLSETS,
+        DEFAULT_TOOLSETS,
+        JIRA_TOOLSETS,
+        get_toolset_tag,
+    )
+
+    return ToolCounts(
+        total_tools=len(tools),
+        jira_tools=sum(name.startswith("jira_") for name in tools),
+        confluence_tools=sum(name.startswith("confluence_") for name in tools),
+        core_tools=sum(
+            get_toolset_tag(info["tags"]) in DEFAULT_TOOLSETS for info in tools.values()
+        ),
+        total_toolsets=len(ALL_TOOLSETS),
+        jira_toolsets=len(JIRA_TOOLSETS),
+        confluence_toolsets=len(CONFLUENCE_TOOLSETS),
+        core_toolsets=len(DEFAULT_TOOLSETS),
+    )
+
+
+def build_toolset_docs(
+    tools: dict[str, dict[str, Any]],
+) -> dict[str, list[ToolsetDoc]]:
+    """Group introspected tools by the registered toolset definitions."""
+    from mcp_atlassian.utils.toolsets import (
+        CONFLUENCE_TOOLSETS,
+        DEFAULT_TOOLSETS,
+        JIRA_TOOLSETS,
+        get_toolset_tag,
+    )
+
+    toolsets_by_name = {
+        name: ToolsetDoc(name=name, core=name in DEFAULT_TOOLSETS)
+        for name in [*JIRA_TOOLSETS, *CONFLUENCE_TOOLSETS]
+    }
+    for tool_name, info in tools.items():
+        toolset_name = get_toolset_tag(info["tags"])
+        if toolset_name not in toolsets_by_name:
+            message = f"Tool '{tool_name}' references unknown toolset '{toolset_name}'"
+            raise ValueError(message)
+        toolsets_by_name[toolset_name].tools.append(tool_name)
+
+    return {
+        "jira": [toolsets_by_name[name] for name in JIRA_TOOLSETS],
+        "confluence": [toolsets_by_name[name] for name in CONFLUENCE_TOOLSETS],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Page generation
 # ---------------------------------------------------------------------------
@@ -439,8 +518,6 @@ def _escape_mdx_in_table(text: str) -> str:
     fails to build the page. This wraps brace-containing segments in backticks
     so they render as inline code instead of being parsed as JSX.
     """
-    import re
-
     if not text or "{" not in text:
         return text
     # Wrap JSON-like brace groups (including nested) in backticks.
@@ -454,10 +531,13 @@ def _escape_mdx_in_table(text: str) -> str:
 
 def generate_pages(
     category_docs: dict[str, list[ToolDoc]],
+    toolset_docs: dict[str, list[ToolsetDoc]],
+    counts: ToolCounts,
     template_dir: Path,
     output_dir: Path,
+    reference_output: Path,
 ) -> None:
-    """Render MDX pages from tool docs and Jinja2 template."""
+    """Render category and tools-reference MDX pages from Jinja2 templates."""
     env = Environment(  # noqa: S701 — MDX output, not HTML; autoescape not needed
         loader=FileSystemLoader(str(template_dir)),
         keep_trailing_newline=True,
@@ -466,19 +546,24 @@ def generate_pages(
     )
     env.filters["escape_pipe"] = lambda s: s.replace("|", "\\|") if s else s
     env.filters["escape_mdx"] = _escape_mdx_in_table
-    template = env.get_template("tool_category.mdx.j2")
+    category_template = env.get_template("tool_category.mdx.j2")
+    reference_template = env.get_template("tools_reference.mdx.j2")
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
     for cat, tool_docs in category_docs.items():
         meta = CATEGORY_META[cat]
-        rendered = template.render(
+        rendered = category_template.render(
             category=meta,
             tools=tool_docs,
         )
         out_path = output_dir / f"{cat}.mdx"
         out_path.write_text(rendered)
         print(f"  wrote {out_path}")
+
+    rendered = reference_template.render(toolsets=toolset_docs, counts=counts)
+    reference_output.write_text(rendered)
+    print(f"  wrote {reference_output}")
 
 
 # ---------------------------------------------------------------------------
@@ -525,6 +610,72 @@ def check_coverage(tools: dict[str, dict[str, Any]]) -> bool:
     return ok
 
 
+COUNT_FILES = (
+    "README.md",
+    ".env.example",
+    "docs.json",
+    "docs/tools-reference.mdx",
+    "docs/configuration.mdx",
+)
+TOOL_COUNT_PATTERN = re.compile(r"~?(\d+)\s+(?:MCP\s+)?tools?\b", re.IGNORECASE)
+TOOLSET_COUNT_PATTERNS = (
+    re.compile(r"(\d+)\s+(?:core\s+)?toolsets?\b", re.IGNORECASE),
+    re.compile(r"\b(?:Jira|Confluence)\s+Toolsets\s+\((\d+)\)", re.IGNORECASE),
+)
+
+
+def _format_expected(values: set[int]) -> str:
+    """Format expected count values for a deterministic error message."""
+    return "{" + ", ".join(str(value) for value in sorted(values)) + "}"
+
+
+def check_counts(tools: dict[str, dict[str, Any]]) -> bool:
+    """Verify documented tool and toolset counts match live registries."""
+    counts = get_tool_counts(tools)
+    allowed_tools = {
+        counts.total_tools,
+        counts.jira_tools,
+        counts.confluence_tools,
+        counts.core_tools,
+    }
+    allowed_toolsets = {
+        counts.total_toolsets,
+        counts.jira_toolsets,
+        counts.confluence_toolsets,
+        counts.core_toolsets,
+    }
+
+    ok = True
+    for relative_path in COUNT_FILES:
+        path = ROOT / relative_path
+        for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+            matches = [
+                (match, allowed_tools) for match in TOOL_COUNT_PATTERN.finditer(line)
+            ]
+            matches.extend(
+                (match, allowed_toolsets)
+                for pattern in TOOLSET_COUNT_PATTERNS
+                for match in pattern.finditer(line)
+            )
+            for match, allowed in matches:
+                found = int(match.group(1))
+                if found not in allowed:
+                    print(
+                        f"{relative_path}:{line_number}: found {found}, "
+                        f"expected one of {_format_expected(allowed)}",
+                        file=sys.stderr,
+                    )
+                    ok = False
+
+    if ok:
+        print(
+            "OK: documented tool and toolset counts match the live registries "
+            f"({counts.total_tools} tools, {counts.total_toolsets} toolsets)."
+        )
+
+    return ok
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -533,6 +684,7 @@ ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 OUTPUT_DIR = ROOT / "docs" / "tools"
 OVERRIDES_DIR = ROOT / "docs" / "_overrides"
+REFERENCE_OUTPUT = ROOT / "docs" / "tools-reference.mdx"
 
 
 def main() -> None:
@@ -543,21 +695,35 @@ def main() -> None:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Verify all tools are mapped (no files written).",
+        help="Verify tool mappings and documented counts (no files written).",
     )
     args = parser.parse_args()
 
     tools = asyncio.run(get_all_tools())
 
     if args.check:
-        sys.exit(0 if check_coverage(tools) else 1)
+        coverage_ok = check_coverage(tools)
+        counts_ok = check_counts(tools)
+        sys.exit(0 if coverage_ok and counts_ok else 1)
 
     overrides = load_overrides(OVERRIDES_DIR)
     category_docs = build_tool_docs(tools, overrides)
+    toolset_docs = build_toolset_docs(tools)
+    counts = get_tool_counts(tools)
 
     total = sum(len(docs) for docs in category_docs.values())
-    print(f"Generating {len(category_docs)} pages for {total} tools...")
-    generate_pages(category_docs, TEMPLATE_DIR, OUTPUT_DIR)
+    print(
+        f"Generating {len(category_docs)} category pages and tools reference "
+        f"for {total} tools..."
+    )
+    generate_pages(
+        category_docs,
+        toolset_docs,
+        counts,
+        TEMPLATE_DIR,
+        OUTPUT_DIR,
+        REFERENCE_OUTPUT,
+    )
     print("Done.")
 
 

--- a/scripts/templates/tools_reference.mdx.j2
+++ b/scripts/templates/tools_reference.mdx.j2
@@ -1,0 +1,114 @@
+---
+title: "Tools Reference"
+description: "Overview of all {{ counts.total_tools }} MCP tools for Jira and Confluence — organized by category with quick links"
+---
+
+MCP Atlassian provides **{{ counts.total_tools }} tools** for interacting with Jira and Confluence. Tools are organized by category below.
+
+## Jira Tools
+
+<CardGroup cols={2}>
+  <Card title="Issues" icon="ticket" href="/docs/tools/jira-issues">
+    Create, read, update, delete, and transition issues
+  </Card>
+  <Card title="Search & Fields" icon="magnifying-glass" href="/docs/tools/jira-search-fields">
+    Search with JQL, explore fields and options
+  </Card>
+  <Card title="Agile" icon="chart-kanban" href="/docs/tools/jira-agile">
+    Boards, sprints, and agile management
+  </Card>
+  <Card title="Comments & Worklogs" icon="comment" href="/docs/tools/jira-comments-worklogs">
+    Comments, worklogs, changelogs, user profiles
+  </Card>
+  <Card title="Links & Versions" icon="link" href="/docs/tools/jira-links-versions">
+    Issue links, epic links, versions, components
+  </Card>
+  <Card title="Attachments" icon="paperclip" href="/docs/tools/jira-attachments">
+    Download attachments and render images
+  </Card>
+  <Card title="Service Desk" icon="headset" href="/docs/tools/jira-service-desk">
+    Customer requests, service desks, and queues
+  </Card>
+  <Card title="Forms & Metrics" icon="chart-line" href="/docs/tools/jira-forms-metrics">
+    ProForma forms, SLA, dates, development info
+  </Card>
+</CardGroup>
+
+## Confluence Tools
+
+<CardGroup cols={2}>
+  <Card title="Pages" icon="file-lines" href="/docs/tools/confluence-pages">
+    Create, read, update, delete pages
+  </Card>
+  <Card title="Search" icon="magnifying-glass" href="/docs/tools/confluence-search">
+    Search content with CQL, find users
+  </Card>
+  <Card title="Attachments" icon="paperclip" href="/docs/tools/confluence-attachments">
+    Upload, download, manage attachments
+  </Card>
+  <Card title="Comments & Labels" icon="tag" href="/docs/tools/confluence-comments">
+    Comments, labels, page analytics
+  </Card>
+  <Card title="Permissions" icon="shield" href="/docs/tools/confluence-permissions">
+    Inspect content and space permissions
+  </Card>
+  <Card title="Templates" icon="copy" href="/docs/tools/confluence-templates">
+    List page templates and create pages from them
+  </Card>
+</CardGroup>
+
+## Tool Access Control
+
+### Toolset Groups
+
+Toolsets group related tools for easier management via `TOOLSETS` env var or `--toolsets` flag.
+
+**Jira Toolsets ({{ counts.jira_toolsets }}):**
+
+| Toolset | Core | Tools |
+|---------|:----:|-------|
+{% for toolset in toolsets.jira -%}
+| `{{ toolset.name }}` | {{ "Yes" if toolset.core else "No" }} | {% for tool_name in toolset.tools %}`{{ tool_name }}`{% if not loop.last %}, {% endif %}{% endfor %} |
+{% endfor %}
+
+**Confluence Toolsets ({{ counts.confluence_toolsets }}):**
+
+| Toolset | Core | Tools |
+|---------|:----:|-------|
+{% for toolset in toolsets.confluence -%}
+| `{{ toolset.name }}` | {{ "Yes" if toolset.core else "No" }} | {% for tool_name in toolset.tools %}`{{ tool_name }}`{% if not loop.last %}, {% endif %}{% endfor %} |
+{% endfor %}
+
+```bash
+# All toolsets are enabled when TOOLSETS is not set.
+# To restrict to core toolsets plus specific extras:
+TOOLSETS=default,jira_agile,jira_attachments
+
+# Enable all toolsets ({{ counts.total_tools }} tools)
+TOOLSETS=all
+
+# Command line
+uvx mcp-atlassian --toolsets "default,jira_agile"
+```
+
+### Enable Specific Tools
+
+Use `ENABLED_TOOLS` environment variable or `--enabled-tools` flag:
+
+```bash
+# Environment variable
+ENABLED_TOOLS="confluence_search,jira_get_issue,jira_search"
+
+# Command line
+uvx mcp-atlassian --enabled-tools "confluence_search,jira_get_issue,jira_search"
+```
+
+### Read-Only Mode
+
+Disable all write operations:
+
+```bash
+READ_ONLY_MODE=true
+```
+
+When enabled, only read operations are available regardless of `ENABLED_TOOLS` setting.


### PR DESCRIPTION
## Summary

The documented tool inventory had drifted from the registered tools: README/.env.example said 93 tools, docs/tools-reference.mdx said 96, while 98 are actually registered (63 Jira + 35 Confluence, 24 toolsets), and the two tools from #1286 (`jira_get_project_epic_hierarchy`, `jira_get_cross_project_dependencies`) appeared in no docs page.

This PR makes that class of drift checkable and fixes the current debt:

- Map the two #1286 tools in `CATEGORY_TOOLS` (jira-links-versions) and widen that category description.
- Add a count-consistency pass to `scripts/generate_tool_docs.py --check`: every tool/toolset count mention in `README.md`, `.env.example`, `docs.json`, `docs/tools-reference.mdx` and `docs/configuration.mdx` is validated against the live registries, with `file:line` diagnostics on mismatch.
- Switch `docs/tools-reference.mdx` to generated output (new `scripts/templates/tools_reference.mdx.j2`) — the hand-maintained toolset membership table had drifted by 11 tools and a whole toolset (`jira_project_analysis`).
- Regenerate all tool pages, absorbing accumulated parameter/description drift (e.g. `return_fields`, inline comments, assignable-user sections), and fix every stale count string (98 tools / 24 toolsets / ~35 core tools).

## Verification

- `uv run python scripts/generate_tool_docs.py --check` → exit 0 on this branch.
- Deliberately breaking the README count to 97 → exit 1 with `README.md:117: found 97, expected one of {35, 63, 98}`; restored.
- Regenerated toolset table: 24 rows, 98 unique tool entries, no missing/extra vs the registry.

A follow-up PR wires this check into CI so it can no longer drift silently.
