### PR TITLE
docs(auth): document required server-side PAT placeholder for multi-user HTTP mode

### DIFF
--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -58,6 +58,13 @@ CONFLUENCE_PERSONAL_TOKEN=your_personal_access_token
 ```
 
 <Note>
+For multi-user HTTP deployments where clients send their own PATs, follow the
+[Server/DC per-request authentication setup](/docs/http-transport#authentication-methods).
+That setup uses non-empty server-side PAT values only to initialize the service
+configuration; each request's `Authorization: Token ...` value replaces them.
+</Note>
+
+<Note>
 Enterprise CA certificates in the OS trust store (Windows Certificate Store, macOS Keychain, Linux system CAs) are trusted automatically.
 For self-signed certificates not in the OS trust store, set `JIRA_SSL_VERIFY=false` and/or `CONFLUENCE_SSL_VERIFY=false`.
 </Note>

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -107,6 +107,20 @@ Both transport types support per-request authentication where each user provides
     ```
   </Tab>
   <Tab title="Server/DC (PAT)">
+    Set a URL and a non-empty server-side PAT value for each enabled service:
+
+    ```bash
+    JIRA_URL=https://jira.your-company.com
+    JIRA_PERSONAL_TOKEN=unused
+
+    CONFLUENCE_URL=https://confluence.your-company.com
+    CONFLUENCE_PERSONAL_TOKEN=unused
+    ```
+
+    These values let the server build its URL, SSL, and proxy configuration at
+    startup. The PAT sent with each request replaces the corresponding
+    server-side value for that API call.
+
     ```json
     {
       "mcpServers": {
@@ -119,6 +133,12 @@ Both transport types support per-request authentication where each user provides
       }
     }
     ```
+
+    <Warning>
+      Keep `ALLOW_GLOBAL_CRED_FALLBACK` disabled when using placeholder values.
+      Requests without a PAT are rejected by default; enabling fallback would
+      use the server-side value as a credential.
+    </Warning>
   </Tab>
 </Tabs>
 
@@ -234,7 +254,7 @@ asyncio.run(main())
 ```
 
 <Note>
-- The server uses fallback authentication when requests don't include user-specific credentials
+- Requests without user-specific credentials are rejected unless `ALLOW_GLOBAL_CRED_FALLBACK=true`
 - User tokens are isolated per request - no cross-tenant data leakage
 - Falls back to global `ATLASSIAN_OAUTH_CLOUD_ID` if header not provided
 </Note>


### PR DESCRIPTION
## Description

The Server/DC per-request PAT example showed the client header but omitted the
server setup needed to initialize Jira and Confluence configuration. This
documents the required startup values and the current fallback behavior.

Fixes: #1501
Related: #590

## Changes

- Add the required non-empty server-side PAT values to the per-request setup.
- Clarify that each request PAT replaces the corresponding server value.
- Link the authentication guide and warn against global fallback with placeholders.

## Testing

- [ ] Unit tests added/updated (documentation-only change)
- [ ] Integration tests passed (not run; documentation-only change)
- [x] Manual checks performed:
  - `uv run pre-commit run --all-files`
  - `uv run python scripts/generate_tool_docs.py --check`
  - `uv run pytest -q` (3,716 passed, 240 skipped)

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [ ] Tests added/updated for changes (not needed for documentation-only changes).
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
