### PR TITLE
docs: suppress TruffleHog JiraToken false-positive on .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,7 +115,7 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # URL configuration (choose one):
 #   a) Set JIRA_URL / CONFLUENCE_URL server-side as usual, OR
 #   b) Let the trusted gateway supply the URL per-request via the
-#      X-Atlassian-Jira-Url / X-Atlassian-Confluence-Url headers
+#      X-Atlassian-Jira-Url / X-Atlassian-Confluence-Url headers  # trufflehog:ignore (header names only, no secret)
 #      (useful for multi-tenant / dynamic routing scenarios). This option also
 #      requires MCP_ALLOWED_URL_DOMAINS so trusted auth headers cannot be sent to
 #      an attacker-controlled public host.


### PR DESCRIPTION
Line 118 header-name comment trips the JiraToken detector; scoped trufflehog:ignore clears it (verified 3.95.9, 1->0). No credential present.