### PR TITLE
fix(confluence): pin atlassian api below v5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "anyio>=4.0.0",
-    "atlassian-python-api>=4.0.0",
+    "atlassian-python-api>=4.0.0,<5.0.0",
     "requests[socks]>=2.31.0",
     "beautifulsoup4>=4.12.3",
     "httpx>=0.28.0",

--- a/tests/unit/test_project_dependencies.py
+++ b/tests/unit/test_project_dependencies.py
@@ -40,3 +40,12 @@ def test_starlette_minimum_version_includes_host_header_fix() -> None:
         int(part) for part in lower_bound.group("version").split(".")
     )
     assert minimum_version >= (1, 0, 1)
+
+
+def test_atlassian_python_api_is_pinned_before_server_dc_breaking_release() -> None:
+    """Keep Confluence Server/DC compatible with the v4 URL layout."""
+    pyproject = Path("pyproject.toml").read_text()
+
+    requirement = re.search(r'"atlassian-python-api(?P<specifiers>[^\"]+)"', pyproject)
+    assert requirement is not None
+    assert "<5.0.0" in requirement.group("specifiers")

--- a/uv.lock
+++ b/uv.lock
@@ -1555,7 +1555,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0.0" },
-    { name = "atlassian-python-api", specifier = ">=4.0.0" },
+    { name = "atlassian-python-api", specifier = ">=4.0.0,<5.0.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "cachetools", specifier = ">=5.0.0" },
     { name = "click", specifier = ">=8.1.7" },


### PR DESCRIPTION
## Summary

Fixes #1588.

- Constrain `atlassian-python-api` to the v4-compatible range `>=4.0.0,<5.0.0`.
- Keep `uv.lock` aligned with the project dependency declaration.
- Add a dependency regression test so the Server/DC compatibility ceiling cannot be removed accidentally.

## Validation

- `python -m pytest tests/unit/test_project_dependencies.py -q` — 3 passed.
- `ruff check pyproject.toml tests/unit/test_project_dependencies.py` — passed.
- `git diff --check` — passed.
