### PR TITLE
fix(confluence): request page versions by number, not by version id

### DIFF
--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -1111,11 +1111,10 @@ class ConfluenceV2Adapter:
         version: int,
         expand: str | None = None,
     ) -> dict[str, Any]:
-        """Get a specific version of a page using the versions API.
+        """Get a specific version of a page.
 
-        Note: The v2 API uses version IDs, not version numbers. We need to:
-        1. List all versions to find the version ID for the given version number
-        2. Fetch the specific version using its version ID
+        The page endpoint serves a previously published version directly when
+        given its version *number*, so no version id lookup is involved.
 
         Args:
             page_id: The ID of page
@@ -1129,24 +1128,8 @@ class ConfluenceV2Adapter:
             ValueError: If page retrieval fails or version not found
         """
         try:
-            # Step 1: Get all versions to find the version ID
-            versions_list = self.get_page_versions_list(page_id)
-
-            # Find the version with the matching version number
-            version_id = None
-            for ver in versions_list:
-                if ver.get("number") == version:
-                    version_id = ver.get("id")
-                    break
-
-            if not version_id:
-                raise ValueError(f"Version {version} not found for page '{page_id}'")
-
-            # Step 2: Fetch the specific version using its version ID
-            url = f"{self.base_url}/api/v2/versions/{version_id}"
-
-            # Convert v1 expand parameters to v2 format
-            params = {"body-format": "storage"}
+            url = f"{self.base_url}/api/v2/pages/{page_id}"
+            params: dict[str, Any] = {"body-format": "storage", "version": version}
 
             response = self.session.get(url, params=params)
             response.raise_for_status()

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -522,3 +522,67 @@ class TestConfluenceV2AdapterComments:
         assert payload["pageId"] == "12345"
         assert "parentCommentId" not in payload
         assert result["id"] == "333444555"
+
+
+class TestConfluenceV2AdapterPageVersion:
+    """`get_page_by_version` must ask the page endpoint for the version (#1373)."""
+
+    @pytest.fixture
+    def mock_session(self):
+        return MagicMock(spec=requests.Session)
+
+    @pytest.fixture
+    def v2_adapter(self, mock_session):
+        return ConfluenceV2Adapter(
+            session=mock_session, base_url="https://example.atlassian.net/wiki"
+        )
+
+    def _page_response(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "id": "123456",
+            "status": "current",
+            "title": "Test Page",
+            "spaceId": "789",
+            "version": {
+                "number": 3,
+                "createdAt": "2024-01-02T10:00:00.000Z",
+                "authorId": "author-id",
+                "message": "third revision",
+            },
+            "body": {
+                "storage": {"value": "<p>v3 content</p>", "representation": "storage"}
+            },
+        }
+        return response
+
+    def _space_response(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"key": "TEST"}
+        return response
+
+    def test_requests_version_from_page_endpoint(self, v2_adapter, mock_session):
+        mock_session.get.side_effect = [self._page_response(), self._space_response()]
+
+        result = v2_adapter.get_page_by_version("123456", 3)
+
+        url, kwargs = (
+            mock_session.get.call_args_list[0][0],
+            mock_session.get.call_args_list[0][1],
+        )
+        assert url[0] == "https://example.atlassian.net/wiki/api/v2/pages/123456"
+        assert kwargs["params"]["version"] == 3
+        assert kwargs["params"]["body-format"] == "storage"
+        assert result["body"]["storage"]["value"] == "<p>v3 content</p>"
+        assert result["version"]["number"] == 3
+
+    def test_does_not_call_the_versions_endpoints(self, v2_adapter, mock_session):
+        """PageVersion objects carry no id, so the two-step lookup can never work."""
+        mock_session.get.side_effect = [self._page_response(), self._space_response()]
+
+        v2_adapter.get_page_by_version("123456", 3)
+
+        requested = [call[0][0] for call in mock_session.get.call_args_list]
+        assert not any("/versions" in url for url in requested)


### PR DESCRIPTION

Closes #1373

`confluence_get_page_history` and `confluence_get_page_diff` fail for every page and every version number under OAuth, including a page's current version:

```
Failed to get page '<id>' version 8: Version 8 not found for page '<id>'
```

`ConfluenceV2Adapter.get_page_by_version()` listed the page's versions and looked for an `id` on each one:

```python
for ver in versions_list:
    if ver.get("number") == version:
        version_id = ver.get("id")
```

The `PageVersion` schema has no `id` field — its properties are `authorId`, `createdAt`, `message`, `minorEdit`, `number` and `page`. So `version_id` was always `None`, the guard below it always tripped, and the error blamed a missing version that was in fact present. The `/api/v2/versions/{id}` request that followed was unreachable, and there is no such endpoint.

### Change

`GET /api/v2/pages/{id}` takes the version *number* directly — "Allows you to retrieve a previously published version. Specify the previous version's number to retrieve its details." — and honours `body-format`, so one request returns the historical version along with its body. That replaces the two-step lookup.

This also drops the `raise ValueError(...)` for a version that cannot be found locally; a genuinely absent version now surfaces as the API's own 404 through the existing error handling.

`get_page_versions_list()` is left in place — it is a valid wrapper for the versions endpoint and is part of the adapter's surface, it simply is not how a single version should be fetched.

Reference: [Get page by id](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api-pages-id-get) — parameters confirmed against the published OpenAPI document (`openapi-v2.v3.json`).

### Tests

Added `TestConfluenceV2AdapterPageVersion` in `tests/unit/confluence/test_v2_adapter.py`:

- the request goes to `/api/v2/pages/{id}` with `version` and `body-format` params, and the returned body and version number survive the v1-compatible conversion
- no request is made to any `/versions` URL

Both fail before this change with the exact error from the report, and pass after.

`tests/unit/confluence` passes (509 tests) and the full unit suite is unchanged at 3819 passed / 5 skipped. `mypy` is at its previous count for this file, `ruff check` drops by one finding (the removed `raise`), and formatting is clean.

### Note on scope

The report also asks whether historical *content* is reachable at all under granular OAuth scopes, having found the v1 fallback returns 401. That concern is addressed by this change rather than worked around: the v2 page endpoint returns the version body, so the OAuth path no longer depends on the v1 endpoint for this call.
