### PR TITLE
test(e2e): review follow-up for #1599 — narrow plan-gate skip to 403, xfail removal note

### DIFF
--- a/tests/e2e/cloud/conftest.py
+++ b/tests/e2e/cloud/conftest.py
@@ -496,6 +496,8 @@ def cloud_image_page(
 # (api.atlassian.com/ex/confluence/{cloudId}) since ~2026-08-17, which breaks
 # every v1-backed operation in OAuth mode until the client migrates to v2.
 # CQL search and /user/current are the only survivors. See issue #1598.
+# If these tests start XPASSing (the v2 migration landed or Atlassian restored
+# the endpoints), this hook has outlived its purpose — delete it.
 _BYO_OAUTH_V1_REMOVED = {
     "test_get_page",
     "test_get_spaces",

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -448,8 +448,12 @@ class TestConfluenceCloudCopyAndRestrictions:
                 edit_users=[account_id],
             )
         except MCPAtlassianAuthenticationError as exc:
+            cause_response = getattr(exc.__cause__, "response", None)
+            if getattr(cause_response, "status_code", None) != 403:
+                raise
             # Altering content restrictions is plan-gated on Confluence Cloud
-            # (PermissionException on Free sites) — not a client regression.
+            # (403 PermissionException on Free sites) — not a client regression.
+            # A 401 (expired/invalid credential) must still fail loudly.
             pytest.skip(f"Page restrictions not available on this site: {exc}")
 
         try:


### PR DESCRIPTION
Post-merge dual review (codex + opus) of #1599 surfaced two advisory findings; this applies both:

- **Restrictions skip narrowed to 403**: `MCPAtlassianAuthenticationError` covers both 401 and 403, so an expired credential would have silently skipped the test. Now only the plan-gated 403 (`PermissionException` on Free sites) skips; 401 re-raises and fails loudly.
- **xfail removal trigger**: comment on the byo_oauth xfail hook stating that XPASS (after the #1598 v2 migration or an Atlassian rollback) means the hook should be deleted.

Verified live against the Cloud e2e site: `8 passed, 1 skipped, 6 xfailed` (0 failures) — skip still triggers via the 403 path.