### PR TITLE
fix(jira): preserve loose ordered lists

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -382,10 +382,19 @@ def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, An
         # --- Ordered list ---
         if re.match(r"^\d+\.\s+", line):
             items_ol: list[dict[str, Any]] = []
-            while i < len(lines) and re.match(r"^\d+\.\s+", lines[i]):
-                item_text = re.sub(r"^\d+\.\s+", "", lines[i])
-                items_ol.append(_make_list_item(item_text, jira_base_url))
-                i += 1
+            while i < len(lines):
+                if re.match(r"^\d+\.\s+", lines[i]):
+                    item_text = re.sub(r"^\d+\.\s+", "", lines[i])
+                    items_ol.append(_make_list_item(item_text, jira_base_url))
+                    i += 1
+                elif (
+                    not lines[i].strip()
+                    and i + 1 < len(lines)
+                    and re.match(r"^\d+\.\s+", lines[i + 1])
+                ):
+                    i += 1
+                else:
+                    break
             doc["content"].append({"type": "orderedList", "content": items_ol})
             continue
 

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -613,6 +613,23 @@ class TestMarkdownToAdf:
             assert item["type"] == "listItem"
             assert item["content"][0]["type"] == "paragraph"
 
+    @pytest.mark.parametrize(
+        "md",
+        [
+            "1. first\n\n2. second\n\n3. third",
+            "1. first\n\n1. second\n\n1. third",
+        ],
+    )
+    def test_ordered_list_with_blank_lines(self, md: str) -> None:
+        """Blank lines between items keep one loose ordered list."""
+        result = markdown_to_adf(md)
+        ordered_lists = [
+            node for node in result["content"] if node["type"] == "orderedList"
+        ]
+
+        assert len(ordered_lists) == 1
+        assert len(ordered_lists[0]["content"]) == 3
+
     def test_task_list_checked(self):
         """- [x] items produce a taskList with taskItem state=DONE."""
         md = "- [x] done task"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Blank-separated Markdown ordered-list items now stay in one ADF list instead of restarting at 1 for every item.

Fixes: #1520

## Changes

<!-- Briefly list the key changes made. -->

- Continue an ordered list across blank lines when another numbered item follows.
- Cover increasing and repeated-number loose-list syntax.
- Keep existing consecutive-list behavior unchanged.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `tests/unit/models/test_adf.py` (105 passed), Ruff format, and Python compilation

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All relevant tests pass locally.
- [x] Documentation updated (not needed for this internal behavior fix).
