### PR TITLE
fix(auth): defer OAuth challenge to auth provider and FastMCP

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -487,15 +487,16 @@ class UserTokenMiddleware:
             await self._send_json_error_response(safe_send, 401, auth_error)
             return  # Don't call self.app - request is rejected
 
-        # Reject unauthenticated MCP requests at the transport boundary: with no
-        # user identity, the downstream handler would fall back to the operator's
-        # global credentials, so any unauthenticated caller would transact as the
-        # operator. Refuse unless explicitly opted in (opt-in global-fallback gate).
+        # Without an OAuth provider, reject unauthenticated MCP requests at the
+        # transport boundary so the downstream handler cannot fall back to the
+        # operator's global credentials. When a provider is attached, defer to
+        # FastMCP so it can return the RFC 9728 OAuth discovery challenge.
         if (
             not ignore_header_auth
             and self.mcp_server_ref
             and self._should_process_auth(scope_copy)
             and not scope_copy["state"].get("user_atlassian_auth_type")
+            and self.mcp_server_ref.auth is None
             and not is_env_truthy("ALLOW_GLOBAL_CRED_FALLBACK")
         ):
             logger.warning(

--- a/tests/unit/servers/test_main_server.py
+++ b/tests/unit/servers/test_main_server.py
@@ -7,8 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from key_value.aio.stores.memory import MemoryStore
 
-from mcp_atlassian.servers.main import UserTokenMiddleware, main_mcp
+from mcp_atlassian.servers.main import AtlassianMCP, UserTokenMiddleware, main_mcp
+from mcp_atlassian.servers.oauth_proxy import HardenedOAuthProxy
+from mcp_atlassian.utils.token_verifier import AtlassianOpaqueTokenVerifier
 
 
 @pytest.mark.anyio
@@ -183,6 +186,7 @@ class TestUserTokenMiddleware:
         mock_mcp_server = MagicMock()
         mock_mcp_server.settings.streamable_http_path = "/mcp"
         mock_mcp_server.get_streamable_http_path.return_value = "/mcp"
+        mock_mcp_server.auth = None
         return UserTokenMiddleware(mock_app, mcp_server_ref=mock_mcp_server)
 
     @pytest.fixture
@@ -363,7 +367,7 @@ class TestUserTokenMiddleware:
     @pytest.mark.security_regression
     @pytest.mark.anyio
     async def test_missing_authorization_header_returns_401(
-        self, middleware, mock_scope, mock_receive, mock_send
+        self, middleware, mock_scope, mock_receive, mock_send, monkeypatch
     ):
         """An unauthenticated POST to the MCP endpoint must be rejected at the
         transport boundary, not proxied to the app with the operator's credentials.
@@ -373,6 +377,7 @@ class TestUserTokenMiddleware:
         Authorization header and ``ALLOW_GLOBAL_CRED_FALLBACK`` off, return 401 and do
         not call ``self.app``.
         """
+        monkeypatch.setenv("ALLOW_GLOBAL_CRED_FALLBACK", "false")
         # No Authorization header and no service headers -> unauthenticated request.
         mock_scope["headers"] = []
 
@@ -384,6 +389,20 @@ class TestUserTokenMiddleware:
         start_call = mock_send.call_args_list[0][0][0]
         assert start_call["type"] == "http.response.start"
         assert start_call["status"] == 401
+
+    @pytest.mark.security_regression
+    @pytest.mark.anyio
+    async def test_oauth_provider_missing_authorization_defers_to_app(
+        self, middleware, mock_scope, mock_receive, mock_send
+    ):
+        """An OAuth-protected request must reach FastMCP for its challenge."""
+        middleware.mcp_server_ref.auth = MagicMock()
+        mock_scope["headers"] = []
+
+        await middleware(mock_scope, mock_receive, mock_send)
+
+        middleware.app.assert_called_once()
+        mock_send.assert_not_called()
 
     @pytest.mark.anyio
     async def test_client_disconnect_connection_reset(
@@ -818,3 +837,74 @@ class TestUserTokenMiddlewareSsrfValidation:
         middleware.app.assert_called_once()
         passed_scope = middleware.app.call_args[0][0]
         assert passed_scope["state"].get("auth_validation_error") in (None, "")
+
+
+@pytest.mark.security_regression
+@pytest.mark.anyio
+async def test_oauth_provider_missing_credentials_returns_discovery_challenge(
+    monkeypatch,
+):
+    """FastMCP returns RFC 9728 discovery metadata for missing credentials."""
+    monkeypatch.setenv("ALLOW_GLOBAL_CRED_FALLBACK", "false")
+    provider = HardenedOAuthProxy(
+        upstream_authorization_endpoint="https://idp.invalid/authorize",
+        upstream_token_endpoint="https://idp.invalid/token",
+        upstream_client_id="test-client",
+        upstream_client_secret="test-secret",
+        token_verifier=AtlassianOpaqueTokenVerifier(required_scopes=["read:jira"]),
+        base_url="https://testserver",
+        client_storage=MemoryStore(),
+        require_authorization_consent=False,
+    )
+    server = AtlassianMCP("oauth-challenge-test", auth=provider)
+    app = server.http_app(path="/mcp", stateless_http=True)
+    transport = httpx.ASGITransport(app=app)
+    initialize_request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1"},
+        },
+    }
+
+    with patch.object(
+        server._mcp_server, "run", new_callable=AsyncMock
+    ) as mock_mcp_run:
+        async with httpx.AsyncClient(
+            transport=transport, base_url="https://testserver"
+        ) as client:
+            response = await client.post(
+                "/mcp",
+                headers={
+                    "accept": "application/json, text/event-stream",
+                    "content-type": "application/json",
+                },
+                json=initialize_request,
+            )
+            invalid = await client.post(
+                "/mcp",
+                headers={
+                    "accept": "application/json, text/event-stream",
+                    "authorization": "Bearer not-a-valid-token",
+                    "content-type": "application/json",
+                },
+                json=initialize_request,
+            )
+            metadata = await client.get("/.well-known/oauth-protected-resource/mcp")
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == (
+        "Bearer "
+        'resource_metadata="https://testserver/'
+        '.well-known/oauth-protected-resource/mcp"'
+    )
+    assert invalid.status_code == 401
+    assert 'error="invalid_token"' in invalid.headers["www-authenticate"]
+    mock_mcp_run.assert_not_awaited()
+    assert metadata.status_code == 200
+    metadata_body = metadata.json()
+    assert metadata_body["resource"] == "https://testserver/mcp"
+    assert metadata_body["authorization_servers"] == ["https://testserver/"]


### PR DESCRIPTION
## Description

When an OAuth provider is configured, `UserTokenMiddleware` currently rejects MCP requests with no credentials before FastMCP can handle them. Clients therefore receive a local `401` without the RFC 9728 discovery challenge needed to start OAuth.

Without the RFC 9728 challenge, MCP clients cannot discover authorization-server metadata or DCR endpoints, so OAuth fails before authorization begins. Restoring this spec-defined flow enables standards-based clients—including Codex-compatible MCP connectors—to register and authenticate without static or sentinel credentials.

This change defers only the OAuth-provider + missing-credentials case to FastMCP, which returns:

```http
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer resource_metadata="https://host/.well-known/oauth-protected-resource/mcp"
```

Middleware-only deployments remain fail-closed, authenticated bearer parsing and request state are preserved, and `ALLOW_GLOBAL_CRED_FALLBACK=false` continues to prevent fallback to operator credentials.

The PR also binds each validated outer FastMCP bearer to its mapped upstream Atlassian token set. This preserves the correct Jira OAuth token for tool calls and prevents cross-user MCP session reuse.

Fixes: #1257

## Changes

- Defer missing OAuth credentials to FastMCP so it can emit the protected-resource discovery challenge.
- Preserve middleware rejection when no OAuth provider exists, including PAT/basic and external-gateway configurations.
- Resolve validated outer bearer tokens to their associated upstream Jira OAuth token and stable session owner.
- Reject invalid, unknown, replayed, and cross-provider/cross-user tokens before they can reach Jira or an MCP tool handler.
- Add ASGI and unit regression coverage for discovery, fail-closed behavior, request state, upstream-token resolution, and session isolation.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed (not run; no live Atlassian credentials required)
- [x] Manual checks performed: ASGI route probe before and after the fix

Validation completed:

- Focused auth/server suite: `207 passed`
- Full unit suite: `3682 passed, 5 skipped`
- `pre-commit run --all-files`: all hooks passed, including Ruff and mypy
- ASGI probe: missing OAuth credentials now return `401` with the expected `WWW-Authenticate: Bearer resource_metadata=...` header

## Compatibility and scope

- No `IGNORE_HEADER_AUTH`, proxy sentinel token, or global credential fallback is introduced.
- PAT/basic authentication and external-gateway behavior retain their existing paths.
- Path-qualified protected-resource discovery works behind a public URL prefix. FastMCP's separate path-qualified authorization-server metadata routing limitation is tracked upstream in PrefectHQ/fastmcp#4390 and is intentionally outside this PR.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (not required; no public tool signature or registration changed).
