### PR TITLE
feat(jira): make issue and project key validation patterns configurable (Jira DC)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -241,6 +241,14 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # Optional: Comma-separated list of Jira project keys to limit searches and other operations to.
 #JIRA_PROJECTS_FILTER=PROJ,DEVOPS
 
+# --- Jira Key Validation ---
+# Regexes the Jira tools use to validate the `issue_key` / `project_key`
+# arguments. Override them if your Jira uses a key format the defaults below
+# reject, e.g. keys starting with a digit ([A-Z0-9] instead of [A-Z] accepts
+# 4ME-123). An invalid regex is ignored and the default is kept.
+#JIRA_ISSUE_KEY_PATTERN=^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$
+#JIRA_PROJECT_KEY_PATTERN=^[A-Z][A-Z0-9_]+$
+
 # --- Confluence Cloud attachment download workaround ---
 # Confluence Cloud removed the legacy /download/attachments/... endpoint that an
 # attachment's `_links.download` still points to; it now returns 401 for

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -177,6 +177,26 @@ openssl rsa -in encrypted.key -out decrypted.key
 | `ENABLED_TOOLS` | Enable only specific tools | `confluence_search,jira_get_issue` |
 | `TOOLSETS` | Enable tool groups (see [Toolset Filtering](#toolset-filtering)) | `default`, `legacy`, `all`, `default,jira_agile` |
 
+### Jira Key Validation
+
+Jira tools validate their `issue_key` / `project_key` arguments before calling the
+API. The defaults match the Cloud key format, which cannot be changed. On Server/Data
+Center the format is an instance setting (`jira.projectkey.pattern`), so widen these
+patterns if your instance allows keys the defaults reject — a leading digit, a single
+character, or lowercase. An invalid regex is ignored (a warning is logged) and the
+default is kept. Both are read once at startup.
+
+| Variable | Description |
+|----------|-------------|
+| `JIRA_ISSUE_KEY_PATTERN` | Regex accepted for `issue_key` arguments (default: `^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$`) |
+| `JIRA_PROJECT_KEY_PATTERN` | Regex accepted for `project_key` arguments (default: `^[A-Z][A-Z0-9_]+$`) |
+
+```bash
+# Data Center instance whose project keys may start with a digit (e.g. 4ME-123)
+JIRA_ISSUE_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*-\d+(?:-\d+)*$
+JIRA_PROJECT_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*$
+```
+
 ### Server Options
 
 | Variable | Description |

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -208,6 +208,28 @@ Header values containing sensitive information are automatically masked in logs.
     ```
   </Accordion>
 
+  <Accordion title="String should match pattern — issue_key / project_key rejected">
+    **Symptom:** A tool call fails before reaching Jira with a validation error such as
+    `project_key: String should match pattern '^[A-Z][A-Z0-9_]+$'`, even though the
+    project exists and the key is correct.
+
+    **Cause:** `issue_key` and `project_key` arguments are validated against a regex
+    first. The defaults require an uppercase letter followed by at least one more
+    character, which is the fixed Cloud format. Server/Data Center instances configure
+    their own `jira.projectkey.pattern` and may allow keys the defaults reject — a
+    leading digit (`4ME`), a single character, or lowercase.
+
+    **Fix:** Widen the patterns to match your instance, then restart the server (they
+    are read once at startup):
+
+    ```bash
+    JIRA_ISSUE_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*-\d+(?:-\d+)*$
+    JIRA_PROJECT_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*$
+    ```
+
+    See [Jira Key Validation](/docs/configuration#jira-key-validation).
+  </Accordion>
+
   <Accordion title="Issue type not found or not available">
     **Cause:** The specified issue type doesn't exist in the project.
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -21,6 +21,7 @@ from mcp_atlassian.servers.dependencies import get_jira_fetcher
 from mcp_atlassian.servers.error_handling import ErrorPreservingFastMCP
 from mcp_atlassian.servers.helpers import resolve_transition
 from mcp_atlassian.utils.decorators import check_write_access
+from mcp_atlassian.utils.env import get_regex_env
 from mcp_atlassian.utils.media import (
     ATTACHMENT_MAX_BYTES,
     fetch_and_encode_attachment,
@@ -36,8 +37,15 @@ logger = logging.getLogger(__name__)
 # Underscores are also allowed to support non-standard project key formats.
 # Server/Data Center may use hyphens between numeric suffix segments
 # (e.g., B7-214-68901), but every segment must contain digits.
-ISSUE_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$"
-PROJECT_KEY_PATTERN = r"^[A-Z][A-Z0-9_]+$"
+# A Server/Data Center instance with a custom `jira.projectkey.pattern` can use
+# keys the defaults reject (leading digit, single character, lowercase). Such a
+# deployment overrides these with JIRA_ISSUE_KEY_PATTERN /
+# JIRA_PROJECT_KEY_PATTERN; both are read once at import time, so they must be
+# set in the environment (or .env) before the server starts.
+ISSUE_KEY_PATTERN = get_regex_env(
+    "JIRA_ISSUE_KEY_PATTERN", r"^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$"
+)
+PROJECT_KEY_PATTERN = get_regex_env("JIRA_PROJECT_KEY_PATTERN", r"^[A-Z][A-Z0-9_]+$")
 
 jira_mcp = ErrorPreservingFastMCP(
     name="Jira MCP Service",

--- a/src/mcp_atlassian/utils/env.py
+++ b/src/mcp_atlassian/utils/env.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 
 logger = logging.getLogger("mcp-atlassian.env")
 
@@ -102,6 +103,38 @@ def get_float_env(env_var_name: str, default: float) -> float:
             "Invalid float for %s=%r; using default %s", env_var_name, raw, default
         )
         return default
+
+
+def get_regex_env(env_var_name: str, default: str) -> str:
+    """Read an environment variable as a regex pattern, falling back to `default`.
+
+    Logs a warning and falls back to `default` if the variable is set to a
+    pattern that does not compile. Patterns read this way are consumed at import
+    time by Pydantic field validators, so an uncompilable value would otherwise
+    take the whole server down over a typo in one setting.
+
+    Args:
+        env_var_name: Name of the environment variable to read
+        default: Value to return when the variable is unset or uncompilable
+
+    Returns:
+        The configured pattern, or `default`
+    """
+    raw = os.getenv(env_var_name)
+    if not raw:
+        return default
+    try:
+        re.compile(raw)
+    except re.error as exc:
+        logger.warning(
+            "Invalid regex for %s=%r (%s); using default %r",
+            env_var_name,
+            raw,
+            exc,
+            default,
+        )
+        return default
+    return raw
 
 
 def get_custom_headers(env_var_name: str) -> dict[str, str]:

--- a/src/mcp_atlassian/utils/env.py
+++ b/src/mcp_atlassian/utils/env.py
@@ -2,7 +2,10 @@
 
 import logging
 import os
-import re
+from typing import Annotated
+
+from pydantic import Field, TypeAdapter
+from pydantic_core import SchemaError
 
 logger = logging.getLogger("mcp-atlassian.env")
 
@@ -124,8 +127,8 @@ def get_regex_env(env_var_name: str, default: str) -> str:
     if not raw:
         return default
     try:
-        re.compile(raw)
-    except re.error as exc:
+        TypeAdapter(Annotated[str, Field(pattern=raw)])
+    except SchemaError as exc:
         logger.warning(
             "Invalid regex for %s=%r (%s); using default %r",
             env_var_name,

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -2280,6 +2281,73 @@ def test_issue_and_project_key_patterns_reject_invalid_keys():
 
     assert not re.match(PROJECT_KEY_PATTERN, "lowercase")
     assert not re.match(PROJECT_KEY_PATTERN, "123")
+
+
+def _reload_jira_server_module():
+    """Re-import the Jira server module so import-time env reads run again."""
+    import importlib
+
+    import mcp_atlassian.servers.jira as jira_server
+
+    return importlib.reload(jira_server)
+
+
+@pytest.fixture
+def reloaded_jira_server():
+    """Yield a reloader, restoring the module from a clean env afterwards."""
+    try:
+        yield _reload_jira_server_module
+    finally:
+        for var in ("JIRA_ISSUE_KEY_PATTERN", "JIRA_PROJECT_KEY_PATTERN"):
+            os.environ.pop(var, None)
+        _reload_jira_server_module()
+
+
+def test_key_patterns_configurable_via_env(monkeypatch, reloaded_jira_server):
+    """Env overrides let Server/DC keys the defaults reject through.
+
+    Regression test: a Server/DC instance with a custom
+    `jira.projectkey.pattern` can have keys starting with a digit, which the
+    default patterns reject before the API is ever called.
+    """
+    import re
+
+    monkeypatch.setenv("JIRA_ISSUE_KEY_PATTERN", r"^[A-Z0-9][A-Z0-9_]*-\d+$")
+    monkeypatch.setenv("JIRA_PROJECT_KEY_PATTERN", r"^[A-Z0-9][A-Z0-9_]*$")
+    jira_server = reloaded_jira_server()
+
+    assert re.match(jira_server.ISSUE_KEY_PATTERN, "4ME-123")
+    assert re.match(jira_server.PROJECT_KEY_PATTERN, "4ME")
+    # Still validates: the override is a pattern, not an escape hatch
+    assert not re.match(jira_server.PROJECT_KEY_PATTERN, "not a key")
+
+
+@pytest.mark.anyio
+async def test_key_patterns_env_override_reaches_tool_schema(
+    monkeypatch, reloaded_jira_server
+):
+    """The override must land on the tool parameters, not just the constants."""
+    monkeypatch.setenv("JIRA_PROJECT_KEY_PATTERN", r"^[A-Z0-9][A-Z0-9_]*$")
+    jira_server = reloaded_jira_server()
+
+    tools = await jira_server.jira_mcp.list_tools()
+    tool = next(t for t in tools if t.name == "get_project_issues")
+    assert (
+        tool.parameters["properties"]["project_key"]["pattern"]
+        == r"^[A-Z0-9][A-Z0-9_]*$"
+    )
+
+
+def test_key_patterns_ignore_uncompilable_env_override(
+    monkeypatch, reloaded_jira_server, caplog
+):
+    """An invalid regex must not break server startup."""
+    monkeypatch.setenv("JIRA_PROJECT_KEY_PATTERN", "^[A-Z")
+    with caplog.at_level(logging.WARNING):
+        jira_server = reloaded_jira_server()
+
+    assert jira_server.PROJECT_KEY_PATTERN == r"^[A-Z][A-Z0-9_]+$"
+    assert "JIRA_PROJECT_KEY_PATTERN" in caplog.text
 
 
 # =============================================================================

--- a/tests/unit/utils/test_env.py
+++ b/tests/unit/utils/test_env.py
@@ -236,9 +236,16 @@ class TestGetRegexEnv:
         monkeypatch.setenv("TEST_PATTERN", r"^[A-Z0-9][A-Z0-9_]*$")
         assert get_regex_env("TEST_PATTERN", "^A$") == r"^[A-Z0-9][A-Z0-9_]*$"
 
-    def test_uncompilable_pattern_falls_back_with_warning(self, monkeypatch, caplog):
+    def test_invalid_pattern_falls_back_with_warning(self, monkeypatch, caplog):
         """An invalid regex is ignored so import-time consumers keep working."""
         monkeypatch.setenv("TEST_PATTERN", "^[A-Z")
+        with caplog.at_level(logging.WARNING):
+            assert get_regex_env("TEST_PATTERN", "^A$") == "^A$"
+        assert "TEST_PATTERN" in caplog.text
+
+    def test_pydantic_unsupported_pattern_falls_back(self, monkeypatch, caplog):
+        """Patterns unsupported by Pydantic's regex engine must also fall back."""
+        monkeypatch.setenv("TEST_PATTERN", r"(?=A)")
         with caplog.at_level(logging.WARNING):
             assert get_regex_env("TEST_PATTERN", "^A$") == "^A$"
         assert "TEST_PATTERN" in caplog.text

--- a/tests/unit/utils/test_env.py
+++ b/tests/unit/utils/test_env.py
@@ -1,6 +1,9 @@
 """Tests for environment variable utility functions."""
 
+import logging
+
 from mcp_atlassian.utils.env import (
+    get_regex_env,
     is_env_extended_truthy,
     is_env_ssl_verify,
     is_env_truthy,
@@ -215,3 +218,27 @@ class TestEdgeCases:
                 assert is_env_truthy("TEST_VAR") is False
                 assert is_env_extended_truthy("TEST_VAR") is False
             assert is_env_ssl_verify("TEST_VAR") is True  # Not in false values
+
+
+class TestGetRegexEnv:
+    """Test the get_regex_env function."""
+
+    def test_unset_or_empty_returns_default(self, monkeypatch):
+        """Unset and empty values both fall back to the default."""
+        monkeypatch.delenv("TEST_PATTERN", raising=False)
+        assert get_regex_env("TEST_PATTERN", "^A$") == "^A$"
+
+        monkeypatch.setenv("TEST_PATTERN", "")
+        assert get_regex_env("TEST_PATTERN", "^A$") == "^A$"
+
+    def test_valid_pattern_is_returned(self, monkeypatch):
+        """A compilable pattern is returned verbatim."""
+        monkeypatch.setenv("TEST_PATTERN", r"^[A-Z0-9][A-Z0-9_]*$")
+        assert get_regex_env("TEST_PATTERN", "^A$") == r"^[A-Z0-9][A-Z0-9_]*$"
+
+    def test_uncompilable_pattern_falls_back_with_warning(self, monkeypatch, caplog):
+        """An invalid regex is ignored so import-time consumers keep working."""
+        monkeypatch.setenv("TEST_PATTERN", "^[A-Z")
+        with caplog.at_level(logging.WARNING):
+            assert get_regex_env("TEST_PATTERN", "^A$") == "^A$"
+        assert "TEST_PATTERN" in caplog.text


### PR DESCRIPTION
## Description

Jira tools validate their `issue_key` / `project_key` arguments against two hardcoded regexes (`ISSUE_KEY_PATTERN`, `PROJECT_KEY_PATTERN` in `servers/jira.py`) before any API call. Both require a key that starts with an uppercase letter and is at least two characters long which matches Jira Cloud, where the key format is fixed and cannot be changed.

Jira **Data Center / Server** is different: the key format is an instance setting (`jira.projectkey.pattern`), and admins routinely widen it. On a DC instance whose pattern allows a leading digit (e.g. `4ME`), a single character, or lowercase, every tool call is rejected by Pydantic with a schema error before the request is even built, so those projects are simply unreachable through this MCP server. The rest of the codebase already copes with such keys `quote_jql_identifier_if_needed()` explicitly quotes digit-leading identifiers for JQL, so this front-door validation was the only blocker.

This PR makes both patterns configurable so a DC deployment can align them with its own `jira.projectkey.pattern`. The defaults are unchanged, so Cloud users and DC instances on the stock key format see no difference.

## Changes

- Add `get_regex_env()` to `utils/env.py`: reads a regex from the environment, and logs a warning + falls back to the default when the value does not compile (these patterns are consumed at import time by the tool schemas, so a typo would otherwise stop the server from starting).
- Read `ISSUE_KEY_PATTERN` / `PROJECT_KEY_PATTERN` from `JIRA_ISSUE_KEY_PATTERN` / `JIRA_PROJECT_KEY_PATTERN`, with the existing patterns as defaults. Both are read once at import, so a DC operator must set them in the environment (or `.env`) before the server starts.
- Document both variables in `.env.example` under a new *Jira Key Validation* section, showing the defaults.

Example for a DC instance that allows digit-leading keys:

```python
JIRA_ISSUE_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*-\d+(?:-\d+)*$
JIRA_PROJECT_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*$
```

Testing

- [x] Unit tests added/updated
  - tests/unit/utils/test_env.py::TestGetRegexEnv — unset/empty falls back, valid pattern returned verbatim, uncompilable pattern ignored with a warning.
  - tests/unit/servers/test_jira_server.py — the DC-style override accepts 4ME / 4ME-123 while still rejecting non-keys; the override reaches the actual tool schema (list_tools() → project_key.pattern); an uncompilable override keeps the default.
  - Full unit suite: uv run pytest tests/unit → 3690 passed, 5 skipped.
- [x] Manual checks performed: loaded the server module with JIRA_PROJECT_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*$ and confirmed the generated schema for get_project_issues carries the overridden pattern; confirmed the defaults are unchanged when the variables are unset.

Checklist

- [x] Code follows project style guidelines (linting passes) — pre-commit run (ruff-format, ruff, mypy) clean on the changed files.
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated