### PR TITLE
test(server): add public policy and stdio readiness contracts

### DIFF
--- a/docs/compatibility.mdx
+++ b/docs/compatibility.mdx
@@ -32,9 +32,10 @@ uv run python scripts/mcp_wire_probe.py \
 ```
 
 The default probe does not invoke any Atlassian tool. It emits machine-readable
-JSON with the negotiated protocol version, installed MCP/FastMCP package
-versions, and discovered tool names, making it useful for comparing supported
-SDK and framework versions.
+JSON with the negotiated protocol version, discovered tool names, and installed
+versions of MCP, MCP types, FastMCP, FastMCP slim, and cryptography. Missing
+distributions are reported as `null`, making the output useful for comparing
+supported SDK and framework environments.
 
 Version-specific test lanes can make protocol negotiation an explicit gate:
 
@@ -43,13 +44,20 @@ uv run python scripts/mcp_wire_probe.py \
   --server-command uv \
   --server-arg=run \
   --server-arg=mcp-atlassian \
-  --expect-protocol-version=2025-11-25
+  --expect-protocol-version=2025-11-25 \
+  --expect-tool-absent=jira_create_issue
 ```
 
 The expected revision is lane-specific. Do not infer it from the installed MCP
 SDK major version: an SDK can retain an older protocol revision unless the
 newer protocol era is explicitly selected. See the MCP 2 / FastMCP 4 findings
 in [issue #1541](https://github.com/sooperset/mcp-atlassian/issues/1541).
+
+Repeat `--expect-tool-present` or `--expect-tool-absent` to make public tool
+discovery an explicit gate. These checks run immediately after `tools/list` and
+before any optional staging reads, so they can diagnose policy visibility
+without contacting Atlassian. Contradictory expectations fail as a probe
+configuration error.
 
 An explicit `--staging-dc-pat` profile can additionally call one fixed Jira DC
 issue and one fixed Confluence DC page. Configure these variables securely

--- a/docs/compatibility.mdx
+++ b/docs/compatibility.mdx
@@ -32,8 +32,24 @@ uv run python scripts/mcp_wire_probe.py \
 ```
 
 The default probe does not invoke any Atlassian tool. It emits machine-readable
-JSON with the negotiated protocol version and discovered tool names, making it
-useful for comparing supported MCP SDK and FastMCP versions.
+JSON with the negotiated protocol version, installed MCP/FastMCP package
+versions, and discovered tool names, making it useful for comparing supported
+SDK and framework versions.
+
+Version-specific test lanes can make protocol negotiation an explicit gate:
+
+```bash
+uv run python scripts/mcp_wire_probe.py \
+  --server-command uv \
+  --server-arg=run \
+  --server-arg=mcp-atlassian \
+  --expect-protocol-version=2025-11-25
+```
+
+The expected revision is lane-specific. Do not infer it from the installed MCP
+SDK major version: an SDK can retain an older protocol revision unless the
+newer protocol era is explicitly selected. See the MCP 2 / FastMCP 4 findings
+in [issue #1541](https://github.com/sooperset/mcp-atlassian/issues/1541).
 
 An explicit `--staging-dc-pat` profile can additionally call one fixed Jira DC
 issue and one fixed Confluence DC page. Configure these variables securely
@@ -64,6 +80,11 @@ The profile fails closed: it forces read-only mode, exposes only
 to one, and caps traffic at 30 requests per minute. It stops before a live call
 if any unexpected tool is exposed. Output records only protocol and result
 shape—it excludes credentials, URLs, request identifiers, and response bodies.
+
+Direct-call policy regressions, including GHSA-3r68, are tested hermetically
+with a mocked backend. The live staging profile intentionally does not call a
+hidden write tool: if policy had regressed, such a canary could perform the
+write it was intended to detect.
 
 Passing this probe verifies the public MCP behaviors it exercises; it does not
 by itself establish compatibility with a future FastMCP major version.

--- a/docs/compatibility.mdx
+++ b/docs/compatibility.mdx
@@ -19,6 +19,55 @@ MCP Atlassian works with any MCP-compatible client. This page documents platform
 | OpenAI Gateway | Compatible | stdio / HTTP | |
 | ChatGPT | Not tested | HTTP | See [ChatGPT notes](#chatgpt) |
 
+## MCP stdio readiness probe
+
+Maintainers can exercise the public MCP initialize and `tools/list` boundary
+without depending on FastMCP internals:
+
+```bash
+uv run python scripts/mcp_wire_probe.py \
+  --server-command uv \
+  --server-arg=run \
+  --server-arg=mcp-atlassian
+```
+
+The default probe does not invoke any Atlassian tool. It emits machine-readable
+JSON with the negotiated protocol version and discovered tool names, making it
+useful for comparing supported MCP SDK and FastMCP versions.
+
+An explicit `--staging-dc-pat` profile can additionally call one fixed Jira DC
+issue and one fixed Confluence DC page. Configure these variables securely
+before running it:
+
+| Variable | Purpose |
+|----------|---------|
+| `MCP_READINESS_JIRA_URL` | Jira DC staging URL |
+| `MCP_READINESS_JIRA_PAT` | Jira DC staging personal access token |
+| `MCP_READINESS_JIRA_ISSUE_KEY` | Fixed issue approved for a read probe |
+| `MCP_READINESS_CONFLUENCE_URL` | Confluence DC staging URL |
+| `MCP_READINESS_CONFLUENCE_PAT` | Confluence DC staging personal access token |
+| `MCP_READINESS_CONFLUENCE_PAGE_ID` | Fixed page approved for a read probe |
+| `MCP_READINESS_MAX_RPM` | Optional request rate from 1–30; defaults to 30 |
+
+Then add the live-profile flag to the preceding command:
+
+```bash
+uv run python scripts/mcp_wire_probe.py \
+  --server-command uv \
+  --server-arg=run \
+  --server-arg=mcp-atlassian \
+  --staging-dc-pat
+```
+
+The profile fails closed: it forces read-only mode, exposes only
+`jira_get_issue` and `confluence_get_page`, disables retries, limits concurrency
+to one, and caps traffic at 30 requests per minute. It stops before a live call
+if any unexpected tool is exposed. Output records only protocol and result
+shape—it excludes credentials, URLs, request identifiers, and response bodies.
+
+Passing this probe verifies the public MCP behaviors it exercises; it does not
+by itself establish compatibility with a future FastMCP major version.
+
 ## Schema Compatibility
 
 MCP Atlassian includes automatic schema sanitization to ensure compatibility with strict AI platforms:

--- a/scripts/mcp_wire_probe.py
+++ b/scripts/mcp_wire_probe.py
@@ -8,6 +8,8 @@ import json
 import os
 import time
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Any
 
@@ -138,6 +140,24 @@ def _validate_staging_tools(tool_names: set[str]) -> None:
         raise RuntimeError(message)
 
 
+def _installed_versions() -> dict[str, str | None]:
+    """Return readiness package versions without importing their internals."""
+    versions: dict[str, str | None] = {}
+    for distribution in ("mcp", "fastmcp"):
+        try:
+            versions[distribution] = package_version(distribution)
+        except PackageNotFoundError:
+            versions[distribution] = None
+    return versions
+
+
+def _validate_protocol_version(actual: str, expected: str | None) -> None:
+    """Fail a version-specific readiness lane on protocol mismatch."""
+    if expected is not None and actual != expected:
+        message = f"Expected MCP protocol {expected}, negotiated {actual}"
+        raise RuntimeError(message)
+
+
 async def probe(args: argparse.Namespace) -> dict[str, Any]:
     """Initialize, list tools, and optionally run paced staging reads."""
     profile = build_staging_profile(os.environ.copy()) if args.staging_dc_pat else None
@@ -155,6 +175,17 @@ async def probe(args: argparse.Namespace) -> dict[str, Any]:
         async with stdio_client(parameters) as (read_stream, write_stream):
             async with ClientSession(read_stream, write_stream) as session:
                 initialized = await session.initialize()
+                protocol_version = str(
+                    _sdk_field(
+                        initialized,
+                        "protocol_version",
+                        "protocolVersion",
+                        default="unknown",
+                    )
+                )
+                _validate_protocol_version(
+                    protocol_version, args.expect_protocol_version
+                )
                 listed = await session.list_tools()
                 tool_names = sorted(tool.name for tool in listed.tools)
 
@@ -178,14 +209,8 @@ async def probe(args: argparse.Namespace) -> dict[str, Any]:
         "transport": "stdio",
         "staging_profile": "jira-dc-confluence-dc-pat" if profile else None,
         "max_rpm": profile.max_rpm if profile else None,
-        "protocol_version": str(
-            _sdk_field(
-                initialized,
-                "protocol_version",
-                "protocolVersion",
-                default="unknown",
-            )
-        ),
+        "protocol_version": protocol_version,
+        "package_versions": _installed_versions(),
         "tool_count": len(tool_names),
         "tool_names": tool_names,
         "probes": probes,
@@ -200,6 +225,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--server-arg", action="append", default=[])
     parser.add_argument("--cwd", type=Path)
     parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--expect-protocol-version")
     parser.add_argument("--staging-dc-pat", action="store_true")
     parser.add_argument("--output", type=Path)
     return parser

--- a/scripts/mcp_wire_probe.py
+++ b/scripts/mcp_wire_probe.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Probe an mcp-atlassian subprocess using only the public MCP SDK."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import anyio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+DEFAULT_MAX_RPM = 30
+MAX_ALLOWED_RPM = 30
+STAGING_ALLOWED_TOOLS = frozenset(
+    {
+        "jira_get_issue",
+        "confluence_get_page",
+    }
+)
+STAGING_ENV_MAP = {
+    "MCP_READINESS_JIRA_URL": "JIRA_URL",
+    "MCP_READINESS_JIRA_PAT": "JIRA_PERSONAL_TOKEN",
+    "MCP_READINESS_CONFLUENCE_URL": "CONFLUENCE_URL",
+    "MCP_READINESS_CONFLUENCE_PAT": "CONFLUENCE_PERSONAL_TOKEN",
+}
+STAGING_INHERITED_ENV = (
+    "HOME",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "PATH",
+    "PATHEXT",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMPDIR",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+)
+
+
+@dataclass(frozen=True)
+class StagingProfile:
+    """Validated, read-only Jira DC and Confluence DC staging profile."""
+
+    child_env: dict[str, str]
+    jira_issue_key: str
+    confluence_page_id: str
+    max_rpm: int
+
+
+def _required(env: dict[str, str], name: str) -> str:
+    """Return a nonempty staging value without logging its contents."""
+    value = env.get(name, "").strip()
+    if not value:
+        message = f"Missing required staging environment variable: {name}"
+        raise ValueError(message)
+    return value
+
+
+def build_staging_profile(env: dict[str, str]) -> StagingProfile:
+    """Build a fail-closed subprocess environment for live read probes."""
+    max_rpm_name = "MCP_READINESS_MAX_RPM"
+    try:
+        max_rpm = int(env.get(max_rpm_name, str(DEFAULT_MAX_RPM)))
+    except ValueError as exc:
+        message = f"{max_rpm_name} must be an integer between 1 and 30"
+        raise ValueError(message) from exc
+    if not 1 <= max_rpm <= MAX_ALLOWED_RPM:
+        message = f"{max_rpm_name} must be between 1 and {MAX_ALLOWED_RPM}"
+        raise ValueError(message)
+
+    child_env = {name: env[name] for name in STAGING_INHERITED_ENV if name in env}
+    for readiness_name, child_name in STAGING_ENV_MAP.items():
+        child_env[child_name] = _required(env, readiness_name)
+    child_env.update(
+        {
+            "READ_ONLY_MODE": "true",
+            "ATLASSIAN_OAUTH_PROXY_ENABLE": "false",
+            "MCP_LOGGING_STDOUT": "false",
+            "TOOLSETS": "all",
+            "ENABLED_TOOLS": ",".join(sorted(STAGING_ALLOWED_TOOLS)),
+            "ATLASSIAN_REQUESTS_PER_SECOND": f"{max_rpm / 60:.6g}",
+            "ATLASSIAN_MAX_CONCURRENT_REQUESTS": "1",
+            "ATLASSIAN_RETRY_TOTAL": "0",
+        }
+    )
+    return StagingProfile(
+        child_env=child_env,
+        jira_issue_key=_required(env, "MCP_READINESS_JIRA_ISSUE_KEY"),
+        confluence_page_id=_required(env, "MCP_READINESS_CONFLUENCE_PAGE_ID"),
+        max_rpm=max_rpm,
+    )
+
+
+def _sdk_field(
+    value: Any,
+    snake_case: str,
+    camel_case: str,
+    *,
+    default: Any,
+) -> Any:
+    """Read an MCP SDK field across the v1/v2 Python naming boundary."""
+    snake_value = getattr(value, snake_case, None)
+    if snake_value is not None:
+        return snake_value
+    return getattr(value, camel_case, default)
+
+
+def _result_record(name: str, result: Any) -> dict[str, Any]:
+    """Record only protocol shape, never Atlassian response content."""
+    return {
+        "tool": name,
+        "is_error": bool(_sdk_field(result, "is_error", "isError", default=False)),
+        "content_types": [
+            getattr(item, "type", "unknown") for item in getattr(result, "content", [])
+        ],
+    }
+
+
+def _validate_staging_tools(tool_names: set[str]) -> None:
+    """Fail before live calls unless exactly the approved reads are exposed."""
+    unexpected = tool_names - STAGING_ALLOWED_TOOLS
+    missing = STAGING_ALLOWED_TOOLS - tool_names
+    if unexpected:
+        message = f"Readiness policy exposed unexpected tools: {sorted(unexpected)}"
+        raise RuntimeError(message)
+    if missing:
+        message = f"Readiness profile is missing required tools: {sorted(missing)}"
+        raise RuntimeError(message)
+
+
+async def probe(args: argparse.Namespace) -> dict[str, Any]:
+    """Initialize, list tools, and optionally run paced staging reads."""
+    profile = build_staging_profile(os.environ.copy()) if args.staging_dc_pat else None
+    child_env = profile.child_env if profile else os.environ.copy()
+    parameters = StdioServerParameters(
+        command=args.server_command,
+        args=args.server_arg,
+        env=child_env,
+        cwd=args.cwd,
+    )
+    started = time.monotonic()
+    probes: list[dict[str, Any]] = []
+
+    with anyio.fail_after(args.timeout):
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                initialized = await session.initialize()
+                listed = await session.list_tools()
+                tool_names = sorted(tool.name for tool in listed.tools)
+
+                if profile:
+                    _validate_staging_tools(set(tool_names))
+                    jira_result = await session.call_tool(
+                        "jira_get_issue",
+                        {"issue_key": profile.jira_issue_key},
+                    )
+                    probes.append(_result_record("jira_get_issue", jira_result))
+                    await anyio.sleep(60 / profile.max_rpm)
+                    confluence_result = await session.call_tool(
+                        "confluence_get_page",
+                        {"page_id": profile.confluence_page_id},
+                    )
+                    probes.append(
+                        _result_record("confluence_get_page", confluence_result)
+                    )
+
+    return {
+        "transport": "stdio",
+        "staging_profile": "jira-dc-confluence-dc-pat" if profile else None,
+        "max_rpm": profile.max_rpm if profile else None,
+        "protocol_version": str(
+            _sdk_field(
+                initialized,
+                "protocol_version",
+                "protocolVersion",
+                default="unknown",
+            )
+        ),
+        "tool_count": len(tool_names),
+        "tool_names": tool_names,
+        "probes": probes,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the wire-probe argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--server-command", default="mcp-atlassian")
+    parser.add_argument("--server-arg", action="append", default=[])
+    parser.add_argument("--cwd", type=Path)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--staging-dc-pat", action="store_true")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    """Run the probe and optionally persist its sanitized evidence."""
+    args = _parser().parse_args()
+    result = anyio.run(probe, args)
+    rendered = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mcp_wire_probe.py
+++ b/scripts/mcp_wire_probe.py
@@ -143,7 +143,13 @@ def _validate_staging_tools(tool_names: set[str]) -> None:
 def _installed_versions() -> dict[str, str | None]:
     """Return readiness package versions without importing their internals."""
     versions: dict[str, str | None] = {}
-    for distribution in ("mcp", "fastmcp"):
+    for distribution in (
+        "mcp",
+        "mcp-types",
+        "fastmcp",
+        "fastmcp-slim",
+        "cryptography",
+    ):
         try:
             versions[distribution] = package_version(distribution)
         except PackageNotFoundError:
@@ -155,6 +161,28 @@ def _validate_protocol_version(actual: str, expected: str | None) -> None:
     """Fail a version-specific readiness lane on protocol mismatch."""
     if expected is not None and actual != expected:
         message = f"Expected MCP protocol {expected}, negotiated {actual}"
+        raise RuntimeError(message)
+
+
+def _validate_tool_expectations(
+    actual: set[str],
+    expected_present: set[str],
+    expected_absent: set[str],
+) -> None:
+    """Fail a readiness lane when public tool discovery violates expectations."""
+    contradictory = expected_present & expected_absent
+    if contradictory:
+        message = f"Tools cannot be both expected and absent: {sorted(contradictory)}"
+        raise ValueError(message)
+
+    missing = expected_present - actual
+    if missing:
+        message = f"Expected tools are missing: {sorted(missing)}"
+        raise RuntimeError(message)
+
+    unexpectedly_present = expected_absent & actual
+    if unexpectedly_present:
+        message = f"Expected-hidden tools are visible: {sorted(unexpectedly_present)}"
         raise RuntimeError(message)
 
 
@@ -170,6 +198,9 @@ async def probe(args: argparse.Namespace) -> dict[str, Any]:
     )
     started = time.monotonic()
     probes: list[dict[str, Any]] = []
+    validation_error: ValueError | RuntimeError | None = None
+    protocol_version = "unknown"
+    tool_names: list[str] = []
 
     with anyio.fail_after(args.timeout):
         async with stdio_client(parameters) as (read_stream, write_stream):
@@ -183,14 +214,28 @@ async def probe(args: argparse.Namespace) -> dict[str, Any]:
                         default="unknown",
                     )
                 )
-                _validate_protocol_version(
-                    protocol_version, args.expect_protocol_version
-                )
-                listed = await session.list_tools()
-                tool_names = sorted(tool.name for tool in listed.tools)
+                try:
+                    _validate_protocol_version(
+                        protocol_version, args.expect_protocol_version
+                    )
+                except RuntimeError as exc:
+                    validation_error = exc
 
-                if profile:
-                    _validate_staging_tools(set(tool_names))
+                if validation_error is None:
+                    listed = await session.list_tools()
+                    tool_names = sorted(tool.name for tool in listed.tools)
+                    try:
+                        _validate_tool_expectations(
+                            set(tool_names),
+                            set(args.expect_tool_present),
+                            set(args.expect_tool_absent),
+                        )
+                        if profile:
+                            _validate_staging_tools(set(tool_names))
+                    except (ValueError, RuntimeError) as exc:
+                        validation_error = exc
+
+                if profile and validation_error is None:
                     jira_result = await session.call_tool(
                         "jira_get_issue",
                         {"issue_key": profile.jira_issue_key},
@@ -204,6 +249,9 @@ async def probe(args: argparse.Namespace) -> dict[str, Any]:
                     probes.append(
                         _result_record("confluence_get_page", confluence_result)
                     )
+
+    if validation_error is not None:
+        raise validation_error
 
     return {
         "transport": "stdio",
@@ -226,6 +274,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--cwd", type=Path)
     parser.add_argument("--timeout", type=float, default=60.0)
     parser.add_argument("--expect-protocol-version")
+    parser.add_argument("--expect-tool-present", action="append", default=[])
+    parser.add_argument("--expect-tool-absent", action="append", default=[])
     parser.add_argument("--staging-dc-pat", action="store_true")
     parser.add_argument("--output", type=Path)
     return parser

--- a/tests/unit/servers/test_tool_policy_contract.py
+++ b/tests/unit/servers/test_tool_policy_contract.py
@@ -2,38 +2,153 @@
 
 import importlib
 from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp import Client
 
+_VALID_WRITE_ARGUMENTS = {
+    "project_key": "TEST",
+    "summary": "Policy contract must not create this issue",
+    "issue_type": "Task",
+}
 
-@pytest.mark.anyio
-@pytest.mark.security_regression
-async def test_read_only_hidden_tool_cannot_be_called(
+
+def _is_error(result: Any) -> bool:
+    """Read the tool-result error flag across MCP SDK v1/v2 field names."""
+    value = getattr(result, "is_error", None)
+    if value is None:
+        value = result.isError
+    return bool(value)
+
+
+def _error_text(result: Any) -> str:
+    """Return text content from a public MCP tool result."""
+    return " ".join(getattr(content, "text", "") for content in result.content)
+
+
+def _configure_jira(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    policy_env: dict[str, str | None],
 ) -> None:
-    """A write tool hidden from discovery must also be unknown at dispatch."""
-    monkeypatch.setenv("READ_ONLY_MODE", "true")
+    """Configure a hermetic Jira server lifespan for a policy test."""
     monkeypatch.setenv("JIRA_URL", "https://jira.example.test")
     monkeypatch.setenv("JIRA_PERSONAL_TOKEN", "policy-contract-placeholder")
     monkeypatch.setenv("ATLASSIAN_OAUTH_PROXY_ENABLE", "false")
-    monkeypatch.setenv("TOOLSETS", "all")
     monkeypatch.setenv("FASTMCP_HOME", str(tmp_path / "fastmcp-home"))
+    for name, value in policy_env.items():
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+
+@pytest.mark.parametrize(
+    "policy_env",
+    [
+        pytest.param(
+            {
+                "READ_ONLY_MODE": "true",
+                "ENABLED_TOOLS": None,
+                "TOOLSETS": "all",
+            },
+            id="read-only",
+        ),
+        pytest.param(
+            {
+                "READ_ONLY_MODE": "false",
+                "ENABLED_TOOLS": "jira_get_issue",
+                "TOOLSETS": "all",
+            },
+            id="enabled-tools",
+        ),
+        pytest.param(
+            {
+                "READ_ONLY_MODE": "false",
+                "ENABLED_TOOLS": None,
+                "TOOLSETS": "jira_comments",
+            },
+            id="toolsets",
+        ),
+    ],
+)
+@pytest.mark.anyio
+@pytest.mark.security_regression
+async def test_hidden_tool_cannot_be_called_through_public_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    policy_env: dict[str, str | None],
+) -> None:
+    """Hidden tools remain unknown and unexecuted (GHSA-3r68, issue #1541)."""
+    _configure_jira(monkeypatch, tmp_path, policy_env)
 
     main_module = importlib.import_module("mcp_atlassian.servers.main")
 
-    async with Client(main_module.main_mcp) as client:
-        hidden_call = await client.call_tool_mcp("jira_create_issue", {})
-        tools = await client.list_tools()
+    with patch(
+        "mcp_atlassian.servers.jira.get_jira_fetcher",
+        new_callable=AsyncMock,
+        side_effect=AssertionError("hidden write reached the Jira fetcher"),
+    ) as get_jira_fetcher:
+        async with Client(main_module.main_mcp) as client:
+            tools = await client.list_tools()
+            hidden_call = await client.call_tool_mcp(
+                "jira_create_issue", _VALID_WRITE_ARGUMENTS
+            )
+            unknown_call = await client.call_tool_mcp("jira_no_such_tool", {})
 
-    hidden_error = " ".join(
-        getattr(content, "text", "") for content in hidden_call.content
-    )
-    is_error = getattr(hidden_call, "is_error", None)
-    if is_error is None:
-        is_error = hidden_call.isError
+    hidden_error = _error_text(hidden_call)
+    unknown_error = _error_text(unknown_call)
 
-    assert is_error
+    assert _is_error(hidden_call)
+    assert _is_error(unknown_call)
     assert "Unknown tool" in hidden_error
+    assert "Unknown tool" in unknown_error
+    assert hidden_error.replace("jira_create_issue", "<tool>") == (
+        unknown_error.replace("jira_no_such_tool", "<tool>")
+    )
     assert "jira_create_issue" not in {tool.name for tool in tools}
+    get_jira_fetcher.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_enabled_read_tool_uses_public_call_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An allowed read reaches its executor, guarding the FastMCP call ABI."""
+    _configure_jira(
+        monkeypatch,
+        tmp_path,
+        {
+            "READ_ONLY_MODE": "true",
+            "ENABLED_TOOLS": "jira_get_issue",
+            "TOOLSETS": "jira_issues",
+        },
+    )
+    main_module = importlib.import_module("mcp_atlassian.servers.main")
+    issue = MagicMock()
+    issue.to_simplified_dict.return_value = {
+        "id": "10001",
+        "key": "TEST-1",
+        "summary": "Policy contract fixture",
+    }
+    jira_fetcher = MagicMock()
+    jira_fetcher.get_issue.return_value = issue
+
+    with patch(
+        "mcp_atlassian.servers.jira.get_jira_fetcher",
+        new_callable=AsyncMock,
+        return_value=jira_fetcher,
+    ) as get_jira_fetcher:
+        async with Client(main_module.main_mcp) as client:
+            tools = await client.list_tools()
+            allowed_call = await client.call_tool_mcp(
+                "jira_get_issue", {"issue_key": "TEST-1"}
+            )
+
+    assert "jira_get_issue" in {tool.name for tool in tools}
+    assert not _is_error(allowed_call)
+    get_jira_fetcher.assert_awaited_once()
+    jira_fetcher.get_issue.assert_called_once()

--- a/tests/unit/servers/test_tool_policy_contract.py
+++ b/tests/unit/servers/test_tool_policy_contract.py
@@ -1,0 +1,39 @@
+"""Public MCP client contracts for server-side tool policy."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+
+@pytest.mark.anyio
+@pytest.mark.security_regression
+async def test_read_only_hidden_tool_cannot_be_called(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A write tool hidden from discovery must also be unknown at dispatch."""
+    monkeypatch.setenv("READ_ONLY_MODE", "true")
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.test")
+    monkeypatch.setenv("JIRA_PERSONAL_TOKEN", "policy-contract-placeholder")
+    monkeypatch.setenv("ATLASSIAN_OAUTH_PROXY_ENABLE", "false")
+    monkeypatch.setenv("TOOLSETS", "all")
+    monkeypatch.setenv("FASTMCP_HOME", str(tmp_path / "fastmcp-home"))
+
+    main_module = importlib.import_module("mcp_atlassian.servers.main")
+
+    async with Client(main_module.main_mcp) as client:
+        hidden_call = await client.call_tool_mcp("jira_create_issue", {})
+        tools = await client.list_tools()
+
+    hidden_error = " ".join(
+        getattr(content, "text", "") for content in hidden_call.content
+    )
+    is_error = getattr(hidden_call, "is_error", None)
+    if is_error is None:
+        is_error = hidden_call.isError
+
+    assert is_error
+    assert "Unknown tool" in hidden_error
+    assert "jira_create_issue" not in {tool.name for tool in tools}

--- a/tests/unit/servers/test_tool_policy_contract.py
+++ b/tests/unit/servers/test_tool_policy_contract.py
@@ -13,6 +13,32 @@ _VALID_WRITE_ARGUMENTS = {
     "summary": "Policy contract must not create this issue",
     "issue_type": "Task",
 }
+_POLICY_CASES = [
+    pytest.param(
+        {
+            "READ_ONLY_MODE": "true",
+            "ENABLED_TOOLS": None,
+            "TOOLSETS": "all",
+        },
+        id="read-only",
+    ),
+    pytest.param(
+        {
+            "READ_ONLY_MODE": "false",
+            "ENABLED_TOOLS": "jira_get_issue",
+            "TOOLSETS": "all",
+        },
+        id="enabled-tools",
+    ),
+    pytest.param(
+        {
+            "READ_ONLY_MODE": "false",
+            "ENABLED_TOOLS": None,
+            "TOOLSETS": "jira_comments",
+        },
+        id="toolsets",
+    ),
+]
 
 
 def _is_error(result: Any) -> bool:
@@ -45,35 +71,28 @@ def _configure_jira(
             monkeypatch.setenv(name, value)
 
 
-@pytest.mark.parametrize(
-    "policy_env",
-    [
-        pytest.param(
-            {
-                "READ_ONLY_MODE": "true",
-                "ENABLED_TOOLS": None,
-                "TOOLSETS": "all",
-            },
-            id="read-only",
-        ),
-        pytest.param(
-            {
-                "READ_ONLY_MODE": "false",
-                "ENABLED_TOOLS": "jira_get_issue",
-                "TOOLSETS": "all",
-            },
-            id="enabled-tools",
-        ),
-        pytest.param(
-            {
-                "READ_ONLY_MODE": "false",
-                "ENABLED_TOOLS": None,
-                "TOOLSETS": "jira_comments",
-            },
-            id="toolsets",
-        ),
-    ],
-)
+@pytest.mark.parametrize("policy_env", _POLICY_CASES)
+@pytest.mark.anyio
+@pytest.mark.security_regression
+async def test_hidden_tool_is_absent_from_public_listing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    policy_env: dict[str, str | None],
+) -> None:
+    """Policy-hidden tools remain undiscoverable (GHSA-3r68, issue #1541)."""
+    _configure_jira(monkeypatch, tmp_path, policy_env)
+    main_module = importlib.import_module("mcp_atlassian.servers.main")
+
+    async with Client(main_module.main_mcp) as client:
+        tools = await client.list_tools()
+
+    visible_tools = {tool.name for tool in tools}
+    assert "jira_create_issue" not in visible_tools, (
+        "tool visibility policy exposed jira_create_issue"
+    )
+
+
+@pytest.mark.parametrize("policy_env", _POLICY_CASES)
 @pytest.mark.anyio
 @pytest.mark.security_regression
 async def test_hidden_tool_cannot_be_called_through_public_client(
@@ -92,12 +111,12 @@ async def test_hidden_tool_cannot_be_called_through_public_client(
         side_effect=AssertionError("hidden write reached the Jira fetcher"),
     ) as get_jira_fetcher:
         async with Client(main_module.main_mcp) as client:
-            tools = await client.list_tools()
             hidden_call = await client.call_tool_mcp(
                 "jira_create_issue", _VALID_WRITE_ARGUMENTS
             )
             unknown_call = await client.call_tool_mcp("jira_no_such_tool", {})
 
+    get_jira_fetcher.assert_not_awaited()
     hidden_error = _error_text(hidden_call)
     unknown_error = _error_text(unknown_call)
 
@@ -108,8 +127,6 @@ async def test_hidden_tool_cannot_be_called_through_public_client(
     assert hidden_error.replace("jira_create_issue", "<tool>") == (
         unknown_error.replace("jira_no_such_tool", "<tool>")
     )
-    assert "jira_create_issue" not in {tool.name for tool in tools}
-    get_jira_fetcher.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_mcp_wire_probe.py
+++ b/tests/unit/test_mcp_wire_probe.py
@@ -1,0 +1,132 @@
+"""Hermetic safety contracts for the MCP stdio readiness probe."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import mcp_wire_probe
+
+
+def _staging_env() -> dict[str, str]:
+    """Return placeholder staging values; no network is contacted."""
+    return {
+        "HOME": "/tmp/readiness-home",
+        "PATH": "/usr/bin",
+        "UNRELATED_SECRET": "must-not-be-inherited",
+        "MCP_READINESS_JIRA_URL": "https://jira-staging.example.test",
+        "MCP_READINESS_JIRA_PAT": "jira-placeholder",
+        "MCP_READINESS_JIRA_ISSUE_KEY": "TEST-1",
+        "MCP_READINESS_CONFLUENCE_URL": "https://wiki-staging.example.test",
+        "MCP_READINESS_CONFLUENCE_PAT": "confluence-placeholder",
+        "MCP_READINESS_CONFLUENCE_PAGE_ID": "12345",
+    }
+
+
+def test_staging_profile_enforces_read_only_and_30_rpm_default() -> None:
+    """The live profile must fail closed with bounded Atlassian traffic."""
+    profile = mcp_wire_probe.build_staging_profile(_staging_env())
+
+    assert profile.max_rpm == 30
+    assert profile.child_env["READ_ONLY_MODE"] == "true"
+    assert profile.child_env["ATLASSIAN_REQUESTS_PER_SECOND"] == "0.5"
+    assert profile.child_env["ATLASSIAN_MAX_CONCURRENT_REQUESTS"] == "1"
+    assert profile.child_env["ATLASSIAN_RETRY_TOTAL"] == "0"
+    assert profile.child_env["ATLASSIAN_OAUTH_PROXY_ENABLE"] == "false"
+    assert profile.child_env["ENABLED_TOOLS"] == ("confluence_get_page,jira_get_issue")
+
+
+@pytest.mark.parametrize("value", ["0", "31", "not-an-integer"])
+def test_staging_profile_rejects_invalid_rate(value: str) -> None:
+    """A caller cannot loosen or disable the live-system traffic limit."""
+    env = _staging_env() | {"MCP_READINESS_MAX_RPM": value}
+
+    with pytest.raises(ValueError, match="between 1 and 30"):
+        mcp_wire_probe.build_staging_profile(env)
+
+
+def test_staging_profile_requires_values_without_echoing_secrets() -> None:
+    """Missing-value errors identify the variable but never another value."""
+    env = _staging_env()
+    secret = env.pop("MCP_READINESS_JIRA_PAT")
+
+    with pytest.raises(ValueError) as exc_info:
+        mcp_wire_probe.build_staging_profile(env)
+
+    assert "MCP_READINESS_JIRA_PAT" in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+
+
+def test_staging_profile_passes_only_approved_environment() -> None:
+    """The server child receives no unrelated parent-process secrets."""
+    profile = mcp_wire_probe.build_staging_profile(_staging_env())
+
+    assert "UNRELATED_SECRET" not in profile.child_env
+    assert "MCP_READINESS_JIRA_PAT" not in profile.child_env
+    assert profile.child_env["JIRA_PERSONAL_TOKEN"] == "jira-placeholder"
+    assert profile.child_env["CONFLUENCE_PERSONAL_TOKEN"] == ("confluence-placeholder")
+    assert set(profile.child_env) <= (
+        set(mcp_wire_probe.STAGING_INHERITED_ENV)
+        | set(mcp_wire_probe.STAGING_ENV_MAP.values())
+        | {
+            "READ_ONLY_MODE",
+            "ATLASSIAN_OAUTH_PROXY_ENABLE",
+            "MCP_LOGGING_STDOUT",
+            "TOOLSETS",
+            "ENABLED_TOOLS",
+            "ATLASSIAN_REQUESTS_PER_SECOND",
+            "ATLASSIAN_MAX_CONCURRENT_REQUESTS",
+            "ATLASSIAN_RETRY_TOTAL",
+        }
+    )
+
+
+def test_staging_tool_gate_requires_exact_read_allowlist() -> None:
+    """Unexpected or missing tools stop the probe before any live calls."""
+    allowed = set(mcp_wire_probe.STAGING_ALLOWED_TOOLS)
+    mcp_wire_probe._validate_staging_tools(allowed)
+
+    with pytest.raises(RuntimeError, match="unexpected tools"):
+        mcp_wire_probe._validate_staging_tools(allowed | {"jira_create_issue"})
+    with pytest.raises(RuntimeError, match="missing required tools"):
+        mcp_wire_probe._validate_staging_tools({"jira_get_issue"})
+
+
+def test_sdk_field_supports_v1_and_v2_names() -> None:
+    """Protocol evidence works across the MCP SDK naming boundary."""
+    assert (
+        mcp_wire_probe._sdk_field(
+            SimpleNamespace(protocol_version="v1"),
+            "protocol_version",
+            "protocolVersion",
+            default="unknown",
+        )
+        == "v1"
+    )
+    assert (
+        mcp_wire_probe._sdk_field(
+            SimpleNamespace(protocolVersion="v2"),
+            "protocol_version",
+            "protocolVersion",
+            default="unknown",
+        )
+        == "v2"
+    )
+
+
+def test_result_record_omits_response_content() -> None:
+    """Recorded evidence contains types but no Atlassian response bodies."""
+    result = SimpleNamespace(
+        isError=False,
+        content=[SimpleNamespace(type="text", text="sensitive issue content")],
+    )
+
+    record = mcp_wire_probe._result_record("jira_get_issue", result)
+    rendered = json.dumps(record)
+
+    assert record == {
+        "tool": "jira_get_issue",
+        "is_error": False,
+        "content_types": ["text"],
+    }
+    assert "sensitive issue content" not in rendered

--- a/tests/unit/test_mcp_wire_probe.py
+++ b/tests/unit/test_mcp_wire_probe.py
@@ -127,16 +127,67 @@ def test_expected_protocol_version_rejects_mismatch() -> None:
         mcp_wire_probe._validate_protocol_version("2025-11-25", "2026-07-28")
 
 
+def test_tool_expectations_accept_matching_listing() -> None:
+    """Presence and absence expectations pass for a matching public listing."""
+    mcp_wire_probe._validate_tool_expectations(
+        {"jira_get_issue"},
+        {"jira_get_issue"},
+        {"jira_create_issue"},
+    )
+
+
+def test_tool_expectations_reject_missing_expected_tool() -> None:
+    """A lane fails clearly when a required tool is not discoverable."""
+    with pytest.raises(RuntimeError, match="Expected tools are missing"):
+        mcp_wire_probe._validate_tool_expectations(
+            set(),
+            {"jira_get_issue"},
+            set(),
+        )
+
+
+def test_tool_expectations_reject_visible_hidden_tool() -> None:
+    """A lane fails clearly when policy exposes an expected-hidden tool."""
+    with pytest.raises(RuntimeError, match="Expected-hidden tools are visible"):
+        mcp_wire_probe._validate_tool_expectations(
+            {"jira_create_issue"},
+            set(),
+            {"jira_create_issue"},
+        )
+
+
+def test_tool_expectations_reject_contradictory_configuration() -> None:
+    """A caller cannot configure the same tool as both present and absent."""
+    with pytest.raises(ValueError, match="cannot be both expected and absent"):
+        mcp_wire_probe._validate_tool_expectations(
+            {"jira_get_issue"},
+            {"jira_get_issue"},
+            {"jira_get_issue"},
+        )
+
+
 def test_installed_versions_are_sanitized_and_tolerate_missing_package() -> None:
     """Version evidence contains package metadata only and permits absence."""
     with patch.object(
         mcp_wire_probe,
         "package_version",
-        side_effect=["2.0.0", mcp_wire_probe.PackageNotFoundError("fastmcp")],
+        side_effect=[
+            "2.0.0",
+            "2.0.0",
+            "4.0.0b1",
+            "4.0.0b1",
+            mcp_wire_probe.PackageNotFoundError("cryptography"),
+        ],
     ):
         versions = mcp_wire_probe._installed_versions()
 
-    assert versions == {"mcp": "2.0.0", "fastmcp": None}
+    assert versions == {
+        "mcp": "2.0.0",
+        "mcp-types": "2.0.0",
+        "fastmcp": "4.0.0b1",
+        "fastmcp-slim": "4.0.0b1",
+        "cryptography": None,
+    }
     assert "MCP_READINESS_JIRA_PAT" not in json.dumps(versions)
 
 

--- a/tests/unit/test_mcp_wire_probe.py
+++ b/tests/unit/test_mcp_wire_probe.py
@@ -2,6 +2,7 @@
 
 import json
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -112,6 +113,31 @@ def test_sdk_field_supports_v1_and_v2_names() -> None:
         )
         == "v2"
     )
+
+
+def test_expected_protocol_version_accepts_matching_lane() -> None:
+    """A lane-specific expected protocol passes when negotiation matches."""
+    mcp_wire_probe._validate_protocol_version("2025-11-25", "2025-11-25")
+    mcp_wire_probe._validate_protocol_version("2025-11-25", None)
+
+
+def test_expected_protocol_version_rejects_mismatch() -> None:
+    """A lane fails clearly instead of silently testing another protocol."""
+    with pytest.raises(RuntimeError, match="Expected MCP protocol 2026-07-28"):
+        mcp_wire_probe._validate_protocol_version("2025-11-25", "2026-07-28")
+
+
+def test_installed_versions_are_sanitized_and_tolerate_missing_package() -> None:
+    """Version evidence contains package metadata only and permits absence."""
+    with patch.object(
+        mcp_wire_probe,
+        "package_version",
+        side_effect=["2.0.0", mcp_wire_probe.PackageNotFoundError("fastmcp")],
+    ):
+        versions = mcp_wire_probe._installed_versions()
+
+    assert versions == {"mcp": "2.0.0", "fastmcp": None}
+    assert "MCP_READINESS_JIRA_PAT" not in json.dumps(versions)
 
 
 def test_result_record_omits_response_content() -> None:


### PR DESCRIPTION
## Summary

- add a public MCP client contract proving that write tools hidden by read-only, enabled-tool, or toolset policy are absent from discovery and remain uncallable by name
- add an SDK-only stdio probe for MCP initialize and tool discovery, with explicit protocol/tool-visibility gates and expanded package evidence
- add an opt-in, fail-closed Jira DC and Confluence DC PAT staging profile
- document hermetic and live-profile usage in the compatibility guide

## Why

The existing security regression covers the internal `AtlassianMCP` dispatch gate. The new contract exercises the same boundary through a public client, providing an end-to-end signal if framework changes cause hidden tools to become discoverable or directly callable. It strengthens the GHSA-3r68 regression contract with valid write arguments, an executor trap that must remain untouched, comparison with a genuinely unknown tool, and a positive allowed-read control.

Issue #1541 also shows why import success alone is not a sufficient MCP 2 / FastMCP 4 readiness signal. The stdio probe therefore makes the negotiated protocol revision and expected tool presence/absence gateable. It records installed `mcp`, `mcp-types`, `fastmcp`, `fastmcp-slim`, and `cryptography` versions using package metadata. This PR remains compatible with FastMCP 3.4.4, changes no production code or dependency bounds, and does not claim FastMCP 4 compatibility.

## Policy contract

The hermetic public-client regression covers:

- `READ_ONLY_MODE` hiding a valid write operation
- `ENABLED_TOOLS` excluding the write operation
- `TOOLSETS` excluding the write operation's toolset
- separate discovery and dispatch contracts so one failure cannot mask the other
- direct calls returning the same unknown-tool shape as a nonexistent name
- the Jira fetcher never being reached for a denied call
- an allowed `jira_get_issue` call still reaching its mocked executor successfully

## Staging safety

The live profile is explicit and is not run by ordinary tests or CI. It:

- forces read-only mode and an exact `jira_get_issue,confluence_get_page` allowlist
- fails before live calls if required tools are missing or any unexpected tool is exposed
- caps traffic at 30 requests per minute, paces calls, limits concurrency to one, and disables retries
- passes only an allowlisted child-process environment
- records protocol/result shape without credentials, URLs, identifiers, arguments, or response bodies

The live probe intentionally never invokes a hidden write canary: if policy regressed, such a canary could perform the write it was intended to detect. The live staging profile was not invoked during PR validation because no staging credentials or approved test identifiers were supplied.

## Validation

- `uv sync --frozen --all-extras --dev`
- `uv run pytest tests/unit/servers/test_tool_policy_contract.py tests/unit/servers/test_mcp_protocol.py tests/unit/test_mcp_wire_probe.py -q` — 51 passed
- `uv run python scripts/mcp_wire_probe.py --server-command uv --server-arg=run --server-arg=mcp-atlassian --expect-protocol-version=2025-11-25 --expect-tool-absent=jira_create_issue` — MCP 1.28.1 / FastMCP 3.4.4 initialized successfully; no Atlassian tools were called
- `uv run pre-commit run --all-files` — all hooks passed, including Ruff, Ruff format, and mypy
- `uv run pytest -q` — 3,739 passed, 240 skipped

The branch changes four approved test/harness/documentation files (600 CLOC; 755 raw additions) and contains no production, dependency, lockfile, or workflow changes.
