### PR TITLE
fix(jira): surface the environment system field on JiraIssue

### DIFF
--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -61,6 +61,7 @@ class JiraIssue(ApiModel, TimestampMixin):
     key: str = JIRA_DEFAULT_KEY
     summary: str = EMPTY_STRING
     description: str | None = None
+    environment: str | None = None
     created: str = EMPTY_STRING
     updated: str = EMPTY_STRING
     status: JiraStatus | None = None
@@ -287,6 +288,14 @@ class JiraIssue(ApiModel, TimestampMixin):
         else:
             description = raw_description
 
+        # Handle environment - like description, it can be a string (Server/DC,
+        # classic editor) or an ADF dict (Jira Cloud new editor)
+        raw_environment = fields.get("environment")
+        if isinstance(raw_environment, dict):
+            environment = adf_to_text(raw_environment)
+        else:
+            environment = raw_environment
+
         # Timestamps
         created = str(fields.get("created", EMPTY_STRING))
         updated = str(fields.get("updated", EMPTY_STRING))
@@ -477,6 +486,7 @@ class JiraIssue(ApiModel, TimestampMixin):
             key=key,
             summary=summary,
             description=description,
+            environment=environment,
             created=created,
             updated=updated,
             status=status,
@@ -538,6 +548,10 @@ class JiraIssue(ApiModel, TimestampMixin):
         # Add description if available and requested
         if self.description and should_include_field("description"):
             result["description"] = self.description
+
+        # Add environment if available and requested
+        if self.environment and should_include_field("environment"):
+            result["environment"] = self.environment
 
         # Add status if available and requested
         if self.status and should_include_field("status"):

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -275,6 +275,32 @@ class TestJiraIssue:
         assert issue.environment == "Prod cluster eu-west-1"
         assert issue.to_simplified_dict()["environment"] == "Prod cluster eu-west-1"
 
+    def test_from_api_response_parses_environment_adf(self):
+        """Test that the Cloud ADF environment value is converted to text."""
+        local_issue_data = {
+            "id": "10002",
+            "key": "PROJ-124",
+            "fields": {
+                "summary": "Cloud issue",
+                "environment": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "Cloud ADF"}],
+                        }
+                    ],
+                },
+            },
+        }
+        issue = JiraIssue.from_api_response(
+            local_issue_data, requested_fields="environment"
+        )
+
+        assert issue.environment == "Cloud ADF"
+        assert issue.to_simplified_dict()["environment"] == "Cloud ADF"
+
     def test_from_api_response_builds_browse_url(self, jira_issue_data):
         """Test creating a browser URL from the configured Jira base URL."""
         issue = JiraIssue.from_api_response(

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -258,6 +258,23 @@ class TestJiraIssue:
         assert issue.security is None
         assert issue.worklog is None
 
+    def test_from_api_response_parses_environment(self):
+        """Test that the ``environment`` system field is parsed and surfaced."""
+        local_issue_data = {
+            "id": "10001",
+            "key": "PROJ-123",
+            "fields": {
+                "summary": "Test issue",
+                "environment": "Prod cluster eu-west-1",
+            },
+        }
+        issue = JiraIssue.from_api_response(
+            local_issue_data, requested_fields="environment"
+        )
+
+        assert issue.environment == "Prod cluster eu-west-1"
+        assert issue.to_simplified_dict()["environment"] == "Prod cluster eu-west-1"
+
     def test_from_api_response_builds_browse_url(self, jira_issue_data):
         """Test creating a browser URL from the configured Jira base URL."""
         issue = JiraIssue.from_api_response(


### PR DESCRIPTION
## Description

`JiraIssue` has no `environment` attribute and `from_api_response` never reads `fields["environment"]`, so the value is dropped while parsing the response — `jira_get_issue` / `jira_search` never return it, regardless of `fields=environment`, `fields=*all` or `expand`.

Fixes: #1540

## Changes

- Add `environment: str | None = None` to `JiraIssue`.
- Parse `fields["environment"]` in `from_api_response`, handling both the Server/DC string form and the Jira Cloud ADF dict form, exactly as `description` is handled.
- Emit `environment` from `to_simplified_dict()` when present and requested.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `reproduced the drop against HEAD, then confirmed the value is returned after the fix`

`test_from_api_response_parses_environment` added in `tests/unit/models/test_jira_issue_model.py`; it fails without the source change and passes with it (verified by stashing the source diff). `tests/unit/models/` is green: 294 passed, 5 skipped.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
