### PR TITLE
fix(auth): prefer request Cloud ID over DC OAuth config

### DIFF
--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -723,7 +723,9 @@ def _create_user_config_for_fetcher(
         global_oauth_cfg = base_config.oauth_config
 
         # Determine if this is DC OAuth (base_url set, no cloud_id)
-        is_dc_oauth = getattr(global_oauth_cfg, "is_data_center", False) is True
+        is_dc_oauth = not cloud_id and (
+            getattr(global_oauth_cfg, "is_data_center", False) is True
+        )
 
         # Use provided cloud_id or fall back to global config cloud_id
         effective_cloud_id = cloud_id if cloud_id else global_oauth_cfg.cloud_id

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -277,6 +277,49 @@ class TestCreateUserConfigForFetcher:
         )  # Should preserve minimal config
 
     @pytest.mark.parametrize("config_type", ["jira", "confluence"])
+    @pytest.mark.parametrize(
+        "cloud_id,expected_cloud_id,expected_base_url",
+        [
+            ("request-cloud-id", "request-cloud-id", None),
+            (None, None, "https://dc.example.com"),
+        ],
+    )
+    def test_oauth_request_cloud_id_overrides_global_dc_config(
+        self,
+        config_factory,
+        config_type,
+        cloud_id,
+        expected_cloud_id,
+        expected_base_url,
+    ):
+        """Request Cloud IDs take precedence over global Data Center OAuth."""
+        dc_base_url = "https://dc.example.com"
+        global_oauth_config = OAuthConfig(
+            client_id="global-client-id",
+            client_secret="global-client-secret",
+            redirect_uri="https://example.com/callback",
+            scope="read",
+            base_url=dc_base_url,
+        )
+        config_builder = getattr(config_factory, f"create_{config_type}_config")
+        base_config = config_builder(
+            auth_type="oauth",
+            url=dc_base_url,
+            oauth_config=global_oauth_config,
+        )
+
+        result_config = _create_user_config_for_fetcher(
+            base_config=base_config,
+            auth_type="oauth",
+            credentials={"oauth_access_token": "user-access-token"},
+            cloud_id=cloud_id,
+        )
+
+        assert result_config.oauth_config is not None
+        assert result_config.oauth_config.cloud_id == expected_cloud_id
+        assert result_config.oauth_config.base_url == expected_base_url
+
+    @pytest.mark.parametrize("config_type", ["jira", "confluence"])
     def test_create_user_config_preserves_proxy_and_wpad_fields(
         self, config_factory, config_type
     ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

An explicit request `X-Atlassian-Cloud-Id` now takes precedence over a
global Data Center OAuth configuration, so per-request Cloud OAuth routing
uses the requested tenant for Jira and Confluence.

Fixes: #1096

## Changes

<!-- Briefly list the key changes made. -->

- Prefer an explicit request Cloud ID when classifying OAuth routing.
- Retain the existing Data Center base-URL fallback when no request Cloud ID is supplied.
- Add Jira and Confluence regression coverage for both routing paths.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed

- `uv run pytest tests/unit/servers/test_dependencies.py::TestCreateUserConfigForFetcher -xvs` — 19 passed
- `uv run pre-commit run --all-files`
- `uv run pytest -xvs` — 3675 passed, 240 skipped

## Checklist

- [x] Code follows project style guidelines (ruff/mypy pass).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).

## References

- #1096
