### PR TITLE
fix(confluence): preserve raw storage page content

### DIFF
--- a/docs/_overrides/confluence_get_page.yaml
+++ b/docs/_overrides/confluence_get_page.yaml
@@ -1,4 +1,4 @@
 example: |
   {"page_id": "12345678", "include_metadata": true}
 tips: |
-  Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date. When Confluence supplies version details, the response metadata includes `version_author` (the author display name) and `version_date` (the raw ISO 8601 version timestamp).
+  Content is returned in Markdown format by default. Set `convert_to_markdown` to `false` to retrieve exact Confluence storage XHTML when macro preservation matters. Use `include_metadata` for labels, version info, and last modified date. When Confluence supplies version details, the response metadata includes `version_author` (the author display name) and `version_date` (the raw ISO 8601 version timestamp).

--- a/docs/tools/confluence-pages.mdx
+++ b/docs/tools/confluence-pages.mdx
@@ -15,7 +15,7 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 | `title` | `string` | No | The exact title of the Confluence page. Use this with 'space_key' if 'page_id' is not known. |
 | `space_key` | `string` | No | The key of the Confluence space where the page resides (e.g., 'DEV', 'TEAM'). Required if using 'title'. |
 | `include_metadata` | `boolean` | No | Whether to include page metadata such as creation date, last update, version, and labels. |
-| `convert_to_markdown` | `boolean` | No | Whether to convert page to markdown (true) or keep it in raw HTML format (false). Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: using HTML significantly increases token usage in AI responses. |
+| `convert_to_markdown` | `boolean` | No | Whether to convert page to markdown (true) or return raw Confluence storage XHTML (false). Storage output preserves macros and task metadata for safe round-tripping, but CAUTION: it significantly increases token usage in AI responses. |
 **Example:**
 
 ```json
@@ -23,7 +23,7 @@ Get content of a specific Confluence page by its ID, or by its title and space k
 ```
 
 <Tip>
-Content is returned in Markdown format (auto-converted from Confluence storage format). Use `include_metadata` for labels, version info, and last modified date. When Confluence supplies version details, the response metadata includes `version_author` (the author display name) and `version_date` (the raw ISO 8601 version timestamp).
+Content is returned in Markdown format by default. Set `convert_to_markdown` to `false` to retrieve exact Confluence storage XHTML when macro preservation matters. Use `include_metadata` for labels, version info, and last modified date. When Confluence supplies version details, the response metadata includes `version_author` (the author display name) and `version_date` (the raw ISO 8601 version timestamp).
 </Tip>
 
 ---

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -188,7 +188,7 @@ class PagesMixin(ConfluenceClient):
         Args:
             page_id: The ID of the page to retrieve
             convert_to_markdown: When True, returns content in
-                markdown format, otherwise returns raw HTML
+                markdown format, otherwise returns raw Confluence storage XHTML
                 (keyword-only)
 
         Returns:
@@ -238,15 +238,16 @@ class PagesMixin(ConfluenceClient):
             page_attachments = (
                 page.get("children", {}).get("attachment", {}).get("results", [])
             )
-            processed_html, processed_markdown = self.preprocessor.process_html_content(
-                content,
-                space_key=space_key,
-                confluence_client=self.confluence,
-                content_id=page_id_str,
-                attachments=page_attachments,
-            )
-
-            page_content = processed_markdown if convert_to_markdown else content
+            if convert_to_markdown:
+                _, page_content = self.preprocessor.process_html_content(
+                    content,
+                    space_key=space_key,
+                    confluence_client=self.confluence,
+                    content_id=page_id_str,
+                    attachments=page_attachments,
+                )
+            else:
+                page_content = content
 
             # Fetch page emoji and width from content properties
             emoji = self._get_page_emoji(page_id)
@@ -560,7 +561,7 @@ class PagesMixin(ConfluenceClient):
             space_key: The key of the space containing the page
             title: The title of the page to retrieve
             convert_to_markdown: When True, returns content in markdown format,
-                               otherwise returns raw HTML (keyword-only)
+                otherwise returns raw Confluence storage XHTML (keyword-only)
 
         Returns:
             ConfluencePage model containing the page content and metadata, or None if not found
@@ -585,15 +586,15 @@ class PagesMixin(ConfluenceClient):
                     f"Page {page.get('id', 'unknown')} missing body.storage.value: {e}"
                 )
                 content = ""
-            processed_html, processed_markdown = self.preprocessor.process_html_content(
-                content,
-                space_key=space_key,
-                confluence_client=self.confluence,
-                content_id=str(page.get("id", "")),
-            )
-
-            # Use the appropriate content format based on the convert_to_markdown flag
-            page_content = processed_markdown if convert_to_markdown else processed_html
+            if convert_to_markdown:
+                _, page_content = self.preprocessor.process_html_content(
+                    content,
+                    space_key=space_key,
+                    confluence_client=self.confluence,
+                    content_id=str(page.get("id", "")),
+                )
+            else:
+                page_content = content
 
             # Fetch page emoji and width from content properties
             emoji = self._get_page_emoji(str(page.get("id", "")))

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -246,7 +246,7 @@ class PagesMixin(ConfluenceClient):
                 attachments=page_attachments,
             )
 
-            page_content = processed_markdown if convert_to_markdown else processed_html
+            page_content = processed_markdown if convert_to_markdown else content
 
             # Fetch page emoji and width from content properties
             emoji = self._get_page_emoji(page_id)

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -328,9 +328,10 @@ async def get_page(
         bool,
         Field(
             description=(
-                "Whether to convert page to markdown (true) or keep it in raw HTML format (false). "
-                "Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: "
-                "using HTML significantly increases token usage in AI responses."
+                "Whether to convert page to markdown (true) or return raw Confluence "
+                "storage XHTML (false). Storage output preserves macros and task "
+                "metadata for safe round-tripping, but CAUTION: it significantly "
+                "increases token usage in AI responses."
             ),
             default=True,
         ),
@@ -345,7 +346,8 @@ async def get_page(
         title: The exact title of the page. Must be used with 'space_key'.
         space_key: The key of the space. Must be used with 'title'.
         include_metadata: Whether to include page metadata.
-        convert_to_markdown: Convert content to markdown (true) or keep raw HTML (false).
+        convert_to_markdown: Convert content to markdown (true) or return raw
+            Confluence storage XHTML (false).
 
     Returns:
         JSON string representing the page content and/or metadata, or an error if not found or parameters are invalid.

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -111,7 +111,7 @@ class TestConfluenceCloudStorageFormat:
         storage_content = (
             "<h1>Cloud E2E Storage Format Test</h1>"
             "<p>This page uses <strong>storage format</strong>.</p>"
-            "<ul><li>Item 1</li><li>Item 2</li></ul>"
+            '<ac:figure><ri:attachment ri:filename="diagram.png" /></ac:figure>'
         )
         page = confluence_fetcher.create_page(
             space_key=cloud_instance.space_key,
@@ -122,6 +122,20 @@ class TestConfluenceCloudStorageFormat:
         )
         resource_tracker.add_confluence_page(page.id)
         assert page.id is not None
+
+        raw_page = confluence_fetcher.confluence.get_page_by_id(
+            page.id,
+            expand="body.storage",
+        )
+        raw_storage = raw_page["body"]["storage"]["value"]
+        fetched = confluence_fetcher.get_page_content(
+            page.id,
+            convert_to_markdown=False,
+        )
+
+        assert "<ri:attachment" in raw_storage
+        assert fetched.content == raw_storage
+        assert fetched.content_format == "storage"
 
 
 class TestConfluenceCloudPageSubtype:

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -142,11 +142,25 @@ class TestPagesMixin:
         assert isinstance(result, list)
         assert len(result) == 0
 
-    def test_get_page_content_html(self, pages_mixin):
-        """Test getting page content in HTML format."""
+    def test_get_page_content_html_preserves_raw_storage(self, pages_mixin):
+        """Test getting page content preserves raw Confluence storage format."""
         pages_mixin.config.url = "https://example.atlassian.net/wiki"
+        raw_storage_content = (
+            '<ac:figure><ri:attachment ri:filename="diagram.png" /></ac:figure>'
+        )
+        page = pages_mixin.confluence.get_page_by_id.return_value
+        pages_mixin.confluence.get_page_by_id.return_value = {
+            **page,
+            "body": {
+                **page["body"],
+                "storage": {
+                    **page["body"]["storage"],
+                    "value": raw_storage_content,
+                },
+            },
+        }
 
-        # Mock the preprocessor to return HTML
+        # Mock the preprocessor to return modified HTML
         pages_mixin.preprocessor.process_html_content.return_value = (
             "<p>Processed HTML</p>",
             "Processed Markdown",
@@ -155,8 +169,8 @@ class TestPagesMixin:
         # Act
         result = pages_mixin.get_page_content("987654321", convert_to_markdown=False)
 
-        # Assert HTML processing was used
-        assert result.content == "<p>Processed HTML</p>"
+        # Assert raw storage content is returned, not processed HTML
+        assert result.content == raw_storage_content
 
     def test_get_page_by_title_success(self, pages_mixin):
         """Test getting a page by title when it exists."""

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -160,17 +160,12 @@ class TestPagesMixin:
             },
         }
 
-        # Mock the preprocessor to return modified HTML
-        pages_mixin.preprocessor.process_html_content.return_value = (
-            "<p>Processed HTML</p>",
-            "Processed Markdown",
-        )
-
         # Act
         result = pages_mixin.get_page_content("987654321", convert_to_markdown=False)
 
         # Assert raw storage content is returned, not processed HTML
         assert result.content == raw_storage_content
+        pages_mixin.preprocessor.process_html_content.assert_not_called()
 
     def test_get_page_by_title_success(self, pages_mixin):
         """Test getting a page by title when it exists."""
@@ -205,6 +200,31 @@ class TestPagesMixin:
         assert result.id == "987654321"
         assert result.title == title
         assert result.content == "Processed Markdown"
+
+    def test_get_page_by_title_preserves_raw_storage(self, pages_mixin):
+        """Test raw storage is preserved when a page is looked up by title."""
+        space_key = "DEMO"
+        title = "Page With Macro"
+        raw_storage_content = (
+            '<ac:structured-macro ac:name="status">'
+            '<ac:parameter ac:name="title">READY</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        pages_mixin.confluence.get_page_by_title.return_value = {
+            "id": "987654321",
+            "title": title,
+            "space": {"key": space_key},
+            "body": {"storage": {"value": raw_storage_content}},
+            "version": {"number": 1},
+        }
+
+        result = pages_mixin.get_page_by_title(
+            space_key, title, convert_to_markdown=False
+        )
+
+        assert result is not None
+        assert result.content == raw_storage_content
+        pages_mixin.preprocessor.process_html_content.assert_not_called()
 
     def test_get_page_by_title_space_not_found(self, pages_mixin):
         """Test getting a page when the space doesn't exist."""


### PR DESCRIPTION
## Summary

- Fix `ConfluenceFetcher.get_page_content(..., convert_to_markdown=False)` to return the exact Confluence `body.storage.value` from the API.
- Preserve storage-format elements such as `ac:figure` when callers round-trip page content through `content_format="storage"`.
- Add a regression test covering an attachment figure tag.

Fixes #1607

## Verification

- `uv run pytest tests/unit/confluence/test_pages.py -xvs`
- `uv run pytest tests/unit/confluence/ -xvs`
- `uv run pytest -q`
- `git diff --check`
- `uv run ruff format --check src/mcp_atlassian/confluence/pages.py tests/unit/confluence/test_pages.py`

Full suite result: 3839 passed, 242 skipped. Existing repository warnings remain in unrelated tests; changed files are formatted and the focused/unit suites pass.
