### PR TITLE
fix(jira): only unwrap bare links in jira_to_markdown, not all bracketed text

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -355,7 +355,17 @@ class JiraPreprocessor(BasePreprocessor):
 
         # Links
         output = re.sub(r"\[([^|]+)\|(.+?)\]", r"[\1](\2)", output)
-        output = re.sub(r"\[(.+?)\]([^\(])", r"\1\2", output)
+        # Bare links: [https://example.com] -> https://example.com. Anchored on a
+        # URI scheme so only actual link targets are unwrapped; an unanchored
+        # `\[(.+?)\]` also strips ordinary bracketed text that carries meaning
+        # ([~user] mentions, [eBay], [redacted], ...) — see #1566. The negative
+        # lookahead keeps already-converted `[text](url)` output from the line
+        # above intact.
+        output = re.sub(
+            r"\[([a-zA-Z][a-zA-Z0-9+.-]*://[^\]\s]+)\](?!\()",
+            r"\1",
+            output,
+        )
 
         # Colored text
         output = re.sub(

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -1479,6 +1479,61 @@ class TestPanelBlocks:
         result = preprocessor.jira_to_markdown("[https://example.com] more text")
         assert "https://example.com" in result, f"URL dropped: {result}"
 
+    @pytest.mark.parametrize(
+        "test_id,input_text",
+        [
+            ("user_mention", "Emailed [~jdoe] to update the owner."),
+            ("bracketed_names", "engagements ([eBay], [Netflix], etc.)"),
+            ("redaction_marker", "Cost is [redacted] for now"),
+            ("bracketed_text_at_end", "Trailing [redacted]"),
+        ],
+    )
+    def test_non_link_brackets_are_preserved(
+        self, preprocessor, test_id: str, input_text: str
+    ):
+        """Bracketed text that is not a link must survive the read path (#1566).
+
+        The bare-link unwrap used to match any `[...]`, so ordinary bracketed
+        content ([~user] mentions, product names, redaction markers) silently
+        lost its brackets on every read of a description or comment.
+        """
+        assert preprocessor.jira_to_markdown(input_text) == input_text, (
+            f"[{test_id}] brackets stripped from non-link text"
+        )
+
+    @pytest.mark.parametrize(
+        "test_id,input_text,expected",
+        [
+            (
+                "http",
+                "See [http://example.com] for details",
+                "See http://example.com for details",
+            ),
+            (
+                "https",
+                "[https://example.com] more text",
+                "https://example.com more text",
+            ),
+            (
+                "at_end",
+                "Bare at end [https://example.com]",
+                "Bare at end https://example.com",
+            ),
+            (
+                "labelled_link_untouched",
+                "Link [text|http://example.com] here",
+                "Link [text](http://example.com) here",
+            ),
+        ],
+    )
+    def test_bare_links_still_unwrapped(
+        self, preprocessor, test_id: str, input_text: str, expected: str
+    ):
+        """Real bare links must still unwrap, and labelled links still convert (#1566)."""
+        assert preprocessor.jira_to_markdown(input_text) == expected, (
+            f"[{test_id}] link conversion regressed"
+        )
+
 
 # Code block placeholder protection tests
 


### PR DESCRIPTION
Closes #1566.

## Problem

The second link substitution in `JiraPreprocessor.jira_to_markdown` (`src/mcp_atlassian/preprocessing/jira.py`) used an unanchored pattern:

```python
output = re.sub(r"\[(.+?)\]([^\(])", r"\1\2", output)
```

It was intended to unwrap a *bare link* (`[https://example.com]` → `https://example.com`, matching how Jira renders it), but `(.+?)` matches any content, so it also stripped the brackets from ordinary text that carries meaning.

This is a **read-path** defect: the stored Jira content is correct, but every MCP read of a description or comment silently rewrote it.

| Input (as stored in Jira) | Before | After |
|---|---|---|
| `Emailed [~jdoe] to update the owner.` | `Emailed ~jdoe to update the owner.` | unchanged ✅ |
| `engagements ([eBay], [Netflix], etc.)` | `engagements (eBay, Netflix, etc.)` | unchanged ✅ |
| `Cost is [redacted] for now` | `Cost is redacted for now` | unchanged ✅ |
| `See [http://example.com] for details` | `See http://example.com for details` | same ✅ |
| `Link [text\|http://example.com] here` | `Link [text](http://example.com) here` | same ✅ |

## Fix

Anchor the pattern on a URI scheme so only real link targets are unwrapped, and use a negative lookahead instead of consuming a trailing character so already-converted `[text](url)` output from the preceding substitution stays intact.

The lookahead also fixes bare links at end-of-string, which the old trailing-character match structurally could not handle (`Bare at end [https://example.com]` was previously left wrapped).

Note: #1311 reports the `[~username]` symptom and analyses it in the markdown→wiki (write) direction. This PR is the general case in the opposite direction; the write path is not touched.

## Testing

Added 8 parametrized regression tests: 4 pinning that non-link brackets survive, 4 pinning that real bare links still unwrap and labelled links still convert. Verified they **fail against the pre-fix code** (4 failures) and pass after.

- `tests/unit/preprocessing/`: 175 passed
- Full `tests/unit/`: 3743 passed. The 4 unrelated failures (`test_upload_attachment_success`, `test_parse_date_timestamp_boundary_max_valid`, `test_mime_type_detection[zip]`, `test_saved_token_file_is_not_group_or_world_readable`) reproduce identically on unmodified `main` on this Windows machine and are environment-specific, not caused by this change.
- `ruff check` (with the repo's pre-commit ignore list) and `ruff format --check`: clean.