### PR TITLE
feat(server): add TLS support for the HTTPS listener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,6 +168,26 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 # Host for 'sse' transport. Default is '0.0.0.0'.
 #HOST=0.0.0.0
 
+# --- Server TLS (HTTPS listener) ---
+# Serve the 'sse'/'streamable-http' transports over HTTPS by terminating TLS at
+# the MCP server itself. Point these at a certificate + private key (PEM).
+# NOTE: this is the SERVER's own listener cert — the opposite direction from the
+# client-side *_CLIENT_CERT mTLS options above (which authenticate the server TO
+# Atlassian). Both must be set together; setting only one, or setting either to
+# an empty string, aborts startup (empty is treated as a configuration error,
+# not as "TLS off"). Under 'stdio' transport they are ignored (no network
+# listener). Useful for end-to-end TLS where the certificate is mounted into
+# the container from a Secret. The key must be UNENCRYPTED (no passphrase
+# support), and the pair is loaded once at startup — rotation requires a
+# process restart.
+# REQUIRES MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE=false (as a real env var or in
+# the default .env; --env-file is loaded too late): the OS trust store
+# injection is client-side only and would reject every inbound TLS handshake,
+# so startup aborts if both are enabled. See the HTTP transport docs for the
+# outbound private-CA setup that replaces the OS trust store.
+#MCP_SSL_CERTFILE=/path/to/server-cert.pem
+#MCP_SSL_KEYFILE=/path/to/server-key.pem
+
 # --- HTTP Timeout ---
 # Timeout in seconds for HTTP requests to Atlassian APIs. Default is 75 seconds.
 #JIRA_TIMEOUT=75

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -185,6 +185,8 @@ openssl rsa -in encrypted.key -out decrypted.key
 | `STATELESS` | Enable stateless mode for streamable-http (`true`/`false`) |
 | `PORT` | Port for HTTP transports (default: `8000`) |
 | `HOST` | Host for HTTP transports (default: `0.0.0.0`) |
+| `MCP_SSL_CERTFILE` | TLS certificate (PEM) for the server's own HTTPS listener (see [HTTP Transport](/docs/http-transport#tls-https-listener)) |
+| `MCP_SSL_KEYFILE` | TLS private key (PEM) for the HTTPS listener; must be set together with the certificate |
 | `READ_ONLY_MODE` | Disable write operations (`true`/`false`) |
 | `MCP_VERBOSE` | Enable verbose logging (`true`/`false`) |
 | `MCP_VERY_VERBOSE` | Enable debug logging (`true`/`false`) |

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -205,6 +205,8 @@ JIRA_PROJECT_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*$
 | `STATELESS` | Enable stateless mode for streamable-http (`true`/`false`) |
 | `PORT` | Port for HTTP transports (default: `8000`) |
 | `HOST` | Host for HTTP transports (default: `0.0.0.0`) |
+| `MCP_SSL_CERTFILE` | TLS certificate (PEM) for the server's own HTTPS listener (see [HTTP Transport](/docs/http-transport#tls-https-listener)) |
+| `MCP_SSL_KEYFILE` | TLS private key (PEM) for the HTTPS listener; must be set together with the certificate |
 | `READ_ONLY_MODE` | Disable write operations (`true`/`false`) |
 | `MCP_VERBOSE` | Enable verbose logging (`true`/`false`) |
 | `MCP_VERY_VERBOSE` | Enable debug logging (`true`/`false`) |

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -85,6 +85,61 @@ The `--stateless` flag is only supported with `streamable-http` transport. Using
   </Tab>
 </Tabs>
 
+## TLS (HTTPS Listener)
+
+By default the HTTP transports listen in plaintext, and TLS is typically terminated
+by a reverse proxy or ingress in front of the server. For end-to-end TLS — for
+example when policy requires encryption all the way to the pod — the server can
+terminate TLS itself. Provide a certificate and private key (PEM) and the listener
+switches to HTTPS:
+
+```bash
+# Using flags
+MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE=false \
+  uvx mcp-atlassian --transport streamable-http --port 9000 \
+  --ssl-certfile /path/to/server-cert.pem \
+  --ssl-keyfile /path/to/server-key.pem
+
+# Or via environment variables (e.g. mounted from a Kubernetes Secret)
+MCP_SSL_CERTFILE=/certs/tls.crt MCP_SSL_KEYFILE=/certs/tls.key \
+  MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE=false \
+  uvx mcp-atlassian --transport streamable-http --port 9000
+```
+
+CLI flags override the environment variables, mirroring host/port precedence.
+
+<Warning>
+The HTTPS listener requires `MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE=false`. The OS
+trust store injection (on by default) replaces Python's `ssl.SSLContext` with a
+client-side-only implementation that rejects every inbound TLS handshake, so
+startup aborts if both are enabled. Set it as a real environment variable or in
+the default `.env` file — `--env-file` is loaded too late to affect trust store
+injection.
+
+With the injection disabled, outbound SSL verification uses the bundled certifi
+CAs. If your Atlassian instance uses a private CA, point **both**
+`REQUESTS_CA_BUNDLE` (covers the Jira/Confluence REST clients and OAuth token
+exchange, via `requests`) **and** `SSL_CERT_FILE` (covers the OAuth proxy
+paths, via `httpx`) at your CA bundle; the bundle must also include public
+roots if you talk to Atlassian Cloud. Do **not** work around certificate errors
+with `JIRA_SSL_VERIFY=false` / `CONFLUENCE_SSL_VERIFY=false` — that disables
+verification on the channel carrying every user's credentials.
+</Warning>
+
+<Note>
+Remember to update client configuration to `https://` URLs once the listener
+serves TLS — the examples elsewhere on this page use `http://`.
+</Note>
+
+<Note>
+Certificate and key must be provided together — setting only one aborts startup.
+These options configure the server's *own* listener certificate; they are
+unrelated to the client-side `*_CLIENT_CERT` mTLS options used when connecting
+to Atlassian. The key must be unencrypted, and the certificate is loaded once at
+startup — rotation requires a restart. Under `stdio` there is no network
+listener, so the options are ignored with a warning.
+</Note>
+
 ## Multi-User Authentication
 
 Both transport types support per-request authentication where each user provides their own credentials.

--- a/src/mcp_atlassian/__init__.py
+++ b/src/mcp_atlassian/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import ssl
 import sys
 import threading
 from importlib.metadata import PackageNotFoundError, version
@@ -49,6 +50,19 @@ try:
 except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"
+
+# Whether truststore.inject_into_ssl() (in the MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE
+# block at the top of this module) actually replaced the stdlib ssl.SSLContext.
+# The HTTPS-listener guard in main() depends on this: truststore's context is
+# client-side only and would reject every inbound TLS handshake.
+_TRUSTSTORE_INJECTED = ssl.SSLContext.__module__.startswith("truststore")
+
+# Cipher suites for the server's own HTTPS listener. uvicorn's default cipher
+# group ("TLSv1") contains NULL-encryption and anonymous suites and no AEAD
+# suites; pin modern AEAD suites instead. TLS 1.0/1.1 have no AEAD suites, so
+# this also excludes them; TLS 1.3 suites are configured separately by OpenSSL
+# and remain enabled.
+_TLS_LISTENER_CIPHERS = "ECDHE+AESGCM:ECDHE+CHACHA20:!aNULL:!eNULL:!MD5"
 
 # Initialize logging with appropriate level
 logging_level = logging.WARNING
@@ -112,6 +126,24 @@ async def _run_stdio_with_stdin_guard(run_kwargs: dict[str, object]) -> None:
             and not isinstance(server_result[0], asyncio.CancelledError)
         ):
             raise server_result[0]
+
+
+def _preflight_tls_certificates(certfile: str, keyfile: str) -> None:
+    """Fail fast if the TLS certificate/key pair cannot be loaded.
+
+    uvicorn only loads the pair deep inside server startup, after the
+    "Starting server" log line, so a mismatched pair, non-PEM content, or an
+    unreadable file would otherwise surface as an opaque late error. The
+    empty-string password callable turns an encrypted key (unsupported) into a
+    clean error instead of an interactive passphrase prompt from OpenSSL.
+    """
+    try:
+        ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER).load_cert_chain(
+            certfile, keyfile, password=lambda: ""
+        )
+    except OSError as exc:  # ssl.SSLError is an OSError subclass
+        logger.error(f"TLS certificate/key could not be loaded: {exc}")
+        sys.exit(1)
 
 
 @click.version_option(__version__, prog_name="mcp-atlassian")
@@ -232,6 +264,21 @@ async def _run_stdio_with_stdin_guard(run_kwargs: dict[str, object]) -> None:
     help="Atlassian Cloud OAuth 2.0 access token (if you have your own you'd like to "
     "use for the session.)",
 )
+@click.option(
+    "--ssl-certfile",
+    default=None,
+    help="Path to the TLS certificate (PEM) for the server's own HTTPS "
+    "listener (sse/streamable-http transports). This terminates TLS at the "
+    "MCP server itself; it is unrelated to the client-side *_CLIENT_CERT "
+    "mTLS options used when connecting to Atlassian. Not validated at parse "
+    "time: stdio ignores it, and the HTTP transports validate it at startup.",
+)
+@click.option(
+    "--ssl-keyfile",
+    default=None,
+    help="Path to the TLS private key (PEM) for the server's own HTTPS "
+    "listener. Must be provided together with --ssl-certfile.",
+)
 def main(
     verbose: int,
     env_file: str | None,
@@ -262,6 +309,8 @@ def main(
     oauth_scope: str | None,
     oauth_cloud_id: str | None,
     oauth_access_token: str | None,
+    ssl_certfile: str | None,
+    ssl_keyfile: str | None,
 ) -> None:
     """MCP Atlassian Server - Jira and Confluence functionality for MCP
 
@@ -370,6 +419,111 @@ def main(
         f"Final path for Streamable HTTP: {final_path if final_path else 'FastMCP default'}"
     )
 
+    # TLS for the server's own HTTPS listener (sse/streamable-http).
+    def resolve_tls_path(
+        env_name: str, cli_name: str, cli_value: str | None
+    ) -> str | None:
+        """CLI wins over env, mirroring host/port/path above. A value that is
+        set but blank (e.g. templated config rendering an unset value as "")
+        is a configuration error, not "TLS off" — checked on the selected
+        source only, so a provided CLI flag overrides a blank env var."""
+        if cli_value is not None:
+            if not cli_value.strip():
+                logger.error(f"{cli_name} is set but empty; provide a file path.")
+                sys.exit(1)
+            return cli_value
+        env_value = os.getenv(env_name)
+        if env_value is not None and not env_value.strip():
+            logger.error(
+                f"{env_name} is set but empty; provide a file path or unset "
+                "the variable."
+            )
+            sys.exit(1)
+        return env_value
+
+    tls_cli_certfile = (
+        ssl_certfile
+        if click_ctx and was_option_provided(click_ctx, "ssl_certfile")
+        else None
+    )
+    tls_cli_keyfile = (
+        ssl_keyfile
+        if click_ctx and was_option_provided(click_ctx, "ssl_keyfile")
+        else None
+    )
+    final_ssl_certfile: str | None = None
+    final_ssl_keyfile: str | None = None
+    final_ssl_enabled = False
+    if final_transport == "stdio":
+        # No network listener: the TLS options are ignored entirely — no
+        # validation, just one warning so the operator isn't silently ignored.
+        if (
+            tls_cli_certfile is not None
+            or tls_cli_keyfile is not None
+            or os.getenv("MCP_SSL_CERTFILE") is not None
+            or os.getenv("MCP_SSL_KEYFILE") is not None
+        ):
+            logger.warning(
+                "TLS certificate configured but transport is 'stdio'; the "
+                "options are ignored because stdio has no network listener."
+            )
+    else:
+        final_ssl_certfile = resolve_tls_path(
+            "MCP_SSL_CERTFILE", "--ssl-certfile", tls_cli_certfile
+        )
+        final_ssl_keyfile = resolve_tls_path(
+            "MCP_SSL_KEYFILE", "--ssl-keyfile", tls_cli_keyfile
+        )
+
+        # A half-configured listener fails obscurely deep in uvicorn startup,
+        # so require both or neither and fail fast with a clear message.
+        if bool(final_ssl_certfile) != bool(final_ssl_keyfile):
+            logger.error(
+                "--ssl-certfile and --ssl-keyfile (env MCP_SSL_CERTFILE / "
+                "MCP_SSL_KEYFILE) must be provided together."
+            )
+            sys.exit(1)
+        final_ssl_enabled = bool(final_ssl_certfile) and bool(final_ssl_keyfile)
+        # The OS trust store injection replaces ssl.SSLContext globally with
+        # truststore's client-side-only context, whose post-handshake
+        # peer-cert verification rejects every INBOUND TLS connection (a
+        # server's peer sends no certificate). uvicorn builds its listener
+        # context from ssl.SSLContext, so the two features cannot coexist in
+        # one process; fail fast with the remediation rather than serving a
+        # listener that resets every connection. This is a static
+        # incompatibility, so check it before the per-deployment file checks.
+        if final_ssl_enabled and _TRUSTSTORE_INJECTED:
+            logger.error(
+                "The HTTPS listener (--ssl-certfile/--ssl-keyfile) cannot be "
+                "used while the OS trust store is injected. Set "
+                "MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE=false as a process "
+                "environment variable or in the default .env file (--env-file "
+                "is loaded too late to affect trust store injection). Outbound "
+                "SSL verification then uses the bundled certifi CAs; for a "
+                "private CA set both REQUESTS_CA_BUNDLE and SSL_CERT_FILE "
+                "(see the HTTP transport docs)."
+            )
+            sys.exit(1)
+        # Neither source is existence-checked at parse time (click must not
+        # reject paths that stdio would ignore), so check the selected values
+        # here: a missing file fails fast with a clear message instead of an
+        # opaque uvicorn error after the listener log line.
+        if final_ssl_certfile and not os.path.isfile(final_ssl_certfile):
+            logger.error(
+                "TLS certificate file not found or not a regular file: "
+                f"{final_ssl_certfile!r}"
+            )
+            sys.exit(1)
+        if final_ssl_keyfile and not os.path.isfile(final_ssl_keyfile):
+            logger.error(
+                "TLS private key file not found or not a regular file: "
+                f"{final_ssl_keyfile!r}"
+            )
+            sys.exit(1)
+        if final_ssl_certfile and final_ssl_keyfile:
+            _preflight_tls_certificates(final_ssl_certfile, final_ssl_keyfile)
+    logger.debug(f"Final TLS for HTTP listener: enabled={final_ssl_enabled}")
+
     # Set env vars for downstream config
     if click_ctx and was_option_provided(click_ctx, "enabled_tools"):
         os.environ["ENABLED_TOOLS"] = enabled_tools
@@ -439,8 +593,17 @@ def main(
 
         run_kwargs["stateless_http"] = final_stateless
 
+        if final_ssl_enabled:
+            run_kwargs["uvicorn_config"] = {
+                "ssl_certfile": final_ssl_certfile,
+                "ssl_keyfile": final_ssl_keyfile,
+                "ssl_ciphers": _TLS_LISTENER_CIPHERS,
+            }
+
+        scheme = "https" if final_ssl_enabled else "http"
         logger.info(
-            f"Starting server with {final_transport.upper()} transport on http://{final_host}:{final_port}{log_display_path}"
+            f"Starting server with {final_transport.upper()} transport on "
+            f"{scheme}://{final_host}:{final_port}{log_display_path}"
         )
     else:
         logger.error(

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -158,7 +158,7 @@ class ConfluenceClient:
             log_config_param(logger, "Confluence", "NO_PROXY", self.config.no_proxy)
 
         # Configure SSL verification using the shared utility
-        configure_ssl_verification(
+        effective_verify = configure_ssl_verification(
             service_name="Confluence",
             url=transport_url,
             session=self.confluence._session,
@@ -168,6 +168,10 @@ class ConfluenceClient:
             client_key_password=self.config.client_key_password,
             no_proxy=self.config.no_proxy,
         )
+        # atlassian-python-api passes verify=self.verify_ssl on every request,
+        # which overrides session.verify; keep the wrapper in sync so an
+        # operator CA bundle applies to normal API calls too.
+        self.confluence.verify_ssl = effective_verify
 
         # Validate redirects for SSRF on every outbound call from this session
         # (covers direct _session.get() paths and global/stdio fetchers, not just

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -171,7 +171,7 @@ class JiraClient:
             log_config_param(logger, "Jira", "NO_PROXY", self.config.no_proxy)
 
         # Configure SSL verification using the shared utility
-        configure_ssl_verification(
+        effective_verify = configure_ssl_verification(
             service_name="Jira",
             url=transport_url,
             session=self.jira._session,
@@ -181,6 +181,10 @@ class JiraClient:
             client_key_password=self.config.client_key_password,
             no_proxy=self.config.no_proxy,
         )
+        # atlassian-python-api passes verify=self.verify_ssl on every request,
+        # which overrides session.verify; keep the wrapper in sync so an
+        # operator CA bundle applies to normal API calls too.
+        self.jira.verify_ssl = effective_verify
 
         # Validate redirects for SSRF on every outbound call from this session
         # (covers direct _session.get() paths and global/stdio fetchers, not just

--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -159,9 +159,9 @@ class DevelopmentMixin(JiraClient):
         # path (/rest/dev-status/1.0/...) not covered by the standard Jira client
         # wrappers. No higher-level wrapper method exists for this non-standard endpoint.
         url = f"{self.config.url}/rest/dev-status/1.0/issue/detail"
-        http_response = self.jira._session.get(
-            url, params=params, verify=self.config.ssl_verify
-        )
+        # SSL verification is configured at session level (adapter/CA bundle);
+        # a per-call verify bool would override it.
+        http_response = self.jira._session.get(url, params=params)
 
         if http_response.status_code == 404:
             logger.debug(
@@ -395,9 +395,7 @@ class DevelopmentMixin(JiraClient):
         params = {"issueId": str(issue_id)}
 
         try:
-            http_response = self.jira._session.get(
-                url, params=params, verify=self.config.ssl_verify
-            )
+            http_response = self.jira._session.get(url, params=params)
             if http_response.status_code in (403, 404):
                 logger.warning(
                     "Dev-status summary returned %s for %s; falling back to "

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -239,7 +239,7 @@ def configure_ssl_verification(
     client_key: str | None = None,
     client_key_password: str | None = None,
     no_proxy: str | None = None,
-) -> None:
+) -> bool | str:
     """Configure SSL verification and client certificates for a specific service.
 
     If SSL verification is disabled, this function will configure the session
@@ -262,6 +262,13 @@ def configure_ssl_verification(
         client_key_password: Password for encrypted private key (optional)
         no_proxy: The no-proxy list to honor on the mounted adapter. Defaults to
             the ``NO_PROXY`` environment variable when not provided.
+
+    Returns:
+        The effective requests ``verify`` value for this service: ``False``
+        when verification is disabled, the operator's CA bundle path when one
+        is configured, else ``True``. Callers must propagate this to wrappers
+        that pass ``verify=`` per request (atlassian-python-api does), because
+        a per-request value overrides ``session.verify``.
     """
     no_proxy = no_proxy or os.environ.get("NO_PROXY") or os.environ.get("no_proxy")
     # Configure client certificate if provided (must be actual string paths).
@@ -290,6 +297,45 @@ def configure_ssl_verification(
             key_configured,
         )
 
+    effective_verify: bool | str = ssl_verify
+    if ssl_verify:
+        # PAT and OAuth sessions run with trust_env=False (so .netrc cannot
+        # override explicit credentials), which also stops requests from
+        # honoring REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE. Resolve the bundle
+        # explicitly so a private CA keeps working on those sessions — e.g.
+        # when the OS trust store injection is disabled for the in-app TLS
+        # listener.
+        # These env vars are operator-only process configuration; nothing in
+        # the per-request (multi-tenant) path may write them.
+        ca_bundle = os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get(
+            "CURL_CA_BUNDLE"
+        )
+        if ca_bundle:
+            # requests accepts a CA bundle file or an OpenSSL-style hashed
+            # CA directory here; accept both (including symlinks to either),
+            # but reject special files — a FIFO would block the TLS layer
+            # instead of failing fast.
+            if not (os.path.isfile(ca_bundle) or os.path.isdir(ca_bundle)):
+                # Log the path server-side only; the raised message can reach
+                # the MCP client via tool errors.
+                logger.error(
+                    "%s CA bundle from REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE is "
+                    "not a regular file or directory: %r",
+                    service_name,
+                    ca_bundle,
+                )
+                raise ValueError(
+                    f"{service_name} CA bundle configuration is invalid; "
+                    "see server logs."
+                )
+            session.verify = ca_bundle
+            effective_verify = ca_bundle
+            logger.debug(
+                "%s outbound SSL verification uses CA bundle: %s",
+                service_name,
+                ca_bundle,
+            )
+
     if not ssl_verify:
         logger.warning(
             f"{service_name} SSL verification disabled. This is insecure and "
@@ -311,3 +357,5 @@ def configure_ssl_verification(
             adapter = NoProxyAdapter(no_proxy=no_proxy)
             session.mount(f"https://{domain}", adapter)
             session.mount(f"http://{domain}", adapter)
+
+    return effective_verify

--- a/tests/unit/jira/test_development.py
+++ b/tests/unit/jira/test_development.py
@@ -526,3 +526,28 @@ class TestDevelopmentMixin:
         assert pr["destination"] == ""
         assert pr["author"] == ""
         assert pr["reviewers"] == []
+
+    def test_dev_status_get_does_not_pass_verify(
+        self, development_mixin, mock_dev_status_response
+    ):
+        """A per-call verify bool would override the session's configured SSL
+        verification (SSLIgnoreAdapter or an explicit CA bundle); the session
+        default must govern."""
+        development_mixin.jira.get_issue.return_value = {
+            "id": "12345",
+            "key": "TEST-123",
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_dev_status_response
+        mock_response.raise_for_status = MagicMock()
+        development_mixin.jira._session.get.return_value = mock_response
+
+        development_mixin.get_issue_development_info(
+            "TEST-123", application_type="stash", data_type="pullrequest"
+        )
+        # Also drive the summary/discovery call site.
+        development_mixin._discover_application_types("TEST-123", "12345")
+
+        assert development_mixin.jira._session.get.call_count >= 2
+        for call in development_mixin.jira._session.get.call_args_list:
+            assert "verify" not in call.kwargs

--- a/tests/unit/jira/test_development.py
+++ b/tests/unit/jira/test_development.py
@@ -527,7 +527,7 @@ class TestDevelopmentMixin:
         assert pr["author"] == ""
         assert pr["reviewers"] == []
 
-    def test_dev_status_get_omits_verify(
+    def testdev_status_get_omits_verify(
         self, development_mixin, mock_dev_status_response
     ):
         """A per-call verify bool would override the session's configured SSL

--- a/tests/unit/jira/test_development.py
+++ b/tests/unit/jira/test_development.py
@@ -527,7 +527,7 @@ class TestDevelopmentMixin:
         assert pr["author"] == ""
         assert pr["reviewers"] == []
 
-    def test_dev_status_get_does_not_pass_verify(
+    def test_dev_status_get_omits_verify(
         self, development_mixin, mock_dev_status_response
     ):
         """A per-call verify bool would override the session's configured SSL

--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -1,11 +1,14 @@
 """Unit tests for transport selection and execution."""
 
 import asyncio
+import shutil
+import ssl
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mcp_atlassian import _run_stdio_with_stdin_guard, main
+from mcp_atlassian import _TLS_LISTENER_CIPHERS, _run_stdio_with_stdin_guard, main
 
 
 class TestMainTransportSelection:
@@ -188,3 +191,853 @@ class TestMainTransportSelection:
                             assert (
                                 mock_exit.call_args_list[1][0][0] == 0
                             )  # Finally exit
+
+
+class TestServerTLSConfiguration:
+    """The server's own HTTPS listener (--ssl-certfile / --ssl-keyfile)."""
+
+    @pytest.fixture(autouse=True)
+    def _no_truststore_injection(self):
+        """Pin the truststore-injection flag to a known False for every test,
+        regardless of how the test process was launched. Tests for the guard
+        itself re-patch the flag to True explicitly."""
+        with patch("mcp_atlassian._TRUSTSTORE_INJECTED", new=False):
+            yield
+
+    @pytest.fixture
+    def preflight_ok(self):
+        """Bypass the real cert/key load for tests that use dummy PEM files;
+        yields the mock so tests can assert the preflight path executed."""
+        with patch("mcp_atlassian._preflight_tls_certificates") as mock_preflight:
+            yield mock_preflight
+
+    @staticmethod
+    def _make_pair(tmp_path, prefix=""):
+        """Create dummy cert/key files (not loadable PEM; tests that reach the
+        preflight must either patch it via preflight_ok or expect the abort)."""
+        cert = tmp_path / f"{prefix}server-cert.pem"
+        key = tmp_path / f"{prefix}server-key.pem"
+        cert.write_text("cert")
+        key.write_text("key")
+        return cert, key
+
+    @pytest.fixture
+    def cert_key(self, tmp_path):
+        return self._make_pair(tmp_path)
+
+    @staticmethod
+    def _run_main():
+        try:
+            main()
+        except SystemExit:
+            pass
+
+    @pytest.mark.parametrize("transport", ["sse", "streamable-http"])
+    def test_tls_env_forwards_uvicorn_config(self, cert_key, preflight_ok, transport):
+        """Both certs via env -> uvicorn_config reaches run_async, for both
+        HTTP transports, with the cipher pin included."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, key = cert_key
+        with patch.object(
+            main_mcp, "run_async", new_callable=AsyncMock
+        ) as mock_run_async:
+            with patch.dict(
+                "os.environ",
+                {
+                    "TRANSPORT": transport,
+                    "MCP_SSL_CERTFILE": str(cert),
+                    "MCP_SSL_KEYFILE": str(key),
+                },
+            ):
+                with patch("sys.argv", ["mcp-atlassian"]):
+                    self._run_main()
+
+        assert preflight_ok.called
+        assert mock_run_async.called
+        assert mock_run_async.call_args[1]["uvicorn_config"] == {
+            "ssl_certfile": str(cert),
+            "ssl_keyfile": str(key),
+            "ssl_ciphers": _TLS_LISTENER_CIPHERS,
+        }
+
+    def test_tls_cli_overrides_env(self, tmp_path, preflight_ok):
+        """CLI --ssl-* wins over a valid env pair and forwards the CLI paths."""
+        from mcp_atlassian.servers import main_mcp
+
+        cli_cert, cli_key = self._make_pair(tmp_path, "cli-")
+        env_cert, env_key = self._make_pair(tmp_path, "env-")
+        with patch.object(
+            main_mcp, "run_async", new_callable=AsyncMock
+        ) as mock_run_async:
+            with patch.dict(
+                "os.environ",
+                {
+                    "TRANSPORT": "streamable-http",
+                    "MCP_SSL_CERTFILE": str(env_cert),
+                    "MCP_SSL_KEYFILE": str(env_key),
+                },
+            ):
+                with patch(
+                    "sys.argv",
+                    [
+                        "mcp-atlassian",
+                        "--ssl-certfile",
+                        str(cli_cert),
+                        "--ssl-keyfile",
+                        str(cli_key),
+                    ],
+                ):
+                    self._run_main()
+
+        assert mock_run_async.called
+        assert mock_run_async.call_args[1]["uvicorn_config"] == {
+            "ssl_certfile": str(cli_cert),
+            "ssl_keyfile": str(cli_key),
+            "ssl_ciphers": _TLS_LISTENER_CIPHERS,
+        }
+
+    def test_tls_cli_cert_with_env_key(self, tmp_path, preflight_ok):
+        """A cross-source pair (cert via CLI, key via env) resolves and
+        forwards both — the two paths resolve independently."""
+        from mcp_atlassian.servers import main_mcp
+
+        cli_cert, _ = self._make_pair(tmp_path, "cli-")
+        _, env_key = self._make_pair(tmp_path, "env-")
+        with patch.object(
+            main_mcp, "run_async", new_callable=AsyncMock
+        ) as mock_run_async:
+            with patch.dict(
+                "os.environ",
+                {
+                    "TRANSPORT": "streamable-http",
+                    "MCP_SSL_KEYFILE": str(env_key),
+                },
+            ):
+                with patch(
+                    "sys.argv",
+                    ["mcp-atlassian", "--ssl-certfile", str(cli_cert)],
+                ):
+                    self._run_main()
+
+        assert mock_run_async.called
+        assert mock_run_async.call_args[1]["uvicorn_config"] == {
+            "ssl_certfile": str(cli_cert),
+            "ssl_keyfile": str(env_key),
+            "ssl_ciphers": _TLS_LISTENER_CIPHERS,
+        }
+
+    @pytest.mark.parametrize("transport", ["sse", "streamable-http"])
+    def test_no_tls_omits_uvicorn_config(self, transport, monkeypatch):
+        """Without TLS configured, run_kwargs carries no uvicorn_config."""
+        from mcp_atlassian.servers import main_mcp
+
+        monkeypatch.delenv("MCP_SSL_CERTFILE", raising=False)
+        monkeypatch.delenv("MCP_SSL_KEYFILE", raising=False)
+        with patch.object(
+            main_mcp, "run_async", new_callable=AsyncMock
+        ) as mock_run_async:
+            with patch.dict("os.environ", {"TRANSPORT": transport}):
+                with patch("sys.argv", ["mcp-atlassian"]):
+                    self._run_main()
+
+        assert mock_run_async.called
+        assert "uvicorn_config" not in mock_run_async.call_args[1]
+
+    @pytest.mark.parametrize("provided", ["cert", "key"])
+    def test_half_configured_tls_aborts(self, cert_key, provided, monkeypatch):
+        """Setting only one of cert/key exits with code 1 via the
+        both-or-neither guard — before the server starts, not via some later
+        uvicorn failure."""
+        from mcp_atlassian.servers import main_mcp
+
+        monkeypatch.delenv("MCP_SSL_CERTFILE", raising=False)
+        monkeypatch.delenv("MCP_SSL_KEYFILE", raising=False)
+        cert, key = cert_key
+        env = {"TRANSPORT": "streamable-http"}
+        if provided == "cert":
+            env["MCP_SSL_CERTFILE"] = str(cert)
+        else:
+            env["MCP_SSL_KEYFILE"] = str(key)
+
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch.object(
+                main_mcp, "run_async", new_callable=AsyncMock
+            ) as mock_run_async:
+                with patch.dict("os.environ", env):
+                    with patch("sys.argv", ["mcp-atlassian"]):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 1
+        assert not mock_run_async.called  # aborted before the server started
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "must be provided together" in errors
+
+    @pytest.mark.parametrize("missing", ["cert", "key"])
+    def test_env_path_not_found_aborts(self, tmp_path, missing):
+        """A cert/key path from env that isn't a file exits with code 1 via the
+        existence guard before the server starts (env paths bypass click's
+        existence check)."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, key = self._make_pair(tmp_path)
+        env = {"TRANSPORT": "streamable-http"}
+        if missing == "cert":
+            env["MCP_SSL_CERTFILE"] = str(tmp_path / "nope-cert.pem")
+            env["MCP_SSL_KEYFILE"] = str(key)
+        else:
+            env["MCP_SSL_CERTFILE"] = str(cert)
+            env["MCP_SSL_KEYFILE"] = str(tmp_path / "nope-key.pem")
+
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch.object(
+                main_mcp, "run_async", new_callable=AsyncMock
+            ) as mock_run_async:
+                with patch.dict("os.environ", env):
+                    with patch("sys.argv", ["mcp-atlassian"]):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 1
+        assert not mock_run_async.called
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "not found" in errors
+
+    def test_tls_under_stdio_warns_and_skips_uvicorn_config(self, cert_key):
+        """Under stdio the certs are ignored (no HTTP listener) but the
+        operator is warned rather than silently served plaintext, and
+        run_kwargs never carries uvicorn_config."""
+        cert, key = cert_key
+        mock_logger = MagicMock()
+        captured_kwargs: dict = {}
+
+        async def _capture_guard(run_kwargs):
+            captured_kwargs.update(run_kwargs)
+
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch(
+                "mcp_atlassian._run_stdio_with_stdin_guard",
+                side_effect=_capture_guard,
+            ) as mock_guard:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "TRANSPORT": "stdio",
+                        "MCP_SSL_CERTFILE": str(cert),
+                        "MCP_SSL_KEYFILE": str(key),
+                    },
+                ):
+                    with patch("sys.argv", ["mcp-atlassian"]):
+                        # click always exits in standalone mode; a clean run
+                        # exits 0, an abort would exit 1 and fail here.
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code in (0, None)
+        assert mock_guard.called  # the stdio run path actually executed
+        assert captured_kwargs.get("transport") == "stdio"
+        warnings = " ".join(
+            str(call.args[0]) for call in mock_logger.warning.call_args_list
+        )
+        assert "ignored" in warnings  # the cert-configured-under-stdio warning
+        assert "uvicorn_config" not in captured_kwargs
+
+    @pytest.mark.parametrize("transport", ["sse", "streamable-http"])
+    def test_tls_with_truststore_injection_aborts(self, cert_key, transport):
+        """With the OS trust store injected, enabling the HTTPS listener exits
+        with code 1 before the server starts: truststore's client-side-only
+        SSLContext would reject every inbound TLS handshake."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, key = cert_key
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian._TRUSTSTORE_INJECTED", new=True):
+            with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+                with patch.object(
+                    main_mcp, "run_async", new_callable=AsyncMock
+                ) as mock_run_async:
+                    with patch.dict(
+                        "os.environ",
+                        {
+                            "TRANSPORT": transport,
+                            "MCP_SSL_CERTFILE": str(cert),
+                            "MCP_SSL_KEYFILE": str(key),
+                        },
+                    ):
+                        with patch("sys.argv", ["mcp-atlassian"]):
+                            with pytest.raises(SystemExit) as exc_info:
+                                main()
+
+        assert exc_info.value.code == 1
+        assert not mock_run_async.called
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE" in errors
+
+    def test_tls_under_stdio_with_truststore_injection_does_not_abort(self, cert_key):
+        """stdio ignores the TLS options, so the truststore guard must not
+        trip: there is no HTTPS listener for the injection to break."""
+        cert, key = cert_key
+        mock_logger = MagicMock()
+
+        async def _noop_guard(run_kwargs):
+            return None
+
+        with patch("mcp_atlassian._TRUSTSTORE_INJECTED", new=True):
+            with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+                with patch(
+                    "mcp_atlassian._run_stdio_with_stdin_guard",
+                    side_effect=_noop_guard,
+                ) as mock_guard:
+                    with patch.dict(
+                        "os.environ",
+                        {
+                            "TRANSPORT": "stdio",
+                            "MCP_SSL_CERTFILE": str(cert),
+                            "MCP_SSL_KEYFILE": str(key),
+                        },
+                    ):
+                        with patch("sys.argv", ["mcp-atlassian"]):
+                            # A clean run exits 0; the guard tripping would
+                            # exit 1 and fail the assertion below.
+                            with pytest.raises(SystemExit) as exc_info:
+                                main()
+
+        assert exc_info.value.code in (0, None)
+        assert mock_guard.called  # the stdio run path actually executed
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE" not in errors
+
+    def test_tls_under_stdio_via_cli_flags_warns(self, cert_key):
+        """The stdio warning also fires when the certs arrive via CLI flags
+        rather than env vars."""
+        cert, key = cert_key
+        mock_logger = MagicMock()
+
+        async def _noop_guard(run_kwargs):
+            return None
+
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch(
+                "mcp_atlassian._run_stdio_with_stdin_guard",
+                side_effect=_noop_guard,
+            ) as mock_guard:
+                with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
+                    with patch(
+                        "sys.argv",
+                        [
+                            "mcp-atlassian",
+                            "--ssl-certfile",
+                            str(cert),
+                            "--ssl-keyfile",
+                            str(key),
+                        ],
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code in (0, None)
+        assert mock_guard.called
+        warnings = " ".join(
+            str(call.args[0]) for call in mock_logger.warning.call_args_list
+        )
+        assert "ignored" in warnings
+
+    @pytest.mark.parametrize("blank", ["cert", "key", "both"])
+    def test_blank_tls_env_aborts(self, cert_key, blank):
+        """A TLS env var that is set but blank is a configuration error (e.g.
+        a template rendering an unset value as \"\"), not \"TLS off\": exit 1
+        instead of silently serving plaintext."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, key = cert_key
+        env = {"TRANSPORT": "streamable-http"}
+        env["MCP_SSL_CERTFILE"] = "" if blank in ("cert", "both") else str(cert)
+        env["MCP_SSL_KEYFILE"] = "" if blank in ("key", "both") else str(key)
+
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch.object(
+                main_mcp, "run_async", new_callable=AsyncMock
+            ) as mock_run_async:
+                with patch.dict("os.environ", env):
+                    with patch("sys.argv", ["mcp-atlassian"]):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 1
+        assert not mock_run_async.called
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "set but empty" in errors
+
+    def test_tls_preflight_rejects_unloadable_pair(self, cert_key):
+        """A pair that exists but cannot be loaded (non-PEM content here;
+        same path catches mismatched pairs and encrypted keys) exits with a
+        clear error before the server starts."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, key = cert_key  # dummy text files: not loadable PEM
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch.object(
+                main_mcp, "run_async", new_callable=AsyncMock
+            ) as mock_run_async:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "TRANSPORT": "streamable-http",
+                        "MCP_SSL_CERTFILE": str(cert),
+                        "MCP_SSL_KEYFILE": str(key),
+                    },
+                ):
+                    with patch("sys.argv", ["mcp-atlassian"]):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 1
+        assert not mock_run_async.called
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "could not be loaded" in errors
+
+    def test_tls_startup_log_uses_https_scheme(self, cert_key, preflight_ok):
+        """The startup log line is the operator's confirmation TLS is active;
+        pin the https:// scheme."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, key = cert_key
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch.object(main_mcp, "run_async", new_callable=AsyncMock):
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "TRANSPORT": "streamable-http",
+                        "MCP_SSL_CERTFILE": str(cert),
+                        "MCP_SSL_KEYFILE": str(key),
+                    },
+                ):
+                    with patch("sys.argv", ["mcp-atlassian"]):
+                        self._run_main()
+
+        infos = " ".join(str(call.args[0]) for call in mock_logger.info.call_args_list)
+        assert "https://" in infos
+
+    def test_truststore_detection_assumption_holds(self):
+        """The guard detects injection via ssl.SSLContext.__module__; pin the
+        truststore layout that detection depends on, so a relocation fails
+        loudly here rather than silently disabling the guard."""
+        truststore = pytest.importorskip("truststore")
+        assert truststore.SSLContext.__module__.startswith("truststore")
+
+    def test_cli_pair_overrides_blank_env(self, tmp_path, preflight_ok):
+        """A complete CLI pair wins over blank env vars — CLI-over-env
+        precedence holds; the blank-env abort applies only when the env value
+        is the selected source."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, key = self._make_pair(tmp_path)
+        with patch.object(
+            main_mcp, "run_async", new_callable=AsyncMock
+        ) as mock_run_async:
+            with patch.dict(
+                "os.environ",
+                {
+                    "TRANSPORT": "streamable-http",
+                    "MCP_SSL_CERTFILE": "",
+                    "MCP_SSL_KEYFILE": "",
+                },
+            ):
+                with patch(
+                    "sys.argv",
+                    [
+                        "mcp-atlassian",
+                        "--ssl-certfile",
+                        str(cert),
+                        "--ssl-keyfile",
+                        str(key),
+                    ],
+                ):
+                    self._run_main()
+
+        assert mock_run_async.called
+        assert mock_run_async.call_args[1]["uvicorn_config"]["ssl_certfile"] == str(
+            cert
+        )
+
+    def test_tls_under_stdio_skips_all_validation(self, tmp_path):
+        """Under stdio the TLS options are ignored entirely: even values that
+        would abort on an HTTP transport (missing files here) only warn."""
+        mock_logger = MagicMock()
+
+        async def _noop_guard(run_kwargs):
+            return None
+
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch(
+                "mcp_atlassian._run_stdio_with_stdin_guard",
+                side_effect=_noop_guard,
+            ) as mock_guard:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "TRANSPORT": "stdio",
+                        "MCP_SSL_CERTFILE": str(tmp_path / "missing-cert.pem"),
+                        "MCP_SSL_KEYFILE": str(tmp_path / "missing-key.pem"),
+                    },
+                ):
+                    with patch("sys.argv", ["mcp-atlassian"]):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code in (0, None)
+        assert mock_guard.called
+        warnings = " ".join(
+            str(call.args[0]) for call in mock_logger.warning.call_args_list
+        )
+        assert "ignored" in warnings
+        assert not mock_logger.error.called
+
+    def test_tls_under_stdio_missing_cli_paths_ignored(self, tmp_path):
+        """Missing CLI paths must also be ignorable under stdio — click does
+        no existence check at parse time, so stdio starts with a warning."""
+        mock_logger = MagicMock()
+
+        async def _noop_guard(run_kwargs):
+            return None
+
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch(
+                "mcp_atlassian._run_stdio_with_stdin_guard",
+                side_effect=_noop_guard,
+            ) as mock_guard:
+                with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
+                    with patch(
+                        "sys.argv",
+                        [
+                            "mcp-atlassian",
+                            "--ssl-certfile",
+                            str(tmp_path / "missing-cert.pem"),
+                            "--ssl-keyfile",
+                            str(tmp_path / "missing-key.pem"),
+                        ],
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code in (0, None)
+        assert mock_guard.called
+        warnings = " ".join(
+            str(call.args[0]) for call in mock_logger.warning.call_args_list
+        )
+        assert "ignored" in warnings
+
+    def test_tls_under_stdio_directory_cli_paths_ignored(self, tmp_path):
+        """Even directory values for the CLI flags must be ignorable under
+        stdio — the options carry no click-level path validation at all."""
+        mock_logger = MagicMock()
+
+        async def _noop_guard(run_kwargs):
+            return None
+
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch(
+                "mcp_atlassian._run_stdio_with_stdin_guard",
+                side_effect=_noop_guard,
+            ) as mock_guard:
+                with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
+                    with patch(
+                        "sys.argv",
+                        [
+                            "mcp-atlassian",
+                            "--ssl-certfile",
+                            str(tmp_path),
+                            "--ssl-keyfile",
+                            str(tmp_path),
+                        ],
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code in (0, None)
+        assert mock_guard.called
+        warnings = " ".join(
+            str(call.args[0]) for call in mock_logger.warning.call_args_list
+        )
+        assert "ignored" in warnings
+
+    def test_missing_cli_path_aborts_on_http_transport(self, cert_key, tmp_path):
+        """With click no longer existence-checking, a missing CLI path on an
+        HTTP transport must still fail fast via the manual file check."""
+        from mcp_atlassian.servers import main_mcp
+
+        cert, _key = cert_key
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch.object(
+                main_mcp, "run_async", new_callable=AsyncMock
+            ) as mock_run_async:
+                with patch.dict("os.environ", {"TRANSPORT": "streamable-http"}):
+                    with patch(
+                        "sys.argv",
+                        [
+                            "mcp-atlassian",
+                            "--ssl-certfile",
+                            str(cert),
+                            "--ssl-keyfile",
+                            str(tmp_path / "missing-key.pem"),
+                        ],
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 1
+        assert not mock_run_async.called
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "not found" in errors
+
+    def test_blank_cli_tls_flag_aborts(self, cert_key):
+        """A blank CLI value is a configuration error on HTTP transports, the
+        same as a blank env var (click no longer rejects empty strings)."""
+        from mcp_atlassian.servers import main_mcp
+
+        _cert, key = cert_key
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.setup_logging", return_value=mock_logger):
+            with patch.object(
+                main_mcp, "run_async", new_callable=AsyncMock
+            ) as mock_run_async:
+                with patch.dict("os.environ", {"TRANSPORT": "streamable-http"}):
+                    with patch(
+                        "sys.argv",
+                        [
+                            "mcp-atlassian",
+                            "--ssl-certfile",
+                            "",
+                            "--ssl-keyfile",
+                            str(key),
+                        ],
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 1
+        assert not mock_run_async.called
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "set but empty" in errors
+
+
+@pytest.fixture(scope="module")
+def real_cert_pairs(tmp_path_factory):
+    """Two real self-signed cert/key pairs, generated with the openssl binary
+    (skipped where openssl is unavailable; present on the CI runners)."""
+    openssl = shutil.which("openssl")
+    if openssl is None:
+        pytest.skip("openssl binary not available")
+    directory = tmp_path_factory.mktemp("tls-real")
+    pairs = []
+    for name in ("a", "b"):
+        cert = directory / f"{name}-cert.pem"
+        key = directory / f"{name}-key.pem"
+        subprocess.run(
+            [
+                openssl,
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                str(key),
+                "-out",
+                str(cert),
+                "-days",
+                "1",
+                "-nodes",
+                "-subj",
+                "/CN=localhost",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        pairs.append((cert, key))
+    return pairs
+
+
+@pytest.fixture
+def stdlib_ssl():
+    """Temporarily undo truststore injection so handshakes use stdlib SSL —
+    matching a real TLS-serving process, where the startup guard requires the
+    injection to be off."""
+    try:
+        import truststore
+    except ImportError:
+        yield
+        return
+    was_injected = ssl.SSLContext.__module__.startswith("truststore")
+    if was_injected:
+        truststore.extract_from_ssl()
+    try:
+        yield
+    finally:
+        if was_injected:
+            truststore.inject_into_ssl()
+
+
+class TestServerTLSRealCertificates:
+    """Real-SSL coverage: the cipher pin resolves, a valid pair passes the
+    preflight, and the listener context negotiates the intended protocols —
+    without mocking the SSL layer."""
+
+    def test_cipher_pin_is_a_valid_openssl_expression(self):
+        ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER).set_ciphers(_TLS_LISTENER_CIPHERS)
+
+    def test_preflight_accepts_valid_pair(self, real_cert_pairs):
+        from mcp_atlassian import _preflight_tls_certificates
+
+        cert, key = real_cert_pairs[0]
+        _preflight_tls_certificates(str(cert), str(key))  # must not exit
+
+    def test_preflight_rejects_mismatched_pair(self, real_cert_pairs):
+        from mcp_atlassian import _preflight_tls_certificates
+
+        cert_a, _ = real_cert_pairs[0]
+        _, key_b = real_cert_pairs[1]
+        mock_logger = MagicMock()
+        with patch("mcp_atlassian.logger", mock_logger):
+            with pytest.raises(SystemExit) as exc_info:
+                _preflight_tls_certificates(str(cert_a), str(key_b))
+        assert exc_info.value.code == 1
+        errors = " ".join(
+            str(call.args[0]) for call in mock_logger.error.call_args_list
+        )
+        assert "could not be loaded" in errors
+
+    @staticmethod
+    def _server_context(cert, key):
+        """Build the listener context the way uvicorn does, with the pin."""
+        from uvicorn.config import create_ssl_context
+
+        return create_ssl_context(
+            certfile=str(cert),
+            keyfile=str(key),
+            password=None,
+            ssl_version=ssl.PROTOCOL_TLS_SERVER,
+            cert_reqs=ssl.CERT_NONE,
+            ca_certs=None,
+            ciphers=_TLS_LISTENER_CIPHERS,
+        )
+
+    @staticmethod
+    def _client_context(minimum=None, maximum=None):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        if minimum is not None:
+            ctx.minimum_version = minimum
+        if maximum is not None:
+            ctx.maximum_version = maximum
+        return ctx
+
+    @staticmethod
+    def _handshake(server_ctx, client_ctx):
+        """In-memory TLS handshake between the two contexts."""
+        c_in, c_out = ssl.MemoryBIO(), ssl.MemoryBIO()
+        s_in, s_out = ssl.MemoryBIO(), ssl.MemoryBIO()
+        client = client_ctx.wrap_bio(c_in, c_out, server_hostname="localhost")
+        server = server_ctx.wrap_bio(s_in, s_out, server_side=True)
+        client_done = server_done = False
+        for _ in range(10):
+            if not client_done:
+                try:
+                    client.do_handshake()
+                    client_done = True
+                except ssl.SSLWantReadError:
+                    pass
+            s_in.write(c_out.read())
+            if not server_done:
+                try:
+                    server.do_handshake()
+                    server_done = True
+                except ssl.SSLWantReadError:
+                    pass
+            c_in.write(s_out.read())
+            if client_done and server_done:
+                return client
+        raise AssertionError("handshake did not complete")
+
+    def test_tls13_negotiates(self, real_cert_pairs, stdlib_ssl):
+        cert, key = real_cert_pairs[0]
+        client = self._handshake(
+            self._server_context(cert, key), self._client_context()
+        )
+        assert client.version() == "TLSv1.3"
+
+    def test_tls12_negotiates_aead_suite(self, real_cert_pairs, stdlib_ssl):
+        cert, key = real_cert_pairs[0]
+        client = self._handshake(
+            self._server_context(cert, key),
+            self._client_context(
+                minimum=ssl.TLSVersion.TLSv1_2, maximum=ssl.TLSVersion.TLSv1_2
+            ),
+        )
+        assert client.version() == "TLSv1.2"
+        cipher_name = client.cipher()[0]
+        assert "GCM" in cipher_name or "CHACHA20" in cipher_name
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.parametrize("legacy", [ssl.TLSVersion.TLSv1, ssl.TLSVersion.TLSv1_1])
+    def test_legacy_tls_is_refused_by_server(self, real_cert_pairs, stdlib_ssl, legacy):
+        """A client genuinely offering TLS 1.0/1.1 must be refused by the
+        SERVER. The handshake is driven step by step so the rejection is
+        attributable: the test skips unless a non-empty ClientHello was
+        actually produced and handed to the server, and the assertion is on
+        the server side of the handshake — a client-side failure (restricted
+        or FIPS builds) can therefore never pass as server rejection."""
+        cert, key = real_cert_pairs[0]
+        client_ctx = self._client_context(minimum=legacy, maximum=legacy)
+        try:
+            # Modern OpenSSL disables TLS < 1.2 at SECLEVEL >= 1.
+            client_ctx.set_ciphers("DEFAULT@SECLEVEL=0")
+        except ssl.SSLError as exc:
+            pytest.skip(f"runtime cannot configure a legacy TLS client: {exc}")
+
+        c_in, c_out = ssl.MemoryBIO(), ssl.MemoryBIO()
+        s_in, s_out = ssl.MemoryBIO(), ssl.MemoryBIO()
+        client = client_ctx.wrap_bio(c_in, c_out, server_hostname="localhost")
+        server = self._server_context(cert, key).wrap_bio(s_in, s_out, server_side=True)
+        try:
+            client.do_handshake()
+        except ssl.SSLWantReadError:
+            pass  # normal: the ClientHello is written, awaiting the server
+        except ssl.SSLError as exc:
+            pytest.skip(f"runtime cannot offer legacy TLS client-side: {exc}")
+        client_hello = c_out.read()
+        if not client_hello:
+            pytest.skip("no ClientHello produced; server rejection not provable")
+
+        s_in.write(client_hello)
+        with pytest.raises(ssl.SSLError) as exc_info:
+            server.do_handshake()  # the server itself must refuse the offer
+        # SSLWantRead/WriteError are SSLError subclasses that mean the server
+        # ACCEPTED the hello and wants more I/O — that is the regression this
+        # test exists to catch, not a pass.
+        assert not isinstance(
+            exc_info.value, ssl.SSLWantReadError | ssl.SSLWantWriteError
+        ), "server continued the legacy handshake instead of rejecting it"

--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -518,7 +518,7 @@ class TestServerTLSConfiguration:
         )
         assert "MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE" not in errors
 
-    def test_stdio_cli_tls_warns(self, cert_key):
+    def teststdio_cli_tls_warns(self, cert_key):
         """The stdio warning also fires when the certs arrive via CLI flags
         rather than env vars."""
         cert, key = cert_key

--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -518,7 +518,7 @@ class TestServerTLSConfiguration:
         )
         assert "MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE" not in errors
 
-    def test_tls_under_stdio_via_cli_flags_warns(self, cert_key):
+    def test_stdio_cli_tls_warns(self, cert_key):
         """The stdio warning also fires when the certs arrive via CLI flags
         rather than env vars."""
         cert, key = cert_key

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -1,5 +1,6 @@
 """Tests for the SSL utilities module."""
 
+import os
 import ssl
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,15 @@ from mcp_atlassian.utils.ssl import (
     configure_ssl_verification,
 )
 from mcp_atlassian.utils.ssrf_adapter import SsrfPinningAdapter
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ca_bundle_env(monkeypatch):
+    """Keep ambient CA-bundle env vars (common in corporate shells) from
+    changing what these tests prove; tests that need them set them
+    explicitly."""
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
 
 
 def test_ssl_ignore_adapter_cert_verify():
@@ -453,3 +463,253 @@ def test_configure_ssl_verification_enabled_with_no_proxy_mounts_adapter(monkeyp
     assert not isinstance(
         session.get_adapter("https://test.example.com"), SSLIgnoreAdapter
     )
+
+
+def test_configure_ssl_verification_applies_requests_ca_bundle(monkeypatch, tmp_path):
+    """A REQUESTS_CA_BUNDLE path is applied to session.verify explicitly, so it
+    works on the PAT/OAuth sessions that run with trust_env=False (where
+    requests itself ignores the variable)."""
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("dummy bundle")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(bundle))
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+    session = Session()
+    session.trust_env = False
+
+    configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com",
+        session=session,
+        ssl_verify=True,
+    )
+
+    assert session.verify == str(bundle)
+
+
+def test_configure_ssl_verification_falls_back_to_curl_ca_bundle(monkeypatch, tmp_path):
+    """CURL_CA_BUNDLE is honored when REQUESTS_CA_BUNDLE is unset, mirroring
+    requests' own env-var precedence."""
+    bundle = tmp_path / "curl-ca.pem"
+    bundle.write_text("dummy bundle")
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.setenv("CURL_CA_BUNDLE", str(bundle))
+    session = Session()
+
+    configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com",
+        session=session,
+        ssl_verify=True,
+    )
+
+    assert session.verify == str(bundle)
+
+
+def test_configure_ssl_verification_missing_ca_bundle_raises(monkeypatch, tmp_path):
+    """A configured bundle path that is not a regular file fails fast instead
+    of surfacing later as an opaque requests error."""
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(tmp_path / "missing.pem"))
+    session = Session()
+
+    with pytest.raises(ValueError, match="CA bundle"):
+        configure_ssl_verification(
+            service_name="TestService",
+            url="https://test.example.com",
+            session=session,
+            ssl_verify=True,
+        )
+
+
+def test_configure_ssl_verification_no_bundle_keeps_default_verify(monkeypatch):
+    """Without a bundle env var, session verification stays at the default."""
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+    session = Session()
+
+    configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com",
+        session=session,
+        ssl_verify=True,
+    )
+
+    assert session.verify is True
+
+
+def test_configure_ssl_verification_disabled_ignores_ca_bundle(monkeypatch, tmp_path):
+    """With ssl_verify=False the ignore adapter governs; the bundle is not
+    applied to session.verify."""
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("dummy bundle")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(bundle))
+    session = Session()
+
+    configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com",
+        session=session,
+        ssl_verify=False,
+    )
+
+    assert session.verify is True  # untouched; SSLIgnoreAdapter handles the bypass
+
+
+def test_configure_ssl_verification_accepts_ca_directory(monkeypatch, tmp_path):
+    """requests supports OpenSSL-style hashed CA directories as verify paths;
+    the fail-fast check must not reject them."""
+    ca_dir = tmp_path / "hashed-cas"
+    ca_dir.mkdir()
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_dir))
+    session = Session()
+
+    effective = configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com",
+        session=session,
+        ssl_verify=True,
+    )
+
+    assert session.verify == str(ca_dir)
+    assert effective == str(ca_dir)
+
+
+def test_configure_ssl_verification_returns_effective_value(monkeypatch, tmp_path):
+    """The return value is the effective requests verify value, for callers
+    that must propagate it to per-request verify= wrappers."""
+    session = Session()
+    assert (
+        configure_ssl_verification(
+            service_name="TestService",
+            url="https://test.example.com",
+            session=session,
+            ssl_verify=True,
+        )
+        is True
+    )
+    assert (
+        configure_ssl_verification(
+            service_name="TestService",
+            url="https://test.example.com",
+            session=Session(),
+            ssl_verify=False,
+        )
+        is False
+    )
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("dummy bundle")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(bundle))
+    assert configure_ssl_verification(
+        service_name="TestService",
+        url="https://test.example.com",
+        session=Session(),
+        ssl_verify=True,
+    ) == str(bundle)
+
+
+def test_atlassian_wrapper_request_uses_ca_bundle(monkeypatch, tmp_path):
+    """The atlassian-python-api wrapper passes verify=self.verify_ssl on every
+    request, overriding session.verify — so the effective value must reach the
+    wrapper attribute for a private CA to apply to normal API calls."""
+    from atlassian import Jira as AtlassianJira
+
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("dummy bundle")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(bundle))
+
+    jira = AtlassianJira(
+        url="https://jira.example.com", token="dummy-pat", verify_ssl=True
+    )
+    jira._session.trust_env = False
+    effective = configure_ssl_verification(
+        service_name="Jira",
+        url="https://jira.example.com",
+        session=jira._session,
+        ssl_verify=True,
+    )
+    jira.verify_ssl = effective  # what JiraClient/ConfluenceClient now do
+
+    mock_response = MagicMock(status_code=200)
+    mock_response.headers = {}
+    with patch.object(
+        jira._session, "request", return_value=mock_response
+    ) as mock_request:
+        jira.get("rest/api/2/myself")
+
+    assert mock_request.call_args.kwargs["verify"] == str(bundle)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX mkfifo")
+def test_configure_ssl_verification_rejects_special_file(monkeypatch, tmp_path):
+    """A FIFO (or other special node) as the CA path must fail fast — the TLS
+    layer would block reading it instead of erroring."""
+    fifo = tmp_path / "ca.fifo"
+    os.mkfifo(fifo)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(fifo))
+
+    with pytest.raises(ValueError, match="CA bundle"):
+        configure_ssl_verification(
+            service_name="TestService",
+            url="https://test.example.com",
+            session=Session(),
+            ssl_verify=True,
+        )
+
+
+def test_jira_client_wrapper_request_carries_ca_bundle(monkeypatch, tmp_path):
+    """Production-seam regression: a real JiraClient must leave the wrapper
+    sending the configured CA path as verify= on ordinary API requests —
+    removing the client's verify_ssl sync would fail this test."""
+    from mcp_atlassian.jira.client import JiraClient
+    from mcp_atlassian.jira.config import JiraConfig
+
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("dummy bundle")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(bundle))
+
+    client = JiraClient(
+        config=JiraConfig(
+            url="https://jira.example.com",
+            auth_type="pat",
+            personal_token="dummy-pat",
+            ssl_verify=True,
+        )
+    )
+    assert client.jira._session.trust_env is False  # the PAT session shape
+
+    mock_response = MagicMock(status_code=200)
+    mock_response.headers = {}
+    with patch.object(
+        client.jira._session, "request", return_value=mock_response
+    ) as mock_request:
+        client.jira.get("rest/api/2/myself")
+
+    assert mock_request.call_args.kwargs["verify"] == str(bundle)
+
+
+def test_confluence_client_wrapper_request_carries_ca_bundle(monkeypatch, tmp_path):
+    """Same production-seam regression for ConfluenceClient."""
+    from mcp_atlassian.confluence.client import ConfluenceClient
+    from mcp_atlassian.confluence.config import ConfluenceConfig
+
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("dummy bundle")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(bundle))
+
+    client = ConfluenceClient(
+        config=ConfluenceConfig(
+            url="https://confluence.example.com",
+            auth_type="pat",
+            personal_token="dummy-pat",
+            ssl_verify=True,
+        )
+    )
+    assert client.confluence._session.trust_env is False
+
+    mock_response = MagicMock(status_code=200)
+    mock_response.headers = {}
+    with patch.object(
+        client.confluence._session, "request", return_value=mock_response
+    ) as mock_request:
+        client.confluence.get("rest/api/space")
+
+    assert mock_request.call_args.kwargs["verify"] == str(bundle)


### PR DESCRIPTION
## Summary

Adds native TLS termination to the `sse`/`streamable-http` transports, so the server can
serve HTTPS directly — for deployments where policy requires encryption all the way to
the process and terminating at a reverse proxy/ingress is not enough.

- `--ssl-certfile` / `--ssl-keyfile` CLI options, with `MCP_SSL_CERTFILE` /
  `MCP_SSL_KEYFILE` env fallback (CLI wins, mirroring host/port precedence — including a
  provided CLI pair overriding blank env vars).
- Forwarded to uvicorn through FastMCP's existing `run_http_async(uvicorn_config=...)`
  seam — no new dependencies.
- Under `stdio` the options are ignored entirely with a single warning — from either
  source: the CLI options carry no parse-time validation at all, so neither a missing
  path nor a directory value can abort a stdio start.

## Fail-closed behavior

Every HTTP-transport misconfiguration aborts startup with a clear message rather than
serving plaintext or failing deep inside uvicorn: cert and key must be provided
together; a selected value that is *set but blank* (e.g. a template rendering an unset
value as `""`) is a configuration error from either source, not "TLS off"; resolved
paths must be regular files; and the pair is preflight-loaded so a mismatched pair,
non-PEM content, or an encrypted key (unsupported) surfaces as a clean startup error
instead of an opaque uvicorn failure or an interactive OpenSSL passphrase prompt.

## Cipher pinning

uvicorn's default `ssl_ciphers="TLSv1"` OpenSSL group contains NULL-encryption and
anonymous suites and no AEAD suites, so the negotiated strength varies with the base
image's OpenSSL security level (a `SECLEVEL=0` image will complete an
authenticated-but-unencrypted handshake). The listener pins
`ECDHE+AESGCM:ECDHE+CHACHA20:!aNULL:!eNULL:!MD5`, which also excludes TLS 1.0/1.1 (no
AEAD suites exist for them). TLS 1.3 suites are configured separately by OpenSSL and
stay enabled. Negotiation is regression-tested with real certificates via in-memory
handshakes: TLS 1.3 and TLS 1.2 (AEAD) negotiate; TLS 1.0 and 1.1 offers are proven
to reach the server as real ClientHellos and are refused on the server side of the
handshake (skipped with an explicit reason where the runtime cannot produce a legacy
offer at all).

## Interaction with the OS trust store injection

`truststore.inject_into_ssl()` (default on) replaces `ssl.SSLContext` with a
client-side-only context whose post-handshake peer-cert verification resets **every
inbound TLS connection** — a server's peer sends no certificate — while startup still
logs success. uvicorn builds its listener context from `ssl.SSLContext`, so the two
features cannot coexist in one process. Startup fails fast with the remediation
(`MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE=false`, set as a real env var or in the default
`.env`; `--env-file` is loaded too late to affect injection).

## Private-CA outbound (first commit)

Disabling the trust store injection moves outbound verification to certifi — but the
PAT/OAuth sessions set `trust_env=False` (so `.netrc` cannot override credentials),
which made requests ignore `REQUESTS_CA_BUNDLE`. Worse, `atlassian-python-api` passes
`verify=self.verify_ssl` on **every wrapper request**, overriding any session-level
value — so normal Jira/Confluence API calls needed the fix at the wrapper seam, not
just the session. The first commit resolves `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` in
`configure_ssl_verification` (single seam, all services): applies it to
`session.verify`, accepts both bundle files and OpenSSL-style hashed CA directories,
returns the effective verify value, and the Jira/Confluence clients propagate it to the
wrapper's `verify_ssl`. Dev-status calls no longer pass a per-request verify bool. A
bundle path that is not a regular file or directory (special files like FIFOs would
block instead of failing) aborts fast, with the path logged server-side only — fetcher
errors can reach the MCP client. Docs cover the full setup: `REQUESTS_CA_BUNDLE` for the requests clients
**and** `SSL_CERT_FILE` for the httpx-based OAuth proxy paths, with a warning against
the `*_SSL_VERIFY=false` workaround.

Note: the listener certificate is unrelated to the client-side `*_CLIENT_CERT` mTLS
options used when connecting *to* Atlassian.

## Known limitation

FastMCP's transport banner hard-codes `http://` in its "Starting MCP server" line
(fastmcp 3.4.4, `server/mixins/transport.py`); our launcher line and uvicorn's own
"running on" line both correctly print `https://`. Candidate for a small upstream
FastMCP fix.

## Testing

- 34 listener tests (`TestServerTLSConfiguration` + `TestServerTLSRealCertificates`):
  precedence (env, CLI, cross-source, CLI-over-blank-env), cipher-pin forwarding,
  half-configured/blank (env and CLI)/missing-path (env and CLI) aborts, preflight
  rejection (garbage pair, mismatched real pair) and acceptance (real pair),
  truststore-guard aborts on both HTTP transports, stdio ignores everything (env, CLI
  flags, missing paths, directory values, would-abort values), https scheme in the
  startup log, truststore-layout detection pin, and the real-certificate protocol
  matrix with server-attributed legacy rejection.
- 12 outbound-CA tests: production-seam regressions through the real `JiraClient` and
  `ConfluenceClient` (an ordinary wrapper request carries the bundle as `verify=`),
  the wrapper-mechanism test, bundle applied on `trust_env=False` sessions,
  CA-directory acceptance, special-file (FIFO) rejection, CURL fallback,
  effective-value return contract, missing-bundle fail-fast, default preserved,
  ignored when `ssl_verify=false`, dev-status covers both call sites.
- Full suite: 3719 passed on this branch. `pre-commit` (ruff-format, ruff, mypy)
  clean.
- Verified live: HTTPS listener serves `/healthz` and MCP initialize; default truststore
  mode aborts with the remediation; a private-CA request through the real `JiraClient`
  (PAT, `trust_env=False`) completes TLS end-to-end with `REQUESTS_CA_BUNDLE`.