### PR TITLE
fix(jira): preserve text colors in issue content

### DIFF
--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -12,13 +12,23 @@ from markdownify import markdownify as md
 
 logger = logging.getLogger("mcp-atlassian")
 
-_COLORED_SPAN_PATTERN = re.compile(
-    r"""<span\b[^>]*\bstyle\s*=\s*(?:
-        "[^"]*(?<![\w-])color\s*:
+_SPAN_TAG_PATTERN = re.compile(
+    r"""<(?P<closing>/?)span\b(?P<attributes>(?:[^'"<>]|"[^"]*"|'[^']*')*)>""",
+    flags=re.IGNORECASE,
+)
+_STYLE_ATTRIBUTE_PATTERN = re.compile(
+    r"""\bstyle\s*=\s*(?:
+        "(?P<double>[^"]*)"
         |
-        '[^']*(?<![\w-])color\s*:
+        '(?P<single>[^']*)'
+        |
+        (?P<unquoted>[^\s>]+)
     )""",
     flags=re.IGNORECASE | re.VERBOSE,
+)
+_COLOR_DECLARATION_PATTERN = re.compile(
+    r"(?:^|;)\s*color\s*:",
+    flags=re.IGNORECASE,
 )
 
 
@@ -69,6 +79,56 @@ def _restore_blocks(text: str, storage: list[str], prefix: str) -> str:
     """
     for i in range(len(storage) - 1, -1, -1):
         text = text.replace(f"\x00{prefix}{i}\x00", storage[i])
+    return text
+
+
+def _span_tag_has_color(attributes: str) -> bool:
+    """Return whether a span's style attribute declares a text color."""
+    style_match = _STYLE_ATTRIBUTE_PATTERN.search(attributes)
+    if not style_match:
+        return False
+
+    style = next(
+        (
+            value
+            for group in ("double", "single", "unquoted")
+            if (value := style_match.group(group)) is not None
+        ),
+        "",
+    )
+    return bool(_COLOR_DECLARATION_PATTERN.search(style))
+
+
+def _protect_colored_span_tags(text: str, storage: list[str]) -> str:
+    """Protect colored span tags while leaving their contents convertible."""
+    open_spans: list[tuple[int, int, bool]] = []
+    replacements: list[tuple[int, int, str]] = []
+
+    for match in _SPAN_TAG_PATTERN.finditer(text):
+        if match.group("closing"):
+            if not open_spans:
+                continue
+
+            start, end, has_color = open_spans.pop()
+            if has_color:
+                replacements.extend(
+                    [
+                        (start, end, text[start:end]),
+                        (match.start(), match.end(), match.group(0)),
+                    ]
+                )
+            continue
+
+        attributes = match.group("attributes")
+        if attributes.rstrip().endswith("/"):
+            continue
+        open_spans.append((match.start(), match.end(), _span_tag_has_color(attributes)))
+
+    for start, end, tag in sorted(replacements, reverse=True):
+        placeholder = f"\x00HTMLCVTCOLOR{len(storage)}\x00"
+        storage.append(tag)
+        text = text[:start] + placeholder + text[end:]
+
     return text
 
 
@@ -496,7 +556,10 @@ class BasePreprocessor:
             "HTMLCVTINLINE",
         )
 
-        if re.search(r"<[^>]+>", text) and not _COLORED_SPAN_PATTERN.search(text):
+        colored_span_tags: list[str] = []
+        text = _protect_colored_span_tags(text, colored_span_tags)
+
+        if re.search(r"<[^>]+>", text):
             try:
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=UserWarning)
@@ -506,7 +569,8 @@ class BasePreprocessor:
             except Exception as e:
                 logger.warning(f"Error converting HTML to markdown: {str(e)}")
 
-        # Restore in reverse order: inline first, then blocks
+        # Restore in reverse order: colored span tags, inline code, then blocks
+        text = _restore_blocks(text, colored_span_tags, "HTMLCVTCOLOR")
         text = _restore_blocks(text, inline_codes, "HTMLCVTINLINE")
         text = _restore_blocks(text, code_blocks, "HTMLCVTBLOCK")
         return text

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -12,6 +12,15 @@ from markdownify import markdownify as md
 
 logger = logging.getLogger("mcp-atlassian")
 
+_COLORED_SPAN_PATTERN = re.compile(
+    r"""<span\b[^>]*\bstyle\s*=\s*(?:
+        "[^"]*(?<![\w-])color\s*:
+        |
+        '[^']*(?<![\w-])color\s*:
+    )""",
+    flags=re.IGNORECASE | re.VERBOSE,
+)
+
 
 def _extract_blocks(
     text: str,
@@ -487,7 +496,7 @@ class BasePreprocessor:
             "HTMLCVTINLINE",
         )
 
-        if re.search(r"<[^>]+>", text):
+        if re.search(r"<[^>]+>", text) and not _COLORED_SPAN_PATTERN.search(text):
             try:
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=UserWarning)

--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -357,7 +357,7 @@ class JiraPreprocessor(BasePreprocessor):
         # Colored text
         output = re.sub(
             r"\{color:([^}]+)\}([\s\S]*?)\{color\}",
-            r"<span style=\"color:\1\">\2</span>",
+            r'<span style="color:\1">\2</span>',
             output,
             flags=re.MULTILINE,
         )

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -76,6 +76,15 @@ def test_clean_jira_issue_content(preprocessor_with_jira):
     assert "test comment" in cleaned_comment.lower()
 
 
+def test_clean_jira_text_preserves_colored_heading(preprocessor_with_jira):
+    """Preserve Jira Server/DC text colors in Markdown headings."""
+    result = preprocessor_with_jira.clean_jira_text(
+        "h1. {color:red}Test red header{color}"
+    )
+
+    assert result == '# <span style="color:red">Test red header</span>'
+
+
 def test_process_html_content_basic(preprocessor_with_confluence):
     """Test basic HTML content processing."""
     html = "<p>Simple text</p>"
@@ -1656,3 +1665,112 @@ class TestHtmlConversionCodeProtection:
         """Direct test of _convert_html_to_markdown with markdown code spans."""
         result = preprocessor._convert_html_to_markdown(md_input)
         assert expected_substr in result, f"Expected '{expected_substr}' in: {result!r}"
+
+
+class TestHtmlConversionColorProtection:
+    """Tests that HTML-to-Markdown conversion preserves colored spans."""
+
+    @pytest.fixture
+    def preprocessor(self):
+        return JiraPreprocessor(base_url="https://example.atlassian.net")
+
+    @pytest.mark.parametrize(
+        "html_input",
+        [
+            pytest.param(
+                '<span style="color:red">Red</span>',
+                id="named-color",
+            ),
+            pytest.param(
+                '<span style="color:#00ff7f">Green</span>',
+                id="hex-color",
+            ),
+            pytest.param(
+                '<span style="color:rgb(1, 2, 3)">Dark</span>',
+                id="functional-color",
+            ),
+            pytest.param(
+                "<span style='color:blue'>Blue</span>",
+                id="single-quotes",
+            ),
+            pytest.param(
+                '<SPAN CLASS="label" '
+                'STYLE="font-weight:bold; COLOR: purple">Purple</SPAN>',
+                id="case-and-additional-styles",
+            ),
+            pytest.param(
+                '<span data-kind="status" style="background:white; color:orange" '
+                'class="label">Orange</span>',
+                id="reordered-attributes",
+            ),
+        ],
+    )
+    def test_convert_html_to_markdown_preserves_colored_span(
+        self,
+        preprocessor,
+        html_input: str,
+    ):
+        """Leave text containing colored spans unchanged."""
+        result = preprocessor._convert_html_to_markdown(html_input)
+
+        assert result == html_input
+
+    def test_convert_html_to_markdown_preserves_multiple_colored_spans(
+        self,
+        preprocessor,
+    ):
+        """Preserve multiple colored spans without placeholder collisions."""
+        html_input = (
+            '<span style="color:red">Red</span> and '
+            '<span style="color:blue">Blue</span>'
+        )
+
+        result = preprocessor._convert_html_to_markdown(html_input)
+
+        assert result == html_input
+
+    def test_convert_html_to_markdown_preserves_nested_colored_spans(
+        self,
+        preprocessor,
+    ):
+        """Preserve nested colored spans as one complete HTML fragment."""
+        html_input = (
+            '<span style="color:red">Outer <span style="color:blue">Inner</span></span>'
+        )
+
+        result = preprocessor._convert_html_to_markdown(html_input)
+
+        assert result == html_input
+
+    def test_convert_html_to_markdown_preserves_surrounding_html(
+        self,
+        preprocessor,
+    ):
+        """Leave all HTML unchanged when the text contains a colored span."""
+        html_input = '<b>Important</b> <span style="color:red">Warning</span>'
+
+        result = preprocessor._convert_html_to_markdown(html_input)
+
+        assert result == html_input
+
+    def test_convert_html_to_markdown_does_not_preserve_non_color_span(
+        self,
+        preprocessor,
+    ):
+        """Keep the existing conversion behavior for spans without colors."""
+        result = preprocessor._convert_html_to_markdown(
+            '<span style="font-weight:bold">Plain</span>'
+        )
+
+        assert result == "Plain"
+
+    def test_convert_html_to_markdown_preserves_colored_span_inside_code(
+        self,
+        preprocessor,
+    ):
+        """Leave span-like HTML inside Markdown code unchanged."""
+        markdown_input = '`<span style="color:red">Code</span>`'
+
+        result = preprocessor._convert_html_to_markdown(markdown_input)
+
+        assert result == markdown_input

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -1746,12 +1746,23 @@ class TestHtmlConversionColorProtection:
         self,
         preprocessor,
     ):
-        """Leave all HTML unchanged when the text contains a colored span."""
+        """Convert surrounding HTML while preserving the colored span."""
         html_input = '<b>Important</b> <span style="color:red">Warning</span>'
 
         result = preprocessor._convert_html_to_markdown(html_input)
 
-        assert result == html_input
+        assert result == '**Important** <span style="color:red">Warning</span>'
+
+    def test_convert_html_to_markdown_does_not_match_background_color(
+        self,
+        preprocessor,
+    ):
+        """Convert spans whose style only sets a background color."""
+        html_input = '<span style="background-color:yellow">Warning</span>'
+
+        result = preprocessor._convert_html_to_markdown(html_input)
+
+        assert result == "Warning"
 
     def test_convert_html_to_markdown_does_not_preserve_non_color_span(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide a brief summary. -->

## Description

<!-- What does this PR do? Why is it needed? -->
<!-- Link related issues: Fixes #<issue_number> -->

Preserves inline text colors when Jira content is converted to Markdown.

Previously, colored content such as:

```text
h1. {color:red}Test red header{color}
```

After `jira_to_markdown`:

```text
# <span style="color:red">Test red header</span>
```
And it's correct.

But we have yet another conversion - `_convert_html_to_markdown()`:

```
# Test red header
```
lost its <span style="color:..."> formatting during HTML-to-Markdown conversion.


## Changes

<!-- Briefly list the key changes made. -->

- Generate valid HTML spans for Jira color markup.
- Preserve content containing spans with inline color styles.
- Add regression tests for colored headings and different color formats.

## Testing

<!-- How did you test these changes? (e.g., unit tests, integration tests, manual checks) -->

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `[briefly describe]`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
