### PR TITLE
feat(confluence): add ADF page support

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -270,6 +270,36 @@ class PagesMixin(ConfluenceClient):
             raise Exception(f"Error retrieving page content: {str(e)}") from e
 
     @handle_auth_errors("Confluence API")
+    def get_page_content_adf(self, page_id: str) -> ConfluencePage:
+        """Get a Confluence Cloud page with its raw ADF body."""
+        v2_adapter = self._cloud_v2_adapter()
+        if not v2_adapter:
+            raise ValueError("atlas_doc_format is only supported for Confluence Cloud")
+
+        try:
+            page = v2_adapter.get_page(
+                page_id=page_id,
+                body_format="atlas_doc_format",
+            )
+            content = page.get("body", {}).get("atlas_doc_format", {}).get("value", "")
+            return ConfluencePage.from_api_response(
+                page,
+                base_url=self.config.url,
+                include_body=True,
+                content_override=content,
+                content_format="atlas_doc_format",
+                is_cloud=True,
+                emoji=self._get_page_emoji(page_id),
+                page_width=self._get_page_width(page_id),
+            )
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error retrieving ADF for page ID {page_id}: {str(e)}")
+            error_msg = f"Error retrieving page ADF: {str(e)}"
+            raise Exception(error_msg) from e
+
+    @handle_auth_errors("Confluence API")
     def get_page_ancestors(self, page_id: str) -> list[ConfluencePage]:
         """
         Get ancestors (parent pages) of a specific page.
@@ -719,14 +749,14 @@ class PagesMixin(ConfluenceClient):
                 final_body = body
                 representation = content_representation or "storage"
 
-            # Use v2 API for OAuth authentication and for Cloud page subtypes
-            # such as Live Docs. The v1 API/client does not expose subtype.
+            # ADF and page subtypes require the Confluence Cloud v2 API.
             v2_adapter = self._v2_adapter
-            if subtype:
+            if subtype or representation == "atlas_doc_format":
                 v2_adapter = self._cloud_v2_adapter()
                 if not v2_adapter:
                     raise ValueError(
-                        "Confluence page subtype is only supported for Confluence Cloud"
+                        "Confluence page subtype and atlas_doc_format are only "
+                        "supported for Confluence Cloud"
                     )
             if v2_adapter:
                 logger.debug(
@@ -832,8 +862,18 @@ class PagesMixin(ConfluenceClient):
 
             logger.debug(f"Updating page {page_id} with title '{title}'")
 
-            # Use v2 API for OAuth authentication, v1 API for token/basic auth
+            # ADF requires the Confluence Cloud v2 API for every auth mode.
             v2_adapter = self._v2_adapter
+            if representation == "atlas_doc_format":
+                if parent_id:
+                    raise ValueError(
+                        "parent_id is not supported with atlas_doc_format updates"
+                    )
+                v2_adapter = self._cloud_v2_adapter()
+                if not v2_adapter:
+                    raise ValueError(
+                        "atlas_doc_format is only supported for Confluence Cloud"
+                    )
             if v2_adapter:
                 logger.debug(
                     f"Using v2 API for OAuth authentication to update page '{page_id}'"

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -306,12 +306,14 @@ class ConfluenceV2Adapter:
         self,
         page_id: str,
         expand: str | None = None,
+        body_format: str = "storage",
     ) -> dict[str, Any]:
         """Get a page using the v2 API.
 
         Args:
             page_id: The ID of the page to retrieve
             expand: Fields to expand in the response (not used in v2 API, for compatibility only)
+            body_format: Content representation to request from the v2 API
 
         Returns:
             The page data from the API response in v1-compatible format
@@ -324,7 +326,10 @@ class ConfluenceV2Adapter:
             url = f"{self.base_url}/api/v2/pages/{page_id}"
 
             # Convert v1 expand parameters to v2 format
-            params = {"body-format": "storage"}
+            if body_format not in ("storage", "atlas_doc_format"):
+                error_msg = f"Unsupported page body format: {body_format}"
+                raise ValueError(error_msg)
+            params = {"body-format": body_format}
 
             response = self.session.get(url, params=params)
             response.raise_for_status()
@@ -339,11 +344,15 @@ class ConfluenceV2Adapter:
             # Convert v2 response to v1-compatible format
             v1_compatible = self._convert_v2_to_v1_format(v2_response, space_key)
 
-            # Add body.storage structure if body content exists
-            if "body" in v2_response and v2_response["body"].get("storage"):
-                storage_value = v2_response["body"]["storage"].get("value", "")
+            # Add the requested body representation to the v1-compatible result.
+            body = v2_response.get("body", {})
+            if isinstance(body, dict) and body.get(body_format):
+                body_value = body[body_format].get("value", "")
                 v1_compatible["body"] = {
-                    "storage": {"value": storage_value, "representation": "storage"}
+                    body_format: {
+                        "value": body_value,
+                        "representation": body_format,
+                    }
                 }
 
             # Add space information with more details

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -179,6 +179,23 @@ def _resolve_page_content(content: str | None, content_file: str | None) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _validate_adf_content(content: str) -> None:
+    """Validate the required root shape of an ADF document."""
+    try:
+        document = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError("ADF content must be valid JSON.") from exc
+
+    if not isinstance(document, dict):
+        raise ValueError("ADF content must be a JSON object.")
+    if type(document.get("version")) is not int or document["version"] != 1:
+        raise ValueError("ADF content must have integer version 1.")
+    if document.get("type") != "doc":
+        raise ValueError("ADF content must have type 'doc'.")
+    if not isinstance(document.get("content"), list):
+        raise ValueError("ADF content must have a content array.")
+
+
 confluence_mcp = ErrorPreservingFastMCP(
     name="Confluence MCP Service",
     instructions="Provides tools for interacting with Atlassian Confluence.",
@@ -335,6 +352,18 @@ async def get_page(
             default=True,
         ),
     ] = True,
+    content_format: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Optional explicit content format. Options: 'markdown', "
+                "'storage', or 'atlas_doc_format'. This overrides "
+                "convert_to_markdown. Raw ADF is available only for "
+                "Confluence Cloud pages fetched by page_id."
+            ),
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Get content of a specific Confluence page by its ID, or by its title and space key.
 
@@ -346,12 +375,23 @@ async def get_page(
         space_key: The key of the space. Must be used with 'title'.
         include_metadata: Whether to include page metadata.
         convert_to_markdown: Convert content to markdown (true) or keep raw HTML (false).
+        content_format: Optional explicit output format. Raw ADF requires page_id.
 
     Returns:
         JSON string representing the page content and/or metadata, or an error if not found or parameters are invalid.
     """
     confluence_fetcher = await get_confluence_fetcher(ctx)
     page_object = None
+
+    if content_format not in (None, "markdown", "storage", "atlas_doc_format"):
+        raise ValueError(
+            "Invalid content_format. Must be 'markdown', 'storage', or "
+            "'atlas_doc_format'."
+        )
+    if content_format == "atlas_doc_format" and not page_id:
+        raise ValueError("atlas_doc_format retrieval requires page_id.")
+    if content_format in ("markdown", "storage"):
+        convert_to_markdown = content_format == "markdown"
 
     if page_id:
         if title or space_key:
@@ -364,9 +404,12 @@ async def get_page(
             # Resolve page ID from URL or tiny link
             page_id_str = _resolve_page_id(page_id_str)
 
-            page_object = confluence_fetcher.get_page_content(
-                page_id_str, convert_to_markdown=convert_to_markdown
-            )
+            if content_format == "atlas_doc_format":
+                page_object = confluence_fetcher.get_page_content_adf(page_id_str)
+            else:
+                page_object = confluence_fetcher.get_page_content(
+                    page_id_str, convert_to_markdown=convert_to_markdown
+                )
         except Exception as e:
             logger.error(f"Error fetching page by ID '{page_id}': {e}")
             return json.dumps(
@@ -696,7 +739,7 @@ async def create_page(
             description=(
                 "The content of the page. Format depends on content_format "
                 "parameter. Can be Markdown (default), wiki markup, storage "
-                "format, or XHTML storage format. Either 'content' or "
+                "format, XHTML storage format, or serialised ADF. Either 'content' or "
                 "'content_file' must be provided, but not both."
             ),
             default=None,
@@ -715,10 +758,12 @@ async def create_page(
         Field(
             description=(
                 "(Optional) The format of the content parameter. Options: "
-                "'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use "
+                "'markdown' (default), 'wiki', 'storage', 'xhtml', or "
+                "'atlas_doc_format'. Use "
                 "'xhtml' when providing Confluence XHTML storage format "
                 "(same as 'storage'). Wiki format uses Confluence wiki "
-                "markup syntax"
+                "markup syntax. atlas_doc_format requires a serialised ADF "
+                "document and Confluence Cloud."
             ),
             default="markdown",
         ),
@@ -802,7 +847,7 @@ async def create_page(
             Useful for bodies too large to pass as an inline tool argument.
         parent_id: Optional parent page ID.
         content_format: The format of the content ('markdown', 'wiki',
-            'storage', or 'xhtml').
+            'storage', 'xhtml', or 'atlas_doc_format').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
@@ -819,13 +864,22 @@ async def create_page(
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
     # Validate content_format
-    if content_format not in ["markdown", "wiki", "storage", "xhtml"]:
-        raise ValueError(
+    if content_format not in [
+        "markdown",
+        "wiki",
+        "storage",
+        "xhtml",
+        "atlas_doc_format",
+    ]:
+        error_msg = (
             f"Invalid content_format: {content_format}. Must be "
-            "'markdown', 'wiki', 'storage', or 'xhtml'"
+            "'markdown', 'wiki', 'storage', 'xhtml', or 'atlas_doc_format'"
         )
+        raise ValueError(error_msg)
 
     resolved_content = _resolve_page_content(content, content_file)
+    if content_format == "atlas_doc_format":
+        _validate_adf_content(resolved_content)
 
     # Determine parameters based on content format
     if content_format == "markdown":
@@ -878,7 +932,8 @@ async def update_page(
             description=(
                 "The new content of the page. Format depends on "
                 "content_format parameter and may be Markdown (default), wiki "
-                "markup, storage format, or XHTML storage format. Either "
+                "markup, storage format, XHTML storage format, or serialised "
+                "ADF. Either "
                 "'content' or 'content_file' must be provided, but not both."
             ),
             default=None,
@@ -900,10 +955,12 @@ async def update_page(
         Field(
             description=(
                 "(Optional) The format of the content parameter. Options: "
-                "'markdown' (default), 'wiki', 'storage', or 'xhtml'. Use "
+                "'markdown' (default), 'wiki', 'storage', 'xhtml', or "
+                "'atlas_doc_format'. Use "
                 "'xhtml' when providing Confluence XHTML storage format "
                 "(same as 'storage'). Wiki format uses Confluence wiki "
-                "markup syntax"
+                "markup syntax. atlas_doc_format requires a serialised ADF "
+                "document and Confluence Cloud."
             ),
             default="markdown",
         ),
@@ -980,7 +1037,7 @@ async def update_page(
         version_comment: Optional comment for this version.
         parent_id: Optional new parent page ID.
         content_format: The format of the content ('markdown', 'wiki',
-            'storage', or 'xhtml').
+            'storage', 'xhtml', or 'atlas_doc_format').
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
@@ -996,13 +1053,22 @@ async def update_page(
     confluence_fetcher = await get_confluence_fetcher(ctx)
 
     # Validate content_format
-    if content_format not in ["markdown", "wiki", "storage", "xhtml"]:
-        raise ValueError(
+    if content_format not in [
+        "markdown",
+        "wiki",
+        "storage",
+        "xhtml",
+        "atlas_doc_format",
+    ]:
+        error_msg = (
             f"Invalid content_format: {content_format}. Must be "
-            "'markdown', 'wiki', 'storage', or 'xhtml'"
+            "'markdown', 'wiki', 'storage', 'xhtml', or 'atlas_doc_format'"
         )
+        raise ValueError(error_msg)
 
     resolved_content = _resolve_page_content(content, content_file)
+    if content_format == "atlas_doc_format":
+        _validate_adf_content(resolved_content)
 
     # Determine parameters based on content format
     if content_format == "markdown":

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -353,6 +353,40 @@ class TestPagesMixin:
                 assert isinstance(result, ConfluencePage)
                 assert result.id == "live_123456789"
 
+    def test_create_page_with_adf_uses_v2_for_cloud_basic_auth(self, pages_mixin):
+        """Test creating ADF uses v2 for Cloud API-token authentication."""
+        adf = '{"version":1,"type":"doc","content":[]}'
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceV2Adapter"
+        ) as mock_v2_adapter_class:
+            mock_v2_adapter = MagicMock()
+            mock_v2_adapter_class.return_value = mock_v2_adapter
+            mock_v2_adapter.create_page.return_value = {
+                "id": "adf_123",
+                "title": "ADF Page",
+            }
+            with patch.object(
+                pages_mixin,
+                "get_page_content",
+                return_value=ConfluencePage(id="adf_123", title="ADF Page"),
+            ):
+                pages_mixin.create_page(
+                    "PROJ",
+                    "ADF Page",
+                    adf,
+                    is_markdown=False,
+                    content_representation="atlas_doc_format",
+                )
+
+        mock_v2_adapter.create_page.assert_called_once_with(
+            space_key="PROJ",
+            title="ADF Page",
+            body=adf,
+            parent_id=None,
+            representation="atlas_doc_format",
+        )
+        pages_mixin.confluence.create_page.assert_not_called()
+
     def test_create_page_error(self, pages_mixin):
         """Test error handling when creating a page."""
         # Arrange
@@ -501,6 +535,40 @@ class TestPagesMixin:
             # Verify result is a ConfluencePage
             assert isinstance(result, ConfluencePage)
             assert result.id == page_id
+
+    def test_update_page_with_adf_uses_v2_for_cloud_basic_auth(self, pages_mixin):
+        """Test updating ADF uses v2 for Cloud API-token authentication."""
+        adf = '{"version":1,"type":"doc","content":[]}'
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceV2Adapter"
+        ) as mock_v2_adapter_class:
+            mock_v2_adapter = MagicMock()
+            mock_v2_adapter_class.return_value = mock_v2_adapter
+            mock_v2_adapter.update_page.return_value = {
+                "id": "adf_123",
+                "title": "ADF Page",
+            }
+            with patch.object(
+                pages_mixin,
+                "get_page_content",
+                return_value=ConfluencePage(id="adf_123", title="ADF Page"),
+            ):
+                pages_mixin.update_page(
+                    "adf_123",
+                    "ADF Page",
+                    adf,
+                    is_markdown=False,
+                    content_representation="atlas_doc_format",
+                )
+
+        mock_v2_adapter.update_page.assert_called_once_with(
+            page_id="adf_123",
+            title="ADF Page",
+            body=adf,
+            representation="atlas_doc_format",
+            version_comment="",
+        )
+        pages_mixin.confluence.update_page.assert_not_called()
 
     def test_delete_page_success(self, pages_mixin):
         """Test successfully deleting a page."""

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -93,6 +93,33 @@ class TestConfluenceV2Adapter:
         with pytest.raises(ValueError, match="Failed to get page '999999'"):
             v2_adapter.get_page("999999")
 
+    def test_get_page_adf(self, v2_adapter, mock_session):
+        """Test retrieval of a raw ADF page body."""
+        adf = '{"version":1,"type":"doc","content":[]}'
+        page_response = Mock()
+        page_response.json.return_value = {
+            "id": "123456",
+            "title": "ADF Page",
+            "spaceId": "789",
+            "body": {
+                "atlas_doc_format": {
+                    "value": adf,
+                    "representation": "atlas_doc_format",
+                }
+            },
+        }
+        space_response = Mock()
+        space_response.json.return_value = {"key": "TEST"}
+        mock_session.get.side_effect = [page_response, space_response]
+
+        result = v2_adapter.get_page("123456", body_format="atlas_doc_format")
+
+        mock_session.get.assert_any_call(
+            "https://example.atlassian.net/wiki/api/v2/pages/123456",
+            params={"body-format": "atlas_doc_format"},
+        )
+        assert result["body"]["atlas_doc_format"]["value"] == adf
+
     def test_get_page_with_minimal_response(self, v2_adapter, mock_session):
         """Test page retrieval with minimal v2 response."""
         # Mock the v2 API response without optional fields

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -616,6 +616,27 @@ async def test_get_page_no_markdown(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
+async def test_get_page_adf(client, mock_confluence_fetcher):
+    """Test get_page can request a raw ADF body."""
+    adf_page = ConfluencePage(
+        id="123456",
+        title="ADF Page",
+        content='{"version":1,"type":"doc","content":[]}',
+        content_format="atlas_doc_format",
+    )
+    mock_confluence_fetcher.get_page_content_adf.return_value = adf_page
+
+    response = await client.call_tool(
+        "confluence_get_page",
+        {"page_id": "123456", "content_format": "atlas_doc_format"},
+    )
+
+    mock_confluence_fetcher.get_page_content_adf.assert_called_once_with("123456")
+    result_data = json.loads(response.content[0].text)
+    assert result_data["metadata"]["content"]["format"] == "atlas_doc_format"
+
+
+@pytest.mark.anyio
 async def test_get_page_children(client, mock_confluence_fetcher):
     """Test the get_page_children tool."""
     response = await client.call_tool(
@@ -896,6 +917,47 @@ async def test_create_page_with_xhtml_format(client, mock_confluence_fetcher):
 
 
 @pytest.mark.anyio
+async def test_create_page_with_adf_format(client, mock_confluence_fetcher):
+    """Test create_page validates and forwards a serialised ADF document."""
+    adf = '{"version":1,"type":"doc","content":[]}'
+
+    response = await client.call_tool(
+        "confluence_create_page",
+        {
+            "space_key": "TEST",
+            "title": "ADF Page",
+            "content": adf,
+            "content_format": "atlas_doc_format",
+        },
+    )
+
+    call_kwargs = mock_confluence_fetcher.create_page.call_args.kwargs
+    assert call_kwargs["body"] == adf
+    assert call_kwargs["is_markdown"] is False
+    assert call_kwargs["content_representation"] == "atlas_doc_format"
+    assert (
+        json.loads(response.content[0].text)["message"] == "Page created successfully"
+    )
+
+
+@pytest.mark.anyio
+async def test_create_page_rejects_invalid_adf(client, mock_confluence_fetcher):
+    """Test create_page rejects malformed ADF before calling Confluence."""
+    with pytest.raises(ToolError, match="ADF content must have integer version 1"):
+        await client.call_tool(
+            "confluence_create_page",
+            {
+                "space_key": "TEST",
+                "title": "Invalid ADF Page",
+                "content": '{"type":"doc","content":[]}',
+                "content_format": "atlas_doc_format",
+            },
+        )
+
+    mock_confluence_fetcher.create_page.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_update_page_with_numeric_parent_id(client, mock_confluence_fetcher):
     """Test updating a page with numeric parent_id (integer) - should convert to string."""
     response = await client.call_tool(
@@ -993,6 +1055,30 @@ async def test_update_page_with_xhtml_format(client, mock_confluence_fetcher):
 
     result_data = json.loads(response.content[0].text)
     assert result_data["message"] == "Page updated successfully"
+
+
+@pytest.mark.anyio
+async def test_update_page_with_adf_format(client, mock_confluence_fetcher):
+    """Test update_page validates and forwards a serialised ADF document."""
+    adf = '{"version":1,"type":"doc","content":[]}'
+
+    response = await client.call_tool(
+        "confluence_update_page",
+        {
+            "page_id": "999999",
+            "title": "Updated ADF Page",
+            "content": adf,
+            "content_format": "atlas_doc_format",
+        },
+    )
+
+    call_kwargs = mock_confluence_fetcher.update_page.call_args.kwargs
+    assert call_kwargs["body"] == adf
+    assert call_kwargs["is_markdown"] is False
+    assert call_kwargs["content_representation"] == "atlas_doc_format"
+    assert (
+        json.loads(response.content[0].text)["message"] == "Page updated successfully"
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add raw `atlas_doc_format` page reads through Confluence Cloud REST API v2
- accept validated serialised ADF for page creation and updates
- route ADF operations through v2 for OAuth and API-token authentication while preserving existing formats

## Safety
- reject malformed ADF roots before API calls
- reject ADF on Server/Data Center
- reject parent moves during ADF updates because that path is not implemented

## Tests
- `uv run pytest tests/unit` (3615 passed, 5 skipped)
- `uv run ruff format --check ...`
- `git diff --check`

A disposable Confluence Cloud round-trip test remains pending before this draft is marked ready.