### PR TITLE
fix(jira,confluence): validate attachment URLs against SSRF

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from ..models.confluence import ConfluenceAttachment
 from ..utils.io import validate_safe_path
-from ..utils.urls import resolve_relative_url
+from ..utils.urls import resolve_relative_url, validate_url_for_ssrf
 from .client import ConfluenceClient
 from .protocols import AttachmentsOperationsProto
 from .v2_adapter import ConfluenceV2Adapter
@@ -348,6 +348,11 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             logger.error("No URL provided for attachment fetch")
             return None
 
+        ssrf_error = validate_url_for_ssrf(url)
+        if ssrf_error:
+            logger.error(f"Refusing to fetch attachment: {ssrf_error}")
+            return None
+
         try:
             logger.info(f"Fetching attachment from {url}")
             response = self.confluence._session.get(url, stream=True)
@@ -380,6 +385,11 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
         """
         if not url:
             logger.error("No URL provided for attachment download")
+            return False
+
+        ssrf_error = validate_url_for_ssrf(url)
+        if ssrf_error:
+            logger.error(f"Refusing to download attachment: {ssrf_error}")
             return False
 
         try:

--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -9,6 +9,7 @@ from typing import Any
 from ..models.jira import JiraAttachment
 from ..utils.io import validate_safe_path
 from ..utils.media import ATTACHMENT_MAX_BYTES
+from ..utils.urls import validate_url_for_ssrf
 from .client import JiraClient
 from .protocols import AttachmentsOperationsProto
 
@@ -32,6 +33,11 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         """
         if not url:
             logger.error("No URL provided for attachment download")
+            return False
+
+        ssrf_error = validate_url_for_ssrf(url)
+        if ssrf_error:
+            logger.error(f"Refusing to download attachment: {ssrf_error}")
             return False
 
         try:
@@ -94,6 +100,11 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
         """
         if not url:
             logger.error("No URL provided for attachment fetch")
+            return None
+
+        ssrf_error = validate_url_for_ssrf(url)
+        if ssrf_error:
+            logger.error(f"Refusing to fetch attachment: {ssrf_error}")
             return None
 
         try:

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -654,6 +654,10 @@ class TestAttachmentsMixin:
             patch("os.path.getsize") as mock_getsize,
             patch("os.makedirs") as mock_makedirs,
             patch("mcp_atlassian.confluence.attachments.validate_safe_path"),
+            patch(
+                "mcp_atlassian.confluence.attachments.validate_url_for_ssrf",
+                return_value=None,
+            ),
         ):
             mock_exists.return_value = True
             mock_getsize.return_value = 12  # Length of "test content"
@@ -692,6 +696,10 @@ class TestAttachmentsMixin:
             patch("os.path.abspath") as mock_abspath,
             patch("os.path.isabs") as mock_isabs,
             patch("mcp_atlassian.confluence.attachments.validate_safe_path"),
+            patch(
+                "mcp_atlassian.confluence.attachments.validate_url_for_ssrf",
+                return_value=None,
+            ),
         ):
             mock_exists.return_value = True
             mock_getsize.return_value = 12
@@ -713,6 +721,20 @@ class TestAttachmentsMixin:
         """Test attachment download with no URL."""
         result = attachments_mixin.download_attachment("", "/tmp/test_file.txt")
         assert result is False
+
+    def test_download_attachment_ssrf_blocked(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test attachment download is refused when the URL fails SSRF validation."""
+        with patch(
+            "mcp_atlassian.confluence.attachments.validate_url_for_ssrf",
+            return_value="Blocked host",
+        ):
+            result = attachments_mixin.download_attachment(
+                "http://169.254.169.254/attachment", "/tmp/test_file.txt"
+            )
+        assert result is False
+        attachments_mixin.confluence._session.get.assert_not_called()
 
     def test_download_attachment_http_error(self, attachments_mixin: AttachmentsMixin):
         """Test attachment download with an HTTP error."""
@@ -799,6 +821,20 @@ class TestAttachmentsMixin:
     ):
         """Test fetch_attachment_content returns None for empty URL."""
         assert attachments_mixin.fetch_attachment_content("") is None
+        attachments_mixin.confluence._session.get.assert_not_called()
+
+    def test_fetch_attachment_content_ssrf_blocked(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test fetch is refused when the URL fails SSRF validation."""
+        with patch(
+            "mcp_atlassian.confluence.attachments.validate_url_for_ssrf",
+            return_value="Blocked host",
+        ):
+            result = attachments_mixin.fetch_attachment_content(
+                "http://169.254.169.254/attachment"
+            )
+        assert result is None
         attachments_mixin.confluence._session.get.assert_not_called()
 
     def test_fetch_attachment_content_http_error(

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -80,6 +80,10 @@ class TestAttachmentsMixin:
             patch("os.path.getsize") as mock_getsize,
             patch("os.makedirs") as mock_makedirs,
             patch("os.getcwd", return_value="/tmp"),
+            patch(
+                "mcp_atlassian.jira.attachments.validate_url_for_ssrf",
+                return_value=None,
+            ),
         ):
             mock_exists.return_value = True
             mock_getsize.return_value = 12  # Length of "test content"
@@ -118,6 +122,10 @@ class TestAttachmentsMixin:
             patch("os.path.isabs") as mock_isabs,
             patch("os.getcwd", return_value="/absolute/path"),
             patch("mcp_atlassian.jira.attachments.validate_safe_path"),
+            patch(
+                "mcp_atlassian.jira.attachments.validate_url_for_ssrf",
+                return_value=None,
+            ),
         ):
             mock_exists.return_value = True
             mock_getsize.return_value = 12
@@ -146,6 +154,20 @@ class TestAttachmentsMixin:
         """Test attachment download with no URL."""
         result = attachments_mixin.download_attachment("", "/tmp/test_file.txt")
         assert result is False
+
+    def test_download_attachment_ssrf_blocked(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test attachment download is refused when the URL fails SSRF validation."""
+        with patch(
+            "mcp_atlassian.jira.attachments.validate_url_for_ssrf",
+            return_value="Blocked host",
+        ):
+            result = attachments_mixin.download_attachment(
+                "http://169.254.169.254/attachment", "/tmp/test_file.txt"
+            )
+        assert result is False
+        attachments_mixin.jira._session.get.assert_not_called()
 
     def test_download_attachment_http_error(self, attachments_mixin: AttachmentsMixin):
         """Test attachment download with an HTTP error."""
@@ -778,9 +800,13 @@ class TestAttachmentsMixin:
         mock_response.raise_for_status = MagicMock()
         attachments_mixin.jira._session.get.return_value = mock_response
 
-        result = attachments_mixin.fetch_attachment_content(
-            "https://test.url/attachment"
-        )
+        with patch(
+            "mcp_atlassian.jira.attachments.validate_url_for_ssrf",
+            return_value=None,
+        ):
+            result = attachments_mixin.fetch_attachment_content(
+                "https://test.url/attachment"
+            )
 
         assert result == b"chunk1chunk2"
         attachments_mixin.jira._session.get.assert_called_once_with(
@@ -791,6 +817,20 @@ class TestAttachmentsMixin:
         """Test fetch with no URL returns None."""
         result = attachments_mixin.fetch_attachment_content("")
         assert result is None
+
+    def test_fetch_attachment_content_ssrf_blocked(
+        self, attachments_mixin: AttachmentsMixin
+    ):
+        """Test fetch is refused when the URL fails SSRF validation."""
+        with patch(
+            "mcp_atlassian.jira.attachments.validate_url_for_ssrf",
+            return_value="Blocked host",
+        ):
+            result = attachments_mixin.fetch_attachment_content(
+                "http://169.254.169.254/attachment"
+            )
+        assert result is None
+        attachments_mixin.jira._session.get.assert_not_called()
 
     def test_fetch_attachment_content_http_error(
         self, attachments_mixin: AttachmentsMixin


### PR DESCRIPTION
## Summary
- `download_attachment`/`fetch_attachment_content` in both Jira and Confluence attachment mixins hit the attachment `url` directly with `_session.get(...)`, without running it through `validate_url_for_ssrf` first — only redirects were pinned/validated.
- Adds the same `validate_url_for_ssrf` check used elsewhere (e.g. header-based Jira/Confluence URLs) before the initial request in all four affected methods.

Closes #1567

## Test plan
- [x] Added regression tests asserting download/fetch is refused (and the session's `get` is never called) when `validate_url_for_ssrf` blocks the URL, for both Jira and Confluence.
- [x] `uv run pytest tests/unit/jira/test_attachments.py tests/unit/confluence/test_attachments.py` — 129 passed.
- [x] `prek run` on all touched files — ruff, ruff-format, mypy all pass.