### PR TITLE
fix(jira): report attachment upload failures

### DIFF
--- a/src/mcp_atlassian/jira/attachments.py
+++ b/src/mcp_atlassian/jira/attachments.py
@@ -473,7 +473,7 @@ class AttachmentsMixin(JiraClient, AttachmentsOperationsProto):
                 )
 
         return {
-            "success": True,
+            "success": bool(uploaded),
             "issue_key": issue_key,
             "total": len(file_paths),
             "uploaded": uploaded,

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2180,12 +2180,21 @@ async def update_issue(
             issue = jira.update_issue(
                 issue_key=issue_key, return_fields=return_fields_list, **all_updates
             )
-            operations_performed.append("fields_updated")
+            if any(key != "attachments" for key in all_updates):
+                operations_performed.append("fields_updated")
             if (
                 hasattr(issue, "custom_fields")
                 and "attachment_results" in issue.custom_fields
             ):
                 attachment_results = issue.custom_fields["attachment_results"]
+                if attachment_results.get("uploaded"):
+                    operations_performed.append("attachments_uploaded")
+                for failure in attachment_results.get("failed", []):
+                    operations_failed.append(
+                        "attachment: "
+                        f"{failure.get('filename', 'unknown')}: "
+                        f"{failure.get('error', 'upload failed')}"
+                    )
         except Exception as e:  # noqa: BLE001 - preserve later operations
             logger.error(
                 f"Error updating fields for issue {issue_key}: {str(e)}",

--- a/tests/unit/jira/test_attachments.py
+++ b/tests/unit/jira/test_attachments.py
@@ -749,6 +749,21 @@ class TestAttachmentsMixin:
             assert result["failed"][0]["filename"] == "file2.pdf"
             assert "File not found" in result["failed"][0]["error"]
 
+    def test_upload_attachments_all_fail(self, attachments_mixin: AttachmentsMixin):
+        """Report failure when no attachment is uploaded."""
+        with patch.object(
+            attachments_mixin,
+            "upload_attachment",
+            return_value={"success": False, "error": "File not found"},
+        ):
+            result = attachments_mixin.upload_attachments(
+                "TEST-123", ["/path/to/file1.txt", "/path/to/file2.txt"]
+            )
+
+        assert result["success"] is False
+        assert result["uploaded"] == []
+        assert len(result["failed"]) == 2
+
     def test_upload_attachments_empty_list(self, attachments_mixin: AttachmentsMixin):
         """Test upload with an empty list of file paths."""
         # Call the method with an empty list

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2796,6 +2796,65 @@ async def test_update_issue_reports_failure_when_all_operations_fail(
 
 
 @pytest.mark.anyio
+async def test_update_issue_reports_failed_attachments(jira_client, mock_jira_fetcher):
+    """Attachment-only failures must not be reported as a successful update."""
+    issue = MagicMock()
+    issue.custom_fields = {
+        "attachment_results": {
+            "success": False,
+            "issue_key": "TEST-123",
+            "total": 1,
+            "uploaded": [],
+            "failed": [{"filename": "missing.xlsx", "error": "File not found"}],
+        }
+    }
+    mock_jira_fetcher.update_issue.side_effect = None
+    mock_jira_fetcher.update_issue.return_value = issue
+
+    response = await jira_client.call_tool(
+        "jira_update_issue",
+        {"issue_key": "TEST-123", "attachments": '["missing.xlsx"]'},
+    )
+
+    result = json.loads(response.content[0].text)
+    assert result["message"] == "Issue update failed"
+    assert result["operations_performed"] == []
+    assert result["operations_failed"] == ["attachment: missing.xlsx: File not found"]
+
+
+@pytest.mark.anyio
+async def test_update_issue_reports_partial_attachment_failure(
+    jira_client, mock_jira_fetcher
+):
+    """A mixed attachment result reports both its success and failure."""
+    issue = MagicMock()
+    issue.custom_fields = {
+        "attachment_results": {
+            "success": True,
+            "issue_key": "TEST-123",
+            "total": 2,
+            "uploaded": [{"filename": "report.xlsx", "id": "1", "size": 10}],
+            "failed": [{"filename": "missing.xlsx", "error": "File not found"}],
+        }
+    }
+    mock_jira_fetcher.update_issue.side_effect = None
+    mock_jira_fetcher.update_issue.return_value = issue
+
+    response = await jira_client.call_tool(
+        "jira_update_issue",
+        {
+            "issue_key": "TEST-123",
+            "attachments": '["report.xlsx", "missing.xlsx"]',
+        },
+    )
+
+    result = json.loads(response.content[0].text)
+    assert result["message"] == "Issue update completed with errors"
+    assert result["operations_performed"] == ["attachments_uploaded"]
+    assert result["operations_failed"] == ["attachment: missing.xlsx: File not found"]
+
+
+@pytest.mark.anyio
 async def test_update_issue_reports_when_no_operations_are_requested(
     jira_client, mock_jira_fetcher
 ):


### PR DESCRIPTION
## Description

`jira_update_issue` currently reports `Issue updated successfully` and `fields_updated` when every requested attachment fails. The batch result also sets `success: true` even when its `uploaded` list is empty.

This is a narrow regression fix following the attachment discussion in #1161.

## Changes

- Mark a batch upload unsuccessful when no files were uploaded, while preserving partial-success behavior.
- Record `attachments_uploaded` separately from field updates.
- Surface per-file attachment errors through `operations_failed`.
- Add regression coverage for complete and partial attachment failures.

## Testing

- [x] Unit tests added/updated.
- [x] Full local suite: `3742 passed, 240 skipped`.
- [x] `pre-commit run --all-files`.
- [x] Generated tool documentation check.

## Checklist

- [x] Code follows project style guidelines.
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation unchanged because the tool signature and registration are unchanged.