### PR TITLE
fix(jira): stop a blank line before `----` becoming an empty `h2.`

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -469,9 +469,12 @@ class JiraPreprocessor(BasePreprocessor):
             "INLINECODE",
         )
 
-        # Headers with = or - underlines
+        # Headers with = or - underlines. A setext heading needs actual text on
+        # the line above the underline, so the lookahead keeps a blank line from
+        # matching: `\n\n----\n` is a horizontal rule, which is already valid
+        # Jira markup, not an empty `h2.` (issue #1587).
         output = re.sub(
-            r"^(.*?)\n([=-])+$",
+            r"^(?=[^\n]*\S)(.*?)\n([=-])+$",
             lambda match: f"h{1 if match.group(2)[0] == '=' else 2}. {match.group(1)}",
             output,
             flags=re.MULTILINE,

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -1175,6 +1175,48 @@ some code
 # Confluence ac:image tag processing tests
 
 
+class TestSetextHeadings:
+    """Setext headings must not swallow blank lines (issue #1587)."""
+
+    def test_horizontal_rule_after_blank_line_is_preserved(
+        self, preprocessor_with_jira
+    ):
+        """`----` on its own line is a horizontal rule, not an empty heading."""
+        result = preprocessor_with_jira.markdown_to_jira("before\n\n----\n\nafter")
+        assert "h2." not in result
+        assert "----" in result
+        assert result == "before\n\n----\n\nafter"
+
+    def test_horizontal_rule_at_start_of_text_is_preserved(
+        self, preprocessor_with_jira
+    ):
+        """A leading rule has no preceding line to consume."""
+        result = preprocessor_with_jira.markdown_to_jira("----\n\nafter")
+        assert "h2." not in result
+        assert result.startswith("----")
+
+    def test_whitespace_only_line_is_not_a_heading(self, preprocessor_with_jira):
+        """A line of spaces is not heading text either."""
+        result = preprocessor_with_jira.markdown_to_jira("before\n   \n----\nafter")
+        assert "h2." not in result
+        assert "----" in result
+
+    def test_setext_h2_still_converts(self, preprocessor_with_jira):
+        """The legitimate `text` over `---` heading is unaffected."""
+        result = preprocessor_with_jira.markdown_to_jira("My Heading\n---\nbody")
+        assert "h2. My Heading" in result
+
+    def test_setext_h1_still_converts(self, preprocessor_with_jira):
+        """The legitimate `text` over `===` heading is unaffected."""
+        result = preprocessor_with_jira.markdown_to_jira("My Heading\n===\nbody")
+        assert "h1. My Heading" in result
+
+    def test_rule_directly_under_text_is_still_a_heading(self, preprocessor_with_jira):
+        """No blank line means it is a setext underline, per CommonMark."""
+        result = preprocessor_with_jira.markdown_to_jira("Some text\n----\nbody")
+        assert "h2. Some text" in result
+
+
 class TestImageProcessing:
     """Tests for Confluence ac:image tag processing."""
 


### PR DESCRIPTION
## Description

`markdown_to_jira` turned a horizontal rule that follows a blank line into an
empty `h2.`, losing the rule:

```
"before\n\n----\n\nafter"  ->  "before\nh2. \n\nafter"
```

The setext heading rule matched `^(.*?)\n([=-])+$`. Because `(.*?)` also matches
the empty string, the blank line above `----` was consumed as the heading's text.

A setext underline needs actual text on the line above it, so a lookahead now
requires at least one non-whitespace character there. `----` on its own line is
then left untouched, which is already the Jira markup for a horizontal rule, so
no separate rule handling is needed.

Fixes: #1587

## Changes

- `preprocessing/jira.py`: added a `(?=[^\n]*\S)` lookahead to the setext heading
  pattern so a blank or whitespace-only line cannot be treated as heading text.
- Added a `TestSetextHeadings` class covering both the bug and the behaviour that
  must not regress.

Legitimate setext headings are unaffected, including a rule placed directly under
a text line with no blank line between them — CommonMark treats that as a setext
underline rather than a thematic break, and it still converts to `h2.`.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: reproduced the reported conversion before the
      change and confirmed it is correct after.

Six new tests in `tests/unit/preprocessing/test_preprocessing.py`:

| Case | Expected |
| --- | --- |
| `before\n\n----\n\nafter` | unchanged, rule preserved |
| `----\n\nafter` (leading rule) | unchanged |
| whitespace-only line before `----` | unchanged |
| `My Heading\n---\nbody` | `h2. My Heading` |
| `My Heading\n===\nbody` | `h1. My Heading` |
| `Some text\n----\nbody` | `h2. Some text` |

Full unit suite: **3817 passed, 5 skipped**. `pre-commit run` passes on the
changed files, including ruff-format, ruff and mypy.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed) — no user-facing docs describe this.

## Note

While here I noticed `([=-])+` also accepts a mixed run, so `Title\n=-=-` is
treated as a heading and `match.group(2)[0]` reads the last character rather than
the first. Left alone to keep this focused on the reported bug — happy to send a
follow-up if you would like that tightened to `(=+|-+)`.
