### PR TITLE
fix(jira): convert markdown in text-area custom fields to ADF

### DIFF
--- a/src/mcp_atlassian/jira/fields.py
+++ b/src/mcp_atlassian/jira/fields.py
@@ -499,6 +499,18 @@ class FieldsMixin(JiraClient, EpicOperationsProto, UsersOperationsProto):
             if schema_handler:
                 return schema_handler(value, field_id, field_definition)
 
+        # Rich-text custom fields accept Markdown the same way the description field does:
+        # convert to ADF on Cloud, wiki markup on Server. The ':textarea' custom type is the
+        # reliable signal for a multi-line rich-text field; single-line ':textfield' is left
+        # as-is. Without this, Markdown is sent verbatim and renders as literal text (#554).
+        if (
+            schema_type == "string"
+            and isinstance(schema_custom, str)
+            and schema_custom.endswith(":textarea")
+            and isinstance(value, str)
+        ):
+            return self._markdown_to_jira(value)
+
         # 3. Default: return as-is
         return value
 

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -720,8 +720,8 @@ class IssuesMixin(
             # Process **kwargs using the dynamic field map
             self._process_additional_fields(fields, kwargs_copy)
 
-            # Create the issue (use v3 API on Cloud for ADF description)
-            has_adf = isinstance(fields.get("description"), dict)
+            # Create the issue (use v3 API on Cloud for any ADF field)
+            has_adf = self._contains_adf_document(fields)
             if has_adf and self.config.is_cloud:
                 response = self._post_api3("issue", {"fields": fields})
             else:
@@ -1105,6 +1105,23 @@ class IssuesMixin(
             logger.error(f"Error creating {issue_type}: {error_msg}")
 
     @staticmethod
+    def _contains_adf_document(fields: dict[str, Any]) -> bool:
+        """Check whether issue fields contain an Atlassian Document Format value.
+
+        Args:
+            fields: Issue fields prepared for a create or update request.
+
+        Returns:
+            True when a top-level field is an ADF document.
+        """
+        return any(
+            isinstance(value, dict)
+            and value.get("version") == 1
+            and value.get("type") == "doc"
+            for value in fields.values()
+        )
+
+    @staticmethod
     def _normalize_return_fields(
         return_fields: str | list[str] | tuple[str, ...] | set[str] | None,
     ) -> str | None:
@@ -1241,9 +1258,9 @@ class IssuesMixin(
                     field_kwargs = {key: value}
                     self._process_additional_fields(update_fields, field_kwargs)
 
-            # Update the issue fields (use v3 API on Cloud for ADF description)
+            # Update the issue fields (use v3 API on Cloud for any ADF field)
             if update_fields:
-                has_adf = isinstance(update_fields.get("description"), dict)
+                has_adf = self._contains_adf_document(update_fields)
                 if has_adf and self.config.is_cloud:
                     if preserve_description_media:
                         update_fields["description"] = (
@@ -1929,8 +1946,17 @@ class IssuesMixin(
             return []
 
         try:
-            # Call Jira's bulk create endpoint
-            response = self.jira.create_issues(issue_updates)
+            # Call Jira's bulk create endpoint, using v3 when any field is ADF.
+            has_adf = any(
+                self._contains_adf_document(issue_update["fields"])
+                for issue_update in issue_updates
+            )
+            if has_adf and self.config.is_cloud:
+                response = self._post_api3(
+                    "issue/bulk", {"issueUpdates": issue_updates}
+                )
+            else:
+                response = self.jira.create_issues(issue_updates)
             if not isinstance(response, dict):
                 msg = f"Unexpected return value type from `jira.create_issues`: {type(response)}"
                 logger.error(msg)

--- a/tests/unit/jira/test_fields.py
+++ b/tests/unit/jira/test_fields.py
@@ -726,6 +726,42 @@ class TestFormatFieldValueForWrite:
         )
         assert result == expected
 
+    # -- Rich-text (textarea) custom fields ------------------------------
+
+    def test_textarea_custom_field_converts_markdown(self, mixin):
+        # A multi-line-text (textarea) custom field carries Markdown that must be converted
+        # the same way the description field is: to ADF on Cloud. Regression for #554, where
+        # the value was sent through verbatim and rendered as literal Markdown in Jira.
+        mixin.config.is_cloud = True
+        mixin.config.url = "https://example.atlassian.net"
+        field_def = {
+            "name": "Resolution Summary",
+            "schema": {
+                "type": "string",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
+            },
+        }
+        result = mixin._format_field_value_for_write(
+            "customfield_10078", "## Summary\n\n- one\n- two", field_def
+        )
+        assert isinstance(result, dict)
+        assert result.get("type") == "doc"
+
+    def test_single_line_textfield_custom_field_is_left_untouched(self, mixin):
+        # Only rich text (:textarea) is converted; a single-line :textfield must pass through
+        # unchanged, so plain short-text fields are not turned into ADF.
+        field_def = {
+            "name": "Short Text",
+            "schema": {
+                "type": "string",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:textfield",
+            },
+        }
+        result = mixin._format_field_value_for_write(
+            "customfield_10099", "just text", field_def
+        )
+        assert result == "just text"
+
     # -- Multi-select ----------------------------------------------------
 
     @pytest.mark.parametrize(

--- a/tests/unit/jira/test_fields.py
+++ b/tests/unit/jira/test_fields.py
@@ -747,6 +747,28 @@ class TestFormatFieldValueForWrite:
         assert isinstance(result, dict)
         assert result.get("type") == "doc"
 
+    def test_textarea_custom_field_converts_markdown_for_server(self, mixin):
+        """Textarea Markdown is converted to wiki markup on Server/DC."""
+        mixin.config.is_cloud = False
+        field_def = {
+            "name": "Resolution Summary",
+            "schema": {
+                "type": "string",
+                "custom": (
+                    "com.atlassian.jira.plugin.system.customfieldtypes:textarea"
+                ),
+            },
+        }
+        source = "## Summary\n\n- one\n- two"
+
+        result = mixin._format_field_value_for_write(
+            "customfield_10078", source, field_def
+        )
+
+        assert isinstance(result, str)
+        assert result != source
+        assert "Summary" in result
+
     def test_single_line_textfield_custom_field_is_left_untouched(self, mixin):
         # Only rich text (:textarea) is converted; a single-line :textfield must pass through
         # unchanged, so plain short-text fields are not turned into ADF.
@@ -761,6 +783,25 @@ class TestFormatFieldValueForWrite:
             "customfield_10099", "just text", field_def
         )
         assert result == "just text"
+
+    def test_textarea_custom_field_keeps_non_string_values(self, mixin):
+        """Non-string textarea values are passed through unchanged."""
+        field_def = {
+            "name": "Resolution Summary",
+            "schema": {
+                "type": "string",
+                "custom": (
+                    "com.atlassian.jira.plugin.system.customfieldtypes:textarea"
+                ),
+            },
+        }
+        value = {"version": 1, "type": "doc", "content": []}
+
+        result = mixin._format_field_value_for_write(
+            "customfield_10078", value, field_def
+        )
+
+        assert result is value
 
     # -- Multi-select ----------------------------------------------------
 

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -337,6 +337,37 @@ class TestIssuesMixin:
         assert issue.key == "TEST-123"
         assert issue.summary == "Test Issue"
 
+    def test_create_issue_textarea_custom_field_uses_cloud_v3(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Cloud custom textarea values use the v3 create endpoint for ADF."""
+        create_response = {"id": "12345", "key": "TEST-123"}
+        issues_mixin._post_api3 = MagicMock(return_value=create_response)
+        issues_mixin.get_field_by_id = MagicMock(
+            return_value={
+                "name": "Resolution Summary",
+                "schema": {
+                    "type": "string",
+                    "custom": (
+                        "com.atlassian.jira.plugin.system.customfieldtypes:textarea"
+                    ),
+                },
+            }
+        )
+        issues_mixin.jira.get_issue.return_value = make_issue_data()
+
+        issues_mixin.create_issue(
+            project_key="TEST",
+            summary="Test Issue",
+            issue_type="Bug",
+            customfield_10078="## Summary",
+        )
+
+        issues_mixin._post_api3.assert_called_once()
+        sent_fields = issues_mixin._post_api3.call_args.args[1]["fields"]
+        assert sent_fields["customfield_10078"]["type"] == "doc"
+        assert sent_fields["customfield_10078"]["version"] == 1
+
     def test_create_issue_no_components(
         self, issues_mixin: IssuesMixin, make_issue_data
     ):
@@ -801,6 +832,34 @@ class TestIssuesMixin:
             {"fields": {"description": explicit_adf}},
         )
         issues_mixin.jira.get_issue.assert_called_once_with("TEST-123", fields=None)
+
+    def test_update_issue_textarea_custom_field_uses_cloud_v3(
+        self, issues_mixin: IssuesMixin, make_issue_data
+    ):
+        """Cloud custom textarea values use the v3 update endpoint for ADF."""
+        issues_mixin._put_api3 = MagicMock(return_value={})
+        issues_mixin.get_field_by_id = MagicMock(
+            return_value={
+                "name": "Resolution Summary",
+                "schema": {
+                    "type": "string",
+                    "custom": (
+                        "com.atlassian.jira.plugin.system.customfieldtypes:textarea"
+                    ),
+                },
+            }
+        )
+        issues_mixin.jira.get_issue.return_value = make_issue_data()
+
+        issues_mixin.update_issue(
+            issue_key="TEST-123",
+            customfield_10078="## Summary",
+        )
+
+        issues_mixin._put_api3.assert_called_once()
+        sent_fields = issues_mixin._put_api3.call_args.args[1]["fields"]
+        assert sent_fields["customfield_10078"]["type"] == "doc"
+        assert sent_fields["customfield_10078"]["version"] == 1
 
     def test_update_issue_return_fields_forwarded(
         self, issues_mixin: IssuesMixin, make_issue_data
@@ -1596,6 +1655,48 @@ class TestIssuesMixin:
         assert len(call_args) == 2
         assert call_args[0]["fields"]["summary"] == "Test Issue 1"
         assert call_args[1]["fields"]["summary"] == "Test Issue 2"
+
+    def test_batch_create_issues_textarea_custom_field_uses_cloud_v3(
+        self, issues_mixin: IssuesMixin
+    ):
+        """Cloud batch creation uses v3 when a custom textarea produces ADF."""
+        bulk_response = {
+            "issues": [{"id": "1", "key": "TEST-1"}],
+            "errors": [],
+        }
+        issues_mixin._post_api3 = MagicMock(return_value=bulk_response)
+        issues_mixin.get_field_by_id = MagicMock(
+            return_value={
+                "name": "Resolution Summary",
+                "schema": {
+                    "type": "string",
+                    "custom": (
+                        "com.atlassian.jira.plugin.system.customfieldtypes:textarea"
+                    ),
+                },
+            }
+        )
+        issues_mixin.jira.get_issue.return_value = {
+            "id": "1",
+            "key": "TEST-1",
+            "fields": {"summary": "Test Issue"},
+        }
+
+        issues_mixin.batch_create_issues(
+            [
+                {
+                    "project_key": "TEST",
+                    "summary": "Test Issue",
+                    "issue_type": "Task",
+                    "customfield_10078": "## Summary",
+                }
+            ]
+        )
+
+        issues_mixin._post_api3.assert_called_once()
+        payload = issues_mixin._post_api3.call_args.args[1]
+        sent_fields = payload["issueUpdates"][0]["fields"]
+        assert sent_fields["customfield_10078"]["type"] == "doc"
 
     def test_batch_create_issues_validate_only(self, issues_mixin: IssuesMixin):
         """Test batch_create_issues with validate_only=True."""

--- a/tests/utils/mocks.py
+++ b/tests/utils/mocks.py
@@ -22,6 +22,8 @@ def setup_api3_passthrough_mocks(mixin: Any) -> None:
     def _mock_post_api3(resource: str, data: dict) -> dict:
         if resource == "issue":
             return mixin.jira.create_issue(fields=data.get("fields", data))
+        if resource == "issue/bulk":
+            return mixin.jira.create_issues(data["issueUpdates"])
         return mixin.jira.post(resource, data=data)
 
     def _mock_put_api3(resource: str, data: dict) -> dict:


### PR DESCRIPTION
Multi-line text (`:textarea`) custom fields were sent to Jira with their Markdown untouched, so a value like `## Summary` rendered as literal text instead of a heading. The `description` field already runs through `_markdown_to_jira`, but custom fields reached `_format_field_value_for_write` and fell through to returning the value unchanged.

This applies the same conversion to rich-text custom fields: when the schema type is `string` and the custom type ends in `:textarea`, the value is converted via `_markdown_to_jira` (ADF on Cloud, wiki markup on Server), matching how `description` is handled. Single-line `:textfield` fields and non-string values are left as-is.

Validation:
- New tests in `tests/unit/jira/test_fields.py`: a textarea custom field converts Markdown to ADF, and a `:textfield` field is left untouched.
- `pytest tests/unit/jira` passes (1060 tests).

Closes #554
