### PR TITLE
fix(confluence): report property delete failures instead of success

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import requests
+from atlassian.errors import ApiError
 from bs4 import BeautifulSoup, Tag
 from requests.exceptions import HTTPError
 
@@ -366,9 +367,13 @@ class PagesMixin(ConfluenceClient):
                 # the removal did not happen and must not be reported as done.
                 try:
                     self.confluence.delete_page_property(page_id, property_key)
-                except HTTPError as http_err:
+                except (HTTPError, ApiError) as api_err:
+                    http_err = (
+                        api_err if isinstance(api_err, HTTPError) else api_err.reason
+                    )
                     if (
-                        http_err.response is not None
+                        isinstance(http_err, HTTPError)
+                        and http_err.response is not None
                         and http_err.response.status_code == 404
                     ):
                         logger.debug(

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -899,16 +899,24 @@ class PagesMixin(ConfluenceClient):
             if emoji is not None:
                 # Empty string means remove emoji, otherwise set it
                 emoji_to_set = emoji if emoji else None
-                if not self._set_page_emoji(page_id, emoji_to_set):
-                    error_message = f"Failed to set page emoji for page {page_id}"
+                emoji_updated = self._set_page_emoji(page_id, emoji_to_set)
+                if not emoji_updated:
+                    error_message = (
+                        f"Page content was updated, but page emoji update failed "
+                        f"for page {page_id}"
+                    )
                     raise _PagePropertyUpdateError(error_message)
 
             # Set or remove the page width if provided
             if page_width is not None:
                 # Empty string means reset to default, otherwise set it
                 width_to_set = page_width if page_width else None
-                if not self._set_page_width(page_id, width_to_set):
-                    error_message = f"Failed to set page width for page {page_id}"
+                width_updated = self._set_page_width(page_id, width_to_set)
+                if not width_updated:
+                    error_message = (
+                        f"Page content was updated, but page width update failed "
+                        f"for page {page_id}"
+                    )
                     raise _PagePropertyUpdateError(error_message)
 
             # After update, refresh the page data

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -386,7 +386,7 @@ class PagesMixin(ConfluenceClient):
                         f"{page_id}: {http_err}"
                     )
                     return False
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     logger.warning(
                         f"Could not delete property '{property_key}' for page "
                         f"{page_id}: {e}"
@@ -895,14 +895,16 @@ class PagesMixin(ConfluenceClient):
                 # Empty string means remove emoji, otherwise set it
                 emoji_to_set = emoji if emoji else None
                 if not self._set_page_emoji(page_id, emoji_to_set):
-                    raise RuntimeError(f"Failed to set page emoji for page {page_id}")
+                    error_message = f"Failed to set page emoji for page {page_id}"
+                    raise RuntimeError(error_message)
 
             # Set or remove the page width if provided
             if page_width is not None:
                 # Empty string means reset to default, otherwise set it
                 width_to_set = page_width if page_width else None
                 if not self._set_page_width(page_id, width_to_set):
-                    raise RuntimeError(f"Failed to set page width for page {page_id}")
+                    error_message = f"Failed to set page width for page {page_id}"
+                    raise RuntimeError(error_message)
 
             # After update, refresh the page data
             return self.get_page_content(page_id)

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -360,12 +360,33 @@ class PagesMixin(ConfluenceClient):
         """
         try:
             if value is None:
-                # Delete the property
+                # Delete the property. A property that is already absent leaves the
+                # page in the requested state, so only a 404 counts as success --
+                # anything else (denied, locked, throttled, transport failure) means
+                # the removal did not happen and must not be reported as done.
                 try:
                     self.confluence.delete_page_property(page_id, property_key)
+                except HTTPError as http_err:
+                    if (
+                        http_err.response is not None
+                        and http_err.response.status_code == 404
+                    ):
+                        logger.debug(
+                            f"Property '{property_key}' already absent on page "
+                            f"{page_id}"
+                        )
+                        return True
+                    logger.warning(
+                        f"Could not delete property '{property_key}' for page "
+                        f"{page_id}: {http_err}"
+                    )
+                    return False
                 except Exception as e:
-                    # Property might not exist, which is fine
-                    logger.debug(f"Could not delete property '{property_key}': {e}")
+                    logger.warning(
+                        f"Could not delete property '{property_key}' for page "
+                        f"{page_id}: {e}"
+                    )
+                    return False
                 return True
 
             # Check if the property already exists (need version for update)

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -894,13 +894,15 @@ class PagesMixin(ConfluenceClient):
             if emoji is not None:
                 # Empty string means remove emoji, otherwise set it
                 emoji_to_set = emoji if emoji else None
-                self._set_page_emoji(page_id, emoji_to_set)
+                if not self._set_page_emoji(page_id, emoji_to_set):
+                    raise RuntimeError(f"Failed to set page emoji for page {page_id}")
 
             # Set or remove the page width if provided
             if page_width is not None:
                 # Empty string means reset to default, otherwise set it
                 width_to_set = page_width if page_width else None
-                self._set_page_width(page_id, width_to_set)
+                if not self._set_page_width(page_id, width_to_set):
+                    raise RuntimeError(f"Failed to set page width for page {page_id}")
 
             # After update, refresh the page data
             return self.get_page_content(page_id)

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -20,10 +20,6 @@ from .v2_adapter import ConfluenceV2Adapter
 logger = logging.getLogger("mcp-atlassian")
 
 
-class _PagePropertyUpdateError(RuntimeError):
-    """Raised when a requested page property update fails."""
-
-
 class PagesMixin(ConfluenceClient):
     """Mixin for Confluence page operations."""
 
@@ -843,7 +839,6 @@ class PagesMixin(ConfluenceClient):
             ConfluencePage model containing the updated page's data
 
         Raises:
-            _PagePropertyUpdateError: If an emoji or page width update fails
             Exception: If there is an error updating the page
         """
         try:
@@ -905,7 +900,7 @@ class PagesMixin(ConfluenceClient):
                         f"Page content was updated, but page emoji update failed "
                         f"for page {page_id}"
                     )
-                    raise _PagePropertyUpdateError(error_message)
+                    raise RuntimeError(error_message)
 
             # Set or remove the page width if provided
             if page_width is not None:
@@ -917,12 +912,10 @@ class PagesMixin(ConfluenceClient):
                         f"Page content was updated, but page width update failed "
                         f"for page {page_id}"
                     )
-                    raise _PagePropertyUpdateError(error_message)
+                    raise RuntimeError(error_message)
 
             # After update, refresh the page data
             return self.get_page_content(page_id)
-        except _PagePropertyUpdateError:
-            raise
         except Exception as e:
             logger.error(f"Error updating page {page_id}: {str(e)}")
             raise Exception(f"Failed to update page {page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -20,6 +20,10 @@ from .v2_adapter import ConfluenceV2Adapter
 logger = logging.getLogger("mcp-atlassian")
 
 
+class _PagePropertyUpdateError(RuntimeError):
+    """Raised when a requested page property update fails."""
+
+
 class PagesMixin(ConfluenceClient):
     """Mixin for Confluence page operations."""
 
@@ -839,6 +843,7 @@ class PagesMixin(ConfluenceClient):
             ConfluencePage model containing the updated page's data
 
         Raises:
+            _PagePropertyUpdateError: If an emoji or page width update fails
             Exception: If there is an error updating the page
         """
         try:
@@ -896,7 +901,7 @@ class PagesMixin(ConfluenceClient):
                 emoji_to_set = emoji if emoji else None
                 if not self._set_page_emoji(page_id, emoji_to_set):
                     error_message = f"Failed to set page emoji for page {page_id}"
-                    raise RuntimeError(error_message)
+                    raise _PagePropertyUpdateError(error_message)
 
             # Set or remove the page width if provided
             if page_width is not None:
@@ -904,10 +909,12 @@ class PagesMixin(ConfluenceClient):
                 width_to_set = page_width if page_width else None
                 if not self._set_page_width(page_id, width_to_set):
                     error_message = f"Failed to set page width for page {page_id}"
-                    raise RuntimeError(error_message)
+                    raise _PagePropertyUpdateError(error_message)
 
             # After update, refresh the page data
             return self.get_page_content(page_id)
+        except _PagePropertyUpdateError:
+            raise
         except Exception as e:
             logger.error(f"Error updating page {page_id}: {str(e)}")
             raise Exception(f"Failed to update page {page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -787,11 +787,23 @@ class PagesMixin(ConfluenceClient):
 
             # Set the page emoji if provided
             if emoji:
-                self._set_page_emoji(page_id, emoji)
+                emoji_updated = self._set_page_emoji(page_id, emoji)
+                if not emoji_updated:
+                    error_message = (
+                        f"Page was created, but page emoji update failed "
+                        f"for page {page_id}"
+                    )
+                    raise RuntimeError(error_message)
 
             # Set the page width if provided
             if page_width:
-                self._set_page_width(page_id, page_width)
+                width_updated = self._set_page_width(page_id, page_width)
+                if not width_updated:
+                    error_message = (
+                        f"Page was created, but page width update failed "
+                        f"for page {page_id}"
+                    )
+                    raise RuntimeError(error_message)
 
             return self.get_page_content(page_id)
         except Exception as e:

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -346,6 +346,44 @@ class TestConfluenceCloudPageLayout:
         assert 'data-table-width="1800"' in storage_body
 
 
+class TestConfluenceCloudPagePropertyRemoval:
+    """Page property removal handling."""
+
+    def test_remove_page_emoji_and_width(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Property Removal Test {uid}",
+            body="<p>Property removal test.</p>",
+            is_markdown=False,
+            content_representation="storage",
+            emoji="📄",
+            page_width="full-width",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        assert page.emoji
+        assert page.page_width == "full-width"
+
+        updated = confluence_fetcher.update_page(
+            page.id,
+            page.title,
+            "<p>Property removal test, updated.</p>",
+            is_markdown=False,
+            content_representation="storage",
+            emoji="",
+            page_width="",
+        )
+
+        assert updated.emoji is None
+        assert updated.page_width is None
+
+
 class TestConfluenceCloudCopyAndRestrictions:
     """Page copy and restriction operations."""
 

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -237,6 +237,44 @@ class TestConfluenceDCPageLayout:
         assert 'data-table-width="1800"' in storage_body
 
 
+class TestConfluenceDCPagePropertyRemoval:
+    """Page property removal handling."""
+
+    def test_remove_page_emoji_and_width(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        dc_instance: DCInstanceInfo,
+        resource_tracker: DCResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=dc_instance.space_key,
+            title=f"E2E Property Removal Test {uid}",
+            body="<p>Property removal test.</p>",
+            is_markdown=False,
+            content_representation="storage",
+            emoji="📄",
+            page_width="full-width",
+        )
+        resource_tracker.add_confluence_page(page.id)
+
+        assert page.emoji
+        assert page.page_width == "full-width"
+
+        updated = confluence_fetcher.update_page(
+            page.id,
+            page.title,
+            "<p>Property removal test, updated.</p>",
+            is_markdown=False,
+            content_representation="storage",
+            emoji="",
+            page_width="",
+        )
+
+        assert updated.emoji is None
+        assert updated.page_width is None
+
+
 class TestConfluenceDCCopyAndRestrictions:
     """Page copy and restriction operations."""
 

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -458,7 +458,7 @@ class TestPagesMixin:
                 pages_mixin, "_set_page_emoji", return_value=False
             ) as mock_set,
             patch.object(pages_mixin, "get_page_content") as mock_get,
-            pytest.raises(RuntimeError) as exc_info,
+            pytest.raises(Exception) as exc_info,
         ):
             pages_mixin.update_page(
                 page_id,
@@ -471,7 +471,8 @@ class TestPagesMixin:
         mock_set.assert_called_once_with(page_id, None)
         mock_get.assert_not_called()
         assert str(exc_info.value) == (
-            f"Page content was updated, but page emoji update failed for page {page_id}"
+            f"Failed to update page {page_id}: Page content was updated, but "
+            f"page emoji update failed for page {page_id}"
         )
 
     def test_update_page_width_reset_failure_is_reported(self, pages_mixin):
@@ -483,7 +484,7 @@ class TestPagesMixin:
                 pages_mixin, "_set_page_width", return_value=False
             ) as mock_set,
             patch.object(pages_mixin, "get_page_content") as mock_get,
-            pytest.raises(RuntimeError) as exc_info,
+            pytest.raises(Exception) as exc_info,
         ):
             pages_mixin.update_page(
                 page_id,
@@ -496,7 +497,8 @@ class TestPagesMixin:
         mock_set.assert_called_once_with(page_id, None)
         mock_get.assert_not_called()
         assert str(exc_info.value) == (
-            f"Page content was updated, but page width update failed for page {page_id}"
+            f"Failed to update page {page_id}: Page content was updated, but "
+            f"page width update failed for page {page_id}"
         )
 
     def test_update_page_error(self, pages_mixin):

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
+from atlassian.errors import ApiError
 from requests.exceptions import ConnectionError, HTTPError
 
 from mcp_atlassian.confluence.pages import PagesMixin
@@ -2271,11 +2272,12 @@ class TestPageEmoji:
         """Test removing emoji when none exists still succeeds."""
         page_id = "no_emoji_123"
 
-        # Mock delete returning 404 (property doesn't exist)
+        # The Atlassian client wraps a 404 from delete_page_property in ApiError.
         response = MagicMock()
         response.status_code = 404
-        pages_mixin.confluence.delete_page_property.side_effect = HTTPError(
-            "404 Not Found", response=response
+        pages_mixin.confluence.delete_page_property.side_effect = ApiError(
+            "There is no content with the given id or permission to view it",
+            reason=HTTPError("404 Not Found", response=response),
         )
 
         result = pages_mixin._set_page_emoji(page_id, None)

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
+from requests.exceptions import ConnectionError, HTTPError
 
 from mcp_atlassian.confluence.pages import PagesMixin
 from mcp_atlassian.confluence.utils import extract_emoji_from_property
@@ -2270,9 +2271,11 @@ class TestPageEmoji:
         """Test removing emoji when none exists still succeeds."""
         page_id = "no_emoji_123"
 
-        # Mock delete returning an error (property doesn't exist)
-        pages_mixin.confluence.delete_page_property.side_effect = Exception(
-            "Property not found"
+        # Mock delete returning 404 (property doesn't exist)
+        response = MagicMock()
+        response.status_code = 404
+        pages_mixin.confluence.delete_page_property.side_effect = HTTPError(
+            "404 Not Found", response=response
         )
 
         result = pages_mixin._set_page_emoji(page_id, None)
@@ -2287,6 +2290,34 @@ class TestPageEmoji:
         pages_mixin.confluence.delete_page_property.assert_any_call(
             page_id, "emoji-title-draft"
         )
+
+    def test_set_page_emoji_remove_reports_failure_on_denied_delete(self, pages_mixin):
+        """A delete rejected by the API must not be reported as a removal."""
+        page_id = "denied_emoji_123"
+
+        response = MagicMock()
+        response.status_code = 403
+        pages_mixin.confluence.delete_page_property.side_effect = HTTPError(
+            "403 Forbidden", response=response
+        )
+
+        result = pages_mixin._set_page_emoji(page_id, None)
+
+        assert result is False
+
+    def test_set_page_emoji_remove_reports_failure_on_transport_error(
+        self, pages_mixin
+    ):
+        """A dropped connection must not be reported as a removal."""
+        page_id = "dropped_emoji_123"
+
+        pages_mixin.confluence.delete_page_property.side_effect = ConnectionError(
+            "connection reset"
+        )
+
+        result = pages_mixin._set_page_emoji(page_id, None)
+
+        assert result is False
 
     def test_set_page_emoji_failure(self, pages_mixin):
         """Test handling failure when setting emoji."""

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -458,7 +458,7 @@ class TestPagesMixin:
                 pages_mixin, "_set_page_emoji", return_value=False
             ) as mock_set,
             patch.object(pages_mixin, "get_page_content") as mock_get,
-            pytest.raises(Exception, match="Failed to set page emoji"),
+            pytest.raises(RuntimeError, match="Failed to set page emoji"),
         ):
             pages_mixin.update_page(
                 page_id,
@@ -480,7 +480,7 @@ class TestPagesMixin:
                 pages_mixin, "_set_page_width", return_value=False
             ) as mock_set,
             patch.object(pages_mixin, "get_page_content") as mock_get,
-            pytest.raises(Exception, match="Failed to set page width"),
+            pytest.raises(RuntimeError, match="Failed to set page width"),
         ):
             pages_mixin.update_page(
                 page_id,

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -458,7 +458,7 @@ class TestPagesMixin:
                 pages_mixin, "_set_page_emoji", return_value=False
             ) as mock_set,
             patch.object(pages_mixin, "get_page_content") as mock_get,
-            pytest.raises(RuntimeError, match="Failed to set page emoji"),
+            pytest.raises(RuntimeError) as exc_info,
         ):
             pages_mixin.update_page(
                 page_id,
@@ -470,6 +470,9 @@ class TestPagesMixin:
 
         mock_set.assert_called_once_with(page_id, None)
         mock_get.assert_not_called()
+        assert str(exc_info.value) == (
+            f"Page content was updated, but page emoji update failed for page {page_id}"
+        )
 
     def test_update_page_width_reset_failure_is_reported(self, pages_mixin):
         """Test that a failed width reset prevents returning stale page data."""
@@ -480,7 +483,7 @@ class TestPagesMixin:
                 pages_mixin, "_set_page_width", return_value=False
             ) as mock_set,
             patch.object(pages_mixin, "get_page_content") as mock_get,
-            pytest.raises(RuntimeError, match="Failed to set page width"),
+            pytest.raises(RuntimeError) as exc_info,
         ):
             pages_mixin.update_page(
                 page_id,
@@ -492,6 +495,9 @@ class TestPagesMixin:
 
         mock_set.assert_called_once_with(page_id, None)
         mock_get.assert_not_called()
+        assert str(exc_info.value) == (
+            f"Page content was updated, but page width update failed for page {page_id}"
+        )
 
     def test_update_page_error(self, pages_mixin):
         """Test error handling when updating a page."""

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -501,6 +501,60 @@ class TestPagesMixin:
             f"page width update failed for page {page_id}"
         )
 
+    def test_create_page_emoji_failure_is_reported(self, pages_mixin):
+        """Test that a failed emoji set prevents reporting a clean creation."""
+        page_id = "123456789"
+        pages_mixin.confluence.create_page.return_value = {"id": page_id}
+
+        with (
+            patch.object(
+                pages_mixin, "_set_page_emoji", return_value=False
+            ) as mock_set,
+            patch.object(pages_mixin, "get_page_content") as mock_get,
+            pytest.raises(Exception) as exc_info,
+        ):
+            pages_mixin.create_page(
+                "PROJ",
+                "New Page",
+                "<p>Content</p>",
+                is_markdown=False,
+                emoji="\U0001f680",
+            )
+
+        mock_set.assert_called_once_with(page_id, "\U0001f680")
+        mock_get.assert_not_called()
+        assert str(exc_info.value) == (
+            f"Failed to create page 'New Page' in space PROJ: Page was created, "
+            f"but page emoji update failed for page {page_id}"
+        )
+
+    def test_create_page_width_failure_is_reported(self, pages_mixin):
+        """Test that a failed width set prevents reporting a clean creation."""
+        page_id = "123456789"
+        pages_mixin.confluence.create_page.return_value = {"id": page_id}
+
+        with (
+            patch.object(
+                pages_mixin, "_set_page_width", return_value=False
+            ) as mock_set,
+            patch.object(pages_mixin, "get_page_content") as mock_get,
+            pytest.raises(Exception) as exc_info,
+        ):
+            pages_mixin.create_page(
+                "PROJ",
+                "New Page",
+                "<p>Content</p>",
+                is_markdown=False,
+                page_width="full-width",
+            )
+
+        mock_set.assert_called_once_with(page_id, "full-width")
+        mock_get.assert_not_called()
+        assert str(exc_info.value) == (
+            f"Failed to create page 'New Page' in space PROJ: Page was created, "
+            f"but page width update failed for page {page_id}"
+        )
+
     def test_update_page_error(self, pages_mixin):
         """Test error handling when updating a page."""
         # Arrange

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -449,6 +449,50 @@ class TestPagesMixin:
                 always_update=True,
             )
 
+    def test_update_page_emoji_removal_failure_is_reported(self, pages_mixin):
+        """Test that a failed emoji removal prevents returning stale page data."""
+        page_id = "987654321"
+
+        with (
+            patch.object(
+                pages_mixin, "_set_page_emoji", return_value=False
+            ) as mock_set,
+            patch.object(pages_mixin, "get_page_content") as mock_get,
+            pytest.raises(Exception, match="Failed to set page emoji"),
+        ):
+            pages_mixin.update_page(
+                page_id,
+                "Updated Page",
+                "<p>Updated content</p>",
+                is_markdown=False,
+                emoji="",
+            )
+
+        mock_set.assert_called_once_with(page_id, None)
+        mock_get.assert_not_called()
+
+    def test_update_page_width_reset_failure_is_reported(self, pages_mixin):
+        """Test that a failed width reset prevents returning stale page data."""
+        page_id = "987654321"
+
+        with (
+            patch.object(
+                pages_mixin, "_set_page_width", return_value=False
+            ) as mock_set,
+            patch.object(pages_mixin, "get_page_content") as mock_get,
+            pytest.raises(Exception, match="Failed to set page width"),
+        ):
+            pages_mixin.update_page(
+                page_id,
+                "Updated Page",
+                "<p>Updated content</p>",
+                is_markdown=False,
+                page_width="",
+            )
+
+        mock_set.assert_called_once_with(page_id, None)
+        mock_get.assert_not_called()
+
     def test_update_page_error(self, pages_mixin):
         """Test error handling when updating a page."""
         # Arrange


### PR DESCRIPTION
Closes #1557

### Change

`_set_single_property()` now treats only a 404 property-delete response as an already-satisfied removal. Permission, lock, throttling, and transport failures return `False`.

`update_page()` now checks the results of `_set_page_emoji()` and `_set_page_width()`. If either metadata update fails, it raises an explicit `_PagePropertyUpdateError` and does not return a refreshed `ConfluencePage`, so callers cannot receive a false success.

### Tests

- `uv run pytest tests/unit -q`: 3821 passed, 5 skipped
- `uv run pytest tests/unit/confluence/test_pages.py -xvs`: 130 passed
- Cloud property-removal E2E: 1 passed, 19 deselected, no skips
- Data Center property-removal E2E: 1 passed, 16 deselected, no skips
- `uv run ruff format --check` and `uv run python scripts/generate_tool_docs.py --check`: passed

The focused unit tests cover failed emoji removal and failed width reset, including the explicit error and the absence of a normal page refresh.