### PR TITLE
fix(jira): allow transition_issue to accept a transition name

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -186,7 +186,7 @@ Transition a Jira issue to a new status.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `transition_id` | `string` | Yes | ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31' |
+| `transition_id` | `string` | Yes | ID or name of the transition to perform (case-insensitive name match, e.g. 'In Progress', 'Done'). Use the jira_get_transitions tool first to see the available transitions for the issue. Example values: '11', '21', '31', 'In Progress' |
 | `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '`{"resolution": {"name": "Fixed"}}`' |
 | `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be customer-visible on JSM and cannot be forced internal): transition without a comment, then post an internal note with jira_add_comment(public=false). |
 **Example:**

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2944,8 +2944,10 @@ async def transition_issue(
         str,
         Field(
             description=(
-                "ID of the transition to perform. Use the jira_get_transitions tool first "
-                "to get the available transition IDs for the issue. Example values: '11', '21', '31'"
+                "ID or name of the transition to perform (case-insensitive name match, "
+                "e.g. 'In Progress', 'Done'). Use the jira_get_transitions tool first to "
+                "see the available transitions for the issue. Example values: '11', '21', "
+                "'31', 'In Progress'"
             )
         ),
     ],
@@ -2979,7 +2981,7 @@ async def transition_issue(
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
-        transition_id: ID of the transition.
+        transition_id: ID or name of the transition.
         fields: Optional JSON string of fields to update during transition.
         comment: Optional comment for the transition in Markdown format.
 
@@ -2998,9 +3000,12 @@ async def transition_issue(
     # Parse fields from JSON string
     update_fields = _parse_additional_fields(fields)
 
+    available_transitions = jira.get_available_transitions(issue_key)
+    resolved_transition_id = resolve_transition(available_transitions, transition_id)
+
     issue = jira.transition_issue(
         issue_key=issue_key,
-        transition_id=transition_id,
+        transition_id=resolved_transition_id,
         fields=update_fields,
         comment=comment,
     )

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2552,6 +2552,66 @@ async def test_update_issue_transition_only_resolves_name(
 
 
 @pytest.mark.anyio
+async def test_transition_issue_resolves_name_to_id(jira_client, mock_jira_fetcher):
+    """jira_transition_issue resolves a transition name to its ID before calling."""
+    mock_jira_fetcher.get_available_transitions.return_value = [
+        {"id": "31", "name": "Done"}
+    ]
+    mock_jira_fetcher.transition_issue.return_value.to_simplified_dict.return_value = {
+        "key": "TEST-123"
+    }
+
+    await jira_client.call_tool(
+        "jira_transition_issue",
+        {"issue_key": "TEST-123", "transition_id": "done"},
+    )
+
+    mock_jira_fetcher.transition_issue.assert_called_once_with(
+        issue_key="TEST-123", transition_id="31", fields={}, comment=None
+    )
+
+
+@pytest.mark.anyio
+async def test_transition_issue_still_accepts_numeric_id(
+    jira_client, mock_jira_fetcher
+):
+    """jira_transition_issue still accepts a raw numeric transition ID."""
+    mock_jira_fetcher.get_available_transitions.return_value = [
+        {"id": "31", "name": "Done"}
+    ]
+    mock_jira_fetcher.transition_issue.return_value.to_simplified_dict.return_value = {
+        "key": "TEST-123"
+    }
+
+    await jira_client.call_tool(
+        "jira_transition_issue",
+        {"issue_key": "TEST-123", "transition_id": "31"},
+    )
+
+    mock_jira_fetcher.transition_issue.assert_called_once_with(
+        issue_key="TEST-123", transition_id="31", fields={}, comment=None
+    )
+
+
+@pytest.mark.anyio
+async def test_transition_issue_unknown_name_raises_with_options(
+    jira_client, mock_jira_fetcher
+):
+    """An unmatched transition name/ID raises a clear error listing options."""
+    mock_jira_fetcher.get_available_transitions.return_value = [
+        {"id": "31", "name": "Done"}
+    ]
+
+    with pytest.raises(ToolError, match=r"Done \(31\)"):
+        await jira_client.call_tool(
+            "jira_transition_issue",
+            {"issue_key": "TEST-123", "transition_id": "Bogus"},
+        )
+
+    mock_jira_fetcher.transition_issue.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_update_issue_comment_only_without_fields(jira_client, mock_jira_fetcher):
     """A comment-only call works when fields is omitted."""
     response = await jira_client.call_tool(


### PR DESCRIPTION
jira_transition_issue previously required a numeric transition ID, forcing a separate jira_get_transitions call even though the tool's sibling, jira_update_issue, already resolves a transition name via resolve_transition(). This reuses that same helper so a case-insensitive status name (e.g. "In Progress", "Done") works as well as the numeric ID, with the existing name-not-found error listing valid options.

Fixes: #

Changes

- jira_transition_issue now calls get_available_transitions() + resolve_transition() to resolve transition_id before calling the client, matching jira_update_issue's existing behavior.
- Updated the transition_id field description and docstring to document name support.
- Added 3 unit tests: name resolves to ID, numeric ID still works, unknown name/ID raises a clear error.

Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: ran full unit suite (uv run pytest tests/unit/) — 3837 passed, 5 skipped; ruff and mypy show no new issues vs. main

Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [ ] Documentation updated (if needed).