### PR TITLE
fix(confluence): separate lists that follow paragraph lines in markdown

### DIFF
--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -78,6 +78,8 @@ class ConfluencePreprocessor(BasePreprocessor):
             "menu",
             "menuitem",
             "nav",
+            "noframes",
+            "noembed",
             "ol",
             "p",
             "pre",
@@ -106,6 +108,9 @@ class ConfluencePreprocessor(BasePreprocessor):
         re.IGNORECASE,
     )
     _HTML_COMMENT_OPEN_PATTERN = re.compile(r"^ {0,3}<!--")
+    _HTML_PROCESSING_INSTRUCTION_OPEN_PATTERN = re.compile(r"^ {0,3}<\?")
+    _HTML_DECLARATION_OPEN_PATTERN = re.compile(r"^ {0,3}<!(?!--|\[)")
+    _HTML_CDATA_OPEN_PATTERN = re.compile(r"^ {0,3}<!\[CDATA\[")
 
     def __init__(self, base_url: str) -> None:
         """
@@ -257,30 +262,25 @@ class ConfluencePreprocessor(BasePreprocessor):
         html_block_tag: str | None = None
         html_block_depth = 0
         in_html_comment = False
+        in_processing_instruction = False
+        in_cdata = False
         previous_line: str | None = None
 
         for line in lines:
             line_content = line.rstrip("\r\n")
-            fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
-            if fence_match:
-                marker = fence_match.group("marker")
-                if not in_fence:
-                    in_fence = True
-                    fence_char = marker[0]
-                    fence_length = len(marker)
-                elif (
-                    fence_char == marker[0]
-                    and len(marker) >= fence_length
-                    and not fence_match.group("info").strip()
-                ):
-                    in_fence = False
-                    fence_char = None
-                    fence_length = 0
-                result.append(line)
-                previous_line = line
-                continue
 
             if in_fence:
+                fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
+                if fence_match:
+                    marker = fence_match.group("marker")
+                    if (
+                        fence_char == marker[0]
+                        and len(marker) >= fence_length
+                        and not fence_match.group("info").strip()
+                    ):
+                        in_fence = False
+                        fence_char = None
+                        fence_length = 0
                 result.append(line)
                 previous_line = line
                 continue
@@ -289,6 +289,20 @@ class ConfluencePreprocessor(BasePreprocessor):
                 result.append(line)
                 if "-->" in line_content:
                     in_html_comment = False
+                previous_line = line
+                continue
+
+            if in_processing_instruction:
+                result.append(line)
+                if "?>" in line_content:
+                    in_processing_instruction = False
+                previous_line = line
+                continue
+
+            if in_cdata:
+                result.append(line)
+                if "]]>" in line_content:
+                    in_cdata = False
                 previous_line = line
                 continue
 
@@ -306,6 +320,33 @@ class ConfluencePreprocessor(BasePreprocessor):
             if cls._HTML_COMMENT_OPEN_PATTERN.match(line_content):
                 result.append(line)
                 in_html_comment = "-->" not in line_content
+                previous_line = line
+                continue
+
+            if cls._HTML_CDATA_OPEN_PATTERN.match(line_content):
+                result.append(line)
+                in_cdata = "]]>" not in line_content
+                previous_line = line
+                continue
+
+            if cls._HTML_PROCESSING_INSTRUCTION_OPEN_PATTERN.match(line_content):
+                result.append(line)
+                in_processing_instruction = "?>" not in line_content
+                previous_line = line
+                continue
+
+            if cls._HTML_DECLARATION_OPEN_PATTERN.match(line_content):
+                result.append(line)
+                previous_line = line
+                continue
+
+            fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
+            if fence_match:
+                marker = fence_match.group("marker")
+                in_fence = True
+                fence_char = marker[0]
+                fence_length = len(marker)
+                result.append(line)
                 previous_line = line
                 continue
 

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -38,6 +38,10 @@ class ConfluencePreprocessor(BasePreprocessor):
     _HEADING_LINE_PATTERN = re.compile(r"^ {0,3}#{1,6}[ \t]+")
     _BLOCKQUOTE_LINE_PATTERN = re.compile(r"^ {0,3}>")
     _FENCE_LINE_PATTERN = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})(?P<info>.*)$")
+    _UNORDERED_LIST_INTERRUPT_PATTERN = re.compile(r"^ {0,3}[-*+][ \t]+\S")
+    _ORDERED_LIST_INTERRUPT_PATTERN = re.compile(r"^ {0,3}1\.[ \t]+\S")
+    _HTML_BLOCK_OPEN_PATTERN = re.compile(r"^<([A-Za-z][\w:-]*)(?:\s[^>]*)?>\s*$")
+    _HTML_BLOCK_CLOSE_PATTERN = re.compile(r"^</([A-Za-z][\w:-]*)>\s*$")
 
     def __init__(self, base_url: str) -> None:
         """
@@ -186,10 +190,26 @@ class ConfluencePreprocessor(BasePreprocessor):
         in_fence = False
         fence_char: str | None = None
         fence_length = 0
+        html_block_tag: str | None = None
         previous_line: str | None = None
 
         for line in lines:
             line_content = line.rstrip("\r\n")
+            if html_block_tag is not None:
+                close_match = cls._HTML_BLOCK_CLOSE_PATTERN.match(line_content)
+                if close_match and close_match.group(1).lower() == html_block_tag:
+                    html_block_tag = None
+                result.append(line)
+                previous_line = line
+                continue
+
+            html_open_match = cls._HTML_BLOCK_OPEN_PATTERN.match(line_content)
+            if html_open_match:
+                html_block_tag = html_open_match.group(1).lower()
+                result.append(line)
+                previous_line = line
+                continue
+
             fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
             if fence_match:
                 marker = fence_match.group("marker")
@@ -216,7 +236,7 @@ class ConfluencePreprocessor(BasePreprocessor):
 
             if (
                 previous_line is not None
-                and cls._is_list_line(line)
+                and cls._may_interrupt_paragraph_list_line(line)
                 and previous_line.strip()
                 and not cls._is_list_line(previous_line)
                 and not cls._HEADING_LINE_PATTERN.match(previous_line)
@@ -236,6 +256,17 @@ class ConfluencePreprocessor(BasePreprocessor):
         return bool(
             cls._LIST_LINE_PATTERN.match(line_content)
             and not cls._THEMATIC_BREAK_PATTERN.fullmatch(line_content)
+        )
+
+    @classmethod
+    def _may_interrupt_paragraph_list_line(cls, line: str) -> bool:
+        """Return whether a list may interrupt a paragraph without a blank line."""
+        line_content = line.rstrip("\r\n")
+        if cls._THEMATIC_BREAK_PATTERN.fullmatch(line_content):
+            return False
+        return bool(
+            cls._UNORDERED_LIST_INTERRUPT_PATTERN.match(line_content)
+            or cls._ORDERED_LIST_INTERRUPT_PATTERN.match(line_content)
         )
 
     @classmethod

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -394,10 +394,7 @@ class ConfluencePreprocessor(BasePreprocessor):
                         html_block_depth = cls._html_block_depth_delta(
                             line_content, tag
                         )
-                    if (
-                        tag not in cls._HTML_VOID_BLOCK_TAGS
-                        and html_block_depth > 0
-                    ):
+                    if tag not in cls._HTML_VOID_BLOCK_TAGS and html_block_depth > 0:
                         html_block_tag = tag
                 result.append(line)
                 previous_line = line
@@ -433,9 +430,7 @@ class ConfluencePreprocessor(BasePreprocessor):
         return False
 
     @staticmethod
-    def _html_declaration_is_closed(
-        line: str, *, has_internal_subset: bool
-    ) -> bool:
+    def _html_declaration_is_closed(line: str, *, has_internal_subset: bool) -> bool:
         """Return whether a declaration closes on the current line."""
         quote: str | None = None
         for index, character in enumerate(line):

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -40,8 +40,72 @@ class ConfluencePreprocessor(BasePreprocessor):
     _FENCE_LINE_PATTERN = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})(?P<info>.*)$")
     _UNORDERED_LIST_INTERRUPT_PATTERN = re.compile(r"^ {0,3}[-*+][ \t]+\S")
     _ORDERED_LIST_INTERRUPT_PATTERN = re.compile(r"^ {0,3}1\.[ \t]+\S")
-    _HTML_BLOCK_OPEN_PATTERN = re.compile(r"^<([A-Za-z][\w:-]*)(?:\s[^>]*)?>\s*$")
-    _HTML_BLOCK_CLOSE_PATTERN = re.compile(r"^</([A-Za-z][\w:-]*)>\s*$")
+    _HTML_BLOCK_TAGS = frozenset(
+        {
+            "address",
+            "article",
+            "aside",
+            "blockquote",
+            "body",
+            "caption",
+            "center",
+            "colgroup",
+            "dd",
+            "details",
+            "dialog",
+            "dir",
+            "div",
+            "dl",
+            "dt",
+            "fieldset",
+            "figcaption",
+            "figure",
+            "footer",
+            "form",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "head",
+            "header",
+            "html",
+            "iframe",
+            "legend",
+            "li",
+            "main",
+            "menu",
+            "menuitem",
+            "nav",
+            "ol",
+            "p",
+            "pre",
+            "script",
+            "section",
+            "summary",
+            "table",
+            "tbody",
+            "td",
+            "tfoot",
+            "th",
+            "thead",
+            "title",
+            "tr",
+            "ul",
+            "style",
+            "textarea",
+        }
+    )
+    _HTML_BLOCK_OPEN_PATTERN = re.compile(
+        r"^ {0,3}<(?P<tag>[A-Za-z][\w:-]*)(?:\s[^>]*)?>",
+        re.IGNORECASE,
+    )
+    _HTML_TAG_PATTERN = re.compile(
+        r"<(?P<closing>/)?(?P<tag>[A-Za-z][\w:-]*)(?:\s[^>]*)?\s*/?>",
+        re.IGNORECASE,
+    )
+    _HTML_COMMENT_OPEN_PATTERN = re.compile(r"^ {0,3}<!--")
 
     def __init__(self, base_url: str) -> None:
         """
@@ -191,25 +255,12 @@ class ConfluencePreprocessor(BasePreprocessor):
         fence_char: str | None = None
         fence_length = 0
         html_block_tag: str | None = None
+        html_block_depth = 0
+        in_html_comment = False
         previous_line: str | None = None
 
         for line in lines:
             line_content = line.rstrip("\r\n")
-            if html_block_tag is not None:
-                close_match = cls._HTML_BLOCK_CLOSE_PATTERN.match(line_content)
-                if close_match and close_match.group(1).lower() == html_block_tag:
-                    html_block_tag = None
-                result.append(line)
-                previous_line = line
-                continue
-
-            html_open_match = cls._HTML_BLOCK_OPEN_PATTERN.match(line_content)
-            if html_open_match:
-                html_block_tag = html_open_match.group(1).lower()
-                result.append(line)
-                previous_line = line
-                continue
-
             fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
             if fence_match:
                 marker = fence_match.group("marker")
@@ -234,6 +285,41 @@ class ConfluencePreprocessor(BasePreprocessor):
                 previous_line = line
                 continue
 
+            if in_html_comment:
+                result.append(line)
+                if "-->" in line_content:
+                    in_html_comment = False
+                previous_line = line
+                continue
+
+            if html_block_tag is not None:
+                result.append(line)
+                html_block_depth += cls._html_block_depth_delta(
+                    line_content, html_block_tag
+                )
+                if html_block_depth <= 0:
+                    html_block_tag = None
+                    html_block_depth = 0
+                previous_line = line
+                continue
+
+            if cls._HTML_COMMENT_OPEN_PATTERN.match(line_content):
+                result.append(line)
+                in_html_comment = "-->" not in line_content
+                previous_line = line
+                continue
+
+            html_open_match = cls._HTML_BLOCK_OPEN_PATTERN.match(line_content)
+            if html_open_match:
+                tag = html_open_match.group("tag").lower()
+                if tag in cls._HTML_BLOCK_TAGS:
+                    html_block_depth = cls._html_block_depth_delta(line_content, tag)
+                    if html_block_depth > 0:
+                        html_block_tag = tag
+                result.append(line)
+                previous_line = line
+                continue
+
             if (
                 previous_line is not None
                 and cls._may_interrupt_paragraph_list_line(line)
@@ -242,12 +328,35 @@ class ConfluencePreprocessor(BasePreprocessor):
                 and not cls._HEADING_LINE_PATTERN.match(previous_line)
                 and not cls._BLOCKQUOTE_LINE_PATTERN.match(previous_line)
             ):
-                result.append("\n")
+                result.append(cls._line_ending(line, previous_line))
 
             result.append(line)
             previous_line = line
 
         return "".join(result)
+
+    @staticmethod
+    def _line_ending(line: str, previous_line: str) -> str:
+        """Return the line-ending convention used by adjacent input lines."""
+        for candidate in (line, previous_line):
+            if candidate.endswith("\r\n"):
+                return "\r\n"
+            if candidate.endswith(("\n", "\r")):
+                return candidate[-1]
+        return "\n"
+
+    @classmethod
+    def _html_block_depth_delta(cls, line: str, tag: str) -> int:
+        """Return the open-minus-close count for one HTML block tag line."""
+        depth_delta = 0
+        for match in cls._HTML_TAG_PATTERN.finditer(line):
+            if match.group("tag").lower() != tag:
+                continue
+            if match.group("closing"):
+                depth_delta -= 1
+            elif not match.group(0).rstrip().endswith("/>"):
+                depth_delta += 1
+        return depth_delta
 
     @classmethod
     def _is_list_line(cls, line: str) -> bool:

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -31,6 +31,10 @@ class ConfluencePreprocessor(BasePreprocessor):
     # restoring an opt-out task list cannot remove user-supplied characters.
     _TASK_MARKER_PREFIX = "\ue000"
     _TASK_MARKER_PATTERN = re.compile(r"(<li\b[^>]*>)(\[[ xX]\])")
+    _LIST_LINE_PATTERN = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+    _HEADING_LINE_PATTERN = re.compile(r"^\s*#{1,6}\s+")
+    _BLOCKQUOTE_LINE_PATTERN = re.compile(r"^\s*>")
+    _FENCE_LINE_PATTERN = re.compile(r"^(`{3,}|~{3,})")
 
     def __init__(self, base_url: str) -> None:
         """
@@ -79,6 +83,7 @@ class ConfluencePreprocessor(BasePreprocessor):
         Returns:
             Confluence storage format (XHTML) string
         """
+        markdown_content = self._ensure_list_paragraph_separation(markdown_content)
         try:
             # First convert markdown to HTML
             html_content = self._fix_attachment_images(
@@ -162,6 +167,57 @@ class ConfluencePreprocessor(BasePreprocessor):
                 storage_format = self._apply_table_layout(storage_format, table_layout)
 
             return storage_format
+
+    @classmethod
+    def _ensure_list_paragraph_separation(cls, markdown_content: str) -> str:
+        """Insert blank lines before lists that directly follow paragraph lines.
+
+        Python-Markdown (used by md2conf) does not implement CommonMark's rule
+        that a list may interrupt a paragraph without a blank line in between.
+        """
+        if not markdown_content:
+            return markdown_content
+
+        lines = markdown_content.splitlines(keepends=True)
+        result: list[str] = []
+        in_fence = False
+        fence_char: str | None = None
+        previous_line: str | None = None
+
+        for line in lines:
+            stripped = line.lstrip()
+            fence_match = cls._FENCE_LINE_PATTERN.match(stripped)
+            if fence_match:
+                marker = fence_match.group(1)[0]
+                if not in_fence:
+                    in_fence = True
+                    fence_char = marker
+                elif fence_char == marker:
+                    in_fence = False
+                    fence_char = None
+                result.append(line)
+                previous_line = line
+                continue
+
+            if in_fence:
+                result.append(line)
+                previous_line = line
+                continue
+
+            if (
+                previous_line is not None
+                and cls._LIST_LINE_PATTERN.match(line)
+                and previous_line.strip()
+                and not cls._LIST_LINE_PATTERN.match(previous_line)
+                and not cls._HEADING_LINE_PATTERN.match(previous_line)
+                and not cls._BLOCKQUOTE_LINE_PATTERN.match(previous_line)
+            ):
+                result.append("\n")
+
+            result.append(line)
+            previous_line = line
+
+        return "".join(result)
 
     @classmethod
     def _get_task_list_marker_prefix(cls, html_content: str) -> str:

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -47,6 +47,7 @@ class ConfluencePreprocessor(BasePreprocessor):
             "aside",
             "blockquote",
             "body",
+            "canvas",
             "caption",
             "center",
             "colgroup",
@@ -62,6 +63,7 @@ class ConfluencePreprocessor(BasePreprocessor):
             "figure",
             "footer",
             "form",
+            "group",
             "h1",
             "h2",
             "h3",
@@ -71,18 +73,26 @@ class ConfluencePreprocessor(BasePreprocessor):
             "head",
             "header",
             "html",
+            "hgroup",
             "iframe",
             "legend",
             "li",
             "main",
             "menu",
             "menuitem",
+            "math",
+            "map",
             "nav",
+            "noscript",
             "noframes",
             "noembed",
             "ol",
+            "object",
+            "option",
+            "output",
             "p",
             "pre",
+            "progress",
             "script",
             "section",
             "summary",
@@ -95,10 +105,13 @@ class ConfluencePreprocessor(BasePreprocessor):
             "title",
             "tr",
             "ul",
+            "video",
+            "hr",
             "style",
             "textarea",
         }
     )
+    _HTML_VOID_BLOCK_TAGS = frozenset({"hr"})
     _HTML_BLOCK_OPEN_PATTERN = re.compile(
         r"^ {0,3}<(?P<tag>[A-Za-z][\w:-]*)(?:\s[^>]*)?>",
         re.IGNORECASE,
@@ -264,26 +277,12 @@ class ConfluencePreprocessor(BasePreprocessor):
         in_html_comment = False
         in_processing_instruction = False
         in_cdata = False
+        in_html_declaration = False
+        html_declaration_has_internal_subset = False
         previous_line: str | None = None
 
         for line in lines:
             line_content = line.rstrip("\r\n")
-
-            if in_fence:
-                fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
-                if fence_match:
-                    marker = fence_match.group("marker")
-                    if (
-                        fence_char == marker[0]
-                        and len(marker) >= fence_length
-                        and not fence_match.group("info").strip()
-                    ):
-                        in_fence = False
-                        fence_char = None
-                        fence_length = 0
-                result.append(line)
-                previous_line = line
-                continue
 
             if in_html_comment:
                 result.append(line)
@@ -306,6 +305,17 @@ class ConfluencePreprocessor(BasePreprocessor):
                 previous_line = line
                 continue
 
+            if in_html_declaration:
+                result.append(line)
+                if cls._html_declaration_is_closed(
+                    line_content,
+                    has_internal_subset=html_declaration_has_internal_subset,
+                ):
+                    in_html_declaration = False
+                    html_declaration_has_internal_subset = False
+                previous_line = line
+                continue
+
             if html_block_tag is not None:
                 result.append(line)
                 html_block_depth += cls._html_block_depth_delta(
@@ -314,6 +324,22 @@ class ConfluencePreprocessor(BasePreprocessor):
                 if html_block_depth <= 0:
                     html_block_tag = None
                     html_block_depth = 0
+                previous_line = line
+                continue
+
+            if in_fence:
+                fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
+                if fence_match:
+                    marker = fence_match.group("marker")
+                    if (
+                        fence_char == marker[0]
+                        and len(marker) >= fence_length
+                        and not fence_match.group("info").strip()
+                    ):
+                        in_fence = False
+                        fence_char = None
+                        fence_length = 0
+                result.append(line)
                 previous_line = line
                 continue
 
@@ -337,6 +363,16 @@ class ConfluencePreprocessor(BasePreprocessor):
 
             if cls._HTML_DECLARATION_OPEN_PATTERN.match(line_content):
                 result.append(line)
+                html_declaration_has_internal_subset = (
+                    cls._html_declaration_contains_internal_subset(line_content)
+                )
+                if not cls._html_declaration_is_closed(
+                    line_content,
+                    has_internal_subset=html_declaration_has_internal_subset,
+                ):
+                    in_html_declaration = True
+                else:
+                    html_declaration_has_internal_subset = False
                 previous_line = line
                 continue
 
@@ -354,8 +390,14 @@ class ConfluencePreprocessor(BasePreprocessor):
             if html_open_match:
                 tag = html_open_match.group("tag").lower()
                 if tag in cls._HTML_BLOCK_TAGS:
-                    html_block_depth = cls._html_block_depth_delta(line_content, tag)
-                    if html_block_depth > 0:
+                    if tag not in cls._HTML_VOID_BLOCK_TAGS:
+                        html_block_depth = cls._html_block_depth_delta(
+                            line_content, tag
+                        )
+                    if (
+                        tag not in cls._HTML_VOID_BLOCK_TAGS
+                        and html_block_depth > 0
+                    ):
                         html_block_tag = tag
                 result.append(line)
                 previous_line = line
@@ -375,6 +417,40 @@ class ConfluencePreprocessor(BasePreprocessor):
             previous_line = line
 
         return "".join(result)
+
+    @staticmethod
+    def _html_declaration_contains_internal_subset(line: str) -> bool:
+        """Return whether a declaration opens an internal subset."""
+        quote: str | None = None
+        for character in line:
+            if quote is not None:
+                if character == quote:
+                    quote = None
+            elif character in {"'", '"'}:
+                quote = character
+            elif character == "[":
+                return True
+        return False
+
+    @staticmethod
+    def _html_declaration_is_closed(
+        line: str, *, has_internal_subset: bool
+    ) -> bool:
+        """Return whether a declaration closes on the current line."""
+        quote: str | None = None
+        for index, character in enumerate(line):
+            if quote is not None:
+                if character == quote:
+                    quote = None
+                continue
+            if character in {"'", '"'}:
+                quote = character
+            elif has_internal_subset:
+                if character == "]" and line[index + 1 : index + 2] == ">":
+                    return True
+            elif character == ">":
+                return True
+        return False
 
     @staticmethod
     def _line_ending(line: str, previous_line: str) -> str:

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -31,10 +31,13 @@ class ConfluencePreprocessor(BasePreprocessor):
     # restoring an opt-out task list cannot remove user-supplied characters.
     _TASK_MARKER_PREFIX = "\ue000"
     _TASK_MARKER_PATTERN = re.compile(r"(<li\b[^>]*>)(\[[ xX]\])")
-    _LIST_LINE_PATTERN = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
-    _HEADING_LINE_PATTERN = re.compile(r"^\s*#{1,6}\s+")
-    _BLOCKQUOTE_LINE_PATTERN = re.compile(r"^\s*>")
-    _FENCE_LINE_PATTERN = re.compile(r"^(`{3,}|~{3,})")
+    _LIST_LINE_PATTERN = re.compile(r"^ {0,3}(?:[-*+]|\d+\.)[ \t]+")
+    _THEMATIC_BREAK_PATTERN = re.compile(
+        r"^ {0,3}(?:(?:-[ \t]*){3,}|(?:\*[ \t]*){3,}|(?:_[ \t]*){3,})$"
+    )
+    _HEADING_LINE_PATTERN = re.compile(r"^ {0,3}#{1,6}[ \t]+")
+    _BLOCKQUOTE_LINE_PATTERN = re.compile(r"^ {0,3}>")
+    _FENCE_LINE_PATTERN = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})(?P<info>.*)$")
 
     def __init__(self, base_url: str) -> None:
         """
@@ -182,19 +185,26 @@ class ConfluencePreprocessor(BasePreprocessor):
         result: list[str] = []
         in_fence = False
         fence_char: str | None = None
+        fence_length = 0
         previous_line: str | None = None
 
         for line in lines:
-            stripped = line.lstrip()
-            fence_match = cls._FENCE_LINE_PATTERN.match(stripped)
+            line_content = line.rstrip("\r\n")
+            fence_match = cls._FENCE_LINE_PATTERN.match(line_content)
             if fence_match:
-                marker = fence_match.group(1)[0]
+                marker = fence_match.group("marker")
                 if not in_fence:
                     in_fence = True
-                    fence_char = marker
-                elif fence_char == marker:
+                    fence_char = marker[0]
+                    fence_length = len(marker)
+                elif (
+                    fence_char == marker[0]
+                    and len(marker) >= fence_length
+                    and not fence_match.group("info").strip()
+                ):
                     in_fence = False
                     fence_char = None
+                    fence_length = 0
                 result.append(line)
                 previous_line = line
                 continue
@@ -206,9 +216,9 @@ class ConfluencePreprocessor(BasePreprocessor):
 
             if (
                 previous_line is not None
-                and cls._LIST_LINE_PATTERN.match(line)
+                and cls._is_list_line(line)
                 and previous_line.strip()
-                and not cls._LIST_LINE_PATTERN.match(previous_line)
+                and not cls._is_list_line(previous_line)
                 and not cls._HEADING_LINE_PATTERN.match(previous_line)
                 and not cls._BLOCKQUOTE_LINE_PATTERN.match(previous_line)
             ):
@@ -218,6 +228,15 @@ class ConfluencePreprocessor(BasePreprocessor):
             previous_line = line
 
         return "".join(result)
+
+    @classmethod
+    def _is_list_line(cls, line: str) -> bool:
+        """Return whether a line starts a Markdown list rather than a rule."""
+        line_content = line.rstrip("\r\n")
+        return bool(
+            cls._LIST_LINE_PATTERN.match(line_content)
+            and not cls._THEMATIC_BREAK_PATTERN.fullmatch(line_content)
+        )
 
     @classmethod
     def _get_task_list_marker_prefix(cls, html_content: str) -> str:

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1145,9 +1145,7 @@ class TestListParagraphSeparation:
 
     def test_nested_list_items_are_not_split(self):
         """Only the first list item after a paragraph gets a separator."""
-        result = self._convert(
-            "**Header:**\n- item one\n  - nested\n- item two\n"
-        )
+        result = self._convert("**Header:**\n- item one\n  - nested\n- item two\n")
         assert "<ul>" in result
         assert "nested" in result
         assert "item two" in result
@@ -1156,7 +1154,4 @@ class TestListParagraphSeparation:
         """Fenced code blocks must not get injected blank lines."""
         markdown = "Intro\n\n```\nline\n- not a list\n```\n"
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
-        assert (
-            preprocessor._ensure_list_paragraph_separation(markdown)
-            == markdown
-        )
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1254,7 +1254,7 @@ class TestListParagraphSeparation:
     @pytest.mark.parametrize(
         "block",
         [
-            "<?target version=\"1.0\"?>",
+            '<?target version="1.0"?>',
             "<![CDATA[\nline\n- literal\n]]>",
             "<noframes>\nline\n- literal\n</noframes>",
         ],
@@ -1268,7 +1268,7 @@ class TestListParagraphSeparation:
     @pytest.mark.parametrize(
         "block",
         [
-            "<?target version=\"1.0\"?>",
+            '<?target version="1.0"?>',
             "<![CDATA[\nline\n- literal\n]]>",
             "<noframes>\nline\n- literal\n</noframes>",
         ],

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1104,3 +1104,59 @@ class TestTaskLists:
 
         assert "<ac:task-list>" in result
         assert 'data-table-width="1800"' in result
+
+
+class TestListParagraphSeparation:
+    """Tests for list-after-paragraph preprocessing in markdown conversion."""
+
+    def _convert(self, md: str) -> str:
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        return preprocessor.markdown_to_confluence_storage(md)
+
+    def test_list_after_bold_header_renders_as_ul(self):
+        """Issue #1493: list immediately after bold paragraph line."""
+        result = self._convert(
+            "**Header:**\n- item one\n- item two\n\nSome other paragraph.\n"
+        )
+        assert "<ul>" in result
+        assert "item one" in result
+        assert "item two" in result
+        assert "Header:</strong> - item one" not in result
+
+    def test_ordered_list_after_paragraph_renders_as_ol(self):
+        """Ordered lists after a paragraph line are also separated."""
+        result = self._convert("**Header:**\n1. item one\n2. item two\n")
+        assert "<ol" in result
+        assert "item one" in result
+        assert "item two" in result
+        assert "1. item one" not in result
+
+    def test_existing_blank_line_is_not_doubled(self):
+        """Content that already has a blank line before the list is unchanged."""
+        with_blank = self._convert("**Header:**\n\n- item one\n- item two\n")
+        without_blank = self._convert("**Header:**\n- item one\n- item two\n")
+        assert with_blank == without_blank
+
+    def test_heading_followed_by_list_is_unchanged(self):
+        """ATX headings already allow lists without an extra blank line."""
+        result = self._convert("# Header\n- item one\n- item two\n")
+        assert "<h1>" in result
+        assert "<ul>" in result
+
+    def test_nested_list_items_are_not_split(self):
+        """Only the first list item after a paragraph gets a separator."""
+        result = self._convert(
+            "**Header:**\n- item one\n  - nested\n- item two\n"
+        )
+        assert "<ul>" in result
+        assert "nested" in result
+        assert "item two" in result
+
+    def test_code_fence_content_is_not_modified(self):
+        """Fenced code blocks must not get injected blank lines."""
+        markdown = "Intro\n\n```\nline\n- not a list\n```\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert (
+            preprocessor._ensure_list_paragraph_separation(markdown)
+            == markdown
+        )

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1267,9 +1267,7 @@ class TestListParagraphSeparation:
     def test_processing_resumes_after_remaining_block(self, tag):
         """List separation resumes after each remaining raw block tag."""
         markdown = f"<{tag}>\nline\n- literal\n</{tag}>\nIntro\n- item\n"
-        expected = (
-            f"<{tag}>\nline\n- literal\n</{tag}>\nIntro\n\n- item\n"
-        )
+        expected = f"<{tag}>\nline\n- literal\n</{tag}>\nIntro\n\n- item\n"
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
         assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
 

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1236,3 +1236,46 @@ class TestListParagraphSeparation:
         """Regression: blank bullets must not become empty list items."""
         result = self._convert("Intro\n- \n")
         assert "<ul>" not in result
+
+    def test_unmatched_fence_inside_pre_does_not_suppress_later_list(self):
+        """Fence-like literals inside <pre> must not leave in_fence set."""
+        markdown = "<pre>\nline\n```\n- literal\n</pre>\nIntro\n- item\n"
+        expected = "<pre>\nline\n```\n- literal\n</pre>\nIntro\n\n- item\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
+
+    def test_unmatched_fence_inside_comment_does_not_suppress_later_list(self):
+        """Fence-like literals inside comments must not leave in_fence set."""
+        markdown = "<!--\nline\n```\n- literal\n-->\nIntro\n- item\n"
+        expected = "<!--\nline\n```\n- literal\n-->\nIntro\n\n- item\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            "<?target version=\"1.0\"?>",
+            "<![CDATA[\nline\n- literal\n]]>",
+            "<noframes>\nline\n- literal\n</noframes>",
+        ],
+    )
+    def test_special_raw_html_blocks_are_preserved(self, block):
+        """Processing instructions, CDATA, and noframes must stay byte-for-byte."""
+        markdown = f"{block}\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            "<?target version=\"1.0\"?>",
+            "<![CDATA[\nline\n- literal\n]]>",
+            "<noframes>\nline\n- literal\n</noframes>",
+        ],
+    )
+    def test_processing_resumes_after_special_raw_html_blocks(self, block):
+        """A later real list still receives its paragraph separator."""
+        markdown = f"{block}\nIntro\n- item\n"
+        expected = f"{block}\nIntro\n\n- item\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1219,6 +1219,60 @@ class TestListParagraphSeparation:
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
         assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
 
+    def test_void_block_html_tag_does_not_start_a_block(self):
+        """Python-Markdown's void block tag must not suppress later lists."""
+        markdown = "<hr>\nIntro\n- item\n"
+        expected = "<hr>\nIntro\n\n- item\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "canvas",
+            "group",
+            "hgroup",
+            "map",
+            "math",
+            "noscript",
+            "object",
+            "option",
+            "output",
+            "progress",
+            "video",
+        ],
+    )
+    def test_remaining_python_markdown_block_content_is_preserved(self, tag):
+        """All Python-Markdown raw block tags preserve literal list markers."""
+        markdown = f"<{tag}>\nline\n- literal\n</{tag}>\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "canvas",
+            "group",
+            "hgroup",
+            "map",
+            "math",
+            "noscript",
+            "object",
+            "option",
+            "output",
+            "progress",
+            "video",
+        ],
+    )
+    def test_processing_resumes_after_remaining_block(self, tag):
+        """List separation resumes after each remaining raw block tag."""
+        markdown = f"<{tag}>\nline\n- literal\n</{tag}>\nIntro\n- item\n"
+        expected = (
+            f"<{tag}>\nline\n- literal\n</{tag}>\nIntro\n\n- item\n"
+        )
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
+
     def test_inserted_separator_preserves_crlf_line_endings(self):
         """Injected blank lines must use the document's existing newline style."""
         markdown = "Intro\r\n- item\r\n"
@@ -1255,7 +1309,9 @@ class TestListParagraphSeparation:
         "block",
         [
             '<?target version="1.0"?>',
+            "<?target\nline\n- literal\n?>",
             "<![CDATA[\nline\n- literal\n]]>",
+            "<!DOCTYPE root [\nline\n- literal\n]>",
             "<noframes>\nline\n- literal\n</noframes>",
         ],
     )
@@ -1269,7 +1325,9 @@ class TestListParagraphSeparation:
         "block",
         [
             '<?target version="1.0"?>',
+            "<?target\nline\n- literal\n?>",
             "<![CDATA[\nline\n- literal\n]]>",
+            "<!DOCTYPE root [\nline\n- literal\n]>",
             "<noframes>\nline\n- literal\n</noframes>",
         ],
     )

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1155,3 +1155,21 @@ class TestListParagraphSeparation:
         markdown = "Intro\n\n```\nline\n- not a list\n```\n"
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
         assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_indented_code_content_is_not_modified(self):
+        """Indented code blocks must not be treated as lists."""
+        markdown = "Intro\n    - not a list\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_shorter_fence_does_not_end_longer_fence(self):
+        """A closing fence must be at least as long as its opening fence."""
+        markdown = "Intro\n````\n- not a list\n```\n- still code\n````\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_thematic_break_is_not_treated_as_a_list(self):
+        """Thematic breaks must not trigger list separation."""
+        markdown = "Intro\n* * *\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1156,6 +1156,12 @@ class TestListParagraphSeparation:
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
         assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
 
+    def test_html_like_fenced_code_content_is_not_modified(self):
+        """HTML-looking fenced code must remain inside the code fence."""
+        markdown = "```\n<pre>\nline\n- not a list\n</pre>\n```\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
     def test_indented_code_content_is_not_modified(self):
         """Indented code blocks must not be treated as lists."""
         markdown = "Intro\n    - not a list\n"
@@ -1186,11 +1192,39 @@ class TestListParagraphSeparation:
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
         assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
 
-    def test_pre_html_block_content_is_preserved(self):
-        """Raw HTML blocks must not get injected blank lines."""
-        markdown = "<pre>\nline\n- literal\n</pre>\n"
+    @pytest.mark.parametrize("tag", ["pre", "script", "style", "textarea"])
+    def test_literal_html_block_content_is_preserved(self, tag):
+        """Literal raw HTML blocks must not get injected blank lines."""
+        markdown = f'<{tag} class="literal">\nline\n- literal\n</{tag}>\n'
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
         assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_nested_raw_html_block_content_is_preserved(self):
+        """Nested raw HTML blocks must remain byte-for-byte unchanged."""
+        markdown = "<div>\n<pre>\nline\n- literal\n</pre>\n- still literal\n</div>\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_processing_resumes_after_raw_html_block(self):
+        """A later real list still receives its paragraph separator."""
+        markdown = "<pre>\nline\n- literal\n</pre>\nIntro\n- item\n"
+        expected = "<pre>\nline\n- literal\n</pre>\nIntro\n\n- item\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
+
+    def test_void_html_tag_does_not_start_a_block(self):
+        """Standalone void HTML tags must not suppress later list handling."""
+        markdown = "<br>\nIntro\n- item\n"
+        expected = "<br>\nIntro\n\n- item\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
+
+    def test_inserted_separator_preserves_crlf_line_endings(self):
+        """Injected blank lines must use the document's existing newline style."""
+        markdown = "Intro\r\n- item\r\n"
+        expected = "Intro\r\n\r\n- item\r\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == expected
 
     def test_numbered_prose_stays_paragraph_in_storage(self):
         """Regression: mid-paragraph numbering must not become an ordered list."""

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -1173,3 +1173,32 @@ class TestListParagraphSeparation:
         markdown = "Intro\n* * *\n"
         preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
         assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_numbered_prose_after_paragraph_is_not_split(self):
+        """Only ordered lists starting at 1 may interrupt a paragraph."""
+        markdown = "Intro\n2. prose\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_empty_bullet_after_paragraph_is_not_split(self):
+        """Blank list markers must not interrupt a paragraph."""
+        markdown = "Intro\n- \n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_pre_html_block_content_is_preserved(self):
+        """Raw HTML blocks must not get injected blank lines."""
+        markdown = "<pre>\nline\n- literal\n</pre>\n"
+        preprocessor = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        assert preprocessor._ensure_list_paragraph_separation(markdown) == markdown
+
+    def test_numbered_prose_stays_paragraph_in_storage(self):
+        """Regression: mid-paragraph numbering must not become an ordered list."""
+        result = self._convert("Intro\n2. prose\n")
+        assert "<ol" not in result
+        assert "2. prose" in result
+
+    def test_empty_bullet_stays_paragraph_in_storage(self):
+        """Regression: blank bullets must not become empty list items."""
+        result = self._convert("Intro\n- \n")
+        assert "<ul>" not in result


### PR DESCRIPTION
## Summary

Insert a preprocessing blank line before Markdown list markers that directly follow a paragraph line, so unordered and ordered lists render correctly in Confluence storage format.

## Motivation

Python-Markdown (used by md2conf) does not implement CommonMark rule that a list may interrupt a paragraph without a blank line. Input like `**Header:**
- item one` was flattened into a single paragraph with literal `-` characters instead of a `<ul>` list (reported in #1493).

## Changes

- Add `ConfluencePreprocessor._ensure_list_paragraph_separation()` and call it at the start of `markdown_to_confluence_storage()`.
- Skip preprocessing inside fenced code blocks; do not alter lists that already follow headings, blockquotes, or other list items.
- Add `TestListParagraphSeparation` regression tests covering unordered lists, ordered lists, idempotency, headings, nested lists, and code fences.

## Tests

```bash
uv run pytest tests/unit/preprocessing/test_content_processing.py::TestListParagraphSeparation -v
uv run pytest tests/unit/preprocessing/ -q
```

Result: 6 new tests pass; all 173 preprocessing unit tests pass.

## Notes

- Lists immediately after a blockquote line (`> quote
- item`) are intentionally unchanged to avoid disturbing blockquote structure.

Fixes #1493