### PR TITLE
fix(jira): exempt non-request issues from the internal-only comment guard

### DIFF
--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -16,7 +16,7 @@ Add a comment to a Jira issue.
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `body` | `string` | Yes | Comment text in Markdown format |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
-| `public` | `boolean` | No | (Optional) For JSM/Service Desk issues only. Set to true for customer-visible comment, false for internal agent-only comment. Posted via the ServiceDesk API as a raw string; Jira Cloud renders it server-side and stores ADF (markdown observed to render on Cloud, without the client-side markdown-to-ADF guarantees of the regular comment path). Cannot be combined with visibility. If the issue's project is listed in JIRA_INTERNAL_ONLY_PROJECTS, only public=false is accepted — public=true or omitting this field is rejected. |
+| `public` | `boolean` | No | (Optional) For JSM/Service Desk issues only. Set to true for customer-visible comment, false for internal agent-only comment. Posted via the ServiceDesk API as a raw string; Jira Cloud renders it server-side and stores ADF (markdown observed to render on Cloud, without the client-side markdown-to-ADF guarantees of the regular comment path). Cannot be combined with visibility. If the issue's project is listed in JIRA_INTERNAL_ONLY_PROJECTS, only public=false is accepted — public=true or omitting this field is rejected. Issues in such a project that are not JSM customer requests (e.g. an agent-created Task) have no portal audience and are exempt: they post through the ordinary comment path and ignore this field. |
 **Example:**
 
 ```json

--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -13,16 +13,40 @@ Internal-only guard (JIRA_INTERNAL_ONLY_PROJECTS) coverage map:
   no production caller (the transition path uses
   TransitionsMixin._add_comment_to_transition_data, whose caller is
   guarded), and update_issue never emits an update.comment block.
+- Scope: the setting names whole *projects*, but the customer-visibility
+  risk it exists for is per *issue* — only a JSM customer request has a
+  portal view. add_comment therefore exempts issues in a guarded project
+  that are not requests (see _is_servicedesk_request), because the
+  ServiceDesk comment API they would need does not exist for them.
 """
 
 import logging
 from typing import Any
+
+from requests.exceptions import HTTPError
 
 from ..models.jira.adf import adf_to_text
 from ..utils import parse_date
 from .client import JiraClient
 
 logger = logging.getLogger("mcp-jira")
+
+
+def _http_status(exc: BaseException) -> int | None:
+    """Extract the HTTP status code from an exception, if it carries one.
+
+    Preferred over matching on ``str(exc)``: an HTTPError raised for a
+    response with an empty body stringifies to ``""``, so a substring test
+    silently misses the status it is looking for.
+
+    Args:
+        exc: The exception to inspect.
+
+    Returns:
+        The HTTP status code, or None if the exception does not carry one.
+    """
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    return status if isinstance(status, int) else None
 
 
 class CommentsMixin(JiraClient):
@@ -77,6 +101,73 @@ class CommentsMixin(JiraClient):
         except Exception as e:
             logger.error(f"Error getting comments for issue {issue_key}: {str(e)}")
             raise Exception(f"Error getting comments: {str(e)}") from e
+
+    def _is_servicedesk_request(self, issue_key: str) -> bool:
+        """Check whether an issue is a JSM customer request.
+
+        JIRA_INTERNAL_ONLY_PROJECTS names whole projects, but only a JSM
+        customer request has a portal view and customer participants. An
+        issue raised internally in the same project — an agent-created Task
+        or Sub-task, say — has no portal presence, so an ordinary Jira
+        comment on it cannot reach a customer.
+
+        The distinction matters because the guard would otherwise leave no
+        way to comment on such an issue at all: ``public=False`` posts via
+        ``rest/servicedeskapi/request/<key>/comment``, which does not exist
+        for a non-request, while ``public=True`` or an omitted ``public`` is
+        refused by :meth:`_enforce_internal_only_add`.
+
+        Fails closed. Only an explicit 404 counts as a negative; every other
+        outcome — 403, 5xx, timeout, unexpected body — reports True so the
+        guard stays in force. Called only for projects listed in
+        JIRA_INTERNAL_ONLY_PROJECTS, so other projects never pay the extra
+        round-trip.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123')
+
+        Returns:
+            True if the issue is a JSM customer request, or if that could
+            not be established. False only on a definite 404.
+        """
+        try:
+            response = self.jira.get(
+                f"rest/servicedeskapi/request/{issue_key}",
+                headers={
+                    **self.jira.default_headers,
+                    "X-ExperimentalApi": "opt-in",
+                },
+            )
+        except HTTPError as exc:
+            if _http_status(exc) == 404:
+                logger.info(
+                    f"{issue_key} is not a JSM customer request; an ordinary "
+                    "Jira comment there has no portal audience, so the "
+                    "internal-only guard does not apply."
+                )
+                return False
+            logger.warning(
+                f"Could not establish whether {issue_key} is a JSM customer "
+                f"request; treating it as one so the internal-only guard "
+                f"stays in force: {exc}"
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                f"Could not establish whether {issue_key} is a JSM customer "
+                f"request; treating it as one so the internal-only guard "
+                f"stays in force: {exc}"
+            )
+            return True
+
+        if isinstance(response, dict) and response.get("issueId"):
+            return True
+        logger.warning(
+            f"ServiceDesk API returned no issueId for {issue_key}; treating "
+            "it as a customer request so the internal-only guard stays in "
+            "force."
+        )
+        return True
 
     def _enforce_internal_only_add(self, issue_key: str, public: bool | None) -> None:
         """Reject add_comment calls that would post client-visible content
@@ -216,7 +307,10 @@ class CommentsMixin(JiraClient):
                 markdown→ADF guarantees of the regular comment path).
                 Cannot be combined with visibility. If issue_key's
                 project is listed in JIRA_INTERNAL_ONLY_PROJECTS, only
-                public=False is accepted.
+                public=False is accepted — unless issue_key is not a JSM
+                customer request, in which case it has no portal audience,
+                this argument is ignored, and the comment posts through
+                the ordinary path.
 
         Returns:
             The created comment details
@@ -227,7 +321,19 @@ class CommentsMixin(JiraClient):
                 exactly False
             Exception: If there is an error adding the comment
         """
-        self._enforce_internal_only_add(issue_key, public)
+        # The guard names a project, but the leak it prevents is per issue.
+        # An issue that is not a JSM customer request has no portal audience,
+        # and the ServiceDesk comment API that public=False needs does not
+        # exist for it — so enforcing the guard there blocks every route
+        # instead of protecting anyone. Fall through to the ordinary comment
+        # path for those. _is_servicedesk_request fails closed, so anything
+        # short of a definite 404 keeps the guard in force.
+        if self._is_internal_only_project(issue_key) and not (
+            self._is_servicedesk_request(issue_key)
+        ):
+            public = None
+        else:
+            self._enforce_internal_only_add(issue_key, public)
 
         # ServiceDesk API path for internal/public comments
         if public is not None:
@@ -348,19 +454,26 @@ class CommentsMixin(JiraClient):
             }
         except Exception as e:
             error_msg = str(e)
-            if "403" in error_msg or "forbidden" in error_msg.lower():
+            # Prefer the status carried on the exception. Matching on the
+            # message alone misses a status whose response body is empty:
+            # str(e) is then "", and the caller gets the generic message
+            # below with nothing after the colon.
+            status = _http_status(e)
+            if status == 403 or "403" in error_msg or "forbidden" in error_msg.lower():
                 raise Exception(
                     f"Issue {issue_key} is not a JSM service "
                     f"desk issue or you lack permission: "
-                    f"{error_msg}"
+                    f"{error_msg or 'HTTP 403'}"
                 ) from e
-            if "404" in error_msg or "not found" in error_msg.lower():
+            if status == 404 or "404" in error_msg or "not found" in error_msg.lower():
                 raise Exception(
                     f"Issue {issue_key} is not a JSM service "
-                    f"desk issue or does not exist: {error_msg}"
+                    f"desk issue or does not exist: "
+                    f"{error_msg or 'HTTP 404'}"
                 ) from e
             raise Exception(
-                f"Error adding ServiceDesk comment to {issue_key}: {error_msg}"
+                f"Error adding ServiceDesk comment to {issue_key}: "
+                f"{error_msg or type(e).__name__}"
             ) from e
 
     def edit_comment(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2493,7 +2493,11 @@ async def add_comment(
                 "with visibility. If the issue's project is "
                 "listed in JIRA_INTERNAL_ONLY_PROJECTS, only "
                 "public=false is accepted — public=true or "
-                "omitting this field is rejected."
+                "omitting this field is rejected. Issues in such "
+                "a project that are not JSM customer requests "
+                "(e.g. an agent-created Task) have no portal "
+                "audience and are exempt: they post through the "
+                "ordinary comment path and ignore this field."
             )
         ),
     ] = None,

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -1021,6 +1021,20 @@ class TestInternalOnlyNonRequestIssues:
         guarded_mixin.jira.post.assert_not_called()
         assert result["id"] == "1"
 
+    def test_non_request_issue_allows_visibility(self, guarded_mixin):
+        """A non-request issue can use ordinary Jira visibility restrictions."""
+        self._not_a_request(guarded_mixin)
+        visibility = {"type": "group", "value": "jira-users"}
+
+        result = guarded_mixin.add_comment(
+            "CC-1", "note", visibility=visibility, public=True
+        )
+
+        guarded_mixin._post_api3.assert_called_once()
+        assert guarded_mixin._post_api3.call_args.args[1]["visibility"] == visibility
+        guarded_mixin.jira.post.assert_not_called()
+        assert result["id"] == "1"
+
     def test_request_issue_still_guarded(self, guarded_mixin):
         """A genuine customer request keeps the guard."""
         guarded_mixin.jira.get.return_value = {"issueId": "10001"}

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -1021,7 +1021,7 @@ class TestInternalOnlyNonRequestIssues:
         guarded_mixin.jira.post.assert_not_called()
         assert result["id"] == "1"
 
-    def test_non_request_issue_allows_visibility(self, guarded_mixin):
+    def test_restricted(self, guarded_mixin):
         """A non-request issue can use ordinary Jira visibility restrictions."""
         self._not_a_request(guarded_mixin)
         visibility = {"type": "group", "value": "jira-users"}

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -648,7 +648,7 @@ class TestCommentsMixin:
         comments_mixin._post_api3 = Mock()
         comments_mixin.jira.issue_add_comment = Mock()
 
-        with pytest.raises(Exception, match="ServiceDesk"):
+        with pytest.raises(Exception, match="ServiceDesk|JSM service desk"):
             comments_mixin.add_comment("TEST-123", "Internal note", public=False)
 
         comments_mixin._post_api3.assert_not_called()
@@ -860,7 +860,7 @@ class TestInternalOnlyProjectsGuard:
         guarded_mixin._post_api3 = Mock()
         guarded_mixin.jira.issue_add_comment = Mock()
 
-        with pytest.raises(Exception, match="ServiceDesk"):
+        with pytest.raises(Exception, match="ServiceDesk|JSM service desk"):
             guarded_mixin.add_comment("CC-1", "Internal note", public=False)
 
         guarded_mixin.jira.post.assert_called_once()
@@ -968,6 +968,131 @@ class TestInternalOnlyProjectsGuard:
         guarded_mixin.jira.get.return_value = response
         with pytest.raises(ValueError, match="PUBLIC"):
             guarded_mixin.edit_comment("CC-1", "5", "Updated text")
+
+
+class TestInternalOnlyNonRequestIssues:
+    """A guarded project may also hold issues that are not JSM requests.
+
+    JIRA_INTERNAL_ONLY_PROJECTS names a project, but only a customer
+    request has a portal view. An agent-created Task or Sub-task in the
+    same project has no portal audience, and the ServiceDesk comment API
+    does not exist for it — so enforcing the guard there left no way to
+    comment on it at all.
+    """
+
+    @pytest.fixture
+    def guarded_mixin(self, jira_config_factory):
+        """CommentsMixin with 'CC' configured as an internal-only project."""
+        config = jira_config_factory(internal_only_projects=frozenset({"CC"}))
+        mixin = CommentsMixin(config=config)
+        mixin.jira = Mock()
+        mixin.jira.default_headers = {}
+        mixin.preprocessor = Mock()
+        mixin.preprocessor.markdown_to_jira = Mock(return_value="formatted")
+        mixin._clean_text = Mock(side_effect=lambda x: x)
+        mixin._post_api3 = Mock(
+            return_value={
+                "id": "1",
+                "body": "note",
+                "created": "2024-01-01T10:00:00.000+0000",
+                "author": {"displayName": "A"},
+            }
+        )
+        return mixin
+
+    @staticmethod
+    def _not_a_request(guarded_mixin) -> None:
+        """Make the request lookup answer 404 (definitely not a request)."""
+        guarded_mixin.jira.get.side_effect = HTTPError(response=Mock(status_code=404))
+
+    @pytest.mark.parametrize("public", [None, True, False])
+    def test_non_request_issue_posts_via_ordinary_path(self, guarded_mixin, public):
+        """A non-request issue accepts a comment whatever `public` says.
+
+        There is no portal audience to leak to, so the guard does not apply
+        and the ordinary comment path is used. Before this, public=True and
+        an omitted public were rejected outright, while public=False failed
+        against a ServiceDesk endpoint that does not exist for the issue —
+        leaving no way in.
+        """
+        self._not_a_request(guarded_mixin)
+        result = guarded_mixin.add_comment("CC-1", "note", public=public)
+        guarded_mixin._post_api3.assert_called_once()
+        guarded_mixin.jira.post.assert_not_called()
+        assert result["id"] == "1"
+
+    def test_request_issue_still_guarded(self, guarded_mixin):
+        """A genuine customer request keeps the guard."""
+        guarded_mixin.jira.get.return_value = {"issueId": "10001"}
+        with pytest.raises(ValueError, match="internal-only"):
+            guarded_mixin.add_comment("CC-1", "Client update", public=True)
+        guarded_mixin._post_api3.assert_not_called()
+        guarded_mixin.jira.post.assert_not_called()
+
+    @pytest.mark.parametrize("status_code", [401, 403, 429, 500, 503])
+    def test_lookup_failure_keeps_guard(self, guarded_mixin, status_code):
+        """Anything short of a definite 404 fails closed."""
+        guarded_mixin.jira.get.side_effect = HTTPError(
+            response=Mock(status_code=status_code)
+        )
+        with pytest.raises(ValueError, match="internal-only"):
+            guarded_mixin.add_comment("CC-1", "Client update", public=True)
+        guarded_mixin._post_api3.assert_not_called()
+
+    def test_lookup_non_http_error_keeps_guard(self, guarded_mixin):
+        """A transport error is not evidence that the issue is unguarded."""
+        guarded_mixin.jira.get.side_effect = Exception("connection reset")
+        with pytest.raises(ValueError, match="internal-only"):
+            guarded_mixin.add_comment("CC-1", "Client update", public=True)
+
+    @pytest.mark.parametrize("response", [{}, {"issueId": None}, "not a dict", None])
+    def test_lookup_unexpected_body_keeps_guard(self, guarded_mixin, response):
+        """An unrecognisable response is not proof of a non-request."""
+        guarded_mixin.jira.get.return_value = response
+        with pytest.raises(ValueError, match="internal-only"):
+            guarded_mixin.add_comment("CC-1", "Client update", public=True)
+
+    def test_unlisted_project_pays_no_lookup(self, guarded_mixin):
+        """Projects outside the setting never pay the extra round-trip."""
+        guarded_mixin.add_comment("TEST-1", "note")
+        guarded_mixin.jira.get.assert_not_called()
+
+
+class TestServiceDeskErrorStatusDetection:
+    """Status classification must not depend on the exception's text.
+
+    An HTTPError raised for a response with an empty body stringifies to
+    "", so the 403/404 branches that matched on str(e) never fired and the
+    caller got the generic message with nothing after the colon.
+    """
+
+    @pytest.fixture
+    def comments_mixin(self, jira_config_factory):
+        mixin = CommentsMixin(config=jira_config_factory())
+        mixin.jira = Mock()
+        mixin.jira.default_headers = {}
+        mixin._clean_text = Mock(side_effect=lambda x: x)
+        return mixin
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected"),
+        [(403, "lack permission"), (404, "does not exist")],
+    )
+    def test_empty_message_still_classified(
+        self, comments_mixin, status_code, expected
+    ):
+        """The status on the exception is used when the message is empty."""
+        comments_mixin.jira.post.side_effect = HTTPError(
+            response=Mock(status_code=status_code)
+        )
+        with pytest.raises(Exception, match=expected):
+            comments_mixin._add_servicedesk_comment("TEST-1", "note", public=False)
+
+    def test_generic_failure_names_the_exception_type(self, comments_mixin):
+        """An unclassified failure still says something after the colon."""
+        comments_mixin.jira.post.side_effect = HTTPError(response=Mock(status_code=500))
+        with pytest.raises(Exception, match="HTTPError"):
+            comments_mixin._add_servicedesk_comment("TEST-1", "note", public=False)
 
 
 def _strong_text_nodes(adf: dict) -> list[str]:


### PR DESCRIPTION
Fixes #1574.

## The bug

`JIRA_INTERNAL_ONLY_PROJECTS` names whole **projects**, but the customer-visibility risk it guards is per **issue** — only a JSM customer request has a portal view and customer participants. A guarded project also contains issues raised internally by agents (`Task`, `Sub-task`), which have no portal presence.

On those, both halves of the guard close at once:

- `public=false` → posts to `rest/servicedeskapi/request/<key>/comment`, which does not exist for a non-request, so it fails.
- `public=true`, omitted, or `visibility=...` → refused by `_enforce_internal_only_add`.

No argument combination can comment on such an issue, even though an ordinary comment there cannot reach a customer.

## The fix

`_is_servicedesk_request(issue_key)` — `GET rest/servicedeskapi/request/<key>`. In `add_comment`, when the project is guarded *and* the issue is not a request, `public` is dropped and the ordinary comment path is used. Otherwise `_enforce_internal_only_add` runs exactly as before.

**It fails closed.** Only a definite 404 counts as "not a request". 403, 5xx, timeouts, transport errors and unrecognised response bodies all return `True`, keeping the guard in force — the direction #1491 established for this setting. The lookup runs only when `_is_internal_only_project()` is already true, so unlisted projects pay no extra round-trip (asserted by a test).

## Also: status detection that could not see the status

`_add_servicedesk_comment` classified failures by substring-matching `str(e)`:

```python
error_msg = str(e)
if "403" in error_msg or "forbidden" in error_msg.lower():
```

An `HTTPError` raised for a response with an empty body stringifies to `""`, so neither branch matched and the caller got:

```
Error adding ServiceDesk comment to PROJ-123:
```

Nothing after the colon, while `e.response.status_code` held the answer the whole time. This is what made the bug above hard to diagnose — the 404 that explains everything never reached the caller. Now the status on the exception is preferred, with the message match kept as a fallback, and no branch can emit a bare trailing colon.

This affects the 403 branch from #1051 the same way, for the same reason.

### Two existing tests asserted the buggy wording

`test_add_comment_servicedesk_failure_never_reaches_jira` and `test_add_comment_internal_only_failure_never_reaches_jira` build `HTTPError(response=Mock(status_code=404))` — an empty message — and asserted the *generic* `"ServiceDesk"` text, which is only produced because classification failed. Their real assertion is the safety property on the following lines: the request must fail rather than fall through to an ordinary comment. That property is untouched; the regex now accepts the accurate message too (`"ServiceDesk|JSM service desk"`).

## Tests

18 new cases across two classes:

**`TestInternalOnlyNonRequestIssues`**
- non-request issue accepts a comment for `public` in `None`/`True`/`False`, via `_post_api3`, never `jira.post`
- a genuine request (`{"issueId": ...}`) still raises on `public=True`
- lookup failure keeps the guard — parametrised over 401, 403, 429, 500, 503
- non-HTTP transport error keeps the guard
- unexpected bodies (`{}`, `{"issueId": None}`, a string, `None`) keep the guard
- an unlisted project performs no lookup

**`TestServiceDeskErrorStatusDetection`**
- 403 and 404 with an empty message are still classified correctly
- an unclassified failure names the exception type rather than ending in a colon

## Verification

```
uv run pytest -q tests/unit/                     3757 passed, 5 skipped
uv run pytest -q tests/unit/jira/test_comments.py   80 passed (was 62)
uv run ruff check <changed files>                All checks passed
uv run ruff format <changed files>               clean
uv run mypy <repo pre-commit args>               Success: no issues found
uv run python scripts/generate_tool_docs.py      docs/tools/jira-comments-worklogs.mdx updated and committed
```

Verified against a live Cloud JSM project: with the project listed in `JIRA_INTERNAL_ONLY_PROJECTS`, a portal-created request still refuses `public=true` and accepts `public=false` as an internal note, while an agent-created sub-task in the same project — previously uncommentable — now posts through the ordinary path.

## Not included

`transitions.py` and `links.py` share the project-wide-versus-issue-level assumption and will behave the same way on a non-request issue. Left out to keep this reviewable; happy to follow up if you would like them in the same shape.
