### PR TITLE
fix(media): treat multipart/form-data as an ambiguous MIME type so JSM portal attachments are detected as images

### DIFF
--- a/src/mcp_atlassian/utils/media.py
+++ b/src/mcp_atlassian/utils/media.py
@@ -22,7 +22,17 @@ _IMAGE_MIME_TYPES = frozenset(
     }
 )
 
-_AMBIGUOUS_MIME_TYPES = frozenset({"application/octet-stream", "application/binary"})
+# MIME types that carry no reliable information about the actual file type,
+# so detection falls back to the filename extension. "multipart/form-data" is
+# what Jira Service Management reports for attachments uploaded through the
+# customer portal, which is the usual source of screenshots on support tickets.
+_AMBIGUOUS_MIME_TYPES = frozenset(
+    {
+        "application/octet-stream",
+        "application/binary",
+        "multipart/form-data",
+    }
+)
 
 _IMAGE_EXTENSIONS = frozenset(
     {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}

--- a/tests/unit/utils/test_media.py
+++ b/tests/unit/utils/test_media.py
@@ -41,6 +41,22 @@ def test_attachment_max_bytes_value() -> None:
             "doc.pdf",
             (False, "application/octet-stream"),
         ),
+        # JSM customer-portal uploads report multipart/form-data
+        (
+            "multipart/form-data",
+            "WhatsApp Image 2026-08-15 at 23.28.03.jpeg",
+            (True, "image/jpeg"),
+        ),
+        (
+            "multipart/form-data",
+            "screenshot.png",
+            (True, "image/png"),
+        ),
+        (
+            "multipart/form-data",
+            "report.pdf",
+            (False, "multipart/form-data"),
+        ),
         # None MIME + image extension -> detected as image
         (None, "photo.png", (True, "image/png")),
         # None MIME + non-image extension -> not an image
@@ -56,6 +72,9 @@ def test_attachment_max_bytes_value() -> None:
         "octet-stream-jpg-ext",
         "binary-png-ext",
         "octet-stream-pdf-ext",
+        "jsm-portal-jpeg-ext",
+        "jsm-portal-png-ext",
+        "jsm-portal-pdf-ext",
         "none-mime-image-ext",
         "none-mime-pdf-ext",
         "both-none",


### PR DESCRIPTION
Fixes #1583

### Problem

Attachments uploaded through the **Jira Service Management customer portal** are reported by the API with `content_type: multipart/form-data`. That value was in neither `_IMAGE_MIME_TYPES` nor `_AMBIGUOUS_MIME_TYPES`, so this branch in `is_image_attachment()` never ran:

```python
if (media_type in _AMBIGUOUS_MIME_TYPES or media_type is None) and filename:
```

Both Jira attachment tools call the same helper (`servers/jira.py:1249` and `:1354`), so a single missing set member produced two different symptoms:

- **`jira_get_issue_images`** returns `{"success": true, "total_images": 0, "message": "No image attachments found"}` for an issue that visibly has JPEG attachments — a confident false negative with nothing in the response to suggest attachments were seen and skipped.
- **`jira_download_attachments`** returns them as base64 `TextContent` instead of an `EmbeddedResource` image blob, since `is_image` is `False`. In my case two phone screenshots came back as 326,584 characters, over the client's token limit, and had to be recovered by hand-decoding the base64.

The docstring already documents the intended behaviour — *"Files with ambiguous MIME types are detected by filename extension as a fallback"* — so only the set membership was wrong.

### Change

Add `multipart/form-data` to `_AMBIGUOUS_MIME_TYPES`, with a comment recording why it is there. `media.py` is shared, so Confluence attachment handling benefits from the same fix.

### Tests

Three cases added to the existing `test_is_image_attachment` parametrization:

| id | input | expected |
|---|---|---|
| `jsm-portal-jpeg-ext` | `("multipart/form-data", "WhatsApp Image 2026-08-15 at 23.28.03.jpeg")` | `(True, "image/jpeg")` |
| `jsm-portal-png-ext` | `("multipart/form-data", "screenshot.png")` | `(True, "image/png")` |
| `jsm-portal-pdf-ext` | `("multipart/form-data", "report.pdf")` | `(False, "multipart/form-data")` |

The first two fail on `main` and pass with the fix; the third is a negative control confirming a non-image extension is still correctly rejected rather than the MIME type being blanket-trusted.

Verified locally:

- `uv run pytest tests/unit` — 3742 passed, 5 skipped
- `uv run pre-commit run --files src/mcp_atlassian/utils/media.py tests/unit/utils/test_media.py` — all hooks pass (ruff-format, ruff, mypy)

No tool signatures or registrations changed, so `scripts/generate_tool_docs.py` output is unaffected.

There is a pre-existing `BLE001` (blind `except Exception`) in `fetch_and_encode_attachment` that `ruff check` reports on this file; it is present on `main`, is not covered by the pre-commit ruff config, and I have deliberately left it alone to keep this diff to the bug.

### Why it matters

This looks like an edge case but appears to be the **normal** path for any attachment a customer uploads through a Service Management portal — which is where screenshots on support tickets come from.

Concrete cost from the live investigation that surfaced it: the two screenshots on the ticket were the most informative artifact on it. They showed a UI element present on the working components and absent on the broken ones, and that element is rendered directly off the flag that turned out to be the root cause. `jira_get_issue_images` reported no images. An agent trusting that response would have worked from the customer's prose alone — which is what happened on an earlier duplicate of the same ticket, closed months prior with no root cause found.
