### PR TITLE
fix(confluence): convert code macros to fenced Markdown blocks (read-only)

### DIFF
--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -88,7 +88,11 @@ def _fenced_code_block(code_text: str, language: str) -> str:
 
 def _prefix_code_block(code_block: str, prefix: str) -> str:
     """Add a Markdown container prefix to every line in a code block."""
-    return code_block.replace("\n", f"\n{prefix}")
+    return re.sub(
+        r"\r\n|\r|\n",
+        lambda match: f"{match.group()}{prefix}",
+        code_block,
+    )
 
 
 def _restore_inline_code_macro(
@@ -175,11 +179,16 @@ def _restore_code_macro_block(
         return text.replace(placeholder, code_block, 1)
 
     body = code_block[stored_opening_end : -len(stored_fence)]
+    # The closing line contains only markdownify's continuation prefix and
+    # the fence, making it the reliable prefix for every restored body line.
+    # The placeholder line can also carry list or quote context, but unlike
+    # the closing line it may be adjacent to content in malformed HTML.
+    continuation_prefix = closing_line[: closing_match.start()]
     container_prefix = opening_line[: opening_match.start()]
     stored_opening_line = code_block[:stored_opening_end].rstrip("\n")
     restored = (
         f"{container_prefix}{stored_opening_line}\n"
-        f"{line_before}{_prefix_code_block(body, line_before)}"
+        f"{continuation_prefix}{_prefix_code_block(body, continuation_prefix)}"
         f"{stored_fence}"
     )
 

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -86,33 +86,100 @@ def _fenced_code_block(code_text: str, language: str) -> str:
     return f"{fence}{language}\n{code_text}{closing_newline}{fence}"
 
 
-_CONTAINER_MARKERS_RE = re.compile(
-    r"(?:[ \t]*(?:>|[*+-][ \t]|\d{1,9}[.)][ \t]))*[ \t]*"
-)
+def _markdown_container_prefix(line: str) -> tuple[str, str]:
+    """Return a Markdown container prefix and its continuation indentation."""
+    prefix = ""
+    continuation = ""
+    position = 0
+
+    while position < len(line):
+        quote_match = re.match(r">[ ]?", line[position:])
+        if quote_match:
+            token = quote_match.group()
+            prefix += token
+            continuation += token
+            position += len(token)
+            continue
+
+        list_match = re.match(r"[ ]*(?:[*+-]|\d+[.)])[ ]+", line[position:])
+        if not list_match:
+            break
+
+        token = list_match.group()
+        prefix += token
+        continuation += " " * len(token)
+        position += len(token)
+
+    return prefix, continuation
+
+
+def _prefix_code_block(code_block: str, prefix: str) -> str:
+    """Add a Markdown container prefix to every line in a code block."""
+    return code_block.replace("\n", f"\n{prefix}")
+
+
+def _restore_code_macro_block(
+    text: str, start: int, placeholder: str, code_block: str
+) -> str:
+    """Restore one code block while retaining its Markdown containers."""
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", start)
+    if line_end == -1:
+        line_end = len(text)
+
+    line_before = text[line_start:start]
+    line_after = text[start + len(placeholder) : line_end]
+    container_prefix, continuation_prefix = _markdown_container_prefix(line_before)
+    before_content = line_before[len(container_prefix) :]
+    after_content = line_after.lstrip()
+    has_container = bool(container_prefix)
+
+    if before_content.strip():
+        block_prefix = continuation_prefix
+        if has_container:
+            blank_line_prefix = continuation_prefix.rstrip()
+            replacement_prefix = f"\n{blank_line_prefix}\n{block_prefix}"
+        else:
+            replacement_prefix = f"\n\n{block_prefix}"
+    else:
+        block_prefix = continuation_prefix if has_container else ""
+        replacement_prefix = ""
+
+    restored = replacement_prefix + _prefix_code_block(code_block, block_prefix)
+
+    if after_content:
+        if has_container:
+            blank_line_prefix = continuation_prefix.rstrip()
+            restored += f"\n{blank_line_prefix}\n{continuation_prefix}{after_content}"
+        else:
+            restored += f"\n\n{after_content}"
+
+    text_before = text[:start]
+    if before_content.strip():
+        text_before = text_before.rstrip(" ")
+
+    suffix_start = line_end if after_content else start + len(placeholder)
+    return text_before + restored + text[suffix_start:]
 
 
 def _restore_code_macro_blocks(markdown_text: str, code_blocks: dict[str, str]) -> str:
-    """Replace code-macro placeholders with their fenced blocks.
+    """Replace code-macro placeholders with fenced blocks in Markdown context."""
+    for placeholder, code_block in sorted(
+        code_blocks.items(),
+        key=lambda item: markdown_text.rfind(item[0]),
+        reverse=True,
+    ):
+        placeholder_start = markdown_text.rfind(placeholder)
+        if placeholder_start == -1:
+            continue
+        markdown_text = _restore_code_macro_block(
+            markdown_text,
+            placeholder_start,
+            placeholder,
+            code_block,
+        )
 
-    Inside a list item or blockquote, markdownify puts the container prefix
-    only on the placeholder's own line. Every restored line repeats that
-    context: blockquote markers verbatim (a bare line would end the quote),
-    list markers as equivalent indentation (repeating them would start new
-    items), so the fence and body stay inside the container.
-    """
-    placeholders = re.compile(
-        "|".join(re.escape(placeholder) for placeholder in code_blocks)
-    )
-
-    def restore(match: re.Match[str]) -> str:
-        line_start = markdown_text.rfind("\n", 0, match.start()) + 1
-        prefix = markdown_text[line_start : match.start()]
-        markers_match = _CONTAINER_MARKERS_RE.match(prefix)
-        markers = markers_match.group() if markers_match else ""
-        continuation = "".join(char if char in ">\t" else " " for char in markers)
-        return code_blocks[match.group()].replace("\n", "\n" + continuation)
-
-    return placeholders.sub(restore, markdown_text)
+    return markdown_text
 
 
 class ConfluenceClient(Protocol):

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -180,12 +180,10 @@ class BasePreprocessor:
                 # code block.
                 continue
 
+            # Empty and whitespace-only bodies still convert: leaving the
+            # macro in place would leak its parameter values as literal text
+            # once markdownify strips the unknown tags.
             code_text = body.get_text()
-            if not code_text.strip():
-                # CDATA exposure differs across parsers; if the body text is
-                # not reachable via get_text(), leave the macro untouched
-                # rather than emit an empty fence that silently drops content.
-                continue
 
             language_param = macro.find("ac:parameter", attrs={"ac:name": "language"})
             language = language_param.get_text(strip=True) if language_param else ""

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -86,33 +86,6 @@ def _fenced_code_block(code_text: str, language: str) -> str:
     return f"{fence}{language}\n{code_text}{closing_newline}{fence}"
 
 
-def _markdown_container_prefix(line: str) -> tuple[str, str]:
-    """Return a Markdown container prefix and its continuation indentation."""
-    prefix = ""
-    continuation = ""
-    position = 0
-
-    while position < len(line):
-        quote_match = re.match(r">[ ]?", line[position:])
-        if quote_match:
-            token = quote_match.group()
-            prefix += token
-            continuation += token
-            position += len(token)
-            continue
-
-        list_match = re.match(r"[ ]*(?:[*+-]|\d+[.)])[ ]+", line[position:])
-        if not list_match:
-            break
-
-        token = list_match.group()
-        prefix += token
-        continuation += " " * len(token)
-        position += len(token)
-
-    return prefix, continuation
-
-
 def _prefix_code_block(code_block: str, prefix: str) -> str:
     """Add a Markdown container prefix to every line in a code block."""
     return code_block.replace("\n", f"\n{prefix}")
@@ -121,7 +94,7 @@ def _prefix_code_block(code_block: str, prefix: str) -> str:
 def _restore_code_macro_block(
     text: str, start: int, placeholder: str, code_block: str
 ) -> str:
-    """Restore one code block while retaining its Markdown containers."""
+    """Restore one code block using the fence context from markdownify."""
     line_start = text.rfind("\n", 0, start) + 1
     line_end = text.find("\n", start)
     if line_end == -1:
@@ -129,37 +102,45 @@ def _restore_code_macro_block(
 
     line_before = text[line_start:start]
     line_after = text[start + len(placeholder) : line_end]
-    container_prefix, continuation_prefix = _markdown_container_prefix(line_before)
-    before_content = line_before[len(container_prefix) :]
-    after_content = line_after.lstrip()
-    has_container = bool(container_prefix)
+    if line_after.strip():
+        return text.replace(placeholder, code_block, 1)
 
-    if before_content.strip():
-        block_prefix = continuation_prefix
-        if has_container:
-            blank_line_prefix = continuation_prefix.rstrip()
-            replacement_prefix = f"\n{blank_line_prefix}\n{block_prefix}"
-        else:
-            replacement_prefix = f"\n\n{block_prefix}"
-    else:
-        block_prefix = continuation_prefix if has_container else ""
-        replacement_prefix = ""
+    opening_line_end = line_start - 1
+    if opening_line_end < 0:
+        return text.replace(placeholder, code_block, 1)
+    opening_line_start = text.rfind("\n", 0, opening_line_end) + 1
+    opening_line = text[opening_line_start:opening_line_end]
 
-    restored = replacement_prefix + _prefix_code_block(code_block, block_prefix)
+    closing_line_start = line_end + 1
+    if closing_line_start > len(text):
+        return text.replace(placeholder, code_block, 1)
+    closing_line_end = text.find("\n", closing_line_start)
+    if closing_line_end == -1:
+        closing_line_end = len(text)
+    closing_line = text[closing_line_start:closing_line_end]
 
-    if after_content:
-        if has_container:
-            blank_line_prefix = continuation_prefix.rstrip()
-            restored += f"\n{blank_line_prefix}\n{continuation_prefix}{after_content}"
-        else:
-            restored += f"\n\n{after_content}"
+    opening_match = re.search(r"(?P<fence>`{3,})(?P<info>[^\r\n]*)$", opening_line)
+    closing_match = re.search(r"(?P<fence>`{3,})[ \t]*$", closing_line)
+    stored_opening = re.match(r"(?P<fence>`+)[^\r\n]*\n", code_block)
+    if not opening_match or not closing_match or not stored_opening:
+        return text.replace(placeholder, code_block, 1)
 
-    text_before = text[:start]
-    if before_content.strip():
-        text_before = text_before.rstrip(" ")
+    stored_fence = stored_opening.group("fence")
+    stored_opening_end = stored_opening.end()
+    if not code_block.endswith(stored_fence):
+        return text.replace(placeholder, code_block, 1)
 
-    suffix_start = line_end if after_content else start + len(placeholder)
-    return text_before + restored + text[suffix_start:]
+    body = code_block[stored_opening_end : -len(stored_fence)]
+    container_prefix = opening_line[: opening_match.start()]
+    stored_opening_line = code_block[:stored_opening_end].rstrip("\n")
+    restored = (
+        f"{container_prefix}{stored_opening_line}\n"
+        f"{line_before}{_prefix_code_block(body, line_before)}"
+        f"{stored_fence}"
+    )
+
+    suffix_start = closing_line_end
+    return text[:opening_line_start] + restored + text[suffix_start:]
 
 
 def _restore_code_macro_blocks(markdown_text: str, code_blocks: dict[str, str]) -> str:
@@ -254,7 +235,8 @@ class BasePreprocessor:
 
             # Convert code-block macros before markdownify strips them
             # (markdown path only). Keep their contents out of markdownify so
-            # it cannot shorten their fences or strip boundary newlines.
+            # it cannot shorten their fences or strip boundary newlines, while
+            # the pre/code wrapper keeps nested Markdown containers intact.
             code_macro_blocks = self._process_code_macros_in_soup(soup)
             processed_markdown = md(
                 str(soup),
@@ -278,9 +260,9 @@ class BasePreprocessor:
         markdownify does not know the ``ac:structured-macro`` element: it strips
         the tags, leaks the parameter values (language, line numbers) into the
         output as literal text, and collapses the whitespace of the code body.
-        Replacing the macro with a placeholder before conversion lets the
-        surrounding HTML be converted while the code body is preserved
-        verbatim for restoration afterward.
+        Replacing the macro with a ``pre/code`` wrapper containing a placeholder
+        lets markdownify establish the surrounding list or blockquote structure
+        while the code body is preserved verbatim for restoration afterward.
 
         Returns:
             Mapping of markdownify-safe placeholders to fenced code blocks.
@@ -312,7 +294,14 @@ class BasePreprocessor:
                 placeholder = f"\x00MCPCODEMACRO{len(code_blocks)}{collision}\x00"
 
             code_blocks[placeholder] = _fenced_code_block(code_text, language)
-            macro.replace_with(placeholder)
+
+            pre_tag = soup.new_tag("pre")
+            code_tag = soup.new_tag("code")
+            if language:
+                code_tag["class"] = f"language-{language}"
+            code_tag.string = placeholder
+            pre_tag.append(code_tag)
+            macro.replace_with(pre_tag)
 
         return code_blocks
 

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -86,6 +86,35 @@ def _fenced_code_block(code_text: str, language: str) -> str:
     return f"{fence}{language}\n{code_text}{closing_newline}{fence}"
 
 
+_CONTAINER_MARKERS_RE = re.compile(
+    r"(?:[ \t]*(?:>|[*+-][ \t]|\d{1,9}[.)][ \t]))*[ \t]*"
+)
+
+
+def _restore_code_macro_blocks(markdown_text: str, code_blocks: dict[str, str]) -> str:
+    """Replace code-macro placeholders with their fenced blocks.
+
+    Inside a list item or blockquote, markdownify puts the container prefix
+    only on the placeholder's own line. Every restored line repeats that
+    context: blockquote markers verbatim (a bare line would end the quote),
+    list markers as equivalent indentation (repeating them would start new
+    items), so the fence and body stay inside the container.
+    """
+    placeholders = re.compile(
+        "|".join(re.escape(placeholder) for placeholder in code_blocks)
+    )
+
+    def restore(match: re.Match[str]) -> str:
+        line_start = markdown_text.rfind("\n", 0, match.start()) + 1
+        prefix = markdown_text[line_start : match.start()]
+        markers_match = _CONTAINER_MARKERS_RE.match(prefix)
+        markers = markers_match.group() if markers_match else ""
+        continuation = "".join(char if char in ">\t" else " " for char in markers)
+        return code_blocks[match.group()].replace("\n", "\n" + continuation)
+
+    return placeholders.sub(restore, markdown_text)
+
+
 class ConfluenceClient(Protocol):
     """Protocol for Confluence client."""
 
@@ -165,13 +194,8 @@ class BasePreprocessor:
                 code_language_callback=_code_language_from_element,
             )
             if code_macro_blocks:
-                placeholders = re.compile(
-                    "|".join(
-                        re.escape(placeholder) for placeholder in code_macro_blocks
-                    )
-                )
-                processed_markdown = placeholders.sub(
-                    lambda match: code_macro_blocks[match.group()], processed_markdown
+                processed_markdown = _restore_code_macro_blocks(
+                    processed_markdown, code_macro_blocks
                 )
 
             return processed_html, processed_markdown

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -75,6 +75,17 @@ def _code_language_from_element(el: Tag) -> str:
     return ""
 
 
+def _fenced_code_block(code_text: str, language: str) -> str:
+    """Wrap code text in a fence that cannot occur in the code body."""
+    longest_backtick_run = max(
+        (len(run) for run in re.findall(r"`+", code_text)),
+        default=0,
+    )
+    fence = "`" * max(3, longest_backtick_run + 1)
+    closing_newline = "" if code_text.endswith(("\n", "\r")) else "\n"
+    return f"{fence}{language}\n{code_text}{closing_newline}{fence}"
+
+
 class ConfluenceClient(Protocol):
     """Protocol for Confluence client."""
 
@@ -146,12 +157,22 @@ class BasePreprocessor:
             processed_html = str(soup)
 
             # Convert code-block macros before markdownify strips them
-            # (markdown path only)
-            self._process_code_macros_in_soup(soup)
+            # (markdown path only). Keep their contents out of markdownify so
+            # it cannot shorten their fences or strip boundary newlines.
+            code_macro_blocks = self._process_code_macros_in_soup(soup)
             processed_markdown = md(
                 str(soup),
                 code_language_callback=_code_language_from_element,
             )
+            if code_macro_blocks:
+                placeholders = re.compile(
+                    "|".join(
+                        re.escape(placeholder) for placeholder in code_macro_blocks
+                    )
+                )
+                processed_markdown = placeholders.sub(
+                    lambda match: code_macro_blocks[match.group()], processed_markdown
+                )
 
             return processed_html, processed_markdown
 
@@ -160,15 +181,20 @@ class BasePreprocessor:
             raise
 
     @staticmethod
-    def _process_code_macros_in_soup(soup: BeautifulSoup) -> None:
+    def _process_code_macros_in_soup(soup: BeautifulSoup) -> dict[str, str]:
         """Convert Confluence code/noformat macros to standard pre/code blocks.
 
         markdownify does not know the ``ac:structured-macro`` element: it strips
         the tags, leaks the parameter values (language, line numbers) into the
         output as literal text, and collapses the whitespace of the code body.
-        Replacing the macro with ``<pre><code>`` before conversion lets
-        markdownify emit a fenced code block with the body preserved verbatim.
+        Replacing the macro with a placeholder before conversion lets the
+        surrounding HTML be converted while the code body is preserved
+        verbatim for restoration afterward.
+
+        Returns:
+            Mapping of markdownify-safe placeholders to fenced code blocks.
         """
+        code_blocks: dict[str, str] = {}
         for macro in soup.find_all(
             "ac:structured-macro", attrs={"ac:name": ["code", "noformat"]}
         ):
@@ -188,14 +214,16 @@ class BasePreprocessor:
             language_param = macro.find("ac:parameter", attrs={"ac:name": "language"})
             language = language_param.get_text(strip=True) if language_param else ""
 
-            pre_tag = soup.new_tag("pre")
-            code_tag = soup.new_tag("code")
-            if language:
-                code_tag["class"] = f"language-{language}"
-                pre_tag["class"] = f"language-{language}"
-            code_tag.string = code_text
-            pre_tag.append(code_tag)
-            macro.replace_with(pre_tag)
+            placeholder = f"\x00MCPCODEMACRO{len(code_blocks)}\x00"
+            collision = 0
+            while placeholder in str(soup):
+                collision += 1
+                placeholder = f"\x00MCPCODEMACRO{len(code_blocks)}{collision}\x00"
+
+            code_blocks[placeholder] = _fenced_code_block(code_text, language)
+            macro.replace_with(placeholder)
+
+        return code_blocks
 
     @staticmethod
     def _process_date_elements_in_soup(soup: BeautifulSoup) -> None:

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -63,6 +63,18 @@ def _restore_blocks(text: str, storage: list[str], prefix: str) -> str:
     return text
 
 
+def _code_language_from_element(el: Tag) -> str:
+    """Extract a language-* class from a pre element or its code child."""
+    for candidate in (el, el.find("code")):
+        if candidate is None or isinstance(candidate, str):
+            continue
+        classes = candidate.get("class") or []
+        for cls in classes:
+            if cls.startswith("language-"):
+                return cls.removeprefix("language-")
+    return ""
+
+
 class ConfluenceClient(Protocol):
     """Protocol for Confluence client."""
 
@@ -129,15 +141,56 @@ class BasePreprocessor:
             # Process Confluence image tags
             self._process_images_in_soup(soup, content_id, attachments)
 
-            # Convert to string and markdown
+            # Convert to string before the code-macro rewrite so the HTML
+            # output keeps the original storage-format macros intact
             processed_html = str(soup)
-            processed_markdown = md(processed_html)
+
+            # Convert code-block macros before markdownify strips them
+            # (markdown path only)
+            self._process_code_macros_in_soup(soup)
+            processed_markdown = md(
+                str(soup),
+                code_language_callback=_code_language_from_element,
+            )
 
             return processed_html, processed_markdown
 
         except Exception as e:
             logger.error(f"Error in process_html_content: {str(e)}")
             raise
+
+    @staticmethod
+    def _process_code_macros_in_soup(soup: BeautifulSoup) -> None:
+        """Convert Confluence code/noformat macros to standard pre/code blocks.
+
+        markdownify does not know the ``ac:structured-macro`` element: it strips
+        the tags, leaks the parameter values (language, line numbers) into the
+        output as literal text, and collapses the whitespace of the code body.
+        Replacing the macro with ``<pre><code>`` before conversion lets
+        markdownify emit a fenced code block with the body preserved verbatim.
+        """
+        for macro in soup.find_all(
+            "ac:structured-macro", attrs={"ac:name": ["code", "noformat"]}
+        ):
+            body = macro.find("ac:plain-text-body")
+            code_text = body.get_text() if body else macro.get_text()
+            if not code_text.strip():
+                # CDATA exposure differs across parsers; if the body text is
+                # not reachable via get_text(), leave the macro untouched
+                # rather than emit an empty fence that silently drops content.
+                continue
+
+            language_param = macro.find("ac:parameter", attrs={"ac:name": "language"})
+            language = language_param.get_text(strip=True) if language_param else ""
+
+            pre_tag = soup.new_tag("pre")
+            code_tag = soup.new_tag("code")
+            if language:
+                code_tag["class"] = f"language-{language}"
+                pre_tag["class"] = f"language-{language}"
+            code_tag.string = code_text
+            pre_tag.append(code_tag)
+            macro.replace_with(pre_tag)
 
     @staticmethod
     def _process_date_elements_in_soup(soup: BeautifulSoup) -> None:

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -91,6 +91,47 @@ def _prefix_code_block(code_block: str, prefix: str) -> str:
     return code_block.replace("\n", f"\n{prefix}")
 
 
+def _restore_inline_code_macro(
+    text: str, start: int, placeholder: str, code_block: str
+) -> str | None:
+    """Restore a code macro that markdownify collapsed into an inline span.
+
+    Inside a table cell markdownify flattens the pre/code wrapper onto the
+    row's line as a backtick span, where a multi-line fence would split the
+    row. Mirror markdownify's own handling of pre/code in that position:
+    collapse the body onto one line inside a span wide enough for any
+    backtick run it contains.
+    """
+    line_start = text.rfind("\n", 0, start) + 1
+    line_end = text.find("\n", start)
+    if line_end == -1:
+        line_end = len(text)
+
+    line_before = text[line_start:start]
+    line_after = text[start + len(placeholder) : line_end]
+    opening = re.search(r"`+[^`\r\n]*$", line_before)
+    closing = re.match(r"[ \t]*`+", line_after)
+    stored_opening = re.match(r"(?P<fence>`+)[^\r\n]*\n", code_block)
+    if not opening or not closing or not stored_opening:
+        return None
+
+    stored_fence = stored_opening.group("fence")
+    if not code_block.endswith(stored_fence):
+        return None
+
+    body = code_block[stored_opening.end() : -len(stored_fence)]
+    collapsed = body.strip("\n").replace("\n", " ")
+    longest_backtick_run = max(
+        (len(run) for run in re.findall(r"`+", collapsed)),
+        default=0,
+    )
+    delimiter = "`" * max(3, longest_backtick_run + 1)
+
+    span_start = line_start + opening.start()
+    span_end = start + len(placeholder) + closing.end()
+    return f"{text[:span_start]}{delimiter} {collapsed} {delimiter}{text[span_end:]}"
+
+
 def _restore_code_macro_block(
     text: str, start: int, placeholder: str, code_block: str
 ) -> str:
@@ -103,6 +144,9 @@ def _restore_code_macro_block(
     line_before = text[line_start:start]
     line_after = text[start + len(placeholder) : line_end]
     if line_after.strip():
+        inline = _restore_inline_code_macro(text, start, placeholder, code_block)
+        if inline is not None:
+            return inline
         return text.replace(placeholder, code_block, 1)
 
     opening_line_end = line_start - 1

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -173,7 +173,14 @@ class BasePreprocessor:
             "ac:structured-macro", attrs={"ac:name": ["code", "noformat"]}
         ):
             body = macro.find("ac:plain-text-body")
-            code_text = body.get_text() if body else macro.get_text()
+            if body is None:
+                # Without a plain-text body, the macro's child text consists
+                # of parameters rather than code. Leave it untouched so
+                # potentially meaningful content is not replaced by a bogus
+                # code block.
+                continue
+
+            code_text = body.get_text()
             if not code_text.strip():
                 # CDATA exposure differs across parsers; if the body text is
                 # not reachable via get_text(), leave the macro untouched

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -139,6 +139,40 @@ def test_code_macro_inline_in_blockquote_stays_inside_single_fenced_block():
     )
 
 
+def test_code_macro_after_list_paragraph_stays_inside_single_fenced_block():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[run me\nsecond line]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(
+        f"<ul><li><p>before</p>{macro}</li></ul>"
+    )
+
+    assert markdown == "* before\n\n  ```python\n  run me\n  second line\n  ```"
+    assert markdown.count("```python") == 1
+    assert markdown.count("```") == 2
+
+
+def test_code_macro_after_blockquote_paragraph_stays_inside_single_fenced_block():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[run me\nsecond line]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(
+        f"<blockquote><p>before</p>{macro}</blockquote>"
+    )
+
+    assert markdown == "> before\n>\n> ```python\n> run me\n> second line\n> ```"
+    assert markdown.count("```python") == 1
+    assert markdown.count("```") == 2
+
+
 def test_code_macro_without_language_still_fenced():
     macro = (
         '<ac:structured-macro ac:name="noformat">'

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -105,6 +105,29 @@ def test_code_macro_nested_in_blockquote_keeps_quote_prefix():
     assert markdown == ("> ````text\n> first line\n> ```\n> last line\n> ````")
 
 
+def test_code_macro_nested_containers_preserve_crlf_body_boundaries():
+    code_body = "first line\r\n  indented line\r\nlast line\r"
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">text</ac:parameter>'
+        f"<ac:plain-text-body><![CDATA[{code_body}]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+
+    _, list_markdown = preprocessor.process_html_content(f"<ul><li>{macro}</li></ul>")
+    _, quote_markdown = preprocessor.process_html_content(
+        f"<blockquote>{macro}</blockquote>"
+    )
+
+    assert list_markdown == (
+        "* ```text\n  first line\r\n    indented line\r\n  last line\r  ```"
+    )
+    assert quote_markdown == (
+        "> ```text\n> first line\r\n>   indented line\r\n> last line\r> ```"
+    )
+
+
 def test_code_macro_inline_in_list_stays_inside_single_fenced_block():
     macro = (
         '<ac:structured-macro ac:name="code">'

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -173,6 +173,59 @@ def test_code_macro_after_blockquote_paragraph_stays_inside_single_fenced_block(
     assert markdown.count("```") == 2
 
 
+def test_code_macro_in_table_cell_collapses_to_inline_span():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[run me]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(
+        "<table><tr><th>What</th><th>Command</th></tr>"
+        f"<tr><td>run it</td><td>{macro}</td></tr></table>"
+    )
+
+    # A fence cannot exist inside a table row; the body collapses onto the
+    # row's line as an inline span, mirroring markdownify's own handling
+    assert markdown == (
+        "| What | Command |\n| --- | --- |\n| run it | ``` run me ``` |"
+    )
+
+
+def test_multiline_code_macro_in_table_cell_keeps_row_intact():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[run me\nsecond line]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(
+        "<table><tr><th>What</th><th>Command</th></tr>"
+        f"<tr><td>run it</td><td>{macro}</td></tr></table>"
+    )
+
+    assert markdown == (
+        "| What | Command |\n| --- | --- |\n| run it | ``` run me second line ``` |"
+    )
+
+
+def test_code_macro_in_table_cell_with_backticks_widens_span():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">text</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[print('```')]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(
+        f"<table><tr><th>H</th></tr><tr><td>{macro}</td></tr></table>"
+    )
+
+    assert markdown == ("| H |\n| --- |\n| ```` print('```') ```` |")
+
+
 def test_code_macro_without_language_still_fenced():
     macro = (
         '<ac:structured-macro ac:name="noformat">'

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -40,6 +40,37 @@ def test_code_macro_becomes_fenced_block():
     assert "After" in markdown
 
 
+def test_code_macro_uses_longer_fence_for_embedded_backticks():
+    code_body = "first line\n```\nlast line"
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">text</ac:parameter>'
+        f"<ac:plain-text-body><![CDATA[{code_body}]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(macro)
+
+    expected_block = f"````text\n{code_body}\n````"
+    assert markdown == expected_block
+    assert markdown.count("````text") == 1
+
+
+def test_code_macro_preserves_boundary_newlines():
+    code_body = "\n\nfirst line\nlast line\n\n"
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">text</ac:parameter>'
+        f"<ac:plain-text-body><![CDATA[{code_body}]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(macro)
+
+    expected_block = f"```text\n{code_body}```"
+    assert markdown == expected_block
+
+
 def test_code_macro_without_language_still_fenced():
     macro = (
         '<ac:structured-macro ac:name="noformat">'

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -71,6 +71,40 @@ def test_code_macro_preserves_boundary_newlines():
     assert markdown == expected_block
 
 
+def test_code_macro_nested_in_list_keeps_list_structure():
+    code_body = "first line\n  indented line\nlast line"
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        f"<ac:plain-text-body><![CDATA[{code_body}]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(f"<ul><li>{macro}</li></ul>")
+
+    # Every line after the marker is indented to the list item's content
+    # column, so the whole fence stays inside the item
+    assert markdown == (
+        "* ```python\n  first line\n    indented line\n  last line\n  ```"
+    )
+
+
+def test_code_macro_nested_in_blockquote_keeps_quote_prefix():
+    code_body = "first line\n```\nlast line"
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">text</ac:parameter>'
+        f"<ac:plain-text-body><![CDATA[{code_body}]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(f"<blockquote>{macro}</blockquote>")
+
+    # The quote marker repeats on every line (a bare line would end the
+    # blockquote), and the embedded backticks still lengthen the fence
+    assert markdown == ("> ````text\n> first line\n> ```\n> last line\n> ````")
+
+
 def test_code_macro_without_language_still_fenced():
     macro = (
         '<ac:structured-macro ac:name="noformat">'

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -105,6 +105,40 @@ def test_code_macro_nested_in_blockquote_keeps_quote_prefix():
     assert markdown == ("> ````text\n> first line\n> ```\n> last line\n> ````")
 
 
+def test_code_macro_inline_in_list_stays_inside_single_fenced_block():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[run me\nsecond line]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(
+        f"<ul><li>step one: {macro}</li><li>step two</li></ul>"
+    )
+
+    assert markdown == (
+        "* step one:\n\n  ```python\n  run me\n  second line\n  ```\n* step two"
+    )
+
+
+def test_code_macro_inline_in_blockquote_stays_inside_single_fenced_block():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[run me\nsecond line]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(
+        f"<blockquote>before {macro} after</blockquote>"
+    )
+
+    assert markdown == (
+        "> before\n>\n> ```python\n> run me\n> second line\n> ```\n>\n> after"
+    )
+
+
 def test_code_macro_without_language_still_fenced():
     macro = (
         '<ac:structured-macro ac:name="noformat">'

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -1,5 +1,7 @@
 """Tests for Confluence code-macro to fenced-Markdown conversion."""
 
+from bs4 import BeautifulSoup
+
 from mcp_atlassian.preprocessing.base import BasePreprocessor
 
 # Mirrors the storage format Confluence Server returns for a code macro,
@@ -49,6 +51,21 @@ def test_code_macro_without_language_still_fenced():
 
     assert "```" in markdown
     assert "plain  spaced   body" in markdown
+
+
+def test_code_macro_without_body_is_left_untouched():
+    soup = BeautifulSoup(
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">text</ac:parameter>'
+        '<ac:parameter ac:name="linenumbers">true</ac:parameter>'
+        "</ac:structured-macro>",
+        "html.parser",
+    )
+
+    BasePreprocessor._process_code_macros_in_soup(soup)
+
+    assert soup.find("ac:structured-macro") is not None
+    assert soup.find("pre") is None
 
 
 def test_non_code_macros_unaffected():

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -68,6 +68,43 @@ def test_code_macro_without_body_is_left_untouched():
     assert soup.find("pre") is None
 
 
+def test_empty_body_code_macro_does_not_leak_parameters():
+    macro = (
+        "<p>Before</p>"
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        '<ac:parameter ac:name="linenumbers">true</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+        "<p>After</p>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(macro)
+
+    # The macro converts to an empty fenced block; the parameter values must
+    # not appear as literal text outside the fence tag
+    assert "```python" in markdown
+    assert "true" not in markdown
+    assert "pythontrue" not in markdown
+    assert "Before" in markdown
+    assert "After" in markdown
+
+
+def test_whitespace_only_body_converts_without_parameter_leak():
+    macro = (
+        '<ac:structured-macro ac:name="code">'
+        '<ac:parameter ac:name="language">python</ac:parameter>'
+        '<ac:parameter ac:name="linenumbers">true</ac:parameter>'
+        "<ac:plain-text-body><![CDATA[   ]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(macro)
+
+    assert "```python" in markdown
+    assert "true" not in markdown
+
+
 def test_non_code_macros_unaffected():
     html = "<p>No macros here, just <code>inline</code>.</p>"
     preprocessor = BasePreprocessor(base_url="https://confluence.example.com")

--- a/tests/unit/preprocessing/test_code_macro_conversion.py
+++ b/tests/unit/preprocessing/test_code_macro_conversion.py
@@ -1,0 +1,69 @@
+"""Tests for Confluence code-macro to fenced-Markdown conversion."""
+
+from mcp_atlassian.preprocessing.base import BasePreprocessor
+
+# Mirrors the storage format Confluence Server returns for a code macro,
+# including the CDATA body with box-drawing characters and indentation.
+CODE_MACRO = (
+    "<p>Before</p>"
+    '<ac:structured-macro ac:name="code" ac:schema-version="1" ac:macro-id="x">'
+    '<ac:parameter ac:name="language">text</ac:parameter>'
+    '<ac:parameter ac:name="linenumbers">true</ac:parameter>'
+    "<ac:plain-text-body><![CDATA[root (1m 11s)\n"
+    "  ├── child A (167ms)\n"
+    "  │     └── grandchild (22ms)\n"
+    "  └── child B (501ms)]]></ac:plain-text-body>"
+    "</ac:structured-macro>"
+    "<p>After</p>"
+)
+
+
+def test_code_macro_becomes_fenced_block():
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    html, markdown = preprocessor.process_html_content(CODE_MACRO)
+
+    # The HTML output keeps the original storage-format macro (raw mode
+    # consumers rely on it); only the markdown path converts it
+    assert 'ac:name="code"' in html
+    assert "ac:plain-text-body" in html
+
+    # Parameter values must not leak into the output as literal text
+    assert "texttrue" not in markdown
+    # The body arrives fenced, with the language tag carried over
+    assert "```text" in markdown
+    # Indentation inside the body survives
+    assert "  │     └── grandchild (22ms)" in markdown
+    # Surrounding prose is intact
+    assert "Before" in markdown
+    assert "After" in markdown
+
+
+def test_code_macro_without_language_still_fenced():
+    macro = (
+        '<ac:structured-macro ac:name="noformat">'
+        "<ac:plain-text-body><![CDATA[plain  spaced   body]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(macro)
+
+    assert "```" in markdown
+    assert "plain  spaced   body" in markdown
+
+
+def test_non_code_macros_unaffected():
+    html = "<p>No macros here, just <code>inline</code>.</p>"
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(html)
+
+    assert "inline" in markdown
+    assert "```" not in markdown
+
+
+def test_multiple_code_macros_in_one_page():
+    page = CODE_MACRO + CODE_MACRO
+    preprocessor = BasePreprocessor(base_url="https://confluence.example.com")
+    _, markdown = preprocessor.process_html_content(page)
+
+    assert markdown.count("```text") == 2
+    assert "texttrue" not in markdown


### PR DESCRIPTION
### Bug Description

`BasePreprocessor.process_html_content` has no handler for
`<ac:structured-macro ac:name="code">`, so storage-format code blocks reach
markdownify as unknown tags. markdownify strips the tags but keeps their
text. The `language` and `linenumbers` parameter values end up glued to the
first code line (`texttrue` for a text-language block with line numbers), the
fence is gone, and whitespace normalization flattens the body's indentation.
Every page with a code block comes back corrupted in markdown mode. Nothing
downstream can repair it; the fencing and indentation are destroyed
server-side.

### Steps to Reproduce

1. Create a Confluence page with a code macro:
   `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">text</ac:parameter><ac:parameter ac:name="linenumbers">true</ac:parameter><ac:plain-text-body><![CDATA[indented\n  body]]></ac:plain-text-body></ac:structured-macro>`
2. Fetch it with `confluence_get_page` in default markdown mode.
3. Inspect the returned content.

### Expected Behavior

A fenced code block with the language tag, body verbatim:

    ```text
    indented
      body
    ```

### Actual Behavior

`texttrueindented body` (parameters leaked as text, no fence, indentation
collapsed).

### Fix

Adds `_process_code_macros_in_soup`, which swaps `code` and `noformat` macros
for `<pre><code class="language-X">` before the markdown conversion. `md()`
now gets a `code_language_callback` so the language class lands on the fence
(markdownify ignores `language-*` classes without one).

Two design calls worth flagging:

- Markdown path only. `processed_html` is serialized before the macro
  rewrite, so the HTML output keeps the original storage-format macros and
  the existing `test_confluence_macro_preservation` passes unchanged.
- If a macro's body text is unreachable, the macro is left alone instead of
  emitting an empty fence that would silently drop content.

The markdown-to-storage direction is untouched.

### Tests

Four new tests in `tests/unit/preprocessing/test_code_macro_conversion.py`
cover the fence and language tag, the parameter leak, CDATA indentation
(box-drawing characters included), the unchanged HTML output, and multiple
macros on one page. Full suite: 3677 passed, 240 skipped (all skips are the
marker-gated e2e/integration tests). Conversion behavior is verified on both
ends of the declared beautifulsoup4 range (the 4.12.3 floor and the locked
4.14.3).
