### PR TITLE
ci: add docs consistency check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: "0.6.10"
+        cache: true
+
+    - name: Install dependencies
+      run: uv sync --frozen --all-extras --dev
+
+    - name: Check generated tool documentation
+      run: uv run python scripts/generate_tool_docs.py --check
+
+    - name: Verify tool documentation diff
+      run: |
+        uv run python scripts/generate_tool_docs.py
+        git diff --exit-code -- docs/tools/ docs/tools-reference.mdx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ uv run pytest --cov=src/mcp_atlassian --cov-report=term-missing  # coverage
 5. **Commits**: Use trailers for attribution, never mention tools/AI
 6. **Commit types**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `ci` — scopes: `jira`, `confluence`, `server`, `auth`, `docker`, `docs`
 7. **File hygiene**: Prefer editing existing files over creating new ones
+8. **Tool docs**: After changing tool signatures or registrations, run `uv run python scripts/generate_tool_docs.py` and commit the diff; CI (`Docs / check`) enforces this
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,8 @@ Thank you for your interest in contributing to MCP Atlassian! This document prov
 
 1. Make your changes
 
+1. After changing tool signatures or registrations, run `uv run python scripts/generate_tool_docs.py` and commit the diff; CI (`Docs / check`) enforces this
+
 1. Ensure tests pass:
 
     ```sh


### PR DESCRIPTION
## Summary

Follow-up to the tool-docs backfill: wire `scripts/generate_tool_docs.py --check` into CI so generated docs and count mentions can no longer drift from the registered tools.

- New `.github/workflows/docs.yml` ("Docs / check"): single Python 3.12 + `uv sync --frozen` (regeneration must be deterministic, so no version matrix), running
  1. `generate_tool_docs.py --check` (tool coverage + count consistency), and
  2. regenerate + `git diff --exit-code -- docs/tools/ docs/tools-reference.mdx` (committed pages must match regenerated output).
- Document the regeneration rule in `AGENTS.md` and `CONTRIBUTING.md`.

Kept out of `lint.yml` (pip-based) and pre-commit deliberately: the generator imports the live server package, so it needs the uv-synced project environment.

After the first successful run on `main`, "Docs / check" should be added to the required status checks on branch protection.
