### PR TITLE
fix(docker): inject VERSION build arg and guard manual-dispatch tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,8 +49,8 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             # Create a tag for PRs (e.g., pr-123) - useful for testing PR builds
             type=ref,event=pr
-            # For manual workflow runs, use branch name with 'manual' suffix
-            type=raw,value={{branch}}-manual,enable=${{ github.event_name == 'workflow_dispatch' }}
+            # For manual workflow runs, use branch name with 'manual' suffix (only when ref is a branch)
+            type=raw,value={{branch}}-manual,enable=${{ github.event_name == 'workflow_dispatch' && github.ref_type == 'branch' }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -72,6 +72,8 @@ jobs:
           # Use tags and labels from metadata action
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           # Enable Docker layer caching
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ ENV UV_COMPILE_BYTECODE=1
 # Copy from the cache instead of linking since it's a mounted volume
 ENV UV_LINK_MODE=copy
 
+# Allow injecting the package version at build time so that the image
+# reports the correct version even without a .git directory.
+ARG VERSION
+
 # Generate proper TOML lockfile first
 RUN --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
@@ -23,6 +27,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Then, copy the rest of the project source code and install it
 COPY . /app
+RUN if [ -n "$VERSION" ] && echo "$VERSION" | grep -qE '^[0-9]'; then \
+      sed -i "s/fallback-version = \"0.0.0\"/fallback-version = \"$VERSION\"/" pyproject.toml; \
+    fi
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     uv sync --frozen --extra wpad --no-dev --no-editable

--- a/tests/unit/test_docker_versioning.py
+++ b/tests/unit/test_docker_versioning.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_dockerfile_injects_version_before_project_install() -> None:
+    lines = (ROOT / "Dockerfile").read_text().splitlines()
+
+    arg_index = lines.index("ARG VERSION")
+    copy_index = lines.index("COPY . /app")
+    rewrite_index = next(i for i, line in enumerate(lines) if "sed -i" in line)
+    install_indices = [
+        i for i, line in enumerate(lines) if "uv sync" in line and "--no-dev" in line
+    ]
+
+    assert arg_index < copy_index < rewrite_index < install_indices[-1]
+    assert 'fallback-version = \\"0.0.0\\"' in lines[rewrite_index]
+    assert 'fallback-version = \\"$VERSION\\"' in lines[rewrite_index]
+
+
+def test_docker_workflow_passes_version_and_guards_manual_tag() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "docker-publish.yml").read_text()
+
+    assert "VERSION=${{ steps.meta.outputs.version }}" in workflow
+    assert (
+        "github.event_name == 'workflow_dispatch' && github.ref_type == 'branch'"
+    ) in workflow


### PR DESCRIPTION
## Description

Docker images built by CI report version `0.0.0` because `.git` is excluded from the build context and `uv-dynamic-versioning` has no tag to read. Additionally, `workflow_dispatch` on a tag ref produces an invalid `{{branch}}-manual` image tag.

## Changes

- Add `VERSION` build arg to Dockerfile; when set, `sed` updates the `fallback-version` in pyproject.toml before the final `uv sync`
- Pass `VERSION=${{ steps.meta.outputs.version }}` from the docker-publish workflow so release images carry the correct version
- Guard the `{{branch}}-manual` metadata tag with `github.ref_type == 'branch'` to prevent invalid tags on tag-ref dispatches

## Testing

- [ ] Unit tests added/updated
- [x] Manual checks performed: built Docker image with `--build-arg VERSION=0.22.0` and verified `mcp-atlassian --version` reports `0.22.0` instead of `0.0.0`

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).