### PR TITLE
fix(jira): resolve jira_assign_issue failures on Server/DC for email, key, and display-name identifiers

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -132,7 +132,7 @@ Assign a Jira issue to a user using the dedicated assignment endpoint.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `assignee` | `string` | No | User identifier to assign (email, display name, or account ID), or a JSON object string from jira_search_assignable_users. Pass null or empty string to unassign the issue. |
+| `assignee` | `string` | No | User identifier (email, display name, account ID, login name, or JIRAUSER key), or a JSON object string from jira_search_assignable_users. Pass null or empty string to unassign. |
 
 ---
 

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1385,7 +1385,7 @@ class IssuesMixin(
                         )
                 self.jira.assign_issue(issue_key, str(assignee_identifier))
             else:
-                account_id = self._get_account_id(assignee)
+                account_id = self._get_account_id(assignee, issue_key=issue_key)
                 self.jira.assign_issue(issue_key, account_id)
 
             # Return the updated issue

--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -240,11 +240,12 @@ class UsersOperationsProto(Protocol):
     """Protocol defining user operations interface."""
 
     @abstractmethod
-    def _get_account_id(self, assignee: str) -> str:
+    def _get_account_id(self, assignee: str, issue_key: str | None = None) -> str:
         """Get the account ID for a username.
 
         Args:
             assignee: Username or account ID
+            issue_key: Optional issue key used to scope an assignable-user fallback
 
         Returns:
             Account ID

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -123,10 +123,10 @@ class UsersMixin(JiraClient):
         Get the account ID for a username or account ID.
 
         Args:
-            assignee (str): Username or account ID.
+            assignee: Username, display name, email, or account/key identifier.
 
         Returns:
-            str: Account ID.
+            str: Account ID (Cloud) or login name / key (Server/DC).
 
         Raises:
             ValueError: If the account ID could not be found.
@@ -143,6 +143,64 @@ class UsersMixin(JiraClient):
             return assignee
         if re.fullmatch(r"\d+:[0-9a-fA-F][0-9a-fA-F-]{7,}", assignee):
             return assignee
+
+        # Server/DC-specific fast paths that mirror the resolution used by
+        # get_user_profile_by_identifier, so that profile lookup and assign
+        # succeed or fail together for the same identifier.
+        if not self.config.is_cloud:
+            # Short-circuit Server/DC user keys (e.g. JIRAUSER56506).
+            # Resolve to the login name via a direct user fetch so the
+            # assignee PUT body carries {"name": "<login>"} as Jira expects.
+            if re.match(r"^JIRAUSER\d+$", assignee, re.IGNORECASE):
+                try:
+                    user_data = self.jira.user(key=assignee)
+                    if isinstance(user_data, dict):
+                        name = user_data.get("name")
+                        if name:
+                            logger.info(
+                                "Resolved Server/DC key '%s' to login name '%s'",
+                                assignee,
+                                name,
+                            )
+                            return name
+                        # Key present but no login name — use key itself as fallback
+                        return assignee
+                except Exception as exc:
+                    logger.info(
+                        "Could not resolve Server/DC key '%s' via user fetch: %s",
+                        assignee,
+                        exc,
+                    )
+                # Fall through to search-based resolution
+
+            # For emails on Server/DC, reuse the same resolution path as
+            # get_user_profile_by_identifier so both always agree on the user.
+            if "@" in assignee:
+                resolved = self._resolve_server_dc_user_params(assignee)
+                if resolved:
+                    value = resolved.get("username") or resolved.get("key")
+                    if value:
+                        return value
+                else:
+                    # Fallback: login name may be the email address itself.
+                    try:
+                        user_data = self.jira.user(username=assignee)
+                        if isinstance(user_data, dict):
+                            name = user_data.get("name")
+                            if name:
+                                logger.info(
+                                    "Resolved Server/DC email '%s' as direct "
+                                    "username → login name '%s'",
+                                    assignee,
+                                    name,
+                                )
+                                return name
+                    except Exception as exc:
+                        logger.info(
+                            "Email-as-username fallback failed for '%s': %s",
+                            assignee,
+                            exc,
+                        )
 
         account_id = self._lookup_user_directly(assignee)
         if account_id:
@@ -184,6 +242,7 @@ class UsersMixin(JiraClient):
                     normalize_text(user.get("displayName", "")) == search_norm
                     or normalize_text(user.get("name", "")) == search_norm
                     or normalize_text(user.get("emailAddress", "")) == search_norm
+                    or normalize_text(user.get("key", "")) == search_norm
                 ):
                     if self.config.is_cloud:
                         if "accountId" in user:

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -118,12 +118,13 @@ class UsersMixin(JiraClient):
             error_msg = f"Unable to get current user account ID: {e}"
             raise Exception(error_msg) from e
 
-    def _get_account_id(self, assignee: str) -> str:
+    def _get_account_id(self, assignee: str, issue_key: str | None = None) -> str:
         """
         Get the account ID for a username or account ID.
 
         Args:
             assignee: Username, display name, email, or account/key identifier.
+            issue_key: Optional issue key used to scope an assignable-user fallback.
 
         Returns:
             str: Account ID (Cloud) or login name / key (Server/DC).
@@ -210,6 +211,41 @@ class UsersMixin(JiraClient):
         if account_id:
             return account_id
 
+        if issue_key:
+            try:
+                assignable_users = self.search_assignable_users(
+                    query=assignee,
+                    issue_key=issue_key,
+                    limit=20,
+                )
+                search_norm = normalize_text(assignee)
+                for user in assignable_users:
+                    if not any(
+                        normalize_text(value) == search_norm
+                        for value in (
+                            user.username,
+                            user.user_key,
+                            user.display_name,
+                            user.email,
+                        )
+                    ):
+                        continue
+
+                    if self.config.is_cloud:
+                        if user.account_id:
+                            return user.account_id
+                    elif user.username:
+                        return user.username
+                    elif user.user_key:
+                        return user.user_key
+            except Exception as exc:
+                logger.info(
+                    "Error looking up assignable user '%s' for issue '%s': %s",
+                    assignee,
+                    issue_key,
+                    exc,
+                )
+
         error_msg = f"Could not find account ID for user: {assignee}"
         raise ValueError(error_msg)
 
@@ -230,7 +266,7 @@ class UsersMixin(JiraClient):
             else:
                 params["username"] = username
 
-            response = self.jira.user_find_by_user_string(**params, start=0, limit=1)
+            response = self.jira.user_find_by_user_string(**params, start=0, limit=20)
             if not isinstance(response, list):
                 msg = f"Unexpected return value type from `jira.user_find_by_user_string`: {type(response)}"
                 logger.error(msg)
@@ -278,7 +314,7 @@ class UsersMixin(JiraClient):
         """
         try:
             response = self.jira.user_find_by_user_string(
-                username=email, start=0, limit=1
+                username=email, start=0, limit=20
             )
             if not isinstance(response, list):
                 return None

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2279,9 +2279,9 @@ async def assign_issue(
         str | None,
         Field(
             description=(
-                "User identifier to assign (email, display name, or account ID), "
-                "or a JSON object string from jira_search_assignable_users. "
-                "Pass null or empty string to unassign the issue."
+                "User identifier (email, display name, account ID, login name, or "
+                "JIRAUSER key), or a JSON object string from "
+                "jira_search_assignable_users. Pass null or empty string to unassign."
             ),
             default=None,
         ),
@@ -2292,12 +2292,17 @@ async def assign_issue(
     This is more reliable than setting assignee via update_issue, which is
     silently ignored by some Jira configurations. Uses PUT /issue/{key}/assignee.
 
+    On Jira Server/DC the following identifier forms are all accepted:
+    login name, email address, display name, or JIRAUSER key. The resolution
+    order is: key lookup → email search (with email-as-username fallback) →
+    text search → assignable-user search scoped to the issue.
+
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
-        assignee: User identifier (email, display name, or account ID), or a
-            JSON object string from jira_search_assignable_users. Pass None or
-            empty string to unassign.
+        assignee: User identifier (email, display name, account ID, or login
+            name / JIRAUSER key for Server/DC), or a JSON object string from
+            jira_search_assignable_users. Pass None or empty string to unassign.
 
     Returns:
         JSON string representing the updated issue object.

--- a/tests/e2e/test_user_lookup_dc.py
+++ b/tests/e2e/test_user_lookup_dc.py
@@ -145,27 +145,22 @@ class TestAssignByEmail:
         issue_key = data["issue"]["key"]
 
         try:
-            # Assign by email
-            update_result = await call_tool(
+            # Assign by email through the dedicated assignment endpoint.
+            assign_result = await call_tool(
                 mcp_client,
-                "jira_update_issue",
+                "jira_assign_issue",
                 {
                     "issue_key": issue_key,
-                    "fields": json.dumps({"assignee": dc_instance.admin_email}),
+                    "assignee": dc_instance.admin_email,
                 },
             )
-            assert not update_result.is_error
+            assert not assign_result.is_error
 
-            # Verify assignment
-            get_result = await call_tool(
-                mcp_client,
-                "jira_get_issue",
-                {"issue_key": issue_key},
-            )
-            assert not get_result.is_error
-            issue_data = json.loads(get_result.content[0].text)
-            assignee = issue_data.get("assignee", "")
-            assert assignee, "Issue should have an assignee after update"
+            # Verify assignment in the dedicated tool response.
+            issue_data = json.loads(assign_result.content[0].text)["issue"]
+            assignee = issue_data.get("assignee")
+            assert isinstance(assignee, dict)
+            assert assignee.get("name") or assignee.get("display_name")
         finally:
             await call_tool(
                 mcp_client,

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1095,7 +1095,9 @@ class TestIssuesMixin:
             issue_key="TEST-123", assignee="user@example.com"
         )
 
-        issues_mixin._get_account_id.assert_called_once_with("user@example.com")
+        issues_mixin._get_account_id.assert_called_once_with(
+            "user@example.com", issue_key="TEST-123"
+        )
         issues_mixin.jira.assign_issue.assert_called_once_with(
             "TEST-123", "account-123"
         )

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -8,6 +8,7 @@ import requests
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.jira.users import UsersMixin, normalize_text
+from mcp_atlassian.models.jira.common import JiraUser
 
 
 class TestUsersMixin:
@@ -302,7 +303,7 @@ class TestUsersMixin:
         assert account_id == "direct-account-id"
         # Verify API call with query parameter for Cloud
         users_mixin.jira.user_find_by_user_string.assert_called_once_with(
-            query="Test User", start=0, limit=1
+            query="Test User", start=0, limit=20
         )
 
     def test_lookup_user_directly_server_dc(self, users_mixin):
@@ -328,8 +329,29 @@ class TestUsersMixin:
         assert account_id == "server-user-name"
         # Verify API call with username parameter for Server/DC
         users_mixin.jira.user_find_by_user_string.assert_called_once_with(
-            username="Test User", start=0, limit=1
+            username="Test User", start=0, limit=20
         )
+
+    def test_lookup_user_directly_server_dc_checks_all_exact_matches(self, users_mixin):
+        """Test Server/DC lookup does not stop at a non-exact first result."""
+        users_mixin.jira.user_find_by_user_string.return_value = [
+            {
+                "key": "server-user-key-1",
+                "name": "test-user-1",
+                "displayName": "Test User One",
+            },
+            {
+                "key": "server-user-key-2",
+                "name": "test-user-2",
+                "displayName": "Test User",
+            },
+        ]
+        users_mixin.config = MagicMock()
+        users_mixin.config.is_cloud = False
+
+        result = users_mixin._lookup_user_directly("Test User")
+
+        assert result == "test-user-2"
 
     def test_lookup_user_directly_server_dc_key_fallback(self, users_mixin):
         """Test _lookup_user_directly for Server/DC falls back to key when name is not available."""
@@ -353,7 +375,7 @@ class TestUsersMixin:
         assert account_id == "server-user-key"
         # Verify API call with username parameter for Server/DC
         users_mixin.jira.user_find_by_user_string.assert_called_once_with(
-            username="Test User", start=0, limit=1
+            username="Test User", start=0, limit=20
         )
 
     def test_lookup_user_directly_not_found(self, users_mixin):
@@ -393,7 +415,7 @@ class TestUsersMixin:
         assert account_id == "data-center-key"
         # Verify API call
         users_mixin.jira.user_find_by_user_string.assert_called_once_with(
-            username="Test User", start=0, limit=1
+            username="Test User", start=0, limit=20
         )
 
     def test_lookup_user_directly_jira_data_center_name(self, users_mixin):
@@ -418,7 +440,7 @@ class TestUsersMixin:
         assert account_id == "data-center-name"
         # Verify API call
         users_mixin.jira.user_find_by_user_string.assert_called_once_with(
-            username="Test User", start=0, limit=1
+            username="Test User", start=0, limit=20
         )
 
     def test_lookup_user_directly_error(self, users_mixin):
@@ -444,7 +466,7 @@ class TestUsersMixin:
         result = users_mixin._resolve_server_dc_user_params("jnovak@firma.cz")
         assert result == {"username": "jnovak"}
         users_mixin.jira.user_find_by_user_string.assert_called_once_with(
-            username="jnovak@firma.cz", start=0, limit=1
+            username="jnovak@firma.cz", start=0, limit=20
         )
 
     def test_resolve_server_dc_user_params_returns_key(self, users_mixin):
@@ -1301,6 +1323,29 @@ class TestGetAccountIdServerDC:
             username="gaurav.nandan@randstad.com"
         )
 
+    def test_server_dc_uses_issue_scoped_assignable_search_as_last_resort(
+        self, dc_mixin
+    ):
+        """Assignment can resolve users without global Browse Users permission."""
+        dc_mixin._lookup_user_directly = MagicMock(return_value=None)
+        dc_mixin._lookup_user_by_permissions = MagicMock(return_value=None)
+        dc_mixin.search_assignable_users = MagicMock(
+            return_value=[
+                JiraUser(
+                    username="gaurav.nandan",
+                    user_key="JIRAUSER56506",
+                    display_name="Gaurav Nandan",
+                )
+            ]
+        )
+
+        result = dc_mixin._get_account_id("Gaurav Nandan", issue_key="JIRA-1234")
+
+        assert result == "gaurav.nandan"
+        dc_mixin.search_assignable_users.assert_called_once_with(
+            query="Gaurav Nandan", issue_key="JIRA-1234", limit=20
+        )
+
     def test_server_dc_profile_and_assign_agree_on_email(self, dc_mixin):
         """Regression: profile lookup and assign resolve the same email identically."""
         dc_mixin._resolve_server_dc_user_params = MagicMock(
@@ -1333,5 +1378,5 @@ class TestGetAccountIdServerDC:
         # Server/DC: returns name when available
         assert result == "gaurav.nandan"
         dc_mixin.jira.user_find_by_user_string.assert_called_once_with(
-            username="JIRAUSER56506", start=0, limit=1
+            username="JIRAUSER56506", start=0, limit=20
         )

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -1193,3 +1193,145 @@ class TestUserProfileMeIdentifier:
             for variant in ["Me", "ME", "mE"]:
                 result = jira_fetcher.get_user_profile_by_identifier(variant)
                 assert result is not None
+
+
+class TestGetAccountIdServerDC:
+    """Regression tests for _get_account_id on Jira Server/DC.
+
+    Covers the bug reported in issue #1535 where jira_assign_issue fails with
+    "Could not find account ID for user" while jira_get_user_profile succeeds
+    for the same identifier on Server/DC.
+    """
+
+    @pytest.fixture
+    def dc_mixin(self, jira_client):
+        """UsersMixin configured as a Server/DC instance."""
+        mixin = UsersMixin(config=jira_client.config)
+        mixin.jira = jira_client.jira
+        mixin.config = MagicMock()
+        mixin.config.is_cloud = False
+        mixin.config.url = "https://jira.example.com"
+        return mixin
+
+    def test_server_dc_key_resolves_to_login_name(self, dc_mixin):
+        """JIRAUSER key is resolved to login name via direct user fetch."""
+        dc_mixin.jira.user = MagicMock(
+            return_value={"name": "gaurav.nandan", "key": "JIRAUSER56506"}
+        )
+
+        result = dc_mixin._get_account_id("JIRAUSER56506")
+
+        assert result == "gaurav.nandan"
+        dc_mixin.jira.user.assert_called_once_with(key="JIRAUSER56506")
+
+    def test_server_dc_key_lowercase_resolves(self, dc_mixin):
+        """Key resolution is case-insensitive for the JIRAUSER prefix."""
+        dc_mixin.jira.user = MagicMock(
+            return_value={"name": "someuser", "key": "jirauser99999"}
+        )
+
+        result = dc_mixin._get_account_id("jirauser99999")
+
+        assert result == "someuser"
+
+    def test_server_dc_key_no_name_returns_key(self, dc_mixin):
+        """When user fetch returns no login name, the key itself is returned."""
+        dc_mixin.jira.user = MagicMock(return_value={"key": "JIRAUSER56506"})
+
+        result = dc_mixin._get_account_id("JIRAUSER56506")
+
+        assert result == "JIRAUSER56506"
+
+    def test_server_dc_key_fetch_fails_falls_through_to_search(self, dc_mixin):
+        """If key fetch raises, resolution falls through to search."""
+        dc_mixin.jira.user = MagicMock(side_effect=Exception("403 Forbidden"))
+        dc_mixin.jira.user_find_by_user_string = MagicMock(
+            return_value=[
+                {
+                    "key": "JIRAUSER56506",
+                    "name": "gaurav.nandan",
+                    "displayName": "JIRAUSER56506",
+                }
+            ]
+        )
+        dc_mixin.jira._session = MagicMock()
+        dc_mixin.jira._session.get.return_value = MagicMock(
+            status_code=200, json=MagicMock(return_value={"users": []})
+        )
+
+        result = dc_mixin._get_account_id("JIRAUSER56506")
+
+        # key matches via _lookup_user_directly key-field matching
+        assert result == "gaurav.nandan"
+
+    def test_server_dc_email_uses_resolve_server_dc_path(self, dc_mixin):
+        """Email on Server/DC goes through _resolve_server_dc_user_params."""
+        dc_mixin._resolve_server_dc_user_params = MagicMock(
+            return_value={"username": "gaurav.nandan"}
+        )
+
+        result = dc_mixin._get_account_id("gaurav.nandan@randstad.com")
+
+        assert result == "gaurav.nandan"
+        dc_mixin._resolve_server_dc_user_params.assert_called_once_with(
+            "gaurav.nandan@randstad.com"
+        )
+
+    def test_server_dc_email_resolves_to_key_when_no_name(self, dc_mixin):
+        """Email resolution returns key when _resolve_server_dc_user_params has no username."""
+        dc_mixin._resolve_server_dc_user_params = MagicMock(
+            return_value={"key": "JIRAUSER56506"}
+        )
+
+        result = dc_mixin._get_account_id("gaurav.nandan@randstad.com")
+
+        assert result == "JIRAUSER56506"
+
+    def test_server_dc_email_fallback_when_search_empty(self, dc_mixin):
+        """When email search returns nothing, try email as login name directly."""
+        dc_mixin._resolve_server_dc_user_params = MagicMock(return_value=None)
+        dc_mixin.jira.user = MagicMock(
+            return_value={"name": "gaurav.nandan@randstad.com"}
+        )
+
+        result = dc_mixin._get_account_id("gaurav.nandan@randstad.com")
+
+        assert result == "gaurav.nandan@randstad.com"
+        dc_mixin.jira.user.assert_called_once_with(
+            username="gaurav.nandan@randstad.com"
+        )
+
+    def test_server_dc_profile_and_assign_agree_on_email(self, dc_mixin):
+        """Regression: profile lookup and assign resolve the same email identically."""
+        dc_mixin._resolve_server_dc_user_params = MagicMock(
+            return_value={"username": "gaurav.nandan"}
+        )
+        # Both _determine_user_api_params and _get_account_id should reach
+        # _resolve_server_dc_user_params and get the same login name.
+        assign_result = dc_mixin._get_account_id("gaurav.nandan@randstad.com")
+        profile_params = dc_mixin._determine_user_api_params(
+            "gaurav.nandan@randstad.com"
+        )
+
+        assert assign_result == "gaurav.nandan"
+        assert profile_params == {"username": "gaurav.nandan"}
+
+    def test_lookup_user_directly_matches_key_field(self, dc_mixin):
+        """_lookup_user_directly matches user whose key equals the search term."""
+        dc_mixin.jira.user_find_by_user_string = MagicMock(
+            return_value=[
+                {
+                    "key": "JIRAUSER56506",
+                    "name": "gaurav.nandan",
+                    "displayName": "Gaurav Nandan",
+                }
+            ]
+        )
+
+        result = dc_mixin._lookup_user_directly("JIRAUSER56506")
+
+        # Server/DC: returns name when available
+        assert result == "gaurav.nandan"
+        dc_mixin.jira.user_find_by_user_string.assert_called_once_with(
+            username="JIRAUSER56506", start=0, limit=1
+        )


### PR DESCRIPTION
## Summary

- **`_get_account_id` Server/DC fast paths**: `JIRAUSER\d+` keys resolve to the login name via `jira.user(key=...)`; emails reuse `_resolve_server_dc_user_params` with an email-as-username fallback, so profile lookup and assignment use the same user resolution
- **User search matching**: direct and email searches inspect up to 20 results and select exact matches, including Server/DC user keys, instead of relying on the first partial result
- **Issue-scoped fallback**: `jira_assign_issue` passes its issue key to an assignable-user search when global user and permission searches cannot resolve the identifier
- **Tool description**: documents accepted identifier forms, including JIRAUSER keys and the issue-scoped fallback
- **11 regression tests** cover the Server/DC key, email, display-name, exact-match, and assignable-search paths
- **Docs regenerated and checked**

## Motivation

On Jira Server/DC, `jira_assign_issue` raised `"Could not find account ID for user: <identifier>"` for email, JIRAUSER key, and display-name inputs even when `jira_get_user_profile` succeeded for the same identifier. The root cause was that `_get_account_id` only recognized Cloud-shaped account IDs, stopped at the first `/user/search` result, and lacked both the email-as-username and issue-scoped assignable-user fallbacks.

Fixes #1535

## Test plan

- [x] `uv run pytest tests/unit -q` — 3,684 passed, 5 skipped
- [x] Ruff check, changed-file format check, and the non-fixing mypy hook pass
- [x] `uv run python scripts/generate_tool_docs.py --check`
- [ ] DC E2E — attempted, but the local shared fixture failed before test execution because Confluence returned 404 for `/rest/api/content`
- [ ] Manual: `jira_assign_issue(issue_key, assignee=<email>)` on a Server/DC instance
- [ ] Manual: `jira_assign_issue(issue_key, assignee="JIRAUSER...")` on a Server/DC instance
