### PR TITLE
fix(confluence): populate metadata for page children

### DIFF
--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -128,7 +128,7 @@ Get child pages and folders of a specific Confluence page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `parent_id` | `string` | Yes | The ID of the parent page whose children you want to retrieve |
-| `expand` | `string` | No | Fields to expand in the response (e.g., 'version', 'body.storage') |
+| `expand` | `string` | No | Fields to expand in the response (e.g., 'version', 'body.storage'). Defaults to 'version,history'. |
 | `limit` | `integer` | No | Maximum number of child items to return (1-50) |
 | `include_content` | `boolean` | No | Whether to include the page content in the response |
 | `convert_to_markdown` | `boolean` | No | Whether to convert page content to markdown (true) or keep it in raw HTML format (false). Only relevant if include_content is true. |

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -1069,7 +1069,7 @@ class PagesMixin(ConfluenceClient):
         page_id: str,
         start: int = 0,
         limit: int = 25,
-        expand: str = "version",
+        expand: str = "version,history",
         *,
         convert_to_markdown: bool = True,
         include_folders: bool = True,

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -205,14 +205,14 @@ class ConfluencePage(ApiModel, TimestampMixin):
             created = history.get("createdDate", EMPTY_STRING)
             updated = history.get("lastUpdated", {}).get("when", EMPTY_STRING)
 
-            # Fall back to version date if no history is available
-            if not updated and version and version.when:
-                updated = version.when
-
             # Fall back to history.createdBy if no top-level author
             if not author:
                 if created_by := history.get("createdBy"):
                     author = ConfluenceUser.from_api_response(created_by)
+
+        # Fall back to the version date when history has no update timestamp
+        if not updated and version and version.when:
+            updated = version.when
 
         # Construct URL if base_url is provided
         url = None

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -421,10 +421,13 @@ async def get_page_children(
     expand: Annotated[
         str,
         Field(
-            description="Fields to expand in the response (e.g., 'version', 'body.storage')",
-            default="version",
+            description=(
+                "Fields to expand in the response (e.g., 'version', "
+                "'body.storage'). Defaults to 'version,history'."
+            ),
+            default="version,history",
         ),
-    ] = "version",
+    ] = "version,history",
     limit: Annotated[
         int,
         Field(

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -695,6 +695,47 @@ class TestPagesMixin:
         assert results[2].id == "111222"
         assert results[2].title == "Child Folder 1"
 
+    def test_get_page_children_default_expands_history(self, pages_mixin):
+        """Test default child lookup requests and returns page metadata."""
+        parent_id = "123456"
+        pages_mixin.config.url = "https://confluence.example.com"
+        pages_mixin.confluence.get_page_child_by_type.return_value = {
+            "results": [
+                {
+                    "id": "789012",
+                    "title": "Child Page With Metadata",
+                    "type": "page",
+                    "space": {"key": "DEMO"},
+                    "history": {
+                        "createdDate": "2026-07-27T16:40:47.000+0200",
+                        "lastUpdated": {"when": "2026-08-17T13:19:17.000+0200"},
+                        "createdBy": {"displayName": "Page Author"},
+                    },
+                    "version": {
+                        "number": 3,
+                        "when": "2026-08-18T09:00:00.000+0200",
+                    },
+                }
+            ]
+        }
+
+        results = pages_mixin.get_page_children(
+            page_id=parent_id, include_folders=False
+        )
+
+        pages_mixin.confluence.get_page_child_by_type.assert_called_once_with(
+            page_id=parent_id,
+            type="page",
+            start=0,
+            limit=25,
+            expand="version,history",
+        )
+        assert len(results) == 1
+        assert results[0].created == "2026-07-27T16:40:47.000+0200"
+        assert results[0].updated == "2026-08-17T13:19:17.000+0200"
+        assert results[0].author is not None
+        assert results[0].author.display_name == "Page Author"
+
     def test_get_page_children_without_folders(self, pages_mixin):
         """Test getting child pages only (without folders)."""
         # Arrange

--- a/tests/unit/models/test_confluence_page_model.py
+++ b/tests/unit/models/test_confluence_page_model.py
@@ -55,6 +55,22 @@ class TestConfluencePage:
         assert page.author.account_id == "abc-123"
         assert page.author.display_name == "History Author"
 
+    def test_from_api_response_uses_version_date_without_history(self):
+        """Test updated falls back to version.when when history is absent."""
+        page = ConfluencePage.from_api_response(
+            {
+                "id": "123456",
+                "title": "Version-only Page",
+                "version": {
+                    "number": 2,
+                    "when": "2026-08-17T13:19:17.000+0200",
+                },
+            }
+        )
+
+        assert page.created == ""
+        assert page.updated == "2026-08-17T13:19:17.000+0200"
+
     def test_from_api_response_with_empty_data(self):
         """Test creating a ConfluencePage from empty data."""
         page = ConfluencePage.from_api_response({})

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -627,7 +627,7 @@ async def test_get_page_children(client, mock_confluence_fetcher):
     assert call_kwargs["page_id"] == "123456"
     assert call_kwargs.get("start") == 0
     assert call_kwargs.get("limit") == 25
-    assert call_kwargs.get("expand") == "version"
+    assert call_kwargs.get("expand") == "version,history"
 
     result_data = json.loads(response.content[0].text)
     assert "parent_id" in result_data


### PR DESCRIPTION
## Description

`confluence_get_page_children` currently requests only `version` by default, so
the Confluence API response does not include the history fields used to populate
`created`, `updated`, and `author`.

Request `history` alongside `version` by default and keep `version.when` as the
fallback update timestamp when history is unavailable.

This follows the metadata expansion pattern previously addressed in #1117 and
#1480.

Fixes: #1602

## Changes

- Expand `version,history` by default when retrieving child pages.
- Use `version.when` as the update timestamp fallback even when `history` is absent.
- Add regression coverage for child-page metadata and version-only responses.
- Update the generated Confluence tool documentation.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: live Data Center response populated `created`, `updated`, and `author`; the shared Cloud hierarchy path also passed E2E.

Commands run:

- `uv run pytest tests/unit/models/test_confluence_page_model.py tests/unit/confluence/test_pages.py tests/unit/servers/test_confluence_server.py -xq`
  - `226 passed`
- `uv run pytest tests/integration/test_real_api.py::TestRealConfluenceAPI::test_page_hierarchy --integration --use-real-data -xv -ra`
  - `1 passed`
- `uv run pytest tests/e2e/test_confluence_dc_operations.py::TestConfluenceDCPageHierarchy::test_create_child_page --dc-e2e -xv -ra`
  - `1 passed`
- `uv run pytest tests/e2e/cloud/test_confluence_cloud_operations.py::TestConfluenceCloudPageHierarchy::test_create_child_page --cloud-e2e -xv -ra`
  - `1 passed`
- Live Data Center metadata assertion
  - `created`, `updated`, and `author` populated
- `uv run python scripts/generate_tool_docs.py --check`
- Ruff format/lint and mypy checks on all changed Python files
- `git diff --check origin/main...HEAD`

## Maintainer verification (2026-08-20)

- Ran the full unit suite: `3839 passed`; the five skips are opt-in real-data model tests, and the targeted regression suite ran without skips (`226 passed`).
- Re-ran the real Confluence hierarchy integration test with Cloud credentials: `1 passed` with no skips.
- Re-ran Data Center and Cloud hierarchy E2E tests: `1 passed` each with no skips.
- Re-ran a live Data Center metadata assertion: `created`, `updated`, and `author` were populated.
- Re-ran generated tool documentation consistency: all 98 tools and 25 toolsets are current.
- Confirmed the PR head remains mergeable with current `main`; all required CI checks are green.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All relevant tests pass locally.
- [x] Documentation updated (if needed).

