### PR TITLE
test(e2e): xfail Confluence byo_oauth ops broken by v1 removal on the OAuth gateway

### DIFF
--- a/tests/e2e/cloud/conftest.py
+++ b/tests/e2e/cloud/conftest.py
@@ -490,3 +490,36 @@ def cloud_image_page(
         pytest.skip(f"Failed to create image test page: {exc}")
     yield page_id
     _delete_page(cloud_instance, page_id)
+
+
+# Confluence v1 REST endpoints are removed (410 Gone) on the OAuth gateway
+# (api.atlassian.com/ex/confluence/{cloudId}) since ~2026-08-17, which breaks
+# every v1-backed operation in OAuth mode until the client migrates to v2.
+# CQL search and /user/current are the only survivors. See issue #1598.
+_BYO_OAUTH_V1_REMOVED = {
+    "test_get_page",
+    "test_get_spaces",
+    "test_create_and_delete_page",
+    "test_update_page",
+    "test_update_page_section",
+    "test_add_comment",
+}
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    xfail_v1_removed = pytest.mark.xfail(
+        reason=(
+            "Confluence v1 REST removed on the OAuth gateway (410 Gone); "
+            "needs v2 migration — see #1598"
+        ),
+        strict=False,
+    )
+    for item in items:
+        if (
+            "test_confluence_auth_matrix" in item.nodeid
+            and "[byo_oauth]" in item.nodeid
+            and getattr(item, "originalname", item.name) in _BYO_OAUTH_V1_REMOVED
+        ):
+            item.add_marker(xfail_v1_removed)

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 
 from mcp_atlassian.confluence import ConfluenceFetcher
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
 
 from .conftest import CloudInstanceInfo, CloudResourceTracker
 
@@ -446,6 +447,12 @@ class TestConfluenceCloudCopyAndRestrictions:
                 read_users=[account_id],
                 edit_users=[account_id],
             )
+        except MCPAtlassianAuthenticationError as exc:
+            # Altering content restrictions is plan-gated on Confluence Cloud
+            # (PermissionException on Free sites) — not a client regression.
+            pytest.skip(f"Page restrictions not available on this site: {exc}")
+
+        try:
             assert result["read"]["users"] == [account_id]
             assert result["update"]["users"] == [account_id]
 


### PR DESCRIPTION
Interim gate normalization for #1598.

- Six `byo_oauth` Confluence auth-matrix variants now **xfail** (non-strict): the v1 endpoints they exercise return 410 Gone on `api.atlassian.com/ex/confluence` since ~2026-08-17. `search` and `user/current` byo variants still pass and stay enforced.
- `test_set_and_get_page_restrictions` **skips** when the site rejects restriction writes with a PermissionException — altering content restrictions is plan-gated on Confluence Cloud Free sites.

Verified live against the e2e Cloud site: `8 passed, 1 skipped, 6 xfailed` (0 failures).

The real fix (OAuth-mode v2 migration) is tracked in #1598.