### PR TITLE
feat(aio): add AIO Tests tool set for test management in Jira

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,3 +176,34 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 
 # Confluence-specific custom headers.
 #CONFLUENCE_CUSTOM_HEADERS=X-Confluence-Service=mcp-integration,X-Custom-Auth=confluence-token,X-ALB-Token=secret-token
+
+# =============================================
+# AIO TESTS (TEST MANAGEMENT FOR JIRA)
+# =============================================
+# AIO Tests is a Jira app with its own REST API. Its tools stay hidden unless
+# one of the settings below enables them.
+
+# --- Atlassian Cloud ---
+# AIO Tests access token. Generate it in Jira: AIO Tests > (?) icon > API Access Token.
+# Setting this is enough to enable the AIO Tests tools; JIRA_URL is not required.
+#AIO_API_TOKEN=your_aio_access_token
+
+# --- Jira Server / Data Center ---
+# On Server/DC the AIO Tests API is served from your Jira base URL and reuses the
+# Jira credentials above, so it must be enabled explicitly.
+#AIO_ENABLED=true
+# Optional: override the credentials used for AIO Tests (defaults to the JIRA_* ones).
+#AIO_PERSONAL_TOKEN=your_pat
+#AIO_USERNAME=your_username
+#AIO_PASSWORD=your_password
+
+# --- Advanced ---
+# Override the API base URL (defaults to the AIO Tests Cloud API, or
+# {JIRA_URL}/rest/aio-tcms-api/1.0 for Server/Data Center).
+#AIO_URL=https://tcms.aiojiraapps.com/aio-tcms/api/v1
+#AIO_SSL_VERIFY=true
+#AIO_HTTP_PROXY=http://aio-proxy.example.com:8080
+#AIO_HTTPS_PROXY=https://aio-proxy.example.com:8443
+#AIO_SOCKS_PROXY=socks5://aio-proxy.example.com:1080
+#AIO_NO_PROXY=localhost,127.0.0.1
+#AIO_CUSTOM_HEADERS=X-Aio-Service=mcp-integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This file provides guidance for autonomous coding agents working inside the **MC
 | `src/mcp_atlassian/` | Library source code (Python ≥ 3.10) |
 | `  ├─ jira/` | Jira client, mixins, and operations |
 | `  ├─ confluence/` | Confluence client, mixins, and operations |
+| `  ├─ aio/` | AIO Tests client, mixins, and operations |
 | `  ├─ models/` | Pydantic data models for API responses |
 | `  ├─ servers/` | FastMCP server implementations |
 | `  └─ utils/` | Shared utilities (auth, logging, SSL) |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | Confluence | Server/Data Center | Supported (v6.0+) |
 | Jira | Cloud | Fully supported |
 | Jira | Server/Data Center | Supported (v8.14+) |
+| AIO Tests | Cloud & Server/Data Center | Supported (opt-in) |
 
 ## Key Tools
 
@@ -97,6 +98,10 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 | `jira_get_issue_sla` - Calculate SLA metrics | `confluence_get_page_views` - Get page view stats (Cloud only) |
+
+**AIO Tests** (test management for Jira) adds `aio_search_test_cases`,
+`aio_get_test_case`, `aio_create_test_case`, `aio_update_test_case` and more.
+Set `AIO_API_TOKEN` (Cloud) or `AIO_ENABLED=true` (Server/DC) to turn them on.
 
 See [Tools Reference](https://personal-1d37018d.mintlify.app/docs/tools-reference) for the complete list.
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -153,6 +153,46 @@ This guide covers IDE integration, environment variables, and advanced configura
 
 See [.env.example](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example) for all available options.
 
+## AIO Tests
+
+[AIO Tests](https://www.aiotests.com/) is a test management app for Jira with its
+own REST API. Its tools stay hidden until you configure it, so nothing changes
+for deployments that do not use the app.
+
+<Tabs>
+  <Tab title="Cloud">
+    Generate an access token in Jira under **AIO Tests → (?) → API Access Token**,
+    then set it. That single variable enables the AIO Tests tools; `JIRA_URL` is
+    not required.
+
+    ```bash
+    AIO_API_TOKEN=your_aio_access_token
+    ```
+  </Tab>
+  <Tab title="Server / Data Center">
+    The API is served from your Jira base URL and reuses the Jira credentials, so
+    it has to be enabled explicitly.
+
+    ```bash
+    JIRA_URL=https://jira.your-company.com
+    JIRA_PERSONAL_TOKEN=your_jira_pat
+    AIO_ENABLED=true
+    ```
+  </Tab>
+</Tabs>
+
+| Variable | Description |
+|----------|-------------|
+| `AIO_API_TOKEN` | AIO Tests access token (Cloud). Enables the tools on its own |
+| `AIO_ENABLED` | Enable AIO Tests on Server/Data Center (`true`/`false`) |
+| `AIO_URL` | Override the API base URL |
+| `AIO_PERSONAL_TOKEN` | Override the PAT used for AIO Tests (defaults to `JIRA_PERSONAL_TOKEN`) |
+| `AIO_USERNAME` / `AIO_PASSWORD` | Override the basic-auth credentials (default to the `JIRA_*` ones) |
+| `AIO_SSL_VERIFY` | SSL verification (`true`/`false`) |
+
+In multi-user HTTP deployments, a per-request token can be passed in the
+`X-Aio-Api-Token` header, which overrides `AIO_API_TOKEN` for that request.
+
 ## Proxy Configuration
 
 MCP Atlassian supports routing API requests through HTTP/HTTPS/SOCKS proxies.

--- a/docs/http-transport.mdx
+++ b/docs/http-transport.mdx
@@ -182,6 +182,8 @@ For multi-tenant applications where each user connects to their own Atlassian cl
 2. Users provide authentication via HTTP headers:
    - `Authorization: Bearer <user_oauth_token>`
    - `X-Atlassian-Cloud-Id: <user_cloud_id>`
+   - `X-Aio-Api-Token: <user_aio_token>` (AIO Tests only; overrides `AIO_API_TOKEN`
+     for that request)
 
 ### Python Example
 

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Tools Reference"
-description: "All available MCP Atlassian tools for Jira and Confluence"
+description: "All available MCP Atlassian tools for Jira, Confluence and AIO Tests"
 ---
 
 # Tools Reference
 
-MCP Atlassian provides tools for interacting with Jira and Confluence.
+MCP Atlassian provides tools for interacting with Jira, Confluence and AIO Tests.
 
 ## Key Tools
 
@@ -27,6 +27,15 @@ MCP Atlassian provides tools for interacting with Jira and Confluence.
     | `confluence_get_page` | Get content of a specific page |
     | `confluence_create_page` | Create a new page |
     | `confluence_update_page` | Update an existing page |
+  </Card>
+  <Card title="AIO Tests Tools" icon="vial">
+    | Tool | Description |
+    |------|-------------|
+    | `aio_get_test_case_schema` | Fields and allowed values of a project |
+    | `aio_search_test_cases` | Search and filter test cases |
+    | `aio_get_test_case` | Get a test case with its steps |
+    | `aio_create_test_case` | Create a Classic or BDD test case |
+    | `aio_update_test_case` | Update an existing test case |
   </Card>
 </CardGroup>
 
@@ -67,6 +76,34 @@ MCP Atlassian provides tools for interacting with Jira and Confluence.
 
 <Note>
 \* `jira_batch_get_changelogs` is only available on Jira Cloud
+</Note>
+
+## AIO Tests Tools
+
+[AIO Tests](https://www.aiotests.com/) is a test management app for Jira. These
+tools are hidden unless AIO Tests is configured — see
+[Configuration](/docs/configuration#aio-tests).
+
+| Operation | Tool | Description |
+|-----------|------|-------------|
+| **Read** | `aio_get_project` | Check whether AIO Tests is enabled for a project and get its key and ID |
+| | `aio_get_test_case_schema` | Built-in fields, custom fields, required fields and allowed values |
+| | `aio_search_test_cases` | Search by title, folder, status, priority, type, tag, owner, requirement or date |
+| | `aio_get_test_case` | Full case details including steps, tags, folder and custom fields |
+| | `aio_get_test_case_versions` | Version history of a test case |
+| | `aio_get_folder_hierarchy` | Folder tree with parent-child relationships and full paths |
+| | `aio_get_tags` | Tags configured for the project |
+| **Write** | `aio_create_test_case` | Create a case with Classic or BDD steps |
+| | `aio_update_test_case` | Update steps, metadata, priority, status or tags |
+| | `aio_create_folder` | Create a folder, or a whole folder path in one call |
+
+Lookup fields accept names or numeric IDs, so `priority: "Critical"` and
+`folder: "/Regression/Checkout"` work as well as their IDs. Names are resolved
+against the project's configuration.
+
+<Note>
+AIO Tests has no public API for renaming, moving or re-describing a folder, so
+there is no `aio_update_folder` tool. Do those edits in the AIO Tests UI.
 </Note>
 
 ## Tool Access Control

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -55,6 +55,16 @@ startCommand:
         type: string
         description: "(Optional) Comma-separated list of Jira project keys to limit searches to (e.g., 'PROJ1,PROJ2')."
 
+      # AIO Tests Config (test management app for Jira)
+      aioApiToken:
+        type: string
+        description: "(Optional) AIO Tests access token (Cloud). Setting it enables the AIO Tests tools."
+        format: password
+      aioEnabled:
+        type: boolean
+        description: "(Optional, Server/DC only) Enable the AIO Tests tools using the Jira credentials. Defaults to false."
+        default: false
+
       # General Config
       readOnlyMode:
         type: boolean
@@ -89,6 +99,10 @@ startCommand:
         JIRA_PERSONAL_TOKEN: config.jiraPersonalToken,
         JIRA_SSL_VERIFY: config.jiraSslVerify !== undefined ? String(config.jiraSslVerify) : 'true',
         JIRA_PROJECTS_FILTER: config.jiraProjectsFilter,
+
+        // AIO Tests ENV VARS
+        AIO_API_TOKEN: config.aioApiToken,
+        AIO_ENABLED: config.aioEnabled !== undefined ? String(config.aioEnabled) : undefined,
 
         // General ENV VARS
         READ_ONLY_MODE: config.readOnlyMode !== undefined ? String(config.readOnlyMode) : 'false',

--- a/src/mcp_atlassian/aio/__init__.py
+++ b/src/mcp_atlassian/aio/__init__.py
@@ -1,0 +1,38 @@
+"""AIO Tests API module for mcp_atlassian.
+
+Provides the client used to talk to the AIO Tests REST API, which powers test
+management inside Jira.
+"""
+
+from .cases import TestCasesMixin
+from .client import AIOApiError, AIOClient
+from .config import AIOConfig, is_aio_enabled
+from .folders import FoldersMixin
+from .projects import ProjectsMixin
+from .tags import TagsMixin
+
+
+class AIOFetcher(TestCasesMixin, ProjectsMixin, FoldersMixin, TagsMixin):
+    """The main AIO Tests client providing access to all AIO Tests operations.
+
+    This class inherits from multiple mixins that provide specific functionality:
+    - TestCasesMixin: Test case search, read, create and update operations
+    - ProjectsMixin: Project configuration and test case schema operations
+    - FoldersMixin: Folder hierarchy operations
+    - TagsMixin: Tag operations
+    """
+
+    pass
+
+
+__all__ = [
+    "AIOApiError",
+    "AIOClient",
+    "AIOConfig",
+    "AIOFetcher",
+    "FoldersMixin",
+    "ProjectsMixin",
+    "TagsMixin",
+    "TestCasesMixin",
+    "is_aio_enabled",
+]

--- a/src/mcp_atlassian/aio/cases.py
+++ b/src/mcp_atlassian/aio/cases.py
@@ -1,0 +1,667 @@
+"""Module for AIO Tests test case operations."""
+
+import html
+import logging
+from typing import Any
+
+from ..models.aio import AIOTestCase, AIOTestCaseSearchResult
+from .constants import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    MIN_PAGE_SIZE,
+    READ_ONLY_CASE_FIELDS,
+    RICH_TEXT_CASE_FIELDS,
+    RICH_TEXT_CUSTOM_FIELD_TYPE,
+    RICH_TEXT_STEP_KEYS,
+    STEP_TYPES,
+)
+from .folders import FoldersMixin
+from .projects import ProjectsMixin
+from .tags import TagsMixin
+
+logger = logging.getLogger("mcp-aio")
+
+# Mapping of the snake_case step keys accepted by this server to the API keys.
+_STEP_KEY_MAP = {
+    "step": "step",
+    "data": "data",
+    "expected_result": "expectedResult",
+    "expectedresult": "expectedResult",
+    "bdd_step": "bddStep",
+    "bddstep": "bddStep",
+    "step_type": "stepType",
+    "steptype": "stepType",
+    "id": "ID",
+}
+
+
+def _build_step_payload(step: dict[str, Any], index: int) -> dict[str, Any]:
+    """Convert a step given to a tool into the API step payload.
+
+    Args:
+        step: Step definition using snake_case or API keys.
+        index: Zero-based position of the step, used in error messages.
+
+    Returns:
+        The API step payload.
+
+    Raises:
+        ValueError: If the step is malformed or uses an unknown step type.
+    """
+    if not isinstance(step, dict):
+        raise ValueError(
+            f"Step {index + 1} must be an object, got {type(step).__name__}"
+        )
+
+    payload: dict[str, Any] = {}
+    for key, value in step.items():
+        normalized = _STEP_KEY_MAP.get(str(key).lower())
+        if normalized is None:
+            if str(key) == "referenced_case_key":
+                payload["referencedCase"] = {"key": value}
+                continue
+            raise ValueError(
+                f"Unknown key '{key}' in step {index + 1}. Supported keys: "
+                "step, data, expected_result, bdd_step, step_type, "
+                "referenced_case_key"
+            )
+        if value is not None:
+            payload[normalized] = value
+
+    step_type = payload.get("stepType")
+    if not step_type:
+        step_type = "BDD_GIVEN" if payload.get("bddStep") else "TEXT"
+        payload["stepType"] = step_type
+    if step_type not in STEP_TYPES:
+        raise ValueError(
+            f"Invalid step_type '{step_type}' in step {index + 1}. "
+            f"Expected one of: {', '.join(STEP_TYPES)}"
+        )
+    if step_type.startswith("BDD_") and not payload.get("bddStep"):
+        raise ValueError(f"Step {index + 1} uses {step_type} but has no bdd_step text")
+    if step_type == "TEXT" and not payload.get("step"):
+        raise ValueError(f"Step {index + 1} is a TEXT step but has no step text")
+    if step_type == "REFERENCE" and "referencedCase" not in payload:
+        raise ValueError(
+            f"Step {index + 1} is a REFERENCE step but has no referenced_case_key"
+        )
+    return payload
+
+
+def _plain_text_to_html(value: Any) -> Any:
+    """Escape plain text so it survives being stored as rich text.
+
+    Args:
+        value: The value to escape; non-string values are returned unchanged.
+
+    Returns:
+        The HTML-escaped value with line breaks preserved.
+    """
+    if not isinstance(value, str):
+        return value
+    return html.escape(value).replace("\n", "<br/>")
+
+
+def _date_criteria(after: str | None, before: str | None) -> dict[str, Any] | None:
+    """Build a date search criteria from an optional range.
+
+    Args:
+        after: Lower bound of the range, if any.
+        before: Upper bound of the range, if any.
+
+    Returns:
+        The criteria payload, or None when no bound was given.
+    """
+    if after and before:
+        return {"comparisonType": "BETWEEN", "value1": after, "value2": before}
+    if after:
+        return {"comparisonType": "AFTER", "value1": after}
+    if before:
+        return {"comparisonType": "BEFORE", "value1": before}
+    return None
+
+
+class TestCasesMixin(ProjectsMixin, FoldersMixin, TagsMixin):
+    """Mixin for AIO Tests test case operations."""
+
+    def get_test_case(
+        self,
+        project_key: str,
+        test_case_id: str,
+        *,
+        version: int | None = None,
+        include_rtf: bool = False,
+        include_attachments: bool = False,
+    ) -> AIOTestCase:
+        """Retrieve the complete details of a test case.
+
+        Args:
+            project_key: Jira project key or ID.
+            test_case_id: Case key (e.g. ``AT-TC-17``) or numeric case ID.
+            version: Case version to read. Ignored when a numeric case ID is
+                given; defaults to the latest version.
+            include_rtf: Keep the HTML markup of rich-text fields.
+            include_attachments: Include attachment metadata.
+
+        Returns:
+            The test case details.
+        """
+        response = self.get(
+            self.project_path(project_key, "testcase", test_case_id, "detail"),
+            params={
+                "needDataInRTF": include_rtf or None,
+                "needAttachments": include_attachments or None,
+                "version": version,
+            },
+        )
+        return AIOTestCase.from_api_response(
+            response if isinstance(response, dict) else {}
+        )
+
+    def get_test_case_versions(
+        self, project_key: str, test_case_id: str
+    ) -> AIOTestCase:
+        """Retrieve the version history of a test case.
+
+        Args:
+            project_key: Jira project key or ID.
+            test_case_id: Case key (e.g. ``AT-TC-17``) or numeric case ID.
+
+        Returns:
+            The test case, whose ``versions`` list holds every saved version
+            with the case ID that stores it.
+        """
+        return self.get_test_case(project_key, test_case_id)
+
+    def search_test_cases(
+        self,
+        project_key: str,
+        *,
+        title: str | None = None,
+        title_match: str = "CONTAINS",
+        keys: list[str] | None = None,
+        folders: list[Any] | None = None,
+        statuses: list[Any] | None = None,
+        priorities: list[Any] | None = None,
+        types: list[Any] | None = None,
+        automation_statuses: list[Any] | None = None,
+        tags: list[str] | None = None,
+        owner_ids: list[str] | None = None,
+        requirement_ids: list[str] | None = None,
+        automation_key: str | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
+        updated_after: str | None = None,
+        updated_before: str | None = None,
+        include_archived: bool | None = None,
+        start_at: int = 0,
+        max_results: int = DEFAULT_PAGE_SIZE,
+        include_rtf: bool = False,
+    ) -> AIOTestCaseSearchResult:
+        """Search test cases in a project.
+
+        Lookup filters accept either names or numeric IDs; names are resolved
+        against the project configuration. When no filter is given, the plain
+        case listing is returned.
+
+        Args:
+            project_key: Jira project key or ID.
+            title: Text to match against the case title.
+            title_match: ``CONTAINS`` or ``EXACT_MATCH``.
+            keys: Case keys to match.
+            folders: Folder IDs, names or paths.
+            statuses: Case status names or IDs.
+            priorities: Case priority names or IDs.
+            types: Case type names or IDs.
+            automation_statuses: Automation status names or IDs.
+            tags: Tag names.
+            owner_ids: Jira account IDs of case owners.
+            requirement_ids: Jira issue keys or IDs covered by the case.
+            automation_key: Automation key to match (contains).
+            created_after: Lower bound of the creation date range.
+            created_before: Upper bound of the creation date range.
+            updated_after: Lower bound of the update date range.
+            updated_before: Upper bound of the update date range.
+            include_archived: Filter on the archived flag.
+            start_at: Index of the first result.
+            max_results: Maximum number of results to return.
+            include_rtf: Keep the HTML markup of rich-text fields.
+
+        Returns:
+            A page of matching test cases.
+
+        Raises:
+            ValueError: If a lookup name or folder cannot be resolved.
+        """
+        criteria: dict[str, Any] = {}
+        if title:
+            match = str(title_match).upper()
+            if match not in ("CONTAINS", "EXACT_MATCH"):
+                raise ValueError(
+                    f"Invalid title_match '{title_match}'. "
+                    "Expected CONTAINS or EXACT_MATCH."
+                )
+            criteria["title"] = {"comparisonType": match, "value": title}
+        if automation_key:
+            criteria["automationKey"] = {
+                "comparisonType": "CONTAINS",
+                "value": automation_key,
+            }
+        if keys:
+            criteria["key"] = {"comparisonType": "IN", "list": [str(k) for k in keys]}
+        if owner_ids:
+            criteria["ownedByID"] = {
+                "comparisonType": "IN",
+                "list": [str(value) for value in owner_ids],
+            }
+        if requirement_ids:
+            criteria["requirementID"] = {
+                "comparisonType": "IN",
+                "list": [str(value) for value in requirement_ids],
+            }
+        if tags:
+            criteria["tag"] = {
+                "comparisonType": "IN",
+                "list": [str(value) for value in tags],
+            }
+        if folders:
+            criteria["folderID"] = {
+                "comparisonType": "IN",
+                "list": [
+                    self.resolve_folder_id(project_key, folder) for folder in folders
+                ],
+            }
+        for field, values, config_key in (
+            ("statusID", statuses, "caseStatuses"),
+            ("priorityID", priorities, "casePriorities"),
+            ("typeID", types, "caseTypes"),
+            ("automationStatusID", automation_statuses, "caseAutomationStatuses"),
+        ):
+            if values:
+                criteria[field] = {
+                    "comparisonType": "IN",
+                    "list": [
+                        self.resolve_lookup_id(project_key, config_key, value)
+                        for value in values
+                    ],
+                }
+        created = _date_criteria(created_after, created_before)
+        if created:
+            criteria["createdDate"] = created
+        updated = _date_criteria(updated_after, updated_before)
+        if updated:
+            criteria["updatedDate"] = updated
+        if include_archived is not None:
+            criteria["isArchived"] = {"value": include_archived}
+
+        requested = max(1, int(max_results))
+        page_size = min(MAX_PAGE_SIZE, max(MIN_PAGE_SIZE, requested))
+        params: dict[str, Any] = {
+            "startAt": start_at,
+            "maxResults": page_size,
+            "needDataInRTF": include_rtf or None,
+        }
+
+        if criteria:
+            response = self.post(
+                self.project_path(project_key, "testcase", "search"),
+                json=criteria,
+                params=params,
+            )
+        else:
+            response = self.get(
+                self.project_path(project_key, "testcase"), params=params
+            )
+
+        result = AIOTestCaseSearchResult.from_api_response(
+            response if isinstance(response, dict) else {}
+        )
+        if len(result.cases) > requested:
+            result.cases = result.cases[:requested]
+            result.is_last = False
+        result.max_results = requested
+        return result
+
+    def create_test_case(
+        self,
+        project_key: str,
+        title: str,
+        *,
+        include_rtf: bool = False,
+        create_folder_if_missing: bool = True,
+        **fields: Any,
+    ) -> AIOTestCase:
+        """Create a test case.
+
+        Args:
+            project_key: Jira project key or ID.
+            title: Case title. The only mandatory field.
+            include_rtf: Treat rich-text field values as HTML instead of plain
+                text.
+            create_folder_if_missing: Create the target folder hierarchy when it
+                does not exist yet.
+            **fields: Optional case fields, see :meth:`_build_case_payload`.
+
+        Returns:
+            The created test case.
+
+        Raises:
+            ValueError: If the title is empty or a field value cannot be
+                resolved.
+        """
+        if not title or not title.strip():
+            raise ValueError("Test case title is required")
+
+        payload = self._build_case_payload(
+            project_key,
+            fields,
+            create_folder_if_missing=create_folder_if_missing,
+        )
+        payload["title"] = title
+
+        response = self.post(
+            self.project_path(project_key, "testcase"),
+            json=payload,
+            params={"needDataInRTF": include_rtf or None},
+        )
+        return AIOTestCase.from_api_response(
+            response if isinstance(response, dict) else {}
+        )
+
+    def update_test_case(
+        self,
+        project_key: str,
+        test_case_id: str,
+        *,
+        version: int | None = None,
+        create_new_version: bool = False,
+        include_rtf: bool = False,
+        create_folder_if_missing: bool = True,
+        **fields: Any,
+    ) -> AIOTestCase:
+        """Update an existing test case.
+
+        Only the supplied fields change; everything else is carried over from
+        the current case, as the API replaces the whole case document.
+
+        Args:
+            project_key: Jira project key or ID.
+            test_case_id: Case key (e.g. ``AT-TC-17``) or numeric case ID.
+            version: Case version to update. Ignored when a numeric case ID is
+                given; defaults to the latest version.
+            create_new_version: Save the change as a new case version instead of
+                modifying the current one.
+            include_rtf: Treat the supplied rich-text values as HTML. When False
+                they are treated as plain text and escaped; either way the
+                formatting of the fields left untouched is preserved.
+            create_folder_if_missing: Create the target folder hierarchy when it
+                does not exist yet.
+            **fields: Case fields to change, see :meth:`_build_case_payload`.
+
+        Returns:
+            The updated test case.
+
+        Raises:
+            ValueError: If no field was supplied or a value cannot be resolved.
+        """
+        # The API replaces the whole case document, so the current case is read
+        # back with its HTML intact and written back the same way. Otherwise the
+        # formatting of every field the caller did not touch would be flattened
+        # to plain text. Plain-text input is escaped to match.
+        changes = self._build_case_payload(
+            project_key,
+            fields,
+            create_folder_if_missing=create_folder_if_missing,
+            escape_rich_text=not include_rtf,
+        )
+        title = fields.get("title")
+        if title is not None:
+            if not str(title).strip():
+                raise ValueError("Test case title cannot be empty")
+            changes["title"] = title
+        if not changes:
+            raise ValueError("No fields to update were provided")
+
+        current = self.get(
+            self.project_path(project_key, "testcase", test_case_id, "detail"),
+            params={"needDataInRTF": True, "version": version},
+        )
+        if not isinstance(current, dict):
+            raise ValueError(f"Test case '{test_case_id}' was not found")
+
+        payload = {
+            key: value
+            for key, value in current.items()
+            if key not in READ_ONLY_CASE_FIELDS
+        }
+        payload.update(changes)
+
+        response = self.put(
+            self.project_path(project_key, "testcase", test_case_id, "detail"),
+            json=payload,
+            params={
+                "needDataInRTF": True,
+                "version": version,
+                "createNewVersion": create_new_version or None,
+            },
+        )
+        return AIOTestCase.from_api_response(
+            response if isinstance(response, dict) else {}
+        )
+
+    def _build_case_payload(
+        self,
+        project_key: str,
+        fields: dict[str, Any],
+        *,
+        create_folder_if_missing: bool,
+        escape_rich_text: bool = False,
+    ) -> dict[str, Any]:
+        """Translate tool-level case fields into an API payload.
+
+        Args:
+            project_key: Jira project key or ID.
+            fields: Supported keys: ``description``, ``precondition``, ``folder``,
+                ``status``, ``priority``, ``type``, ``script_type``,
+                ``automation_status``, ``automation_key``, ``automation_owner_id``,
+                ``owner_id``, ``estimated_effort``, ``steps``, ``tags``,
+                ``requirement_ids``, ``component_ids``, ``release_ids`` and
+                ``custom_fields``. ``title`` is handled by the callers.
+            create_folder_if_missing: Create the target folder hierarchy when it
+                does not exist yet.
+            escape_rich_text: Escape rich-text values as HTML, for requests that
+                are sent with ``needDataInRTF`` enabled.
+
+        Returns:
+            The API payload holding only the supplied fields.
+
+        Raises:
+            ValueError: If a key is unknown or a value cannot be resolved.
+        """
+        known = {
+            "title",
+            "description",
+            "precondition",
+            "folder",
+            "status",
+            "priority",
+            "type",
+            "script_type",
+            "automation_status",
+            "automation_key",
+            "automation_owner_id",
+            "owner_id",
+            "estimated_effort",
+            "steps",
+            "tags",
+            "requirement_ids",
+            "component_ids",
+            "release_ids",
+            "custom_fields",
+        }
+        unknown = set(fields) - known
+        if unknown:
+            raise ValueError(
+                f"Unknown test case field(s): {', '.join(sorted(unknown))}. "
+                f"Supported fields: {', '.join(sorted(known))}"
+            )
+
+        payload: dict[str, Any] = {}
+        for key, api_key in (
+            ("description", "description"),
+            ("precondition", "precondition"),
+            ("owner_id", "ownedByID"),
+            ("automation_key", "automationKey"),
+            ("automation_owner_id", "automationOwnerID"),
+            ("estimated_effort", "estimatedEffort"),
+        ):
+            value = fields.get(key)
+            if value is not None:
+                payload[api_key] = (
+                    _plain_text_to_html(value)
+                    if escape_rich_text and api_key in RICH_TEXT_CASE_FIELDS
+                    else value
+                )
+
+        for key, api_key, config_key in (
+            ("status", "status", "caseStatuses"),
+            ("priority", "priority", "casePriorities"),
+            ("type", "type", "caseTypes"),
+            ("script_type", "scriptType", "caseScriptTypes"),
+            ("automation_status", "automationStatus", "caseAutomationStatuses"),
+        ):
+            value = fields.get(key)
+            if value is not None:
+                resolved = self.resolve_lookup_id(project_key, config_key, value)
+                if resolved is not None:
+                    payload[api_key] = {"ID": resolved}
+
+        folder = fields.get("folder")
+        if folder is not None:
+            folder_id = self.resolve_folder_id(
+                project_key,
+                folder,
+                "testcase",
+                create_missing=create_folder_if_missing,
+            )
+            if folder_id is not None:
+                payload["folder"] = {"ID": folder_id}
+
+        steps = fields.get("steps")
+        if steps is not None:
+            if not isinstance(steps, list):
+                raise ValueError("steps must be a list of step objects")
+            step_payloads = [
+                _build_step_payload(step, index) for index, step in enumerate(steps)
+            ]
+            if escape_rich_text:
+                for step_payload in step_payloads:
+                    for step_key in RICH_TEXT_STEP_KEYS:
+                        if step_key in step_payload:
+                            step_payload[step_key] = _plain_text_to_html(
+                                step_payload[step_key]
+                            )
+            payload["steps"] = step_payloads
+
+        tags = fields.get("tags")
+        if tags is not None:
+            payload["tags"] = self.resolve_tags(project_key, list(tags))
+
+        requirement_ids = fields.get("requirement_ids")
+        if requirement_ids is not None:
+            payload["jiraRequirementIDs"] = [str(value) for value in requirement_ids]
+        component_ids = fields.get("component_ids")
+        if component_ids is not None:
+            payload["jiraComponentIDs"] = [int(value) for value in component_ids]
+        release_ids = fields.get("release_ids")
+        if release_ids is not None:
+            payload["jiraReleaseIDs"] = [int(value) for value in release_ids]
+
+        custom_fields = fields.get("custom_fields")
+        if custom_fields is not None:
+            payload["customFields"] = self._build_custom_fields(
+                project_key, custom_fields, escape_rich_text=escape_rich_text
+            )
+        return payload
+
+    def _build_custom_fields(
+        self,
+        project_key: str,
+        custom_fields: Any,
+        *,
+        escape_rich_text: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Translate custom field values into the API payload shape.
+
+        Args:
+            project_key: Jira project key or ID.
+            custom_fields: Either a mapping of field name to value, or a list of
+                ``{"name"|"id": ..., "value": ...}`` entries.
+            escape_rich_text: Escape multi-line text values as HTML, for requests
+                that are sent with ``needDataInRTF`` enabled.
+
+        Returns:
+            A list of ``{"ID": ..., "name": ..., "value": ...}`` entries.
+
+        Raises:
+            ValueError: If a custom field name is not defined for the project.
+        """
+        if isinstance(custom_fields, dict):
+            entries = [
+                {"name": name, "value": value} for name, value in custom_fields.items()
+            ]
+        elif isinstance(custom_fields, list):
+            entries = list(custom_fields)
+        else:
+            raise ValueError(
+                "custom_fields must be an object of name/value pairs or a list "
+                "of {name|id, value} entries"
+            )
+
+        config = self.get_project_configuration(project_key)
+        defined = [
+            field
+            for field in (config.get("customFields") or [])
+            if isinstance(field, dict)
+        ]
+        by_name = {
+            str(field.get("name", "")).lower(): field
+            for field in defined
+            if field.get("name")
+        }
+        rich_text_ids = {
+            field.get("ID")
+            for field in defined
+            if field.get("type") == RICH_TEXT_CUSTOM_FIELD_TYPE
+        }
+
+        payload: dict[int | str, dict[str, Any]] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    "Each custom field entry must be an object with name or id "
+                    "and value"
+                )
+            field_id = entry.get("id", entry.get("ID"))
+            name = entry.get("name")
+            if field_id is None:
+                if not name:
+                    raise ValueError("Custom field entries need a name or an id")
+                match = by_name.get(str(name).lower())
+                if match is None:
+                    available = ", ".join(sorted(str(f.get("name")) for f in defined))
+                    raise ValueError(
+                        f"Custom field '{name}' is not defined for project "
+                        f"'{project_key}'. Available: {available or 'none'}"
+                    )
+                field_id = match.get("ID")
+                name = match.get("name")
+            value = entry.get("value")
+            if escape_rich_text and field_id in rich_text_ids:
+                value = _plain_text_to_html(value)
+            payload[field_id if field_id is not None else str(name)] = {
+                "ID": field_id,
+                "name": name,
+                "value": value,
+            }
+        return list(payload.values())

--- a/src/mcp_atlassian/aio/client.py
+++ b/src/mcp_atlassian/aio/client.py
@@ -1,0 +1,268 @@
+"""Base client module for AIO Tests API interactions."""
+
+import logging
+import os
+from typing import Any
+from urllib.parse import quote
+
+import requests
+from requests import Response, Session
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.utils.logging import log_config_param, mask_sensitive
+from mcp_atlassian.utils.ssl import configure_ssl_verification
+
+from .config import AIOConfig
+
+logger = logging.getLogger("mcp-aio")
+
+# Requests that take longer than this are aborted, in seconds.
+DEFAULT_TIMEOUT = 60
+
+
+class AIOApiError(Exception):
+    """Raised when the AIO Tests API returns an error response."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        """Initialize the error.
+
+        Args:
+            message: Human-readable error message.
+            status_code: HTTP status code returned by the API, if any.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class AIOClient:
+    """Base client for AIO Tests API interactions.
+
+    AIO Tests is not covered by ``atlassian-python-api``, so this client speaks
+    to the REST API directly over a configured :class:`requests.Session`.
+    """
+
+    config: AIOConfig
+
+    def __init__(self, config: AIOConfig | None = None) -> None:
+        """Initialize the AIO Tests client.
+
+        Args:
+            config: Optional configuration object (loaded from env vars if omitted).
+
+        Raises:
+            ValueError: If the configuration is invalid or credentials are missing.
+        """
+        self.config = config or AIOConfig.from_env()
+        self.session = Session()
+
+        if self.config.auth_type == "token":
+            logger.debug(
+                "Initializing AIO Tests client with AioAuth token. "
+                f"URL: {self.config.url}, "
+                f"Token (masked): {mask_sensitive(str(self.config.api_token))}"
+            )
+            self.session.headers["Authorization"] = f"AioAuth {self.config.api_token}"
+        elif self.config.auth_type == "pat":
+            logger.debug(
+                "Initializing AIO Tests client with Token (PAT) auth. "
+                f"URL: {self.config.url}, "
+                f"Token (masked): {mask_sensitive(str(self.config.personal_token))}"
+            )
+            self.session.headers["Authorization"] = (
+                f"Bearer {self.config.personal_token}"
+            )
+        else:  # basic auth
+            logger.debug(
+                "Initializing AIO Tests client with Basic auth. "
+                f"URL: {self.config.url}, Username: {self.config.username}"
+            )
+            self.session.auth = (
+                str(self.config.username),
+                str(self.config.password),
+            )
+
+        self.session.headers["Accept"] = "application/json"
+
+        configure_ssl_verification(
+            service_name="AIO Tests",
+            url=self.config.url,
+            session=self.session,
+            ssl_verify=self.config.ssl_verify,
+            client_cert=self.config.client_cert,
+            client_key=self.config.client_key,
+            client_key_password=self.config.client_key_password,
+        )
+
+        proxies = {}
+        if self.config.http_proxy:
+            proxies["http"] = self.config.http_proxy
+        if self.config.https_proxy:
+            proxies["https"] = self.config.https_proxy
+        if self.config.socks_proxy:
+            proxies["socks"] = self.config.socks_proxy
+        if proxies:
+            self.session.proxies.update(proxies)
+            for key, value in proxies.items():
+                log_config_param(
+                    logger, "AIO Tests", f"{key.upper()}_PROXY", value, sensitive=True
+                )
+        if self.config.no_proxy and isinstance(self.config.no_proxy, str):
+            os.environ["NO_PROXY"] = self.config.no_proxy
+            log_config_param(logger, "AIO Tests", "NO_PROXY", self.config.no_proxy)
+
+        if self.config.custom_headers:
+            logger.debug(
+                f"Applying {len(self.config.custom_headers)} custom headers to "
+                "AIO Tests session"
+            )
+            self.session.headers.update(self.config.custom_headers)
+
+    @staticmethod
+    def project_path(project_key: str, *segments: str | int) -> str:
+        """Build a project-scoped API path with URL-escaped segments.
+
+        Args:
+            project_key: Jira project key or numeric ID.
+            *segments: Additional path segments appended after the project.
+
+        Returns:
+            A relative API path such as ``/project/PROJ/testcase/detail``.
+
+        Raises:
+            ValueError: If the project key is empty.
+        """
+        if not str(project_key).strip():
+            raise ValueError("Project key or ID is required")
+        parts = [quote(str(project_key).strip(), safe="")]
+        parts.extend(quote(str(segment), safe="") for segment in segments)
+        return "/project/" + "/".join(parts)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: Any | None = None,
+    ) -> Any:
+        """Send a request to the AIO Tests API and return the decoded body.
+
+        Args:
+            method: HTTP method (``GET``, ``POST``, ``PUT``, ...).
+            path: API path relative to the configured base URL.
+            params: Optional query parameters; ``None`` values are dropped.
+            json: Optional JSON request body.
+
+        Returns:
+            The decoded JSON response, or the raw text when the body is not JSON.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If the API rejects the credentials.
+            AIOApiError: If the API returns any other error response.
+        """
+        url = f"{self.config.url}{path}"
+        query = (
+            {key: value for key, value in params.items() if value is not None}
+            if params
+            else None
+        )
+        logger.debug(f"AIO Tests request: {method} {url} params={query}")
+
+        try:
+            response = self.session.request(
+                method,
+                url,
+                params=query,
+                json=json,
+                timeout=DEFAULT_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            raise AIOApiError(f"Network error calling AIO Tests API: {exc}") from exc
+
+        if not response.ok:
+            self._raise_for_response(method, path, response)
+
+        if not response.content:
+            return None
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    @staticmethod
+    def _raise_for_response(method: str, path: str, response: Response) -> None:
+        """Translate an error response into the matching exception.
+
+        Args:
+            method: HTTP method of the failed request.
+            path: API path of the failed request.
+            response: The error response.
+
+        Raises:
+            MCPAtlassianAuthenticationError: For 401 and 403 responses.
+            AIOApiError: For every other error status.
+        """
+        detail = response.text.strip()
+        if len(detail) > 500:
+            detail = f"{detail[:500]}..."
+        message = (
+            f"AIO Tests API error {response.status_code} for {method} {path}"
+            f"{f': {detail}' if detail else ''}"
+        )
+        if response.status_code in (401, 403):
+            logger.error(message)
+            raise MCPAtlassianAuthenticationError(
+                f"Authentication failed for AIO Tests ({response.status_code}). "
+                "Verify AIO_API_TOKEN (Cloud) or the Jira credentials (Server/DC), "
+                "and that the user has access to the project."
+            )
+        logger.error(message)
+        raise AIOApiError(message, status_code=response.status_code)
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        """Send a GET request.
+
+        Args:
+            path: API path relative to the configured base URL.
+            params: Optional query parameters.
+
+        Returns:
+            The decoded JSON response.
+        """
+        return self.request("GET", path, params=params)
+
+    def post(
+        self,
+        path: str,
+        json: Any | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Send a POST request.
+
+        Args:
+            path: API path relative to the configured base URL.
+            json: Optional JSON request body.
+            params: Optional query parameters.
+
+        Returns:
+            The decoded JSON response.
+        """
+        return self.request("POST", path, params=params, json=json)
+
+    def put(
+        self,
+        path: str,
+        json: Any | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Send a PUT request.
+
+        Args:
+            path: API path relative to the configured base URL.
+            json: Optional JSON request body.
+            params: Optional query parameters.
+
+        Returns:
+            The decoded JSON response.
+        """
+        return self.request("PUT", path, params=params, json=json)

--- a/src/mcp_atlassian/aio/config.py
+++ b/src/mcp_atlassian/aio/config.py
@@ -1,0 +1,172 @@
+"""Configuration module for AIO Tests API interactions."""
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import urlparse
+
+from ..utils.env import get_custom_headers, is_env_ssl_verify, is_env_truthy
+from ..utils.urls import is_atlassian_cloud_url
+from .constants import AIO_CLOUD_API_BASE, AIO_CLOUD_HOSTNAME, AIO_SERVER_API_PATH
+
+logger = logging.getLogger("mcp-atlassian.aio.config")
+
+
+def _resolve_base_url(explicit_url: str | None, jira_url: str | None) -> str | None:
+    """Resolve the AIO Tests API base URL.
+
+    Args:
+        explicit_url: Value of AIO_URL, if set.
+        jira_url: Value of JIRA_URL, if set.
+
+    Returns:
+        The API base URL without a trailing slash, or None if it cannot be
+        determined.
+    """
+    if explicit_url:
+        return explicit_url.rstrip("/")
+    if not jira_url:
+        # Cloud is reachable without JIRA_URL: the AIO token identifies the tenant.
+        return AIO_CLOUD_API_BASE if os.getenv("AIO_API_TOKEN") else None
+    if is_atlassian_cloud_url(jira_url):
+        return AIO_CLOUD_API_BASE
+    return f"{jira_url.rstrip('/')}{AIO_SERVER_API_PATH}"
+
+
+@dataclass
+class AIOConfig:
+    """AIO Tests API configuration.
+
+    AIO Tests is a Jira app with its own REST API, so authentication differs by
+    deployment:
+
+    - Cloud: an AIO Tests access token sent as ``Authorization: AioAuth <token>``.
+    - Server/Data Center: the Jira credentials (personal access token or basic
+      auth), because the API is served from the Jira base URL.
+    """
+
+    url: str  # Base URL of the AIO Tests API (no trailing slash)
+    auth_type: Literal["token", "pat", "basic"]  # Authentication type
+    api_token: str | None = None  # AIO Tests access token (Cloud)
+    username: str | None = None  # Email or username (Server/DC basic auth)
+    password: str | None = None  # API token or password (Server/DC basic auth)
+    personal_token: str | None = None  # Personal access token (Server/DC)
+    ssl_verify: bool = True  # Whether to verify SSL certificates
+    http_proxy: str | None = None  # HTTP proxy URL
+    https_proxy: str | None = None  # HTTPS proxy URL
+    no_proxy: str | None = None  # Comma-separated list of hosts to bypass proxy
+    socks_proxy: str | None = None  # SOCKS proxy URL
+    custom_headers: dict[str, str] | None = None  # Custom HTTP headers
+    client_cert: str | None = None  # Client certificate file path (.pem)
+    client_key: str | None = None  # Client private key file path (.pem)
+    client_key_password: str | None = None  # Password for encrypted private key
+
+    @property
+    def is_cloud(self) -> bool:
+        """Check whether this configuration targets AIO Tests Cloud.
+
+        Returns:
+            True when the API base URL points at the AIO Tests Cloud service.
+        """
+        return urlparse(self.url).hostname == AIO_CLOUD_HOSTNAME
+
+    @classmethod
+    def from_env(cls) -> "AIOConfig":
+        """Create configuration from environment variables.
+
+        Returns:
+            AIOConfig with values from environment variables.
+
+        Raises:
+            ValueError: If the API base URL or credentials cannot be determined.
+        """
+        jira_url = os.getenv("JIRA_URL")
+        url = _resolve_base_url(os.getenv("AIO_URL"), jira_url)
+        if not url:
+            raise ValueError(
+                "Cannot determine the AIO Tests API URL. Set AIO_API_TOKEN for "
+                "AIO Tests Cloud, or set JIRA_URL (Server/Data Center), or set "
+                "AIO_URL explicitly."
+            )
+
+        api_token = os.getenv("AIO_API_TOKEN")
+        # Server/DC serves the AIO API from Jira, so fall back to Jira credentials.
+        personal_token = os.getenv("AIO_PERSONAL_TOKEN") or os.getenv(
+            "JIRA_PERSONAL_TOKEN"
+        )
+        username = os.getenv("AIO_USERNAME") or os.getenv("JIRA_USERNAME")
+        password = os.getenv("AIO_PASSWORD") or os.getenv("JIRA_API_TOKEN")
+
+        is_cloud = urlparse(url).hostname == AIO_CLOUD_HOSTNAME
+        auth_type: Literal["token", "pat", "basic"]
+        if api_token:
+            auth_type = "token"
+        elif is_cloud:
+            raise ValueError(
+                "AIO Tests Cloud requires an access token. Set AIO_API_TOKEN "
+                "(generate one in Jira under AIO Tests > API Access Token)."
+            )
+        elif personal_token:
+            auth_type = "pat"
+        elif username and password:
+            auth_type = "basic"
+        else:
+            raise ValueError(
+                "AIO Tests Server/Data Center authentication requires "
+                "AIO_PERSONAL_TOKEN or JIRA_PERSONAL_TOKEN, or a username and "
+                "password/API token pair."
+            )
+
+        return cls(
+            url=url,
+            auth_type=auth_type,
+            api_token=api_token,
+            username=username,
+            password=password,
+            personal_token=personal_token,
+            ssl_verify=is_env_ssl_verify("AIO_SSL_VERIFY"),
+            http_proxy=os.getenv("AIO_HTTP_PROXY", os.getenv("HTTP_PROXY")),
+            https_proxy=os.getenv("AIO_HTTPS_PROXY", os.getenv("HTTPS_PROXY")),
+            no_proxy=os.getenv("AIO_NO_PROXY", os.getenv("NO_PROXY")),
+            socks_proxy=os.getenv("AIO_SOCKS_PROXY", os.getenv("SOCKS_PROXY")),
+            custom_headers=get_custom_headers("AIO_CUSTOM_HEADERS"),
+            client_cert=os.getenv("AIO_CLIENT_CERT", os.getenv("JIRA_CLIENT_CERT")),
+            client_key=os.getenv("AIO_CLIENT_KEY", os.getenv("JIRA_CLIENT_KEY")),
+            client_key_password=os.getenv(
+                "AIO_CLIENT_KEY_PASSWORD", os.getenv("JIRA_CLIENT_KEY_PASSWORD")
+            ),
+        )
+
+    def is_auth_configured(self) -> bool:
+        """Check whether authentication is complete enough to call the API.
+
+        Returns:
+            True if authentication is fully configured, False otherwise.
+        """
+        if self.auth_type == "token":
+            return bool(self.api_token)
+        if self.auth_type == "pat":
+            return bool(self.personal_token)
+        if self.auth_type == "basic":
+            return bool(self.username and self.password)
+        logger.warning(f"Unknown or unsupported auth_type: {self.auth_type}")
+        return False
+
+
+def is_aio_enabled() -> bool:
+    """Check whether AIO Tests support should be activated.
+
+    AIO Tests Cloud opts in implicitly by providing an access token. Server/Data
+    Center reuses the Jira credentials, so it requires the explicit AIO_ENABLED
+    flag - otherwise every Jira deployment without the app installed would expose
+    tools that cannot work.
+
+    Returns:
+        True if AIO Tests tools should be registered.
+    """
+    if os.getenv("AIO_API_TOKEN"):
+        return True
+    if not is_env_truthy("AIO_ENABLED"):
+        return False
+    return bool(os.getenv("AIO_URL") or os.getenv("JIRA_URL"))

--- a/src/mcp_atlassian/aio/constants.py
+++ b/src/mcp_atlassian/aio/constants.py
@@ -1,0 +1,65 @@
+"""Constants for AIO Tests API interactions."""
+
+# Default base URL for the AIO Tests Cloud REST API (v1).
+AIO_CLOUD_API_BASE = "https://tcms.aiojiraapps.com/aio-tcms/api/v1"
+
+# Path appended to a Jira Server/Data Center base URL to reach the AIO Tests API.
+AIO_SERVER_API_PATH = "/rest/aio-tcms-api/1.0"
+
+# Hostname of the AIO Tests Cloud service.
+AIO_CLOUD_HOSTNAME = "tcms.aiojiraapps.com"
+
+# Entity types that own an independent folder tree in AIO Tests. The API path
+# segment matches the entity name, e.g. /project/{key}/testcase/folder.
+FOLDER_ENTITY_TYPES = ("testcase", "testcycle", "testset")
+
+# Default page size for paginated list/search calls. The API caps pages at 100
+# and silently resets anything outside 10-100 back to 100.
+DEFAULT_PAGE_SIZE = 50
+MIN_PAGE_SIZE = 10
+MAX_PAGE_SIZE = 100
+
+# Step types accepted by the Case create/update APIs.
+CLASSIC_STEP_TYPES = ("TEXT", "REFERENCE")
+BDD_STEP_TYPES = (
+    "BDD_GIVEN",
+    "BDD_WHEN",
+    "BDD_AND",
+    "BDD_BUT",
+    "BDD_THEN",
+    "BDD_STAR",
+)
+STEP_TYPES = CLASSIC_STEP_TYPES + BDD_STEP_TYPES
+
+# Comparison operators supported by the Case search API, per criteria type.
+LIST_COMPARISONS = ("IN",)
+TEXT_COMPARISONS = ("CONTAINS", "EXACT_MATCH")
+DATE_COMPARISONS = ("EMPTY", "BEFORE", "AFTER", "EQUALS", "BETWEEN")
+
+# Case attributes whose values are stored as rich text (HTML).
+RICH_TEXT_CASE_FIELDS = ("description", "precondition")
+
+# Step attributes whose values are stored as rich text (HTML).
+RICH_TEXT_STEP_KEYS = ("step", "data", "expectedResult", "bddStep")
+
+# Custom field type whose values are stored as rich text (HTML).
+RICH_TEXT_CUSTOM_FIELD_TYPE = "MULTI_LINE_TEXT"
+
+# Read-only Case attributes. These are rejected or ignored by the update API, so
+# they are stripped from any payload built from a previously fetched case.
+READ_ONLY_CASE_FIELDS = frozenset(
+    {
+        "attachments",
+        "createdDate",
+        "descriptionAttachments",
+        "hasDataSets",
+        "isArchived",
+        "jiraProjectID",
+        "key",
+        "permission",
+        "preconditionAttachments",
+        "updatedDate",
+        "version",
+        "versions",
+    }
+)

--- a/src/mcp_atlassian/aio/folders.py
+++ b/src/mcp_atlassian/aio/folders.py
@@ -1,0 +1,261 @@
+"""Module for AIO Tests folder operations."""
+
+import logging
+from typing import Any
+
+from ..models.aio import AIOFolder, AIOFolderTree
+from .client import AIOClient
+from .constants import FOLDER_ENTITY_TYPES
+
+logger = logging.getLogger("mcp-aio")
+
+
+def normalize_folder_path(folder_path: str) -> list[str]:
+    """Split a folder path into its individual folder names.
+
+    Args:
+        folder_path: Path such as ``/Release 1.0/Regression`` or a single name.
+
+    Returns:
+        The folder names in top-down order.
+
+    Raises:
+        ValueError: If the path contains no usable folder name.
+    """
+    names = [part.strip() for part in folder_path.split("/")]
+    names = [name for name in names if name]
+    if not names:
+        raise ValueError("Folder path must contain at least one folder name")
+    return names
+
+
+class FoldersMixin(AIOClient):
+    """Mixin for AIO Tests folder operations."""
+
+    _folder_tree_cache: dict[tuple[str, str], list[AIOFolderTree]]
+
+    @staticmethod
+    def _validate_folder_type(folder_type: str) -> str:
+        """Validate the folder entity type.
+
+        Args:
+            folder_type: One of ``testcase``, ``testcycle`` or ``testset``.
+
+        Returns:
+            The validated folder type.
+
+        Raises:
+            ValueError: If the folder type is not supported.
+        """
+        if folder_type not in FOLDER_ENTITY_TYPES:
+            raise ValueError(
+                f"Invalid folder type '{folder_type}'. Expected one of: "
+                f"{', '.join(FOLDER_ENTITY_TYPES)}"
+            )
+        return folder_type
+
+    def get_folder_hierarchy(
+        self,
+        project_key: str,
+        folder_type: str = "testcase",
+        *,
+        refresh: bool = False,
+    ) -> list[AIOFolderTree]:
+        """Retrieve the folder tree of a project.
+
+        Args:
+            project_key: Jira project key or ID.
+            folder_type: Folder tree to read: ``testcase``, ``testcycle`` or
+                ``testset``.
+            refresh: Bypass the per-instance cache.
+
+        Returns:
+            The root folders, each carrying its descendants and full path.
+        """
+        folder_type = self._validate_folder_type(folder_type)
+        cache = getattr(self, "_folder_tree_cache", None)
+        if cache is None:
+            cache = {}
+            self._folder_tree_cache = cache
+        cache_key = (str(project_key), folder_type)
+        if not refresh and cache_key in cache:
+            return cache[cache_key]
+
+        response = self.get(self.project_path(project_key, folder_type, "folder"))
+        folders = [
+            AIOFolderTree.from_api_response(item)
+            for item in (response or [])
+            if isinstance(item, dict)
+        ]
+        cache[cache_key] = folders
+        return folders
+
+    def flatten_folders(
+        self,
+        project_key: str,
+        folder_type: str = "testcase",
+        *,
+        refresh: bool = False,
+    ) -> list[AIOFolder]:
+        """Retrieve the folder tree flattened into a list with full paths.
+
+        Args:
+            project_key: Jira project key or ID.
+            folder_type: Folder tree to read.
+            refresh: Bypass the per-instance cache.
+
+        Returns:
+            Every folder in the tree, parents before children.
+        """
+        folders: list[AIOFolder] = []
+        for root in self.get_folder_hierarchy(
+            project_key, folder_type, refresh=refresh
+        ):
+            folders.extend(root.flatten())
+        return folders
+
+    def find_folder(
+        self,
+        project_key: str,
+        folder_path: str,
+        folder_type: str = "testcase",
+        *,
+        refresh: bool = False,
+    ) -> AIOFolder | None:
+        """Find a folder by full path, or by name when the name is unique.
+
+        Args:
+            project_key: Jira project key or ID.
+            folder_path: Full path such as ``/Regression/Checkout``, or a folder
+                name.
+            folder_type: Folder tree to search.
+            refresh: Bypass the per-instance cache.
+
+        Returns:
+            The matching folder, or None when no folder matches.
+
+        Raises:
+            ValueError: If a bare name matches more than one folder.
+        """
+        names = normalize_folder_path(folder_path)
+        wanted_path = "/" + "/".join(names)
+        folders = self.flatten_folders(project_key, folder_type, refresh=refresh)
+
+        for folder in folders:
+            if (folder.path or "").lower() == wanted_path.lower():
+                return folder
+        if len(names) > 1:
+            return None
+
+        matches = [
+            folder
+            for folder in folders
+            if (folder.name or "").lower() == names[0].lower()
+        ]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            paths = ", ".join(str(folder.path) for folder in matches)
+            raise ValueError(
+                f"Folder name '{names[0]}' is ambiguous in project "
+                f"'{project_key}'. Use a full path. Matches: {paths}"
+            )
+        return matches[0]
+
+    def create_folder(
+        self,
+        project_key: str,
+        folder_path: str,
+        folder_type: str = "testcase",
+        parent_folder_id: int | None = None,
+    ) -> AIOFolder:
+        """Create a folder hierarchy, returning the leaf folder.
+
+        The AIO Tests API is get-or-create: existing folders in the path are
+        reused and only the missing ones are created.
+
+        Args:
+            project_key: Jira project key or ID.
+            folder_path: Folder name, or a path such as
+                ``/Release 1.0/Regression/Checkout`` to create nested folders.
+            folder_type: Folder tree to create in: ``testcase``, ``testcycle`` or
+                ``testset``.
+            parent_folder_id: Optional existing folder to create the path under.
+                Omit to create from the top level.
+
+        Returns:
+            The leaf folder of the created (or already existing) hierarchy.
+        """
+        folder_type = self._validate_folder_type(folder_type)
+        names = normalize_folder_path(folder_path)
+        payload: dict[str, Any] = {"folderHierarchy": names}
+        if parent_folder_id is not None:
+            payload["baseFolderId"] = parent_folder_id
+
+        response = self.put(
+            self.project_path(project_key, folder_type, "folder", "hierarchy"),
+            json=payload,
+        )
+        # The tree changed, so drop the cached copy for this project.
+        cache = getattr(self, "_folder_tree_cache", None)
+        if cache is not None:
+            cache.pop((str(project_key), folder_type), None)
+
+        folder = AIOFolder.from_api_response(
+            response if isinstance(response, dict) else {}
+        )
+        if folder.id is not None and not folder.path:
+            resolved = next(
+                (
+                    item
+                    for item in self.flatten_folders(project_key, folder_type)
+                    if item.id == folder.id
+                ),
+                None,
+            )
+            if resolved is not None:
+                folder.path = resolved.path
+                folder.parent_id = resolved.parent_id
+        return folder
+
+    def resolve_folder_id(
+        self,
+        project_key: str,
+        folder: Any,
+        folder_type: str = "testcase",
+        *,
+        create_missing: bool = False,
+    ) -> int | None:
+        """Resolve a folder given as an ID, a name or a path to its numeric ID.
+
+        Args:
+            project_key: Jira project key or ID.
+            folder: Numeric folder ID, numeric string, folder name or path.
+            folder_type: Folder tree to search.
+            create_missing: Create the folder hierarchy when it does not exist.
+
+        Returns:
+            The folder ID, or None when no folder was given.
+
+        Raises:
+            ValueError: If the folder does not exist and ``create_missing`` is
+                False.
+        """
+        if folder is None or (isinstance(folder, str) and not folder.strip()):
+            return None
+        if isinstance(folder, int) and not isinstance(folder, bool):
+            return folder
+        text = str(folder).strip()
+        if text.isdigit():
+            return int(text)
+
+        found = self.find_folder(project_key, text, folder_type)
+        if found is not None and found.id is not None:
+            return found.id
+        if not create_missing:
+            raise ValueError(
+                f"Folder '{text}' was not found in project '{project_key}'. "
+                "Create it first with aio_create_folder, or pass a folder ID."
+            )
+        created = self.create_folder(project_key, text, folder_type)
+        return created.id

--- a/src/mcp_atlassian/aio/projects.py
+++ b/src/mcp_atlassian/aio/projects.py
@@ -1,0 +1,266 @@
+"""Module for AIO Tests project and schema operations."""
+
+import logging
+from typing import Any
+
+from ..models.aio import AIOProject, AIOSchemaField, AIOTestCaseSchema
+from .client import AIOApiError, AIOClient
+
+logger = logging.getLogger("mcp-aio")
+
+# Built-in test case fields accepted by the Create/Update Case APIs. AIO Tests
+# reports only custom fields in its project configuration, so the built-in ones
+# are described here to give the full picture in one schema call.
+CASE_FIELD_CATALOG: tuple[AIOSchemaField, ...] = (
+    AIOSchemaField(
+        name="title",
+        type="string",
+        description="Case title. The only mandatory field when creating a case.",
+        required=True,
+    ),
+    AIOSchemaField(
+        name="description",
+        type="string",
+        description="Case description. Accepts HTML when include_rtf is enabled.",
+    ),
+    AIOSchemaField(
+        name="precondition",
+        type="string",
+        description="Conditions that must hold before the case can be executed.",
+    ),
+    AIOSchemaField(
+        name="folder",
+        type="folder",
+        description=(
+            "Folder the case belongs to. Cases without a folder land in 'Not Assigned'."
+        ),
+    ),
+    AIOSchemaField(
+        name="status",
+        type="lookup",
+        description="Case status, e.g. Draft or Published.",
+        allowed_values_from="statuses",
+    ),
+    AIOSchemaField(
+        name="priority",
+        type="lookup",
+        description="Case priority, e.g. Critical or Low.",
+        allowed_values_from="priorities",
+    ),
+    AIOSchemaField(
+        name="type",
+        type="lookup",
+        description="Case type, e.g. Functional or Performance.",
+        allowed_values_from="types",
+    ),
+    AIOSchemaField(
+        name="scriptType",
+        type="lookup",
+        description="Step style: Classic (step/data/expected result) or BDD.",
+        allowed_values_from="script_types",
+    ),
+    AIOSchemaField(
+        name="steps",
+        type="array",
+        description=(
+            "Ordered test steps. Classic steps use step/data/expectedResult with "
+            "stepType TEXT; BDD steps use bddStep with a BDD_* stepType."
+        ),
+    ),
+    AIOSchemaField(
+        name="tags",
+        type="array",
+        description="Tags associated with the case.",
+    ),
+    AIOSchemaField(
+        name="ownedByID",
+        type="string",
+        description="Jira account ID of the case owner.",
+    ),
+    AIOSchemaField(
+        name="estimatedEffort",
+        type="integer",
+        description="Estimated execution effort in seconds.",
+    ),
+    AIOSchemaField(
+        name="automationStatus",
+        type="lookup",
+        description="Automation status, e.g. Manual or Automated.",
+        allowed_values_from="automation_statuses",
+    ),
+    AIOSchemaField(
+        name="automationKey",
+        type="string",
+        description="Key used to match imported automated execution results.",
+    ),
+    AIOSchemaField(
+        name="automationOwnerID",
+        type="string",
+        description="Jira account ID of the automation owner.",
+    ),
+    AIOSchemaField(
+        name="jiraRequirementIDs",
+        type="array",
+        description="Jira issue keys or IDs covered by the case.",
+    ),
+    AIOSchemaField(
+        name="jiraComponentIDs",
+        type="array",
+        description="Jira component IDs associated with the case.",
+    ),
+    AIOSchemaField(
+        name="jiraReleaseIDs",
+        type="array",
+        description="Jira release (version) IDs associated with the case.",
+    ),
+    AIOSchemaField(
+        name="customFields",
+        type="array",
+        description="Custom field values, each identified by ID or name.",
+    ),
+    AIOSchemaField(
+        name="key",
+        type="string",
+        description="Case key such as AT-TC-17.",
+        read_only=True,
+    ),
+    AIOSchemaField(
+        name="version",
+        type="integer",
+        description="Case version number.",
+        read_only=True,
+    ),
+    AIOSchemaField(
+        name="createdDate",
+        type="date-time",
+        description="Creation timestamp.",
+        read_only=True,
+    ),
+    AIOSchemaField(
+        name="updatedDate",
+        type="date-time",
+        description="Last update timestamp.",
+        read_only=True,
+    ),
+    AIOSchemaField(
+        name="isArchived",
+        type="boolean",
+        description="Whether the case is archived.",
+        read_only=True,
+    ),
+)
+
+
+class ProjectsMixin(AIOClient):
+    """Mixin for AIO Tests project configuration operations."""
+
+    _project_config_cache: dict[str, dict[str, Any]]
+
+    def get_project_configuration(
+        self, project_key: str, *, refresh: bool = False
+    ) -> dict[str, Any]:
+        """Fetch the AIO Tests configuration of a Jira project.
+
+        The result is cached per client instance because it backs name-to-ID
+        resolution for statuses, priorities, types and custom fields.
+
+        Args:
+            project_key: Jira project key or ID.
+            refresh: Bypass the cache and re-fetch the configuration.
+
+        Returns:
+            The raw project configuration payload.
+        """
+        cache = getattr(self, "_project_config_cache", None)
+        if cache is None:
+            cache = {}
+            self._project_config_cache = cache
+        cache_key = str(project_key)
+        if not refresh and cache_key in cache:
+            return cache[cache_key]
+
+        config = self.get(self.project_path(project_key, "config"))
+        if not isinstance(config, dict):
+            raise AIOApiError(
+                f"Unexpected AIO Tests configuration response for '{project_key}'"
+            )
+        cache[cache_key] = config
+        return config
+
+    def get_project(self, project_key: str) -> AIOProject:
+        """Check whether AIO Tests is enabled for a project and describe it.
+
+        Args:
+            project_key: Jira project key or ID.
+
+        Returns:
+            Project information including the resolved Jira project ID. When AIO
+            Tests is not enabled (or the project is unknown), ``aio_enabled`` is
+            False and ``error`` explains why.
+        """
+        try:
+            config = self.get_project_configuration(project_key)
+        except AIOApiError as exc:
+            logger.info(f"AIO Tests is unavailable for project '{project_key}': {exc}")
+            return AIOProject(key=project_key, aio_enabled=False, error=str(exc))
+        return AIOProject.from_api_response(config, project_key=project_key)
+
+    def get_test_case_schema(self, project_key: str) -> AIOTestCaseSchema:
+        """Retrieve the complete test case schema configuration for a project.
+
+        Args:
+            project_key: Jira project key or ID.
+
+        Returns:
+            The schema: built-in fields, custom fields, required fields and the
+            allowed values for every lookup field.
+        """
+        config = self.get_project_configuration(project_key)
+        return AIOTestCaseSchema.from_api_response(
+            config, project_key=project_key, fields=list(CASE_FIELD_CATALOG)
+        )
+
+    def resolve_lookup_id(
+        self, project_key: str, config_key: str, value: Any
+    ) -> int | None:
+        """Resolve a lookup value given as a name or an ID to its numeric ID.
+
+        Args:
+            project_key: Jira project key or ID.
+            config_key: Key in the project configuration, e.g. ``casePriorities``.
+            value: A numeric ID, a numeric string, or a case-insensitive name.
+
+        Returns:
+            The numeric ID, or None when the value is empty.
+
+        Raises:
+            ValueError: If a name is given that the project does not define.
+        """
+        if value is None or (isinstance(value, str) and not value.strip()):
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"Invalid value for {config_key}: {value!r}")
+        if isinstance(value, int):
+            return value
+        text = str(value).strip()
+        if text.isdigit():
+            return int(text)
+
+        config = self.get_project_configuration(project_key)
+        options = [
+            option
+            for option in (config.get(config_key) or [])
+            if isinstance(option, dict)
+        ]
+        for option in options:
+            if str(option.get("name", "")).strip().lower() == text.lower():
+                option_id = option.get("ID")
+                if option_id is not None:
+                    return int(option_id)
+        available = ", ".join(
+            str(option.get("name")) for option in options if option.get("name")
+        )
+        raise ValueError(
+            f"'{text}' is not a valid {config_key} value for project "
+            f"'{project_key}'. Available values: {available or 'none'}"
+        )

--- a/src/mcp_atlassian/aio/tags.py
+++ b/src/mcp_atlassian/aio/tags.py
@@ -1,0 +1,125 @@
+"""Module for AIO Tests tag operations."""
+
+import logging
+from typing import Any
+
+from ..models.aio import AIOTag
+from .client import AIOClient
+
+logger = logging.getLogger("mcp-aio")
+
+
+class TagsMixin(AIOClient):
+    """Mixin for AIO Tests tag operations."""
+
+    def get_tags(self, project_key: str) -> list[AIOTag]:
+        """Retrieve every tag defined for a project.
+
+        Args:
+            project_key: Jira project key or ID.
+
+        Returns:
+            The tags configured in AIO Tests for the project.
+        """
+        response = self.get(self.project_path(project_key, "tag"))
+        return [
+            AIOTag.from_api_response(item)
+            for item in (response or [])
+            if isinstance(item, dict)
+        ]
+
+    def create_tags(self, project_key: str, names: list[str]) -> list[AIOTag]:
+        """Create tags in a project.
+
+        Args:
+            project_key: Jira project key or ID.
+            names: Names of the tags to create.
+
+        Returns:
+            The newly created tags.
+        """
+        response = self.post(
+            self.project_path(project_key, "tag"),
+            json=[{"name": name} for name in names],
+        )
+        return [
+            AIOTag.from_api_response(item)
+            for item in (response or [])
+            if isinstance(item, dict)
+        ]
+
+    def resolve_tags(
+        self, project_key: str, tags: list[Any], *, create_missing: bool = True
+    ) -> list[dict[str, Any]]:
+        """Resolve tag names or IDs into the payload shape used by case APIs.
+
+        Args:
+            project_key: Jira project key or ID.
+            tags: Tag names, numeric IDs or numeric strings.
+            create_missing: Create tags that the project does not define yet.
+                A case cannot reference a tag that does not exist.
+
+        Returns:
+            A list of ``{"tag": {"ID": ..., "name": ...}}`` entries.
+
+        Raises:
+            ValueError: If a tag is unknown and ``create_missing`` is False.
+        """
+        if not tags:
+            return []
+        existing = {
+            (tag.name or "").lower(): tag for tag in self.get_tags(project_key) if tag
+        }
+        by_id = {tag.id: tag for tag in existing.values() if tag.id is not None}
+
+        resolved: list[dict[str, Any]] = []
+        missing: list[str] = []
+        for value in tags:
+            if isinstance(value, int) and not isinstance(value, bool):
+                tag = by_id.get(value)
+                resolved.append(
+                    {"tag": {"ID": value, "name": tag.name} if tag else {"ID": value}}
+                )
+                continue
+            text = str(value).strip()
+            if not text:
+                continue
+            if text.isdigit():
+                tag = by_id.get(int(text))
+                resolved.append(
+                    {
+                        "tag": {"ID": int(text), "name": tag.name}
+                        if tag
+                        else {"ID": int(text)}
+                    }
+                )
+                continue
+            tag = existing.get(text.lower())
+            if tag is not None:
+                resolved.append({"tag": {"ID": tag.id, "name": tag.name}})
+            else:
+                missing.append(text)
+                resolved.append({"tag": {"name": text}})
+
+        if missing:
+            if not create_missing:
+                raise ValueError(
+                    f"Unknown tags for project '{project_key}': {', '.join(missing)}"
+                )
+            logger.info(
+                f"Creating {len(missing)} new AIO Tests tag(s) in '{project_key}': "
+                f"{', '.join(missing)}"
+            )
+            created = {
+                (tag.name or "").lower(): tag
+                for tag in self.create_tags(project_key, missing)
+            }
+            for entry in resolved:
+                tag_payload = entry["tag"]
+                if "ID" in tag_payload:
+                    continue
+                created_tag = created.get(str(tag_payload.get("name", "")).lower())
+                if created_tag is not None:
+                    tag_payload["ID"] = created_tag.id
+
+        return resolved

--- a/src/mcp_atlassian/models/__init__.py
+++ b/src/mcp_atlassian/models/__init__.py
@@ -1,10 +1,26 @@
 """
-Pydantic models for Jira and Confluence API responses.
+Pydantic models for Jira, Confluence and AIO Tests API responses.
 
 This package provides type-safe models for working with Atlassian API data,
 including conversion methods from API responses to structured models and
 simplified dictionaries for API responses.
 """
+
+# AIO Tests models
+from .aio import (
+    AIOCustomField,
+    AIOEntity,
+    AIOFolder,
+    AIOFolderTree,
+    AIOProject,
+    AIOSchemaField,
+    AIOTag,
+    AIOTestCase,
+    AIOTestCaseSchema,
+    AIOTestCaseSearchResult,
+    AIOTestCaseVersion,
+    AIOTestStep,
+)
 
 # Re-export models for easier imports
 from .base import ApiModel, TimestampMixin
@@ -63,6 +79,19 @@ __all__ = [
     # Base models
     "ApiModel",
     "TimestampMixin",
+    # AIO Tests models
+    "AIOCustomField",
+    "AIOEntity",
+    "AIOFolder",
+    "AIOFolderTree",
+    "AIOProject",
+    "AIOSchemaField",
+    "AIOTag",
+    "AIOTestCase",
+    "AIOTestCaseSchema",
+    "AIOTestCaseSearchResult",
+    "AIOTestCaseVersion",
+    "AIOTestStep",
     # Constants
     "CONFLUENCE_DEFAULT_ID",
     "CONFLUENCE_DEFAULT_SPACE",

--- a/src/mcp_atlassian/models/aio/__init__.py
+++ b/src/mcp_atlassian/models/aio/__init__.py
@@ -1,0 +1,30 @@
+"""AIO Tests data models for the MCP Atlassian integration."""
+
+from .case import (
+    AIOTestCase,
+    AIOTestCaseSearchResult,
+    AIOTestCaseVersion,
+    AIOTestStep,
+)
+from .common import AIOEntity, AIOFolder, AIOFolderTree, AIOTag
+from .project import (
+    AIOCustomField,
+    AIOProject,
+    AIOSchemaField,
+    AIOTestCaseSchema,
+)
+
+__all__ = [
+    "AIOCustomField",
+    "AIOEntity",
+    "AIOFolder",
+    "AIOFolderTree",
+    "AIOProject",
+    "AIOSchemaField",
+    "AIOTag",
+    "AIOTestCase",
+    "AIOTestCaseSchema",
+    "AIOTestCaseSearchResult",
+    "AIOTestCaseVersion",
+    "AIOTestStep",
+]

--- a/src/mcp_atlassian/models/aio/case.py
+++ b/src/mcp_atlassian/models/aio/case.py
@@ -1,0 +1,324 @@
+"""Models for AIO Tests test cases."""
+
+from typing import Any
+
+from ..base import ApiModel
+from .common import AIOEntity, AIOFolder, AIOTag
+
+
+class AIOTestStep(ApiModel):
+    """A single step of a test case, in either Classic or BDD form."""
+
+    id: int | None = None
+    step_type: str | None = None
+    step: str | None = None
+    data: str | None = None
+    expected_result: str | None = None
+    bdd_step: str | None = None
+    referenced_case_key: str | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOTestStep":
+        """Create a step from an AIO Tests API response.
+
+        Args:
+            data: Raw step payload.
+            **kwargs: Unused, accepted for interface compatibility.
+
+        Returns:
+            The parsed step.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        referenced = data.get("referencedCase")
+        return cls(
+            id=data.get("ID"),
+            step_type=data.get("stepType"),
+            step=data.get("step"),
+            data=data.get("data"),
+            expected_result=data.get("expectedResult"),
+            bdd_step=data.get("bddStep"),
+            referenced_case_key=(
+                referenced.get("key") if isinstance(referenced, dict) else None
+            ),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary with the populated step fields.
+        """
+        result: dict[str, Any] = {}
+        if self.id is not None:
+            result["id"] = self.id
+        if self.step_type:
+            result["step_type"] = self.step_type
+        if self.step:
+            result["step"] = self.step
+        if self.data:
+            result["data"] = self.data
+        if self.expected_result:
+            result["expected_result"] = self.expected_result
+        if self.bdd_step:
+            result["bdd_step"] = self.bdd_step
+        if self.referenced_case_key:
+            result["referenced_case_key"] = self.referenced_case_key
+        return result
+
+
+class AIOTestCaseVersion(ApiModel):
+    """A saved version of a test case."""
+
+    version: int | None = None
+    id: int | None = None
+    is_current: bool = False
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "AIOTestCaseVersion":
+        """Create a version entry from an AIO Tests API response.
+
+        Args:
+            data: Raw ``{"version": n, "ID": n}`` payload.
+            **kwargs: Optional ``current_version`` to flag the active version.
+
+        Returns:
+            The parsed version entry.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        version = data.get("version")
+        current_version = kwargs.get("current_version")
+        return cls(
+            version=version,
+            id=data.get("ID"),
+            is_current=version is not None and version == current_version,
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary with the version number, case ID and current flag.
+        """
+        result: dict[str, Any] = {"is_current": self.is_current}
+        if self.version is not None:
+            result["version"] = self.version
+        if self.id is not None:
+            result["id"] = self.id
+        return result
+
+
+class AIOTestCase(ApiModel):
+    """Full details of an AIO Tests test case."""
+
+    id: int | None = None
+    key: str | None = None
+    title: str | None = None
+    version: int | None = None
+    description: str | None = None
+    precondition: str | None = None
+    owned_by_id: str | None = None
+    folder: AIOFolder | None = None
+    status: AIOEntity | None = None
+    priority: AIOEntity | None = None
+    type: AIOEntity | None = None
+    script_type: AIOEntity | None = None
+    automation_status: AIOEntity | None = None
+    automation_key: str | None = None
+    automation_owner_id: str | None = None
+    estimated_effort: int | None = None
+    jira_project_id: int | None = None
+    jira_component_ids: list[int] = []
+    jira_release_ids: list[int] = []
+    jira_requirement_ids: list[str] = []
+    tags: list[AIOTag] = []
+    steps: list[AIOTestStep] = []
+    custom_fields: list[dict[str, Any]] = []
+    versions: list[AIOTestCaseVersion] = []
+    created_date: str | None = None
+    updated_date: str | None = None
+    is_archived: bool | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOTestCase":
+        """Create a test case from an AIO Tests API response.
+
+        Args:
+            data: Raw ``CaseFullDetails`` payload.
+            **kwargs: Unused, accepted for interface compatibility.
+
+        Returns:
+            The parsed test case.
+        """
+        if not isinstance(data, dict):
+            return cls()
+
+        def entity(key: str) -> AIOEntity | None:
+            value = data.get(key)
+            return (
+                AIOEntity.from_api_response(value) if isinstance(value, dict) else None
+            )
+
+        folder = data.get("folder")
+        version = data.get("version")
+        return cls(
+            id=data.get("ID"),
+            key=data.get("key"),
+            title=data.get("title"),
+            version=version,
+            description=data.get("description"),
+            precondition=data.get("precondition"),
+            owned_by_id=data.get("ownedByID"),
+            folder=(
+                AIOFolder.from_api_response(folder)
+                if isinstance(folder, dict)
+                else None
+            ),
+            status=entity("status"),
+            priority=entity("priority"),
+            type=entity("type"),
+            script_type=entity("scriptType"),
+            automation_status=entity("automationStatus"),
+            automation_key=data.get("automationKey"),
+            automation_owner_id=data.get("automationOwnerID"),
+            estimated_effort=data.get("estimatedEffort"),
+            jira_project_id=data.get("jiraProjectID"),
+            jira_component_ids=list(data.get("jiraComponentIDs") or []),
+            jira_release_ids=list(data.get("jiraReleaseIDs") or []),
+            jira_requirement_ids=[
+                str(value) for value in (data.get("jiraRequirementIDs") or [])
+            ],
+            tags=[
+                AIOTag.from_api_response(tag)
+                for tag in (data.get("tags") or [])
+                if isinstance(tag, dict)
+            ],
+            steps=[
+                AIOTestStep.from_api_response(step)
+                for step in (data.get("steps") or [])
+                if isinstance(step, dict)
+            ],
+            custom_fields=[
+                field
+                for field in (data.get("customFields") or [])
+                if isinstance(field, dict)
+            ],
+            versions=[
+                AIOTestCaseVersion.from_api_response(entry, current_version=version)
+                for entry in (data.get("versions") or [])
+                if isinstance(entry, dict)
+            ],
+            created_date=data.get("createdDate"),
+            updated_date=data.get("updatedDate"),
+            is_archived=data.get("isArchived"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary with the populated test case fields.
+        """
+        result: dict[str, Any] = {}
+        for key, value in (
+            ("id", self.id),
+            ("key", self.key),
+            ("title", self.title),
+            ("version", self.version),
+            ("description", self.description),
+            ("precondition", self.precondition),
+            ("owned_by_id", self.owned_by_id),
+            ("automation_key", self.automation_key),
+            ("automation_owner_id", self.automation_owner_id),
+            ("estimated_effort", self.estimated_effort),
+            ("jira_project_id", self.jira_project_id),
+            ("created_date", self.created_date),
+            ("updated_date", self.updated_date),
+            ("is_archived", self.is_archived),
+        ):
+            if value is not None:
+                result[key] = value
+
+        for key, entity in (
+            ("folder", self.folder),
+            ("status", self.status),
+            ("priority", self.priority),
+            ("type", self.type),
+            ("script_type", self.script_type),
+            ("automation_status", self.automation_status),
+        ):
+            if entity is not None:
+                simplified = entity.to_simplified_dict()
+                if simplified:
+                    result[key] = simplified
+
+        if self.jira_component_ids:
+            result["jira_component_ids"] = self.jira_component_ids
+        if self.jira_release_ids:
+            result["jira_release_ids"] = self.jira_release_ids
+        if self.jira_requirement_ids:
+            result["jira_requirement_ids"] = self.jira_requirement_ids
+        if self.tags:
+            result["tags"] = [tag.to_simplified_dict() for tag in self.tags]
+        if self.steps:
+            result["steps"] = [step.to_simplified_dict() for step in self.steps]
+        if self.custom_fields:
+            result["custom_fields"] = self.custom_fields
+        if self.versions:
+            result["versions"] = [
+                version.to_simplified_dict() for version in self.versions
+            ]
+        return result
+
+
+class AIOTestCaseSearchResult(ApiModel):
+    """A page of test cases returned by the list or search API."""
+
+    cases: list[AIOTestCase] = []
+    start_at: int = 0
+    max_results: int = 0
+    is_last: bool = True
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "AIOTestCaseSearchResult":
+        """Create a search result page from an AIO Tests API response.
+
+        Args:
+            data: Raw ``TestCasePaginatedResponse`` payload.
+            **kwargs: Unused, accepted for interface compatibility.
+
+        Returns:
+            The parsed page of results.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        items = data.get("items") or []
+        return cls(
+            cases=[
+                AIOTestCase.from_api_response(item)
+                for item in items
+                if isinstance(item, dict)
+            ],
+            start_at=data.get("startAt") or 0,
+            max_results=data.get("maxResults") or 0,
+            is_last=bool(data.get("isLast", True)),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary with the page of test cases and pagination metadata.
+        """
+        return {
+            "start_at": self.start_at,
+            "max_results": self.max_results,
+            "count": len(self.cases),
+            "is_last": self.is_last,
+            "test_cases": [case.to_simplified_dict() for case in self.cases],
+        }

--- a/src/mcp_atlassian/models/aio/common.py
+++ b/src/mcp_atlassian/models/aio/common.py
@@ -1,0 +1,222 @@
+"""Common models shared across AIO Tests entities."""
+
+from typing import Any
+
+from ..base import ApiModel
+
+
+class AIOEntity(ApiModel):
+    """A named, identified AIO Tests lookup value.
+
+    Covers the ``ID``/``name``/``description`` shape used by case statuses,
+    priorities, types, script types and automation statuses.
+    """
+
+    id: int | None = None
+    name: str | None = None
+    description: str | None = None
+    is_default: bool | None = None
+    is_archived: bool | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOEntity":
+        """Create an entity from an AIO Tests API response.
+
+        Args:
+            data: Raw entity payload.
+            **kwargs: Unused, accepted for interface compatibility.
+
+        Returns:
+            The parsed entity.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        return cls(
+            id=data.get("ID"),
+            name=data.get("name"),
+            description=data.get("description"),
+            is_default=data.get("isDefault"),
+            is_archived=data.get("isArchived"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary with the populated entity fields.
+        """
+        result: dict[str, Any] = {}
+        if self.id is not None:
+            result["id"] = self.id
+        if self.name is not None:
+            result["name"] = self.name
+        if self.description:
+            result["description"] = self.description
+        if self.is_default is not None:
+            result["is_default"] = self.is_default
+        if self.is_archived is not None:
+            result["is_archived"] = self.is_archived
+        return result
+
+
+class AIOTag(ApiModel):
+    """A tag defined for a Jira project in AIO Tests."""
+
+    id: int | None = None
+    name: str | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOTag":
+        """Create a tag from an AIO Tests API response.
+
+        Accepts both the bare ``Tag`` shape and the ``CaseTag`` wrapper returned
+        on case details, which nests the tag under a ``tag`` key.
+
+        Args:
+            data: Raw tag payload.
+            **kwargs: Unused, accepted for interface compatibility.
+
+        Returns:
+            The parsed tag.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        if "tag" in data and isinstance(data["tag"], dict):
+            data = data["tag"]
+        return cls(id=data.get("ID"), name=data.get("name"))
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary with the tag ID and name.
+        """
+        result: dict[str, Any] = {}
+        if self.id is not None:
+            result["id"] = self.id
+        if self.name is not None:
+            result["name"] = self.name
+        return result
+
+
+class AIOFolder(ApiModel):
+    """A single AIO Tests folder without its children."""
+
+    id: int | None = None
+    name: str | None = None
+    description: str | None = None
+    parent_id: int | None = None
+    path: str | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOFolder":
+        """Create a folder from an AIO Tests API response.
+
+        Args:
+            data: Raw folder payload.
+            **kwargs: Optional ``path`` giving the full folder path.
+
+        Returns:
+            The parsed folder.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        return cls(
+            id=data.get("ID"),
+            name=data.get("name"),
+            description=data.get("description"),
+            parent_id=data.get("parentID"),
+            path=kwargs.get("path"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary with the populated folder fields.
+        """
+        result: dict[str, Any] = {}
+        if self.id is not None:
+            result["id"] = self.id
+        if self.name is not None:
+            result["name"] = self.name
+        if self.description:
+            result["description"] = self.description
+        if self.parent_id is not None:
+            result["parent_id"] = self.parent_id
+        if self.path:
+            result["path"] = self.path
+        return result
+
+
+class AIOFolderTree(AIOFolder):
+    """An AIO Tests folder together with its descendants."""
+
+    children: list["AIOFolderTree"] = []
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOFolderTree":
+        """Create a folder tree from an AIO Tests API response.
+
+        The API omits ``parentID`` on nested folders, so the parent ID and the
+        full path are derived while walking the tree.
+
+        Args:
+            data: Raw folder payload, possibly containing a ``children`` list.
+            **kwargs: Optional ``parent_path`` and ``parent_id`` for nested nodes.
+
+        Returns:
+            The parsed folder tree.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        name = data.get("name") or ""
+        parent_path = kwargs.get("parent_path") or ""
+        path = f"{parent_path}/{name}" if parent_path else f"/{name}"
+        folder = cls(
+            id=data.get("ID"),
+            name=data.get("name"),
+            description=data.get("description"),
+            parent_id=data.get("parentID", kwargs.get("parent_id")),
+            path=path,
+        )
+        children = data.get("children") or []
+        folder.children = [
+            cls.from_api_response(child, parent_path=path, parent_id=folder.id)
+            for child in children
+            if isinstance(child, dict)
+        ]
+        return folder
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary including nested children.
+
+        Returns:
+            Dictionary with the folder fields and a ``children`` list.
+        """
+        result = super().to_simplified_dict()
+        if self.children:
+            result["children"] = [child.to_simplified_dict() for child in self.children]
+        return result
+
+    def flatten(self) -> list[AIOFolder]:
+        """Flatten the tree into a list of folders with resolved paths.
+
+        Returns:
+            All folders in the tree, parents before children.
+        """
+        folders: list[AIOFolder] = [
+            AIOFolder(
+                id=self.id,
+                name=self.name,
+                description=self.description,
+                parent_id=self.parent_id,
+                path=self.path,
+            )
+        ]
+        for child in self.children:
+            folders.extend(child.flatten())
+        return folders
+
+
+AIOFolderTree.model_rebuild()

--- a/src/mcp_atlassian/models/aio/project.py
+++ b/src/mcp_atlassian/models/aio/project.py
@@ -1,0 +1,258 @@
+"""Models for AIO Tests project information and test case schema."""
+
+from typing import Any
+
+from ..base import ApiModel
+from .common import AIOEntity
+
+
+class AIOProject(ApiModel):
+    """Basic AIO Tests information about a Jira project."""
+
+    key: str | None = None
+    id: int | None = None
+    aio_enabled: bool = False
+    error: str | None = None
+    adhoc_cycle_key: str | None = None
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOProject":
+        """Create project info from an AIO Tests project configuration response.
+
+        The AIO Tests API has no dedicated project resource; a successful
+        configuration call is itself the proof that AIO Tests is enabled, and the
+        Jira project ID is carried on the project's ad-hoc cycle.
+
+        Args:
+            data: Raw ``ProjectConfiguration`` payload.
+            **kwargs: Optional ``project_key`` used as requested by the caller.
+
+        Returns:
+            The parsed project information.
+        """
+        adhoc = data.get("adhocTestCycle") if isinstance(data, dict) else None
+        adhoc = adhoc if isinstance(adhoc, dict) else {}
+        return cls(
+            key=kwargs.get("project_key"),
+            id=adhoc.get("jiraProjectID"),
+            aio_enabled=True,
+            adhoc_cycle_key=adhoc.get("key"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary describing the project and its AIO Tests availability.
+        """
+        result: dict[str, Any] = {"aio_enabled": self.aio_enabled}
+        if self.key:
+            result["project_key"] = self.key
+        if self.id is not None:
+            result["project_id"] = self.id
+        if self.adhoc_cycle_key:
+            result["adhoc_cycle_key"] = self.adhoc_cycle_key
+        if self.error:
+            result["error"] = self.error
+        return result
+
+
+class AIOCustomField(ApiModel):
+    """A custom field configured for AIO Tests test cases."""
+
+    id: int | None = None
+    name: str | None = None
+    description: str | None = None
+    type: str | None = None
+    required: bool = False
+    jira_field: str | None = None
+    allowed_values: list[dict[str, Any]] = []
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "AIOCustomField":
+        """Create a custom field from an AIO Tests API response.
+
+        Args:
+            data: Raw ``CustomField`` payload.
+            **kwargs: Unused, accepted for interface compatibility.
+
+        Returns:
+            The parsed custom field.
+        """
+        if not isinstance(data, dict):
+            return cls()
+        association = data.get("caseAssociation")
+        association = association if isinstance(association, dict) else {}
+        allowed: list[dict[str, Any]] = []
+        for value in data.get("allowedListValues") or []:
+            if isinstance(value, dict):
+                allowed.append({"id": value.get("ID"), "value": value.get("value")})
+        for value in data.get("colorAllowedListValues") or []:
+            if isinstance(value, dict):
+                allowed.append(
+                    {
+                        "id": value.get("ID"),
+                        "value": value.get("description"),
+                        "hex_code": value.get("hexCode"),
+                    }
+                )
+        return cls(
+            id=data.get("ID"),
+            name=data.get("name"),
+            description=data.get("description"),
+            type=data.get("type"),
+            required=bool(association.get("isRequired")),
+            jira_field=data.get("jiraField"),
+            allowed_values=allowed,
+        )
+
+    @property
+    def is_associated_with_cases(self) -> bool:
+        """Whether the field applies to test cases.
+
+        Returns:
+            True when the field is associated with the case entity.
+        """
+        return True
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary describing the custom field and its allowed values.
+        """
+        result: dict[str, Any] = {"required": self.required}
+        if self.id is not None:
+            result["id"] = self.id
+        if self.name:
+            result["name"] = self.name
+        if self.description:
+            result["description"] = self.description
+        if self.type:
+            result["type"] = self.type
+        if self.jira_field:
+            result["jira_field"] = self.jira_field
+        if self.allowed_values:
+            result["allowed_values"] = self.allowed_values
+        return result
+
+
+class AIOSchemaField(ApiModel):
+    """A built-in test case field exposed by the create/update APIs."""
+
+    name: str
+    type: str
+    description: str
+    required: bool = False
+    read_only: bool = False
+    allowed_values_from: str | None = None
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary describing the field.
+        """
+        result: dict[str, Any] = {
+            "name": self.name,
+            "type": self.type,
+            "description": self.description,
+            "required": self.required,
+        }
+        if self.read_only:
+            result["read_only"] = True
+        if self.allowed_values_from:
+            result["allowed_values_from"] = self.allowed_values_from
+        return result
+
+
+class AIOTestCaseSchema(ApiModel):
+    """The complete test case schema configuration for a project."""
+
+    project_key: str | None = None
+    project_id: int | None = None
+    fields: list[AIOSchemaField] = []
+    custom_fields: list[AIOCustomField] = []
+    priorities: list[AIOEntity] = []
+    statuses: list[AIOEntity] = []
+    types: list[AIOEntity] = []
+    script_types: list[AIOEntity] = []
+    automation_statuses: list[AIOEntity] = []
+
+    @classmethod
+    def from_api_response(
+        cls, data: dict[str, Any], **kwargs: Any
+    ) -> "AIOTestCaseSchema":
+        """Create a schema from an AIO Tests project configuration response.
+
+        Args:
+            data: Raw ``ProjectConfiguration`` payload.
+            **kwargs: ``project_key`` of the request and ``fields`` catalog of
+                built-in case fields.
+
+        Returns:
+            The parsed schema.
+        """
+        if not isinstance(data, dict):
+            data = {}
+
+        def entities(key: str) -> list[AIOEntity]:
+            return [
+                AIOEntity.from_api_response(value)
+                for value in (data.get(key) or [])
+                if isinstance(value, dict)
+            ]
+
+        adhoc = data.get("adhocTestCycle")
+        adhoc = adhoc if isinstance(adhoc, dict) else {}
+        custom_fields = [
+            AIOCustomField.from_api_response(value)
+            for value in (data.get("customFields") or [])
+            if isinstance(value, dict)
+            and isinstance(value.get("caseAssociation"), dict)
+            and value["caseAssociation"].get("isAssociated")
+        ]
+        return cls(
+            project_key=kwargs.get("project_key"),
+            project_id=adhoc.get("jiraProjectID"),
+            fields=list(kwargs.get("fields") or []),
+            custom_fields=custom_fields,
+            priorities=entities("casePriorities"),
+            statuses=entities("caseStatuses"),
+            types=entities("caseTypes"),
+            script_types=entities("caseScriptTypes"),
+            automation_statuses=entities("caseAutomationStatuses"),
+        )
+
+    def to_simplified_dict(self) -> dict[str, Any]:
+        """Convert to a simplified dictionary.
+
+        Returns:
+            Dictionary describing fields, custom fields and allowed values.
+        """
+        result: dict[str, Any] = {}
+        if self.project_key:
+            result["project_key"] = self.project_key
+        if self.project_id is not None:
+            result["project_id"] = self.project_id
+        result["fields"] = [field.to_simplified_dict() for field in self.fields]
+        result["required_fields"] = [
+            field.name for field in self.fields if field.required
+        ] + [
+            field.name for field in self.custom_fields if field.required and field.name
+        ]
+        result["custom_fields"] = [
+            field.to_simplified_dict() for field in self.custom_fields
+        ]
+        result["allowed_values"] = {
+            "priorities": [entity.to_simplified_dict() for entity in self.priorities],
+            "statuses": [entity.to_simplified_dict() for entity in self.statuses],
+            "types": [entity.to_simplified_dict() for entity in self.types],
+            "script_types": [
+                entity.to_simplified_dict() for entity in self.script_types
+            ],
+            "automation_statuses": [
+                entity.to_simplified_dict() for entity in self.automation_statuses
+            ],
+        }
+        return result

--- a/src/mcp_atlassian/servers/aio.py
+++ b/src/mcp_atlassian/servers/aio.py
@@ -1,0 +1,668 @@
+"""AIO Tests FastMCP server instance and tool definitions."""
+
+import json
+import logging
+from typing import Annotated, Any
+
+from fastmcp import Context, FastMCP
+from pydantic import Field
+
+from mcp_atlassian.aio.constants import DEFAULT_PAGE_SIZE, FOLDER_ENTITY_TYPES
+from mcp_atlassian.servers.dependencies import get_aio_fetcher
+from mcp_atlassian.utils.decorators import check_write_access
+
+logger = logging.getLogger(__name__)
+
+aio_mcp = FastMCP(
+    name="AIO Tests MCP Service",
+    instructions=(
+        "Provides tools for managing test cases, folders and tags in AIO Tests, "
+        "the test management app for Jira. Every tool is scoped to a Jira "
+        "project; call aio_get_project first to confirm AIO Tests is enabled, "
+        "and aio_get_test_case_schema before creating or updating cases so the "
+        "correct field names and allowed values are used."
+    ),
+)
+
+ProjectKey = Annotated[
+    str,
+    Field(description="Jira project key or numeric project ID (e.g. 'PROJ')"),
+]
+TestCaseId = Annotated[
+    str,
+    Field(description="Test case key (e.g. 'AT-TC-17') or numeric case ID"),
+]
+FolderType = Annotated[
+    str,
+    Field(
+        description=(
+            "Folder tree to operate on: 'testcase', 'testcycle' or 'testset'. "
+            "Defaults to 'testcase'."
+        ),
+        default="testcase",
+    ),
+]
+
+_CASE_FIELD_DOC = (
+    "Optional case fields. Lookup fields accept a name or a numeric ID: "
+    "description, precondition, folder (name, path or ID), status, priority, "
+    "type, script_type ('Classic' or 'BDD'), automation_status, automation_key, "
+    "automation_owner_id, owner_id (Jira account ID), estimated_effort "
+    "(seconds), tags (list of names), requirement_ids (Jira issue keys or IDs), "
+    "component_ids, release_ids, custom_fields (object of name/value pairs)."
+)
+_STEPS_DOC = (
+    "Ordered test steps, replacing any existing steps. Classic steps use "
+    '{"step": "...", "data": "...", "expected_result": "..."}; BDD steps use '
+    '{"step_type": "BDD_GIVEN|BDD_WHEN|BDD_THEN|BDD_AND|BDD_BUT|BDD_STAR", '
+    '"bdd_step": "..."}. A step may instead reference another case with '
+    '{"step_type": "REFERENCE", "referenced_case_key": "AT-TC-9"}.'
+)
+
+
+def _dumps(payload: Any) -> str:
+    """Serialize a tool result to JSON.
+
+    Args:
+        payload: The result payload.
+
+    Returns:
+        The indented JSON representation.
+    """
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+@aio_mcp.tool(
+    tags={"aio", "read"},
+    annotations={"title": "Get Project", "readOnlyHint": True},
+)
+async def get_project(ctx: Context, project_key: ProjectKey) -> str:
+    """Verify that AIO Tests is enabled for a Jira project and get its details.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+
+    Returns:
+        JSON string with the project key, project ID and whether AIO Tests is
+        enabled for the project.
+    """
+    aio = await get_aio_fetcher(ctx)
+    project = aio.get_project(project_key)
+    return _dumps(project.to_simplified_dict())
+
+
+@aio_mcp.tool(
+    tags={"aio", "read"},
+    annotations={"title": "Get Test Case Schema", "readOnlyHint": True},
+)
+async def get_test_case_schema(ctx: Context, project_key: ProjectKey) -> str:
+    """Get the test case schema of a project: fields, custom fields and allowed values.
+
+    Call this before creating or updating test cases to learn which fields exist,
+    which are required, and which values the project accepts for statuses,
+    priorities, types, script types and automation statuses.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+
+    Returns:
+        JSON string describing built-in fields, custom fields, required fields
+        and allowed values.
+    """
+    aio = await get_aio_fetcher(ctx)
+    schema = aio.get_test_case_schema(project_key)
+    return _dumps(schema.to_simplified_dict())
+
+
+@aio_mcp.tool(
+    tags={"aio", "read"},
+    annotations={"title": "Search Test Cases", "readOnlyHint": True},
+)
+async def search_test_cases(
+    ctx: Context,
+    project_key: ProjectKey,
+    title: Annotated[
+        str | None,
+        Field(description="(Optional) Text to match against the case title"),
+    ] = None,
+    title_match: Annotated[
+        str,
+        Field(
+            description="How to match the title: 'CONTAINS' or 'EXACT_MATCH'",
+            default="CONTAINS",
+        ),
+    ] = "CONTAINS",
+    keys: Annotated[
+        list[str] | None,
+        Field(description="(Optional) Case keys to match (e.g. ['AT-TC-17'])"),
+    ] = None,
+    folders: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "(Optional) Folder names, paths (e.g. '/Regression/Checkout') "
+                "or numeric folder IDs"
+            )
+        ),
+    ] = None,
+    statuses: Annotated[
+        list[str] | None,
+        Field(description="(Optional) Case status names or IDs (e.g. ['Published'])"),
+    ] = None,
+    priorities: Annotated[
+        list[str] | None,
+        Field(description="(Optional) Case priority names or IDs (e.g. ['Critical'])"),
+    ] = None,
+    types: Annotated[
+        list[str] | None,
+        Field(description="(Optional) Case type names or IDs (e.g. ['Functional'])"),
+    ] = None,
+    automation_statuses: Annotated[
+        list[str] | None,
+        Field(description="(Optional) Automation status names or IDs"),
+    ] = None,
+    tags: Annotated[
+        list[str] | None, Field(description="(Optional) Tag names to match")
+    ] = None,
+    owner_ids: Annotated[
+        list[str] | None,
+        Field(description="(Optional) Jira account IDs of the case owners"),
+    ] = None,
+    requirement_ids: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "(Optional) Jira issue keys or IDs the cases must cover "
+                "(e.g. ['PROJ-42'])"
+            )
+        ),
+    ] = None,
+    automation_key: Annotated[
+        str | None,
+        Field(description="(Optional) Automation key to match (contains)"),
+    ] = None,
+    created_after: Annotated[
+        str | None,
+        Field(description="(Optional) ISO 8601 lower bound of the creation date"),
+    ] = None,
+    created_before: Annotated[
+        str | None,
+        Field(description="(Optional) ISO 8601 upper bound of the creation date"),
+    ] = None,
+    updated_after: Annotated[
+        str | None,
+        Field(description="(Optional) ISO 8601 lower bound of the last update date"),
+    ] = None,
+    updated_before: Annotated[
+        str | None,
+        Field(description="(Optional) ISO 8601 upper bound of the last update date"),
+    ] = None,
+    include_archived: Annotated[
+        bool | None,
+        Field(
+            description=(
+                "(Optional) Set to true to return archived cases, false to "
+                "exclude them. Omit to leave the filter unset."
+            ),
+            default=None,
+        ),
+    ] = None,
+    start_at: Annotated[
+        int,
+        Field(description="Index of the first result to return", default=0, ge=0),
+    ] = 0,
+    max_results: Annotated[
+        int,
+        Field(
+            description="Maximum number of results to return (1-100)",
+            default=DEFAULT_PAGE_SIZE,
+            ge=1,
+            le=100,
+        ),
+    ] = DEFAULT_PAGE_SIZE,
+    include_rtf: Annotated[
+        bool,
+        Field(
+            description="Keep the HTML markup of rich-text fields",
+            default=False,
+        ),
+    ] = False,
+) -> str:
+    """Search and filter test cases in a project.
+
+    Filters combine with AND. Lookup filters accept names or numeric IDs. With no
+    filter at all, the project's test cases are listed in their natural order.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+        title: Text to match against the case title.
+        title_match: 'CONTAINS' or 'EXACT_MATCH'.
+        keys: Case keys to match.
+        folders: Folder names, paths or IDs.
+        statuses: Case status names or IDs.
+        priorities: Case priority names or IDs.
+        types: Case type names or IDs.
+        automation_statuses: Automation status names or IDs.
+        tags: Tag names to match.
+        owner_ids: Jira account IDs of the case owners.
+        requirement_ids: Jira issue keys or IDs the cases must cover.
+        automation_key: Automation key to match.
+        created_after: Lower bound of the creation date.
+        created_before: Upper bound of the creation date.
+        updated_after: Lower bound of the last update date.
+        updated_before: Upper bound of the last update date.
+        include_archived: Filter on the archived flag.
+        start_at: Index of the first result.
+        max_results: Maximum number of results.
+        include_rtf: Keep the HTML markup of rich-text fields.
+
+    Returns:
+        JSON string with the matching test cases and pagination metadata.
+    """
+    aio = await get_aio_fetcher(ctx)
+    result = aio.search_test_cases(
+        project_key,
+        title=title,
+        title_match=title_match,
+        keys=keys,
+        folders=folders,
+        statuses=statuses,
+        priorities=priorities,
+        types=types,
+        automation_statuses=automation_statuses,
+        tags=tags,
+        owner_ids=owner_ids,
+        requirement_ids=requirement_ids,
+        automation_key=automation_key,
+        created_after=created_after,
+        created_before=created_before,
+        updated_after=updated_after,
+        updated_before=updated_before,
+        include_archived=include_archived,
+        start_at=start_at,
+        max_results=max_results,
+        include_rtf=include_rtf,
+    )
+    return _dumps(result.to_simplified_dict())
+
+
+@aio_mcp.tool(
+    tags={"aio", "read"},
+    annotations={"title": "Get Test Case", "readOnlyHint": True},
+)
+async def get_test_case(
+    ctx: Context,
+    project_key: ProjectKey,
+    test_case_id: TestCaseId,
+    version: Annotated[
+        int | None,
+        Field(
+            description=(
+                "(Optional) Case version to read. Only applies when a case key "
+                "is given; defaults to the latest version."
+            ),
+            default=None,
+        ),
+    ] = None,
+    include_rtf: Annotated[
+        bool,
+        Field(description="Keep the HTML markup of rich-text fields", default=False),
+    ] = False,
+    include_attachments: Annotated[
+        bool,
+        Field(description="Include attachment metadata", default=False),
+    ] = False,
+) -> str:
+    """Get the complete details of a test case, including its steps.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+        test_case_id: Case key or numeric case ID.
+        version: Case version to read.
+        include_rtf: Keep the HTML markup of rich-text fields.
+        include_attachments: Include attachment metadata.
+
+    Returns:
+        JSON string with the case metadata, steps, tags, folder, requirements
+        and custom fields.
+    """
+    aio = await get_aio_fetcher(ctx)
+    case = aio.get_test_case(
+        project_key,
+        test_case_id,
+        version=version,
+        include_rtf=include_rtf,
+        include_attachments=include_attachments,
+    )
+    return _dumps(case.to_simplified_dict())
+
+
+@aio_mcp.tool(
+    tags={"aio", "read"},
+    annotations={"title": "Get Test Case Versions", "readOnlyHint": True},
+)
+async def get_test_case_versions(
+    ctx: Context, project_key: ProjectKey, test_case_id: TestCaseId
+) -> str:
+    """Get every saved version of a test case.
+
+    Use the returned version numbers with aio_get_test_case to read the content
+    of a specific historical version.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+        test_case_id: Case key or numeric case ID.
+
+    Returns:
+        JSON string with the case key, its current version and every saved
+        version with the case ID that stores it.
+    """
+    aio = await get_aio_fetcher(ctx)
+    case = aio.get_test_case_versions(project_key, test_case_id)
+    return _dumps(
+        {
+            "key": case.key,
+            "title": case.title,
+            "current_version": case.version,
+            "versions": [version.to_simplified_dict() for version in case.versions],
+        }
+    )
+
+
+@aio_mcp.tool(
+    tags={"aio", "write"},
+    annotations={"title": "Create Test Case", "destructiveHint": False},
+)
+@check_write_access
+async def create_test_case(
+    ctx: Context,
+    project_key: ProjectKey,
+    title: Annotated[str, Field(description="Case title. The only required field.")],
+    steps: Annotated[
+        list[dict[str, Any]] | None,
+        Field(description=f"(Optional) {_STEPS_DOC}", default=None),
+    ] = None,
+    fields: Annotated[
+        dict[str, Any] | None,
+        Field(description=f"(Optional) {_CASE_FIELD_DOC}", default=None),
+    ] = None,
+    include_rtf: Annotated[
+        bool,
+        Field(
+            description=("Treat rich-text field values as HTML instead of plain text"),
+            default=False,
+        ),
+    ] = False,
+    create_folder_if_missing: Annotated[
+        bool,
+        Field(
+            description=(
+                "Create the target folder hierarchy when it does not exist yet"
+            ),
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Create a test case in AIO Tests, with Classic or BDD steps.
+
+    A case with no folder is created in the 'Not Assigned' folder. Call
+    aio_get_test_case_schema first if unsure which field values the project
+    accepts.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+        title: Case title.
+        steps: Ordered test steps.
+        fields: Optional case fields such as folder, priority, status or tags.
+        include_rtf: Treat rich-text values as HTML.
+        create_folder_if_missing: Create the target folder when it is missing.
+
+    Returns:
+        JSON string with the created test case.
+    """
+    aio = await get_aio_fetcher(ctx)
+    payload: dict[str, Any] = dict(fields or {})
+    payload.pop("title", None)
+    if steps is not None:
+        payload["steps"] = steps
+    case = aio.create_test_case(
+        project_key,
+        title,
+        include_rtf=include_rtf,
+        create_folder_if_missing=create_folder_if_missing,
+        **payload,
+    )
+    return _dumps({"success": True, "test_case": case.to_simplified_dict()})
+
+
+@aio_mcp.tool(
+    tags={"aio", "write"},
+    annotations={"title": "Update Test Case", "destructiveHint": True},
+)
+@check_write_access
+async def update_test_case(
+    ctx: Context,
+    project_key: ProjectKey,
+    test_case_id: TestCaseId,
+    steps: Annotated[
+        list[dict[str, Any]] | None,
+        Field(description=f"(Optional) {_STEPS_DOC}", default=None),
+    ] = None,
+    fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description=(
+                f"(Optional) Fields to change, omitted fields keep their current "
+                f"value. Also accepts 'title'. {_CASE_FIELD_DOC}"
+            ),
+            default=None,
+        ),
+    ] = None,
+    version: Annotated[
+        int | None,
+        Field(
+            description=(
+                "(Optional) Case version to update. Only applies when a case key "
+                "is given; defaults to the latest version."
+            ),
+            default=None,
+        ),
+    ] = None,
+    create_new_version: Annotated[
+        bool,
+        Field(
+            description=(
+                "Save the change as a new case version instead of modifying the "
+                "current one"
+            ),
+            default=False,
+        ),
+    ] = False,
+    include_rtf: Annotated[
+        bool,
+        Field(
+            description=(
+                "Treat the supplied rich-text values as HTML instead of plain "
+                "text. Formatting of the fields left untouched is preserved "
+                "either way."
+            ),
+            default=False,
+        ),
+    ] = False,
+    create_folder_if_missing: Annotated[
+        bool,
+        Field(
+            description=(
+                "Create the target folder hierarchy when it does not exist yet"
+            ),
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Update an existing test case: steps, metadata, priority, status or tags.
+
+    Only the supplied fields change. Supplying `steps` or `tags` replaces the
+    existing list. By default this modifies the case in place without creating a
+    new version.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+        test_case_id: Case key or numeric case ID.
+        steps: Replacement test steps.
+        fields: Fields to change.
+        version: Case version to update.
+        create_new_version: Save the change as a new version.
+        include_rtf: Treat rich-text values as HTML.
+        create_folder_if_missing: Create the target folder when it is missing.
+
+    Returns:
+        JSON string with the updated test case.
+    """
+    aio = await get_aio_fetcher(ctx)
+    payload: dict[str, Any] = dict(fields or {})
+    if steps is not None:
+        payload["steps"] = steps
+    case = aio.update_test_case(
+        project_key,
+        test_case_id,
+        version=version,
+        create_new_version=create_new_version,
+        include_rtf=include_rtf,
+        create_folder_if_missing=create_folder_if_missing,
+        **payload,
+    )
+    return _dumps({"success": True, "test_case": case.to_simplified_dict()})
+
+
+@aio_mcp.tool(
+    tags={"aio", "read"},
+    annotations={"title": "Get Folder Hierarchy", "readOnlyHint": True},
+)
+async def get_folder_hierarchy(
+    ctx: Context,
+    project_key: ProjectKey,
+    folder_type: FolderType = "testcase",
+    flat: Annotated[
+        bool,
+        Field(
+            description=(
+                "Return a flat list of folders with their full paths instead of "
+                "a nested tree"
+            ),
+            default=False,
+        ),
+    ] = False,
+) -> str:
+    """Get the folder structure of a project, with parent-child relationships and paths.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+        folder_type: 'testcase', 'testcycle' or 'testset'.
+        flat: Return a flat list instead of a nested tree.
+
+    Returns:
+        JSON string with the folder hierarchy.
+    """
+    aio = await get_aio_fetcher(ctx)
+    if flat:
+        folders = [
+            folder.to_simplified_dict()
+            for folder in aio.flatten_folders(project_key, folder_type)
+        ]
+    else:
+        folders = [
+            folder.to_simplified_dict()
+            for folder in aio.get_folder_hierarchy(project_key, folder_type)
+        ]
+    return _dumps({"folder_type": folder_type, "folders": folders})
+
+
+@aio_mcp.tool(
+    tags={"aio", "write"},
+    annotations={"title": "Create Folder", "destructiveHint": False},
+)
+@check_write_access
+async def create_folder(
+    ctx: Context,
+    project_key: ProjectKey,
+    folder_path: Annotated[
+        str,
+        Field(
+            description=(
+                "Folder name, or a path such as '/Release 1.0/Regression/Checkout' "
+                "to create nested folders in one call"
+            )
+        ),
+    ],
+    folder_type: FolderType = "testcase",
+    parent_folder_id: Annotated[
+        int | None,
+        Field(
+            description=(
+                "(Optional) ID of an existing folder to create the path under. "
+                "Omit to create from the top level."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Create a folder (or a whole folder path) in AIO Tests.
+
+    Folders that already exist along the path are reused, so this is safe to call
+    repeatedly.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+        folder_path: Folder name or path to create.
+        folder_type: 'testcase', 'testcycle' or 'testset'.
+        parent_folder_id: Existing folder to create the path under.
+
+    Returns:
+        JSON string with the leaf folder of the created hierarchy.
+    """
+    aio = await get_aio_fetcher(ctx)
+    folder = aio.create_folder(
+        project_key,
+        folder_path,
+        folder_type=folder_type,
+        parent_folder_id=parent_folder_id,
+    )
+    return _dumps(
+        {
+            "success": True,
+            "folder_type": folder_type,
+            "folder": folder.to_simplified_dict(),
+        }
+    )
+
+
+@aio_mcp.tool(
+    tags={"aio", "read"},
+    annotations={"title": "Get Tags", "readOnlyHint": True},
+)
+async def get_tags(ctx: Context, project_key: ProjectKey) -> str:
+    """Get every tag configured for a project, for organizing and filtering test cases.
+
+    Args:
+        ctx: The FastMCP context.
+        project_key: Jira project key or numeric project ID.
+
+    Returns:
+        JSON string with the project's tags.
+    """
+    aio = await get_aio_fetcher(ctx)
+    tags = aio.get_tags(project_key)
+    return _dumps({"tags": [tag.to_simplified_dict() for tag in tags]})
+
+
+# Exported for tests and documentation.
+SUPPORTED_FOLDER_TYPES = FOLDER_ENTITY_TYPES

--- a/src/mcp_atlassian/servers/context.py
+++ b/src/mcp_atlassian/servers/context.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from mcp_atlassian.aio.config import AIOConfig
     from mcp_atlassian.confluence.config import ConfluenceConfig
     from mcp_atlassian.jira.config import JiraConfig
 
@@ -11,12 +12,13 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class MainAppContext:
     """
-    Context holding fully configured Jira and Confluence configurations
-    loaded from environment variables at server startup.
+    Context holding fully configured Jira, Confluence and AIO Tests
+    configurations loaded from environment variables at server startup.
     These configurations include any global/default authentication details.
     """
 
     full_jira_config: JiraConfig | None = None
     full_confluence_config: ConfluenceConfig | None = None
+    full_aio_config: AIOConfig | None = None
     read_only: bool = False
     enabled_tools: list[str] | None = None

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from fastmcp.server.dependencies import get_http_request
 from starlette.requests import Request
 
+from mcp_atlassian.aio import AIOConfig, AIOFetcher
 from mcp_atlassian.confluence import ConfluenceConfig, ConfluenceFetcher
 from mcp_atlassian.jira import JiraConfig, JiraFetcher
 from mcp_atlassian.servers.context import MainAppContext
@@ -297,6 +298,76 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
     logger.error("Jira configuration could not be resolved.")
     raise ValueError(
         "Jira client (fetcher) not available. Ensure server is configured correctly."
+    )
+
+
+async def get_aio_fetcher(ctx: Context) -> AIOFetcher:
+    """Returns an AIOFetcher instance appropriate for the current request context.
+
+    AIO Tests authenticates with its own access token rather than the Atlassian
+    user token, so a per-request token is only taken from the dedicated
+    ``X-Aio-Api-Token`` header. Otherwise the global configuration is used.
+
+    Args:
+        ctx: The FastMCP context.
+
+    Returns:
+        AIOFetcher instance for the current user or global config.
+
+    Raises:
+        ValueError: If configuration or credentials are invalid.
+    """
+    logger.debug(f"get_aio_fetcher: ENTERED. Context ID: {id(ctx)}")
+    global_config: AIOConfig | None = None
+    lifespan_ctx_dict = ctx.request_context.lifespan_context  # type: ignore
+    app_lifespan_ctx: MainAppContext | None = (
+        lifespan_ctx_dict.get("app_lifespan_context")
+        if isinstance(lifespan_ctx_dict, dict)
+        else None
+    )
+    if app_lifespan_ctx:
+        global_config = app_lifespan_ctx.full_aio_config
+
+    try:
+        request: Request = get_http_request()
+        if hasattr(request.state, "aio_fetcher") and request.state.aio_fetcher:
+            logger.debug("get_aio_fetcher: Returning AIOFetcher from request.state.")
+            return request.state.aio_fetcher
+
+        service_headers = getattr(request.state, "atlassian_service_headers", {})
+        user_token = service_headers.get("X-Aio-Api-Token")
+        if user_token:
+            if not global_config:
+                raise ValueError(
+                    "AIO Tests global configuration (URL, SSL) is not available "
+                    "from lifespan context."
+                )
+            logger.info("Creating user-specific AIOFetcher from X-Aio-Api-Token header")
+            user_config = dataclasses.replace(
+                global_config, auth_type="token", api_token=user_token
+            )
+            try:
+                user_aio_fetcher = AIOFetcher(config=user_config)
+            except Exception as e:
+                logger.error(
+                    f"get_aio_fetcher: Failed to create user-specific AIOFetcher: {e}",
+                    exc_info=True,
+                )
+                raise ValueError(f"Invalid user AIO Tests token or configuration: {e}")
+            request.state.aio_fetcher = user_aio_fetcher
+            return user_aio_fetcher
+    except RuntimeError:
+        logger.debug(
+            "Not in an HTTP request context. Attempting global AIOFetcher for non-HTTP."
+        )
+
+    if global_config:
+        logger.debug("get_aio_fetcher: Using global AIOFetcher from lifespan_context.")
+        return AIOFetcher(config=global_config)
+    logger.error("AIO Tests configuration could not be resolved.")
+    raise ValueError(
+        "AIO Tests client (fetcher) not available. Set AIO_API_TOKEN (Cloud) or "
+        "AIO_ENABLED=true with Jira Server/Data Center credentials."
     )
 
 

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -16,6 +16,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from mcp_atlassian.aio.config import AIOConfig
 from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.config import ConfluenceConfig
 from mcp_atlassian.jira import JiraFetcher
@@ -25,6 +26,7 @@ from mcp_atlassian.utils.io import is_read_only_mode
 from mcp_atlassian.utils.logging import mask_sensitive
 from mcp_atlassian.utils.tools import get_enabled_tools, should_include_tool
 
+from .aio import aio_mcp
 from .confluence import confluence_mcp
 from .context import MainAppContext
 from .jira import jira_mcp
@@ -45,6 +47,7 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
 
     loaded_jira_config: JiraConfig | None = None
     loaded_confluence_config: ConfluenceConfig | None = None
+    loaded_aio_config: AIOConfig | None = None
 
     if services.get("jira"):
         try:
@@ -76,9 +79,26 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
         except Exception as e:
             logger.error(f"Failed to load Confluence configuration: {e}", exc_info=True)
 
+    if services.get("aio"):
+        try:
+            aio_config = AIOConfig.from_env()
+            if aio_config.is_auth_configured():
+                loaded_aio_config = aio_config
+                logger.info(
+                    "AIO Tests configuration loaded and authentication is configured."
+                )
+            else:
+                logger.warning(
+                    "AIO Tests URL found, but authentication is not fully configured. "
+                    "AIO Tests tools will be unavailable."
+                )
+        except Exception as e:
+            logger.error(f"Failed to load AIO Tests configuration: {e}", exc_info=True)
+
     app_context = MainAppContext(
         full_jira_config=loaded_jira_config,
         full_confluence_config=loaded_confluence_config,
+        full_aio_config=loaded_aio_config,
         read_only=read_only,
         enabled_tools=enabled_tools,
     )
@@ -99,6 +119,8 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
                 logger.debug("Cleaning up Jira resources...")
             if loaded_confluence_config:
                 logger.debug("Cleaning up Confluence resources...")
+            if loaded_aio_config:
+                logger.debug("Cleaning up AIO Tests resources...")
         except Exception as e:
             logger.error(f"Error during cleanup: {e}", exc_info=True)
         logger.info("Main Atlassian MCP server lifespan shutdown complete.")
@@ -167,10 +189,22 @@ class AtlassianMCP(FastMCP[MainAppContext]):
                 )
                 continue
 
-            # Exclude Jira/Confluence tools if config is not fully authenticated
+            # Exclude Jira/Confluence/AIO tools if config is not fully authenticated
             is_jira_tool = "jira" in tool_tags
             is_confluence_tool = "confluence" in tool_tags
+            is_aio_tool = "aio" in tool_tags
             service_configured_and_available = True
+            if is_aio_tool:
+                aio_available = (
+                    app_lifespan_state is not None
+                    and app_lifespan_state.full_aio_config is not None
+                ) or header_based_services.get("aio", False)
+                if not aio_available:
+                    logger.debug(
+                        f"Excluding AIO Tests tool '{registered_name}' as AIO Tests "
+                        "configuration/authentication is incomplete."
+                    )
+                    continue
             if app_lifespan_state:
                 jira_available = (
                     app_lifespan_state.full_jira_config is not None
@@ -372,6 +406,7 @@ class UserTokenMiddleware:
                 b"x-atlassian-confluence-personal-token"
             )
             confluence_url_header = headers.get(b"x-atlassian-confluence-url")
+            aio_token_header = headers.get(b"x-aio-api-token")
 
             # Convert service header bytes to strings
             jira_token_str = (
@@ -390,9 +425,14 @@ class UserTokenMiddleware:
                 if confluence_url_header
                 else None
             )
+            aio_token_str = (
+                aio_token_header.decode("latin-1") if aio_token_header else None
+            )
 
             # Build service headers dict
             service_headers = {}
+            if aio_token_str:
+                service_headers["X-Aio-Api-Token"] = aio_token_str
             if jira_token_str:
                 service_headers["X-Atlassian-Jira-Personal-Token"] = jira_token_str
             if jira_url_str:
@@ -501,6 +541,7 @@ class UserTokenMiddleware:
 main_mcp = AtlassianMCP(name="Atlassian MCP", lifespan=main_lifespan)
 main_mcp.mount(jira_mcp, "jira")
 main_mcp.mount(confluence_mcp, "confluence")
+main_mcp.mount(aio_mcp, "aio")
 
 
 @main_mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -3,6 +3,7 @@
 import logging
 import os
 
+from ..aio.config import is_aio_enabled
 from .urls import is_atlassian_cloud_url
 
 logger = logging.getLogger("mcp-atlassian.utils.environment")
@@ -135,6 +136,13 @@ def get_available_services(
             jira_is_setup = True
             logger.info("Using Jira authentication from header personal token")
 
+    aio_is_setup = is_aio_enabled()
+    if aio_is_setup:
+        logger.info("Using AIO Tests (test management for Jira)")
+    elif headers.get("X-Aio-Api-Token"):
+        aio_is_setup = True
+        logger.info("Using AIO Tests authentication from header access token")
+
     if not confluence_is_setup:
         logger.info(
             "Confluence is not configured or required environment variables are missing."
@@ -143,5 +151,14 @@ def get_available_services(
         logger.info(
             "Jira is not configured or required environment variables are missing."
         )
+    if not aio_is_setup:
+        logger.info(
+            "AIO Tests is not configured. Set AIO_API_TOKEN (Cloud) or "
+            "AIO_ENABLED=true (Server/Data Center) to enable it."
+        )
 
-    return {"confluence": confluence_is_setup, "jira": jira_is_setup}
+    return {
+        "confluence": confluence_is_setup,
+        "jira": jira_is_setup,
+        "aio": aio_is_setup,
+    }

--- a/tests/fixtures/aio_mocks.py
+++ b/tests/fixtures/aio_mocks.py
@@ -1,0 +1,135 @@
+"""Mock AIO Tests API responses for tests."""
+
+MOCK_AIO_PROJECT_CONFIG = {
+    "caseTypes": [
+        {"ID": 1, "name": "Functional", "isDefault": True},
+        {"ID": 2, "name": "Performance"},
+    ],
+    "casePriorities": [
+        {"ID": 10, "name": "Critical"},
+        {"ID": 11, "name": "Medium", "isDefault": True},
+    ],
+    "caseStatuses": [
+        {"ID": 20, "name": "Draft", "description": "Work in progress"},
+        {"ID": 21, "name": "Published", "description": "Ready for execution"},
+    ],
+    "caseAutomationStatuses": [
+        {"ID": 30, "name": "Manual", "isDefault": True},
+        {"ID": 31, "name": "Automated"},
+    ],
+    "caseScriptTypes": [
+        {"ID": 40, "name": "Classic", "isEnabled": True},
+        {"ID": 41, "name": "BDD", "isEnabled": True},
+    ],
+    "runStatuses": [{"ID": 50, "name": "Passed"}],
+    "runStepStatuses": [{"ID": 60, "name": "Passed"}],
+    "customFields": [
+        {
+            "ID": 10113,
+            "name": "Environment",
+            "description": "Setup used for the case",
+            "type": "SINGLE_SELECT_LIST",
+            "caseAssociation": {"isAssociated": True, "isRequired": True},
+            "allowedListValues": [
+                {"ID": 1, "value": "Staging"},
+                {"ID": 2, "value": "Production"},
+            ],
+        },
+        {
+            "ID": 10114,
+            "name": "Reviewer",
+            "type": "SINGLE_USER_SELECTOR",
+            "caseAssociation": {"isAssociated": True, "isRequired": False},
+        },
+        {
+            "ID": 10116,
+            "name": "Notes",
+            "type": "MULTI_LINE_TEXT",
+            "caseAssociation": {"isAssociated": True, "isRequired": False},
+        },
+        {
+            "ID": 10115,
+            "name": "Run Note",
+            "type": "SINGLE_LINE_TEXT",
+            "caseAssociation": {"isAssociated": False, "isRequired": False},
+            "runAssociation": {"isAssociated": True, "isRequired": False},
+        },
+    ],
+    "adhocTestCycle": {"ID": 900, "key": "AT-CY-1", "jiraProjectID": 10010},
+}
+
+MOCK_AIO_TAGS = [
+    {"ID": 1, "name": "AutomationEligible"},
+    {"ID": 2, "name": "Smoke"},
+]
+
+MOCK_AIO_FOLDER_TREE = [
+    {
+        "ID": 100,
+        "name": "Regression",
+        "description": "Regression suites",
+        "children": [
+            {"ID": 101, "name": "Checkout", "children": []},
+            {"ID": 102, "name": "Login", "children": []},
+        ],
+    },
+    {"ID": 200, "name": "Smoke", "children": []},
+]
+
+MOCK_AIO_TEST_CASE = {
+    "ID": 16557,
+    "jiraProjectID": 10010,
+    "key": "AT-TC-17",
+    "version": 2,
+    "title": "Validate quick Add to Cart functionality",
+    "description": "Add an item to the cart from the search page",
+    "precondition": "Item is available in inventory",
+    "ownedByID": "5df1c9f826a4bb0011684aa",
+    "folder": {"ID": 101, "name": "Checkout", "parentID": 100},
+    "status": {"ID": 21, "name": "Published"},
+    "priority": {"ID": 10, "name": "Critical"},
+    "type": {"ID": 1, "name": "Functional"},
+    "scriptType": {"ID": 40, "name": "Classic"},
+    "automationStatus": {"ID": 30, "name": "Manual"},
+    "estimatedEffort": 3600,
+    "createdDate": "2026-01-05T10:00:00.000Z",
+    "updatedDate": "2026-02-11T09:30:00.000Z",
+    "isArchived": False,
+    "jiraRequirementIDs": ["10221"],
+    "jiraComponentIDs": [10000],
+    "jiraReleaseIDs": [10500],
+    "tags": [
+        {"tag": {"ID": 2, "name": "Smoke"}, "associationID": 12},
+    ],
+    "steps": [
+        {
+            "ID": 1,
+            "stepType": "TEXT",
+            "step": "Search for an item",
+            "data": "shoes",
+            "expectedResult": "Results are listed",
+        },
+        {
+            "ID": 2,
+            "stepType": "TEXT",
+            "step": "Click quick add to cart",
+            "expectedResult": "Item is added to the cart",
+        },
+    ],
+    "customFields": [{"ID": 10113, "name": "Environment", "value": "Staging"}],
+    "versions": [{"version": 2, "ID": 16557}, {"version": 1, "ID": 16556}],
+}
+
+MOCK_AIO_SEARCH_RESPONSE = {
+    "items": [MOCK_AIO_TEST_CASE],
+    "startAt": 0,
+    "maxResults": 50,
+    "isLast": True,
+}
+
+MOCK_AIO_FOLDER_DETAILS = {
+    "ID": 101,
+    "name": "Checkout",
+    "description": "Checkout flows",
+    "parentID": 100,
+}

--- a/tests/unit/aio/conftest.py
+++ b/tests/unit/aio/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for AIO Tests unit tests."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.aio import AIOFetcher
+from mcp_atlassian.aio.config import AIOConfig
+
+
+@pytest.fixture
+def aio_config() -> AIOConfig:
+    """Provide a Cloud AIO Tests configuration."""
+    return AIOConfig(
+        url="https://tcms.aiojiraapps.com/aio-tcms/api/v1",
+        auth_type="token",
+        api_token="test-token",
+    )
+
+
+@pytest.fixture
+def aio_fetcher(aio_config: AIOConfig) -> AIOFetcher:
+    """Provide an AIOFetcher whose HTTP session is mocked out."""
+    fetcher = AIOFetcher(config=aio_config)
+    fetcher.session = MagicMock()
+    return fetcher

--- a/tests/unit/aio/test_cases.py
+++ b/tests/unit/aio/test_cases.py
@@ -1,0 +1,605 @@
+"""Tests for AIO Tests test case operations."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.aio.cases import _build_step_payload, _date_criteria
+from tests.fixtures.aio_mocks import (
+    MOCK_AIO_FOLDER_TREE,
+    MOCK_AIO_PROJECT_CONFIG,
+    MOCK_AIO_SEARCH_RESPONSE,
+    MOCK_AIO_TEST_CASE,
+)
+
+
+@pytest.fixture
+def fetcher(aio_fetcher):
+    """Provide a fetcher whose reads are routed to the right mock payload."""
+
+    def fake_get(path, params=None):
+        if path.endswith("/config"):
+            return MOCK_AIO_PROJECT_CONFIG
+        if path.endswith("/folder"):
+            return MOCK_AIO_FOLDER_TREE
+        if path.endswith("/tag"):
+            return [{"ID": 2, "name": "Smoke"}]
+        if path.endswith("/detail"):
+            return MOCK_AIO_TEST_CASE
+        return MOCK_AIO_SEARCH_RESPONSE
+
+    aio_fetcher.get = MagicMock(side_effect=fake_get)
+    aio_fetcher.post = MagicMock(return_value=MOCK_AIO_TEST_CASE)
+    aio_fetcher.put = MagicMock(return_value=MOCK_AIO_TEST_CASE)
+    return aio_fetcher
+
+
+class TestBuildStepPayload:
+    """Tests for step payload construction."""
+
+    def test_classic_step_defaults_to_text(self):
+        """A step without an explicit type is a Classic TEXT step."""
+        payload = _build_step_payload(
+            {"step": "Do it", "data": "x", "expected_result": "done"}, 0
+        )
+
+        assert payload == {
+            "step": "Do it",
+            "data": "x",
+            "expectedResult": "done",
+            "stepType": "TEXT",
+        }
+
+    def test_bdd_step_defaults_to_given(self):
+        """A step with only BDD text defaults to a Given step."""
+        payload = _build_step_payload({"bdd_step": "I am logged in"}, 0)
+
+        assert payload == {"bddStep": "I am logged in", "stepType": "BDD_GIVEN"}
+
+    def test_bdd_step_type_is_kept(self):
+        """An explicit BDD keyword is preserved."""
+        payload = _build_step_payload(
+            {"bdd_step": "I click", "step_type": "BDD_WHEN"}, 0
+        )
+
+        assert payload["stepType"] == "BDD_WHEN"
+
+    def test_reference_step(self):
+        """A referenced case is nested under referencedCase."""
+        payload = _build_step_payload(
+            {"step_type": "REFERENCE", "referenced_case_key": "AT-TC-9"}, 0
+        )
+
+        assert payload == {
+            "stepType": "REFERENCE",
+            "referencedCase": {"key": "AT-TC-9"},
+        }
+
+    def test_camel_case_keys_are_accepted(self):
+        """API-style keys work as well as snake_case ones."""
+        payload = _build_step_payload(
+            {"step": "a", "expectedResult": "b", "stepType": "TEXT"}, 0
+        )
+
+        assert payload["expectedResult"] == "b"
+
+    def test_unknown_key_raises(self):
+        """A typo in a step key is reported instead of silently dropped."""
+        with pytest.raises(ValueError, match="Unknown key 'expect'"):
+            _build_step_payload({"step": "a", "expect": "b"}, 0)
+
+    def test_invalid_step_type_raises(self):
+        """Only documented step types are accepted."""
+        with pytest.raises(ValueError, match="Invalid step_type"):
+            _build_step_payload({"step": "a", "step_type": "SCENARIO"}, 0)
+
+    def test_text_step_without_text_raises(self):
+        """A TEXT step needs step text."""
+        with pytest.raises(ValueError, match="no step text"):
+            _build_step_payload({"data": "x"}, 0)
+
+    def test_bdd_step_without_text_raises(self):
+        """A BDD step needs BDD text."""
+        with pytest.raises(ValueError, match="no bdd_step text"):
+            _build_step_payload({"step_type": "BDD_THEN"}, 2)
+
+    def test_reference_step_without_key_raises(self):
+        """A REFERENCE step needs the referenced case key."""
+        with pytest.raises(ValueError, match="no referenced_case_key"):
+            _build_step_payload({"step_type": "REFERENCE"}, 0)
+
+    def test_non_object_step_raises(self):
+        """Steps must be objects."""
+        with pytest.raises(ValueError, match="must be an object"):
+            _build_step_payload("just text", 0)  # type: ignore[arg-type]
+
+
+class TestDateCriteria:
+    """Tests for date search criteria."""
+
+    def test_between(self):
+        """Two bounds produce a BETWEEN criteria."""
+        assert _date_criteria("a", "b") == {
+            "comparisonType": "BETWEEN",
+            "value1": "a",
+            "value2": "b",
+        }
+
+    def test_after_only(self):
+        """A lower bound alone produces AFTER."""
+        assert _date_criteria("a", None) == {"comparisonType": "AFTER", "value1": "a"}
+
+    def test_before_only(self):
+        """An upper bound alone produces BEFORE."""
+        assert _date_criteria(None, "b") == {"comparisonType": "BEFORE", "value1": "b"}
+
+    def test_no_bounds(self):
+        """No bounds produce no criteria."""
+        assert _date_criteria(None, None) is None
+
+
+class TestGetTestCase:
+    """Tests for get_test_case."""
+
+    def test_returns_parsed_case(self, fetcher):
+        """The case payload is parsed into the model."""
+        case = fetcher.get_test_case("PROJ", "AT-TC-17")
+
+        assert case.key == "AT-TC-17"
+        assert case.priority.name == "Critical"
+        assert case.folder.name == "Checkout"
+        assert [step.step for step in case.steps] == [
+            "Search for an item",
+            "Click quick add to cart",
+        ]
+        assert [tag.name for tag in case.tags] == ["Smoke"]
+
+    def test_sends_optional_parameters(self, fetcher):
+        """Optional flags reach the API as query parameters."""
+        fetcher.get_test_case(
+            "PROJ", "AT-TC-17", version=1, include_rtf=True, include_attachments=True
+        )
+
+        args, kwargs = fetcher.get.call_args
+        assert args[0] == "/project/PROJ/testcase/AT-TC-17/detail"
+        assert kwargs["params"] == {
+            "needDataInRTF": True,
+            "needAttachments": True,
+            "version": 1,
+        }
+
+    def test_unset_flags_are_not_sent(self, fetcher):
+        """Defaults leave the query parameters unset."""
+        fetcher.get_test_case("PROJ", "AT-TC-17")
+
+        _, kwargs = fetcher.get.call_args
+        assert kwargs["params"] == {
+            "needDataInRTF": None,
+            "needAttachments": None,
+            "version": None,
+        }
+
+    def test_simplified_dict_shape(self, fetcher):
+        """The simplified dict keeps the useful case fields."""
+        result = fetcher.get_test_case("PROJ", "AT-TC-17").to_simplified_dict()
+
+        assert result["key"] == "AT-TC-17"
+        assert result["status"] == {"id": 21, "name": "Published"}
+        assert result["jira_requirement_ids"] == ["10221"]
+        assert result["custom_fields"] == [
+            {"ID": 10113, "name": "Environment", "value": "Staging"}
+        ]
+
+
+class TestGetTestCaseVersions:
+    """Tests for get_test_case_versions."""
+
+    def test_marks_the_current_version(self, fetcher):
+        """The case's own version is flagged as current."""
+        case = fetcher.get_test_case_versions("PROJ", "AT-TC-17")
+
+        assert [version.to_simplified_dict() for version in case.versions] == [
+            {"is_current": True, "version": 2, "id": 16557},
+            {"is_current": False, "version": 1, "id": 16556},
+        ]
+
+
+class TestSearchTestCases:
+    """Tests for search_test_cases."""
+
+    def test_without_filters_lists_cases(self, fetcher):
+        """With no criteria the plain listing endpoint is used."""
+        result = fetcher.search_test_cases("PROJ")
+
+        fetcher.post.assert_not_called()
+        args, kwargs = fetcher.get.call_args
+        assert args[0] == "/project/PROJ/testcase"
+        assert kwargs["params"]["startAt"] == 0
+        assert len(result.cases) == 1
+
+    def test_title_criteria(self, fetcher):
+        """A title filter posts a CONTAINS criteria."""
+        fetcher.search_test_cases("PROJ", title="cart")
+
+        args, kwargs = fetcher.post.call_args
+        assert args[0] == "/project/PROJ/testcase/search"
+        assert kwargs["json"] == {
+            "title": {"comparisonType": "CONTAINS", "value": "cart"}
+        }
+
+    def test_invalid_title_match_raises(self, fetcher):
+        """Only the two documented comparisons are allowed."""
+        with pytest.raises(ValueError, match="Invalid title_match"):
+            fetcher.search_test_cases("PROJ", title="x", title_match="STARTS_WITH")
+
+    def test_lookup_names_are_resolved(self, fetcher):
+        """Status, priority and type names resolve to IDs."""
+        fetcher.search_test_cases(
+            "PROJ",
+            statuses=["Published"],
+            priorities=["Critical"],
+            types=["Functional"],
+            automation_statuses=["Automated"],
+        )
+
+        _, kwargs = fetcher.post.call_args
+        assert kwargs["json"]["statusID"] == {"comparisonType": "IN", "list": [21]}
+        assert kwargs["json"]["priorityID"] == {"comparisonType": "IN", "list": [10]}
+        assert kwargs["json"]["typeID"] == {"comparisonType": "IN", "list": [1]}
+        assert kwargs["json"]["automationStatusID"] == {
+            "comparisonType": "IN",
+            "list": [31],
+        }
+
+    def test_folder_paths_are_resolved(self, fetcher):
+        """Folder names and paths resolve to folder IDs."""
+        fetcher.search_test_cases("PROJ", folders=["/Regression/Checkout", 200])
+
+        _, kwargs = fetcher.post.call_args
+        assert kwargs["json"]["folderID"] == {
+            "comparisonType": "IN",
+            "list": [101, 200],
+        }
+
+    def test_text_and_list_criteria(self, fetcher):
+        """Keys, tags, owners and requirements map to list criteria."""
+        fetcher.search_test_cases(
+            "PROJ",
+            keys=["AT-TC-1"],
+            tags=["Smoke"],
+            owner_ids=["acc-1"],
+            requirement_ids=["PROJ-42"],
+            automation_key="com.example.Test",
+        )
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["key"] == {"comparisonType": "IN", "list": ["AT-TC-1"]}
+        assert payload["tag"] == {"comparisonType": "IN", "list": ["Smoke"]}
+        assert payload["ownedByID"] == {"comparisonType": "IN", "list": ["acc-1"]}
+        assert payload["requirementID"] == {"comparisonType": "IN", "list": ["PROJ-42"]}
+        assert payload["automationKey"] == {
+            "comparisonType": "CONTAINS",
+            "value": "com.example.Test",
+        }
+
+    def test_date_and_archived_criteria(self, fetcher):
+        """Date ranges and the archived flag map to their criteria."""
+        fetcher.search_test_cases(
+            "PROJ",
+            created_after="2026-01-01T00:00:00Z",
+            updated_before="2026-02-01T00:00:00Z",
+            include_archived=False,
+        )
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["createdDate"]["comparisonType"] == "AFTER"
+        assert payload["updatedDate"]["comparisonType"] == "BEFORE"
+        assert payload["isArchived"] == {"value": False}
+
+    def test_page_size_is_clamped_to_api_minimum(self, fetcher):
+        """The API rejects pages below 10, so a small ask is padded then trimmed."""
+        result = fetcher.search_test_cases("PROJ", max_results=1)
+
+        _, kwargs = fetcher.get.call_args
+        assert kwargs["params"]["maxResults"] == 10
+        assert result.max_results == 1
+
+    def test_extra_results_are_trimmed(self, aio_fetcher):
+        """Results beyond the requested count are dropped and flagged."""
+        aio_fetcher.get = MagicMock(
+            return_value={
+                "items": [MOCK_AIO_TEST_CASE] * 10,
+                "startAt": 0,
+                "maxResults": 10,
+                "isLast": True,
+            }
+        )
+
+        result = aio_fetcher.search_test_cases("PROJ", max_results=3)
+
+        assert len(result.cases) == 3
+        assert result.is_last is False
+
+    def test_simplified_dict_shape(self, fetcher):
+        """The search result exposes pagination metadata."""
+        result = fetcher.search_test_cases("PROJ").to_simplified_dict()
+
+        assert result["count"] == 1
+        assert result["start_at"] == 0
+        assert result["is_last"] is True
+        assert result["test_cases"][0]["key"] == "AT-TC-17"
+
+
+class TestCreateTestCase:
+    """Tests for create_test_case."""
+
+    def test_minimal_case(self, fetcher):
+        """A title alone is enough to create a case."""
+        fetcher.create_test_case("PROJ", "New case")
+
+        args, kwargs = fetcher.post.call_args
+        assert args[0] == "/project/PROJ/testcase"
+        assert kwargs["json"] == {"title": "New case"}
+
+    @pytest.mark.parametrize("title", ["", "   "])
+    def test_empty_title_raises(self, fetcher, title):
+        """An empty title is rejected before any call."""
+        with pytest.raises(ValueError, match="title is required"):
+            fetcher.create_test_case("PROJ", title)
+        fetcher.post.assert_not_called()
+
+    def test_resolves_lookups_and_folder(self, fetcher):
+        """Field names are resolved to the IDs the API expects."""
+        fetcher.create_test_case(
+            "PROJ",
+            "New case",
+            priority="Critical",
+            status="Published",
+            type="Functional",
+            script_type="BDD",
+            automation_status="Automated",
+            folder="/Regression/Checkout",
+        )
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["priority"] == {"ID": 10}
+        assert payload["status"] == {"ID": 21}
+        assert payload["type"] == {"ID": 1}
+        assert payload["scriptType"] == {"ID": 41}
+        assert payload["automationStatus"] == {"ID": 31}
+        assert payload["folder"] == {"ID": 101}
+
+    def test_builds_steps(self, fetcher):
+        """Steps are translated into the API shape."""
+        fetcher.create_test_case(
+            "PROJ",
+            "New case",
+            steps=[{"step": "Login", "expected_result": "Home page"}],
+        )
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["steps"] == [
+            {"step": "Login", "expectedResult": "Home page", "stepType": "TEXT"}
+        ]
+
+    def test_resolves_tags(self, fetcher):
+        """Tag names resolve to existing tag IDs."""
+        fetcher.create_test_case("PROJ", "New case", tags=["Smoke"])
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["tags"] == [{"tag": {"ID": 2, "name": "Smoke"}}]
+
+    def test_custom_fields_from_mapping(self, fetcher):
+        """A name/value mapping resolves to custom field IDs."""
+        fetcher.create_test_case(
+            "PROJ", "New case", custom_fields={"Environment": "Staging"}
+        )
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["customFields"] == [
+            {"ID": 10113, "name": "Environment", "value": "Staging"}
+        ]
+
+    def test_custom_fields_from_list(self, fetcher):
+        """A list of entries works too, including explicit IDs."""
+        fetcher.create_test_case(
+            "PROJ",
+            "New case",
+            custom_fields=[{"id": 10114, "value": "acc-1"}],
+        )
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["customFields"] == [
+            {"ID": 10114, "name": None, "value": "acc-1"}
+        ]
+
+    def test_unknown_custom_field_raises(self, fetcher):
+        """An undefined custom field name is reported with the alternatives."""
+        with pytest.raises(ValueError, match="is not defined for project"):
+            fetcher.create_test_case("PROJ", "New case", custom_fields={"Nope": 1})
+
+    def test_jira_associations(self, fetcher):
+        """Requirement, component and release IDs are forwarded."""
+        fetcher.create_test_case(
+            "PROJ",
+            "New case",
+            requirement_ids=["PROJ-42"],
+            component_ids=[10000],
+            release_ids=["10500"],
+        )
+
+        payload = fetcher.post.call_args[1]["json"]
+        assert payload["jiraRequirementIDs"] == ["PROJ-42"]
+        assert payload["jiraComponentIDs"] == [10000]
+        assert payload["jiraReleaseIDs"] == [10500]
+
+    def test_unknown_field_raises(self, fetcher):
+        """A misspelled field name is reported instead of dropped."""
+        with pytest.raises(ValueError, match="Unknown test case field"):
+            fetcher.create_test_case("PROJ", "New case", priorty="Critical")
+
+    def test_include_rtf_flag(self, fetcher):
+        """The RTF flag reaches the API as a query parameter."""
+        fetcher.create_test_case("PROJ", "New case", include_rtf=True)
+
+        assert fetcher.post.call_args[1]["params"] == {"needDataInRTF": True}
+
+    def test_missing_folder_is_created(self, fetcher):
+        """A folder that does not exist yet is created on demand."""
+        fetcher.create_test_case("PROJ", "New case", folder="/Brand/New")
+
+        fetcher.put.assert_called_once()
+        assert fetcher.put.call_args[1]["json"] == {"folderHierarchy": ["Brand", "New"]}
+
+    def test_missing_folder_can_be_rejected(self, fetcher):
+        """Folder creation can be turned off."""
+        with pytest.raises(ValueError, match="was not found"):
+            fetcher.create_test_case(
+                "PROJ",
+                "New case",
+                folder="/Brand/New",
+                create_folder_if_missing=False,
+            )
+
+
+class TestUpdateTestCase:
+    """Tests for update_test_case."""
+
+    def test_merges_with_current_case(self, fetcher):
+        """Unspecified fields keep their current values."""
+        fetcher.update_test_case("PROJ", "AT-TC-17", priority="Medium")
+
+        args, kwargs = fetcher.put.call_args
+        assert args[0] == "/project/PROJ/testcase/AT-TC-17/detail"
+        payload = kwargs["json"]
+        assert payload["priority"] == {"ID": 11}
+        assert payload["title"] == MOCK_AIO_TEST_CASE["title"]
+        assert payload["steps"] == MOCK_AIO_TEST_CASE["steps"]
+
+    def test_strips_read_only_fields(self, fetcher):
+        """Read-only attributes are never sent back."""
+        fetcher.update_test_case("PROJ", "AT-TC-17", priority="Medium")
+
+        payload = fetcher.put.call_args[1]["json"]
+        for field in ("key", "version", "createdDate", "isArchived", "versions"):
+            assert field not in payload
+
+    def test_replaces_steps(self, fetcher):
+        """Supplying steps replaces the whole list."""
+        fetcher.update_test_case("PROJ", "AT-TC-17", steps=[{"bdd_step": "I log in"}])
+
+        payload = fetcher.put.call_args[1]["json"]
+        assert payload["steps"] == [{"bddStep": "I log in", "stepType": "BDD_GIVEN"}]
+
+    def test_updates_title(self, fetcher):
+        """The title can be changed like any other field."""
+        fetcher.update_test_case("PROJ", "AT-TC-17", title="Renamed")
+
+        assert fetcher.put.call_args[1]["json"]["title"] == "Renamed"
+
+    def test_empty_title_raises(self, fetcher):
+        """Clearing the title is rejected."""
+        with pytest.raises(ValueError, match="title cannot be empty"):
+            fetcher.update_test_case("PROJ", "AT-TC-17", title="  ")
+
+    def test_no_changes_raises(self, fetcher):
+        """An update with nothing to change is rejected."""
+        with pytest.raises(ValueError, match="No fields to update"):
+            fetcher.update_test_case("PROJ", "AT-TC-17")
+        fetcher.put.assert_not_called()
+
+    def test_does_not_create_a_version_by_default(self, fetcher):
+        """In-place update is the default behaviour."""
+        fetcher.update_test_case("PROJ", "AT-TC-17", priority="Medium")
+
+        assert fetcher.put.call_args[1]["params"]["createNewVersion"] is None
+
+    def test_can_create_a_new_version(self, fetcher):
+        """A new version is created only when asked for."""
+        fetcher.update_test_case(
+            "PROJ", "AT-TC-17", priority="Medium", create_new_version=True
+        )
+
+        assert fetcher.put.call_args[1]["params"]["createNewVersion"] is True
+
+    def test_targets_a_specific_version(self, fetcher):
+        """The version parameter is forwarded to both the read and the write."""
+        fetcher.update_test_case("PROJ", "AT-TC-17", priority="Medium", version=1)
+
+        assert fetcher.get.call_args[1]["params"]["version"] == 1
+        assert fetcher.put.call_args[1]["params"]["version"] == 1
+
+    def test_round_trips_rich_text_markup(self, fetcher):
+        """Both sides of the round trip keep HTML so formatting is not flattened."""
+        fetcher.update_test_case("PROJ", "AT-TC-17", priority="Medium")
+
+        assert fetcher.get.call_args[1]["params"]["needDataInRTF"] is True
+        assert fetcher.put.call_args[1]["params"]["needDataInRTF"] is True
+
+    def test_escapes_plain_text_values(self, fetcher):
+        """Plain-text input is escaped so it is stored as written."""
+        fetcher.update_test_case(
+            "PROJ",
+            "AT-TC-17",
+            description="a < b & c\nsecond line",
+            precondition="x > y",
+        )
+
+        payload = fetcher.put.call_args[1]["json"]
+        assert payload["description"] == "a &lt; b &amp; c<br/>second line"
+        assert payload["precondition"] == "x &gt; y"
+
+    def test_escapes_plain_text_steps(self, fetcher):
+        """Step text is escaped along with the other rich-text fields."""
+        fetcher.update_test_case(
+            "PROJ", "AT-TC-17", steps=[{"step": "click <ok>", "data": "a & b"}]
+        )
+
+        step = fetcher.put.call_args[1]["json"]["steps"][0]
+        assert step["step"] == "click &lt;ok&gt;"
+        assert step["data"] == "a &amp; b"
+
+    def test_escapes_multi_line_custom_fields_only(self, fetcher):
+        """Only multi-line text custom fields are escaped."""
+        fetcher.update_test_case(
+            "PROJ",
+            "AT-TC-17",
+            custom_fields={"Notes": "a < b", "Environment": "a < b"},
+        )
+
+        by_name = {
+            field["name"]: field["value"]
+            for field in fetcher.put.call_args[1]["json"]["customFields"]
+        }
+        assert by_name["Notes"] == "a &lt; b"
+        assert by_name["Environment"] == "a < b"
+
+    def test_html_input_is_passed_through(self, fetcher):
+        """With include_rtf the caller's HTML reaches the API untouched."""
+        fetcher.update_test_case(
+            "PROJ",
+            "AT-TC-17",
+            description="<p>Rich <b>text</b></p>",
+            include_rtf=True,
+        )
+
+        payload = fetcher.put.call_args[1]["json"]
+        assert payload["description"] == "<p>Rich <b>text</b></p>"
+
+    def test_create_does_not_escape_plain_text(self, fetcher):
+        """Creation has nothing to round-trip, so values are sent verbatim."""
+        fetcher.create_test_case("PROJ", "New case", description="a < b")
+
+        assert fetcher.post.call_args[1]["json"]["description"] == "a < b"
+
+    def test_missing_case_raises(self, aio_fetcher):
+        """A case that cannot be read is reported clearly."""
+        aio_fetcher.get = MagicMock(
+            side_effect=lambda path, params=None: (
+                MOCK_AIO_PROJECT_CONFIG if path.endswith("/config") else None
+            )
+        )
+        aio_fetcher.put = MagicMock()
+
+        with pytest.raises(ValueError, match="was not found"):
+            aio_fetcher.update_test_case("PROJ", "AT-TC-99", priority="Medium")

--- a/tests/unit/aio/test_client.py
+++ b/tests/unit/aio/test_client.py
@@ -1,0 +1,215 @@
+"""Tests for the AIO Tests HTTP client."""
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from mcp_atlassian.aio.client import AIOApiError, AIOClient
+from mcp_atlassian.aio.config import AIOConfig
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+
+
+def make_response(
+    status_code: int = 200, json_body=None, text: str = "", content: bytes = b"{}"
+) -> MagicMock:
+    """Build a mock requests.Response.
+
+    Args:
+        status_code: HTTP status code.
+        json_body: Body returned by ``.json()``; a ValueError is raised if unset.
+        text: Raw response text.
+        content: Raw response bytes.
+
+    Returns:
+        The mock response.
+    """
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = status_code < 400
+    response.text = text
+    response.content = content
+    if json_body is None:
+        response.json.side_effect = ValueError("no json")
+    else:
+        response.json.return_value = json_body
+    return response
+
+
+class TestAIOClientAuth:
+    """Tests for authentication header setup."""
+
+    def test_cloud_token_uses_aioauth_scheme(self):
+        """Cloud tokens are sent with the AioAuth scheme."""
+        client = AIOClient(
+            config=AIOConfig(url="https://x/api/v1", auth_type="token", api_token="tok")
+        )
+        assert client.session.headers["Authorization"] == "AioAuth tok"
+
+    def test_pat_uses_bearer_scheme(self):
+        """Server/DC PATs are sent as bearer tokens."""
+        client = AIOClient(
+            config=AIOConfig(
+                url="https://x/api/v1", auth_type="pat", personal_token="pat"
+            )
+        )
+        assert client.session.headers["Authorization"] == "Bearer pat"
+
+    def test_basic_auth_sets_session_auth(self):
+        """Basic auth is applied to the session."""
+        client = AIOClient(
+            config=AIOConfig(
+                url="https://x/api/v1",
+                auth_type="basic",
+                username="user",
+                password="pass",
+            )
+        )
+        assert client.session.auth == ("user", "pass")
+
+    def test_custom_headers_applied(self):
+        """Custom headers reach the session."""
+        client = AIOClient(
+            config=AIOConfig(
+                url="https://x/api/v1",
+                auth_type="token",
+                api_token="tok",
+                custom_headers={"X-Trace": "1"},
+            )
+        )
+        assert client.session.headers["X-Trace"] == "1"
+
+
+class TestProjectPath:
+    """Tests for project path building."""
+
+    def test_builds_escaped_path(self):
+        """Segments are joined and URL-escaped."""
+        assert (
+            AIOClient.project_path("PROJ", "testcase", "AT-TC-1", "detail")
+            == "/project/PROJ/testcase/AT-TC-1/detail"
+        )
+
+    def test_escapes_special_characters(self):
+        """Slashes inside a segment cannot break out of the path."""
+        assert AIOClient.project_path("A/B", "tag") == "/project/A%2FB/tag"
+
+    def test_numeric_segments(self):
+        """Numeric segments are stringified."""
+        assert (
+            AIOClient.project_path(10010, "testcase", 5) == "/project/10010/testcase/5"
+        )
+
+    @pytest.mark.parametrize("project_key", ["", "   "])
+    def test_empty_project_key_raises(self, project_key):
+        """An empty project key is rejected."""
+        with pytest.raises(ValueError, match="Project key or ID is required"):
+            AIOClient.project_path(project_key)
+
+
+class TestAIOClientRequest:
+    """Tests for request execution and error handling."""
+
+    @pytest.fixture
+    def client(self) -> AIOClient:
+        """Provide a client with a mocked session."""
+        client = AIOClient(
+            config=AIOConfig(
+                url="https://tcms.example.com/api/v1",
+                auth_type="token",
+                api_token="tok",
+            )
+        )
+        client.session = MagicMock()
+        return client
+
+    def test_get_returns_json(self, client):
+        """A successful GET returns the decoded body."""
+        client.session.request.return_value = make_response(json_body={"ID": 1})
+
+        assert client.get("/project/PROJ/tag") == {"ID": 1}
+        _, kwargs = client.session.request.call_args
+        args, _ = client.session.request.call_args
+        assert args[0] == "GET"
+        assert args[1] == "https://tcms.example.com/api/v1/project/PROJ/tag"
+
+    def test_none_params_are_dropped(self, client):
+        """Unset query parameters are not sent."""
+        client.session.request.return_value = make_response(json_body={})
+
+        client.get("/path", params={"a": 1, "b": None, "c": False})
+
+        _, kwargs = client.session.request.call_args
+        assert kwargs["params"] == {"a": 1, "c": False}
+
+    def test_empty_params_send_none(self, client):
+        """An empty parameter dict is sent as no parameters."""
+        client.session.request.return_value = make_response(json_body={})
+
+        client.get("/path")
+
+        _, kwargs = client.session.request.call_args
+        assert kwargs["params"] is None
+
+    def test_empty_body_returns_none(self, client):
+        """A 204-style empty body decodes to None."""
+        client.session.request.return_value = make_response(content=b"")
+
+        assert client.put("/path") is None
+
+    def test_non_json_body_returns_text(self, client):
+        """A non-JSON body is returned as text."""
+        client.session.request.return_value = make_response(
+            text="plain", content=b"plain"
+        )
+
+        assert client.post("/path") == "plain"
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    def test_auth_errors_raise_authentication_error(self, client, status_code):
+        """401 and 403 map to the shared authentication error."""
+        client.session.request.return_value = make_response(
+            status_code=status_code, text="denied", content=b"denied"
+        )
+
+        with pytest.raises(MCPAtlassianAuthenticationError, match="Authentication"):
+            client.get("/path")
+
+    def test_other_errors_raise_api_error_with_status(self, client):
+        """Other error statuses surface as AIOApiError."""
+        client.session.request.return_value = make_response(
+            status_code=404, text="Resource Not Found", content=b"Resource Not Found"
+        )
+
+        with pytest.raises(AIOApiError, match="404") as exc_info:
+            client.get("/path")
+        assert exc_info.value.status_code == 404
+        assert "Resource Not Found" in str(exc_info.value)
+
+    def test_long_error_body_is_truncated(self, client):
+        """Very long error bodies are truncated before logging."""
+        body = "x" * 900
+        client.session.request.return_value = make_response(
+            status_code=500, text=body, content=body.encode()
+        )
+
+        with pytest.raises(AIOApiError) as exc_info:
+            client.get("/path")
+        assert "..." in str(exc_info.value)
+        assert len(str(exc_info.value)) < 700
+
+    def test_network_error_raises_api_error(self, client):
+        """Network failures are wrapped in AIOApiError."""
+        client.session.request.side_effect = requests.ConnectionError("boom")
+
+        with pytest.raises(AIOApiError, match="Network error"):
+            client.get("/path")
+
+    def test_post_sends_json_body(self, client):
+        """POST forwards the JSON payload."""
+        client.session.request.return_value = make_response(json_body={"ok": True})
+
+        client.post("/path", json={"title": "x"})
+
+        _, kwargs = client.session.request.call_args
+        assert kwargs["json"] == {"title": "x"}

--- a/tests/unit/aio/test_config.py
+++ b/tests/unit/aio/test_config.py
@@ -1,0 +1,190 @@
+"""Tests for the AIOConfig class."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from mcp_atlassian.aio.config import AIOConfig, is_aio_enabled
+from mcp_atlassian.aio.constants import AIO_CLOUD_API_BASE
+
+
+class TestAIOConfigFromEnv:
+    """Tests for AIOConfig.from_env."""
+
+    def test_cloud_token_without_jira_url(self):
+        """An AIO token alone is enough to reach AIO Tests Cloud."""
+        with patch.dict(os.environ, {"AIO_API_TOKEN": "tok"}, clear=True):
+            config = AIOConfig.from_env()
+
+        assert config.url == AIO_CLOUD_API_BASE
+        assert config.auth_type == "token"
+        assert config.api_token == "tok"
+        assert config.is_cloud is True
+        assert config.is_auth_configured() is True
+
+    def test_cloud_jira_url_uses_cloud_api_base(self):
+        """A Jira Cloud URL still routes to the AIO Tests Cloud API host."""
+        env = {
+            "JIRA_URL": "https://example.atlassian.net",
+            "AIO_API_TOKEN": "tok",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = AIOConfig.from_env()
+
+        assert config.url == AIO_CLOUD_API_BASE
+        assert config.is_cloud is True
+
+    def test_cloud_without_token_raises(self):
+        """AIO Tests Cloud cannot authenticate with Jira credentials."""
+        env = {
+            "JIRA_URL": "https://example.atlassian.net",
+            "JIRA_USERNAME": "user@example.com",
+            "JIRA_API_TOKEN": "jira-token",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="requires an access token"):
+                AIOConfig.from_env()
+
+    def test_server_derives_url_and_reuses_jira_pat(self):
+        """Server/DC serves the AIO API from Jira and reuses its PAT."""
+        env = {
+            "JIRA_URL": "https://jira.internal.example.com",
+            "JIRA_PERSONAL_TOKEN": "pat-token",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = AIOConfig.from_env()
+
+        assert config.url == ("https://jira.internal.example.com/rest/aio-tcms-api/1.0")
+        assert config.auth_type == "pat"
+        assert config.personal_token == "pat-token"
+        assert config.is_cloud is False
+
+    def test_server_basic_auth(self):
+        """Server/DC falls back to basic auth when no PAT is configured."""
+        env = {
+            "JIRA_URL": "https://jira.internal.example.com",
+            "JIRA_USERNAME": "user",
+            "JIRA_API_TOKEN": "secret",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = AIOConfig.from_env()
+
+        assert config.auth_type == "basic"
+        assert config.username == "user"
+        assert config.password == "secret"
+        assert config.is_auth_configured() is True
+
+    def test_server_without_credentials_raises(self):
+        """A Server/DC URL without credentials is an error."""
+        with patch.dict(
+            os.environ, {"JIRA_URL": "https://jira.internal.example.com"}, clear=True
+        ):
+            with pytest.raises(ValueError, match="Server/Data Center authentication"):
+                AIOConfig.from_env()
+
+    def test_missing_url_raises(self):
+        """Without any URL hint the configuration cannot be built."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Cannot determine the AIO Tests"):
+                AIOConfig.from_env()
+
+    def test_explicit_url_overrides_and_strips_slash(self):
+        """AIO_URL wins over the derived URL and loses its trailing slash."""
+        env = {
+            "AIO_URL": "https://aio.internal.example.com/api/v1/",
+            "AIO_PERSONAL_TOKEN": "pat",
+            "JIRA_URL": "https://example.atlassian.net",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = AIOConfig.from_env()
+
+        assert config.url == "https://aio.internal.example.com/api/v1"
+        assert config.auth_type == "pat"
+        assert config.is_cloud is False
+
+    def test_aio_credentials_take_precedence_over_jira(self):
+        """AIO-specific credentials win over the Jira fallbacks."""
+        env = {
+            "JIRA_URL": "https://jira.internal.example.com",
+            "JIRA_PERSONAL_TOKEN": "jira-pat",
+            "AIO_PERSONAL_TOKEN": "aio-pat",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = AIOConfig.from_env()
+
+        assert config.personal_token == "aio-pat"
+
+    def test_proxy_and_ssl_settings(self):
+        """Proxy and SSL settings are read from the environment."""
+        env = {
+            "AIO_API_TOKEN": "tok",
+            "AIO_SSL_VERIFY": "false",
+            "AIO_HTTP_PROXY": "http://proxy:8080",
+            "AIO_CUSTOM_HEADERS": "X-Trace=1,X-Env=test",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = AIOConfig.from_env()
+
+        assert config.ssl_verify is False
+        assert config.http_proxy == "http://proxy:8080"
+        assert config.custom_headers == {"X-Trace": "1", "X-Env": "test"}
+
+
+class TestAIOConfigAuth:
+    """Tests for AIOConfig.is_auth_configured."""
+
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            ({"auth_type": "token", "api_token": "t"}, True),
+            ({"auth_type": "token"}, False),
+            ({"auth_type": "pat", "personal_token": "t"}, True),
+            ({"auth_type": "pat"}, False),
+            ({"auth_type": "basic", "username": "u", "password": "p"}, True),
+            ({"auth_type": "basic", "username": "u"}, False),
+        ],
+    )
+    def test_is_auth_configured(self, kwargs, expected):
+        """Each auth type requires its own credentials."""
+        config = AIOConfig(url="https://example.com", **kwargs)
+        assert config.is_auth_configured() is expected
+
+    def test_unknown_auth_type_is_not_configured(self):
+        """An unexpected auth type is reported as unconfigured."""
+        config = AIOConfig(url="https://example.com", auth_type="basic")
+        config.auth_type = "unknown"  # type: ignore[assignment]
+        assert config.is_auth_configured() is False
+
+
+class TestIsAIOEnabled:
+    """Tests for the is_aio_enabled opt-in helper."""
+
+    def test_token_enables_implicitly(self):
+        """A Cloud token is itself the opt-in."""
+        with patch.dict(os.environ, {"AIO_API_TOKEN": "tok"}, clear=True):
+            assert is_aio_enabled() is True
+
+    def test_jira_alone_does_not_enable(self):
+        """A Jira deployment without the app must not expose AIO tools."""
+        env = {
+            "JIRA_URL": "https://jira.internal.example.com",
+            "JIRA_PERSONAL_TOKEN": "pat",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert is_aio_enabled() is False
+
+    def test_explicit_flag_enables_server(self):
+        """AIO_ENABLED opts a Server/DC deployment in."""
+        env = {
+            "JIRA_URL": "https://jira.internal.example.com",
+            "JIRA_PERSONAL_TOKEN": "pat",
+            "AIO_ENABLED": "true",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert is_aio_enabled() is True
+
+    def test_flag_without_url_does_not_enable(self):
+        """The flag alone is not enough without a URL to call."""
+        with patch.dict(os.environ, {"AIO_ENABLED": "true"}, clear=True):
+            assert is_aio_enabled() is False

--- a/tests/unit/aio/test_folders.py
+++ b/tests/unit/aio/test_folders.py
@@ -1,0 +1,204 @@
+"""Tests for AIO Tests folder operations."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.aio.folders import normalize_folder_path
+from tests.fixtures.aio_mocks import MOCK_AIO_FOLDER_DETAILS, MOCK_AIO_FOLDER_TREE
+
+
+@pytest.fixture
+def fetcher(aio_fetcher):
+    """Provide a fetcher whose folder tree call returns the mock tree."""
+    aio_fetcher.get = MagicMock(return_value=MOCK_AIO_FOLDER_TREE)
+    aio_fetcher.put = MagicMock(return_value=MOCK_AIO_FOLDER_DETAILS)
+    return aio_fetcher
+
+
+class TestNormalizeFolderPath:
+    """Tests for folder path parsing."""
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("Regression", ["Regression"]),
+            ("/Regression/Checkout", ["Regression", "Checkout"]),
+            ("Regression/Checkout/", ["Regression", "Checkout"]),
+            ("  /A / B ", ["A", "B"]),
+        ],
+    )
+    def test_splits_paths(self, path, expected):
+        """Paths split into their folder names, ignoring empty segments."""
+        assert normalize_folder_path(path) == expected
+
+    @pytest.mark.parametrize("path", ["", "/", "   ", "//"])
+    def test_empty_paths_raise(self, path):
+        """A path with no folder name is rejected."""
+        with pytest.raises(ValueError, match="at least one folder name"):
+            normalize_folder_path(path)
+
+
+class TestGetFolderHierarchy:
+    """Tests for get_folder_hierarchy."""
+
+    def test_builds_nested_tree_with_paths(self, fetcher):
+        """Children get a resolved parent ID and full path."""
+        roots = fetcher.get_folder_hierarchy("PROJ")
+
+        assert [root.name for root in roots] == ["Regression", "Smoke"]
+        checkout = roots[0].children[0]
+        assert checkout.path == "/Regression/Checkout"
+        assert checkout.parent_id == 100
+        fetcher.get.assert_called_once_with("/project/PROJ/testcase/folder")
+
+    def test_uses_requested_folder_type(self, fetcher):
+        """The folder type selects the tree to read."""
+        fetcher.get_folder_hierarchy("PROJ", "testcycle")
+
+        fetcher.get.assert_called_once_with("/project/PROJ/testcycle/folder")
+
+    def test_rejects_unknown_folder_type(self, fetcher):
+        """An unsupported folder type is rejected before any call."""
+        with pytest.raises(ValueError, match="Invalid folder type"):
+            fetcher.get_folder_hierarchy("PROJ", "testplan")
+
+    def test_result_is_cached(self, fetcher):
+        """The tree is fetched once per project and folder type."""
+        fetcher.get_folder_hierarchy("PROJ")
+        fetcher.get_folder_hierarchy("PROJ")
+
+        assert fetcher.get.call_count == 1
+
+    def test_flatten_returns_all_folders(self, fetcher):
+        """Flattening yields parents before children with full paths."""
+        folders = fetcher.flatten_folders("PROJ")
+
+        assert [folder.path for folder in folders] == [
+            "/Regression",
+            "/Regression/Checkout",
+            "/Regression/Login",
+            "/Smoke",
+        ]
+
+    def test_simplified_dict_nests_children(self, fetcher):
+        """The simplified tree keeps its children."""
+        root = fetcher.get_folder_hierarchy("PROJ")[0].to_simplified_dict()
+
+        assert root["name"] == "Regression"
+        assert [child["name"] for child in root["children"]] == ["Checkout", "Login"]
+
+
+class TestFindFolder:
+    """Tests for find_folder."""
+
+    def test_finds_by_full_path(self, fetcher):
+        """A full path matches exactly one folder."""
+        folder = fetcher.find_folder("PROJ", "/Regression/Checkout")
+
+        assert folder is not None
+        assert folder.id == 101
+
+    def test_finds_by_unique_name(self, fetcher):
+        """A bare name works when it is unique in the project."""
+        folder = fetcher.find_folder("PROJ", "Login")
+
+        assert folder is not None
+        assert folder.id == 102
+
+    def test_match_is_case_insensitive(self, fetcher):
+        """Folder lookups ignore case."""
+        assert fetcher.find_folder("PROJ", "checkout").id == 101
+
+    def test_missing_folder_returns_none(self, fetcher):
+        """An unknown folder is simply not found."""
+        assert fetcher.find_folder("PROJ", "/Nope") is None
+
+    def test_ambiguous_name_raises(self, aio_fetcher):
+        """A duplicated folder name requires a full path."""
+        aio_fetcher.get = MagicMock(
+            return_value=[
+                {"ID": 1, "name": "A", "children": [{"ID": 2, "name": "Shared"}]},
+                {"ID": 3, "name": "B", "children": [{"ID": 4, "name": "Shared"}]},
+            ]
+        )
+
+        with pytest.raises(ValueError, match="is ambiguous"):
+            aio_fetcher.find_folder("PROJ", "Shared")
+
+
+class TestCreateFolder:
+    """Tests for create_folder."""
+
+    def test_creates_hierarchy(self, fetcher):
+        """The folder path is sent as a hierarchy of names."""
+        folder = fetcher.create_folder("PROJ", "/Regression/Checkout")
+
+        fetcher.put.assert_called_once_with(
+            "/project/PROJ/testcase/folder/hierarchy",
+            json={"folderHierarchy": ["Regression", "Checkout"]},
+        )
+        assert folder.id == 101
+        assert folder.name == "Checkout"
+
+    def test_creates_under_parent_folder(self, fetcher):
+        """A base folder ID scopes the created hierarchy."""
+        fetcher.create_folder("PROJ", "Checkout", parent_folder_id=100)
+
+        _, kwargs = fetcher.put.call_args
+        assert kwargs["json"] == {
+            "folderHierarchy": ["Checkout"],
+            "baseFolderId": 100,
+        }
+
+    def test_invalidates_cached_tree(self, fetcher):
+        """The cached tree is dropped so later reads see the new folder."""
+        fetcher.get_folder_hierarchy("PROJ")
+        fetcher.create_folder("PROJ", "New")
+        fetcher.get_folder_hierarchy("PROJ")
+
+        # One call before creation and one re-fetch afterwards while resolving
+        # the new folder's path; the read after that is served from the
+        # repopulated cache.
+        assert fetcher.get.call_count == 2
+
+    def test_rejects_unknown_folder_type(self, fetcher):
+        """An unsupported folder type is rejected before any call."""
+        with pytest.raises(ValueError, match="Invalid folder type"):
+            fetcher.create_folder("PROJ", "New", folder_type="testplan")
+        fetcher.put.assert_not_called()
+
+
+class TestResolveFolderId:
+    """Tests for resolve_folder_id."""
+
+    def test_passes_through_integer(self, fetcher):
+        """An integer is already a folder ID."""
+        assert fetcher.resolve_folder_id("PROJ", 42) == 42
+        fetcher.get.assert_not_called()
+
+    def test_passes_through_numeric_string(self, fetcher):
+        """A numeric string is treated as a folder ID."""
+        assert fetcher.resolve_folder_id("PROJ", "42") == 42
+
+    def test_resolves_path(self, fetcher):
+        """A path resolves to the matching folder ID."""
+        assert fetcher.resolve_folder_id("PROJ", "/Regression/Login") == 102
+
+    def test_missing_folder_raises_by_default(self, fetcher):
+        """Unknown folders are an error unless creation is requested."""
+        with pytest.raises(ValueError, match="was not found"):
+            fetcher.resolve_folder_id("PROJ", "/Nope")
+        fetcher.put.assert_not_called()
+
+    def test_missing_folder_can_be_created(self, fetcher):
+        """With create_missing the hierarchy is created on demand."""
+        folder_id = fetcher.resolve_folder_id("PROJ", "/Nope", create_missing=True)
+
+        assert folder_id == 101
+        fetcher.put.assert_called_once()
+
+    @pytest.mark.parametrize("value", [None, "", "  "])
+    def test_empty_values_return_none(self, fetcher, value):
+        """Empty values resolve to nothing."""
+        assert fetcher.resolve_folder_id("PROJ", value) is None

--- a/tests/unit/aio/test_projects.py
+++ b/tests/unit/aio/test_projects.py
@@ -1,0 +1,153 @@
+"""Tests for AIO Tests project and schema operations."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.aio.client import AIOApiError
+from tests.fixtures.aio_mocks import MOCK_AIO_PROJECT_CONFIG
+
+
+@pytest.fixture
+def fetcher(aio_fetcher):
+    """Provide a fetcher whose configuration call returns the mock config."""
+    aio_fetcher.get = MagicMock(return_value=MOCK_AIO_PROJECT_CONFIG)
+    return aio_fetcher
+
+
+class TestGetProject:
+    """Tests for get_project."""
+
+    def test_returns_enabled_project(self, fetcher):
+        """A successful configuration call proves AIO Tests is enabled."""
+        project = fetcher.get_project("PROJ")
+
+        assert project.aio_enabled is True
+        assert project.key == "PROJ"
+        assert project.id == 10010
+        assert project.adhoc_cycle_key == "AT-CY-1"
+        fetcher.get.assert_called_once_with("/project/PROJ/config")
+
+    def test_reports_disabled_project(self, aio_fetcher):
+        """An API error means AIO Tests is unavailable for the project."""
+        aio_fetcher.get = MagicMock(
+            side_effect=AIOApiError("AIO Tests API error 404", status_code=404)
+        )
+
+        project = aio_fetcher.get_project("NOPE")
+
+        assert project.aio_enabled is False
+        assert project.key == "NOPE"
+        assert "404" in (project.error or "")
+        assert project.to_simplified_dict()["aio_enabled"] is False
+
+    def test_configuration_is_cached(self, fetcher):
+        """The configuration is fetched once per project."""
+        fetcher.get_project("PROJ")
+        fetcher.get_project("PROJ")
+
+        assert fetcher.get.call_count == 1
+
+    def test_refresh_bypasses_cache(self, fetcher):
+        """An explicit refresh re-fetches the configuration."""
+        fetcher.get_project_configuration("PROJ")
+        fetcher.get_project_configuration("PROJ", refresh=True)
+
+        assert fetcher.get.call_count == 2
+
+    def test_unexpected_response_raises(self, aio_fetcher):
+        """A non-object configuration response is an error."""
+        aio_fetcher.get = MagicMock(return_value=["not", "a", "dict"])
+
+        with pytest.raises(AIOApiError, match="Unexpected AIO Tests configuration"):
+            aio_fetcher.get_project_configuration("PROJ")
+
+
+class TestGetTestCaseSchema:
+    """Tests for get_test_case_schema."""
+
+    def test_includes_builtin_fields_and_allowed_values(self, fetcher):
+        """The schema merges the built-in field catalog with project values."""
+        schema = fetcher.get_test_case_schema("PROJ").to_simplified_dict()
+
+        assert schema["project_key"] == "PROJ"
+        assert schema["project_id"] == 10010
+        field_names = {field["name"] for field in schema["fields"]}
+        assert {"title", "steps", "priority", "folder"} <= field_names
+        assert schema["allowed_values"]["priorities"] == [
+            {"id": 10, "name": "Critical"},
+            {"id": 11, "name": "Medium", "is_default": True},
+        ]
+        assert [status["name"] for status in schema["allowed_values"]["statuses"]] == [
+            "Draft",
+            "Published",
+        ]
+
+    def test_marks_read_only_fields(self, fetcher):
+        """Read-only fields are flagged so they are never sent on writes."""
+        schema = fetcher.get_test_case_schema("PROJ").to_simplified_dict()
+
+        read_only = {
+            field["name"] for field in schema["fields"] if field.get("read_only")
+        }
+        assert {"key", "version", "createdDate", "isArchived"} <= read_only
+
+    def test_lists_required_fields(self, fetcher):
+        """Required built-in and custom fields are listed together."""
+        schema = fetcher.get_test_case_schema("PROJ").to_simplified_dict()
+
+        assert schema["required_fields"] == ["title", "Environment"]
+
+    def test_only_case_custom_fields_are_included(self, fetcher):
+        """Custom fields not associated with cases are filtered out."""
+        schema = fetcher.get_test_case_schema("PROJ").to_simplified_dict()
+
+        names = {field["name"] for field in schema["custom_fields"]}
+        assert names == {"Environment", "Reviewer", "Notes"}
+
+    def test_custom_field_allowed_values(self, fetcher):
+        """Select-list custom fields expose their allowed values."""
+        schema = fetcher.get_test_case_schema("PROJ").to_simplified_dict()
+
+        environment = next(
+            field for field in schema["custom_fields"] if field["name"] == "Environment"
+        )
+        assert environment["required"] is True
+        assert environment["type"] == "SINGLE_SELECT_LIST"
+        assert environment["allowed_values"] == [
+            {"id": 1, "value": "Staging"},
+            {"id": 2, "value": "Production"},
+        ]
+
+
+class TestResolveLookupId:
+    """Tests for resolve_lookup_id."""
+
+    def test_resolves_name_case_insensitively(self, fetcher):
+        """Names are matched without regard to case."""
+        assert fetcher.resolve_lookup_id("PROJ", "casePriorities", "critical") == 10
+
+    def test_passes_through_integer(self, fetcher):
+        """An integer is already an ID."""
+        assert fetcher.resolve_lookup_id("PROJ", "casePriorities", 99) == 99
+        fetcher.get.assert_not_called()
+
+    def test_passes_through_numeric_string(self, fetcher):
+        """A numeric string is treated as an ID."""
+        assert fetcher.resolve_lookup_id("PROJ", "caseStatuses", "21") == 21
+
+    @pytest.mark.parametrize("value", [None, "", "   "])
+    def test_empty_values_return_none(self, fetcher, value):
+        """Empty values resolve to nothing."""
+        assert fetcher.resolve_lookup_id("PROJ", "caseStatuses", value) is None
+
+    def test_unknown_name_lists_available_values(self, fetcher):
+        """An unknown name reports what the project does accept."""
+        with pytest.raises(ValueError, match="Available values: Draft, Published"):
+            fetcher.resolve_lookup_id("PROJ", "caseStatuses", "Retired")
+
+    def test_boolean_is_rejected(self, fetcher):
+        """A boolean is never a valid lookup value."""
+        value = True
+        with pytest.raises(ValueError, match="Invalid value"):
+            fetcher.resolve_lookup_id("PROJ", "caseStatuses", value)

--- a/tests/unit/aio/test_tags.py
+++ b/tests/unit/aio/test_tags.py
@@ -1,0 +1,92 @@
+"""Tests for AIO Tests tag operations."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.fixtures.aio_mocks import MOCK_AIO_TAGS
+
+
+@pytest.fixture
+def fetcher(aio_fetcher):
+    """Provide a fetcher whose tag call returns the mock tags."""
+    aio_fetcher.get = MagicMock(return_value=MOCK_AIO_TAGS)
+    aio_fetcher.post = MagicMock(return_value=[{"ID": 9, "name": "Nightly"}])
+    return aio_fetcher
+
+
+class TestGetTags:
+    """Tests for get_tags."""
+
+    def test_returns_project_tags(self, fetcher):
+        """Tags are parsed into models."""
+        tags = fetcher.get_tags("PROJ")
+
+        assert [tag.to_simplified_dict() for tag in tags] == [
+            {"id": 1, "name": "AutomationEligible"},
+            {"id": 2, "name": "Smoke"},
+        ]
+        fetcher.get.assert_called_once_with("/project/PROJ/tag")
+
+    def test_empty_response(self, aio_fetcher):
+        """A project without tags returns an empty list."""
+        aio_fetcher.get = MagicMock(return_value=None)
+
+        assert aio_fetcher.get_tags("PROJ") == []
+
+
+class TestCreateTags:
+    """Tests for create_tags."""
+
+    def test_posts_tag_names(self, fetcher):
+        """Tags are created from their names."""
+        created = fetcher.create_tags("PROJ", ["Nightly"])
+
+        fetcher.post.assert_called_once_with(
+            "/project/PROJ/tag", json=[{"name": "Nightly"}]
+        )
+        assert created[0].id == 9
+
+
+class TestResolveTags:
+    """Tests for resolve_tags."""
+
+    def test_resolves_existing_names(self, fetcher):
+        """Known tag names resolve to their IDs without creating anything."""
+        resolved = fetcher.resolve_tags("PROJ", ["Smoke"])
+
+        assert resolved == [{"tag": {"ID": 2, "name": "Smoke"}}]
+        fetcher.post.assert_not_called()
+
+    def test_name_match_is_case_insensitive(self, fetcher):
+        """Tag names match without regard to case."""
+        assert fetcher.resolve_tags("PROJ", ["smoke"])[0]["tag"]["ID"] == 2
+
+    def test_numeric_values_are_ids(self, fetcher):
+        """Numeric values are used directly as tag IDs."""
+        assert fetcher.resolve_tags("PROJ", [1, "2"]) == [
+            {"tag": {"ID": 1, "name": "AutomationEligible"}},
+            {"tag": {"ID": 2, "name": "Smoke"}},
+        ]
+
+    def test_creates_missing_tags(self, fetcher):
+        """Unknown tags are created so the case can reference them."""
+        resolved = fetcher.resolve_tags("PROJ", ["Smoke", "Nightly"])
+
+        fetcher.post.assert_called_once_with(
+            "/project/PROJ/tag", json=[{"name": "Nightly"}]
+        )
+        assert resolved == [
+            {"tag": {"ID": 2, "name": "Smoke"}},
+            {"tag": {"name": "Nightly", "ID": 9}},
+        ]
+
+    def test_missing_tags_can_be_rejected(self, fetcher):
+        """Creation can be turned off, which makes unknown tags an error."""
+        with pytest.raises(ValueError, match="Unknown tags"):
+            fetcher.resolve_tags("PROJ", ["Nightly"], create_missing=False)
+
+    def test_empty_list_short_circuits(self, fetcher):
+        """No tags means no API calls at all."""
+        assert fetcher.resolve_tags("PROJ", []) == []
+        fetcher.get.assert_not_called()

--- a/tests/unit/servers/test_aio_dependencies.py
+++ b/tests/unit/servers/test_aio_dependencies.py
@@ -1,0 +1,133 @@
+"""Unit tests for the AIO Tests fetcher dependency provider."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+
+from mcp_atlassian.aio import AIOFetcher
+from mcp_atlassian.aio.config import AIOConfig
+from mcp_atlassian.servers.context import MainAppContext
+from mcp_atlassian.servers.dependencies import get_aio_fetcher
+
+
+@pytest.fixture
+def global_config() -> AIOConfig:
+    """Provide the global AIO Tests configuration."""
+    return AIOConfig(
+        url="https://tcms.aiojiraapps.com/aio-tcms/api/v1",
+        auth_type="token",
+        api_token="global-token",
+    )
+
+
+def make_context(config: AIOConfig | None) -> MagicMock:
+    """Build a FastMCP context exposing the given AIO configuration.
+
+    Args:
+        config: Configuration to publish in the lifespan context.
+
+    Returns:
+        The mock context.
+    """
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {
+        "app_lifespan_context": MainAppContext(full_aio_config=config)
+    }
+    return ctx
+
+
+def make_request(headers: dict[str, str] | None = None) -> MagicMock:
+    """Build a mock Starlette request with the given service headers.
+
+    Args:
+        headers: Service headers to expose on the request state.
+
+    Returns:
+        The mock request.
+    """
+    request = MagicMock(spec=Request)
+    request.state = MagicMock()
+    request.state.aio_fetcher = None
+    request.state.atlassian_service_headers = headers or {}
+    return request
+
+
+@pytest.mark.anyio
+async def test_uses_global_config_outside_http(global_config):
+    """Outside an HTTP request the global configuration is used."""
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request",
+        side_effect=RuntimeError("no request"),
+    ):
+        fetcher = await get_aio_fetcher(make_context(global_config))
+
+    assert isinstance(fetcher, AIOFetcher)
+    assert fetcher.config.api_token == "global-token"
+
+
+@pytest.mark.anyio
+async def test_missing_config_raises():
+    """Without a configuration the tools cannot run."""
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request",
+        side_effect=RuntimeError("no request"),
+    ):
+        with pytest.raises(ValueError, match="AIO Tests client"):
+            await get_aio_fetcher(make_context(None))
+
+
+@pytest.mark.anyio
+async def test_reuses_fetcher_from_request_state(global_config):
+    """A fetcher already built for this request is reused."""
+    existing = MagicMock(spec=AIOFetcher)
+    request = make_request()
+    request.state.aio_fetcher = existing
+
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request", return_value=request
+    ):
+        fetcher = await get_aio_fetcher(make_context(global_config))
+
+    assert fetcher is existing
+
+
+@pytest.mark.anyio
+async def test_header_token_overrides_global_token(global_config):
+    """A per-request token replaces the global one."""
+    request = make_request({"X-Aio-Api-Token": "user-token"})
+
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request", return_value=request
+    ):
+        fetcher = await get_aio_fetcher(make_context(global_config))
+
+    assert fetcher.config.api_token == "user-token"
+    assert fetcher.config.auth_type == "token"
+    assert fetcher.config.url == global_config.url
+    assert request.state.aio_fetcher is fetcher
+
+
+@pytest.mark.anyio
+async def test_header_token_without_global_config_raises():
+    """A per-request token still needs the global URL and SSL settings."""
+    request = make_request({"X-Aio-Api-Token": "user-token"})
+
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request", return_value=request
+    ):
+        with pytest.raises(ValueError, match="global configuration"):
+            await get_aio_fetcher(make_context(None))
+
+
+@pytest.mark.anyio
+async def test_falls_back_to_global_without_header(global_config):
+    """An HTTP request without the header uses the global configuration."""
+    request = make_request()
+
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request", return_value=request
+    ):
+        fetcher = await get_aio_fetcher(make_context(global_config))
+
+    assert fetcher.config.api_token == "global-token"

--- a/tests/unit/servers/test_aio_server.py
+++ b/tests/unit/servers/test_aio_server.py
@@ -1,0 +1,545 @@
+"""Unit tests for the AIO Tests FastMCP server implementation."""
+
+import json
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.client import FastMCPTransport
+from fastmcp.exceptions import ToolError
+from starlette.requests import Request
+
+from mcp_atlassian.aio import AIOFetcher
+from mcp_atlassian.aio.config import AIOConfig
+from mcp_atlassian.models.aio import (
+    AIOFolder,
+    AIOFolderTree,
+    AIOProject,
+    AIOTag,
+    AIOTestCase,
+    AIOTestCaseSchema,
+    AIOTestCaseSearchResult,
+)
+from mcp_atlassian.servers.context import MainAppContext
+from mcp_atlassian.servers.main import AtlassianMCP
+from tests.fixtures.aio_mocks import (
+    MOCK_AIO_FOLDER_TREE,
+    MOCK_AIO_PROJECT_CONFIG,
+    MOCK_AIO_SEARCH_RESPONSE,
+    MOCK_AIO_TAGS,
+    MOCK_AIO_TEST_CASE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def mock_aio_fetcher():
+    """Create a mock AIOFetcher backed by the AIO Tests fixtures."""
+    fetcher = MagicMock(spec=AIOFetcher)
+    fetcher.config = MagicMock()
+    fetcher.config.url = "https://tcms.aiojiraapps.com/aio-tcms/api/v1"
+
+    fetcher.get_project.return_value = AIOProject.from_api_response(
+        MOCK_AIO_PROJECT_CONFIG, project_key="PROJ"
+    )
+    fetcher.get_test_case_schema.return_value = AIOTestCaseSchema.from_api_response(
+        MOCK_AIO_PROJECT_CONFIG, project_key="PROJ", fields=[]
+    )
+    fetcher.get_test_case.return_value = AIOTestCase.from_api_response(
+        MOCK_AIO_TEST_CASE
+    )
+    fetcher.get_test_case_versions.return_value = AIOTestCase.from_api_response(
+        MOCK_AIO_TEST_CASE
+    )
+    fetcher.search_test_cases.return_value = AIOTestCaseSearchResult.from_api_response(
+        MOCK_AIO_SEARCH_RESPONSE
+    )
+    fetcher.create_test_case.return_value = AIOTestCase.from_api_response(
+        MOCK_AIO_TEST_CASE
+    )
+    fetcher.update_test_case.return_value = AIOTestCase.from_api_response(
+        MOCK_AIO_TEST_CASE
+    )
+    fetcher.get_folder_hierarchy.return_value = [
+        AIOFolderTree.from_api_response(item) for item in MOCK_AIO_FOLDER_TREE
+    ]
+    fetcher.flatten_folders.return_value = [
+        folder
+        for root in MOCK_AIO_FOLDER_TREE
+        for folder in AIOFolderTree.from_api_response(root).flatten()
+    ]
+    fetcher.create_folder.return_value = AIOFolder(
+        id=101, name="Checkout", parent_id=100, path="/Regression/Checkout"
+    )
+    fetcher.get_tags.return_value = [
+        AIOTag.from_api_response(tag) for tag in MOCK_AIO_TAGS
+    ]
+    return fetcher
+
+
+@pytest.fixture
+def mock_base_aio_config():
+    """Create a mock base AIOConfig for MainAppContext."""
+    return AIOConfig(
+        url="https://tcms.aiojiraapps.com/aio-tcms/api/v1",
+        auth_type="token",
+        api_token="mock-token",
+    )
+
+
+def _build_test_mcp(aio_config: AIOConfig | None, read_only: bool) -> AtlassianMCP:
+    """Build a test server exposing the AIO Tests tools.
+
+    Args:
+        aio_config: AIO configuration to publish in the lifespan context.
+        read_only: Whether the server runs in read-only mode.
+
+    Returns:
+        The configured server.
+    """
+
+    @asynccontextmanager
+    async def test_lifespan(app: FastMCP) -> AsyncGenerator[dict, None]:
+        # Mirrors main_lifespan, which publishes the context under this key.
+        try:
+            yield {
+                "app_lifespan_context": MainAppContext(
+                    full_aio_config=aio_config, read_only=read_only
+                )
+            }
+        finally:
+            pass
+
+    test_mcp = AtlassianMCP(
+        "TestAIO", instructions="Test AIO Tests MCP Server", lifespan=test_lifespan
+    )
+    from mcp_atlassian.servers.aio import aio_mcp
+
+    test_mcp.mount(aio_mcp, prefix="aio")
+    return test_mcp
+
+
+@pytest.fixture
+def test_aio_mcp(mock_base_aio_config):
+    """Create a test FastMCP instance with an AIO Tests configuration."""
+    return _build_test_mcp(mock_base_aio_config, read_only=False)
+
+
+@pytest.fixture
+def read_only_aio_mcp(mock_base_aio_config):
+    """Create a read-only test FastMCP instance."""
+    return _build_test_mcp(mock_base_aio_config, read_only=True)
+
+
+@pytest.fixture
+def unconfigured_aio_mcp():
+    """Create a test FastMCP instance without an AIO Tests configuration."""
+    return _build_test_mcp(None, read_only=False)
+
+
+@pytest.fixture
+def mock_request():
+    """Provide a mock Starlette Request object with a state."""
+    request = MagicMock(spec=Request)
+    request.state = MagicMock()
+    request.state.aio_fetcher = None
+    request.state.atlassian_service_headers = {}
+    return request
+
+
+@pytest.fixture
+async def aio_client(test_aio_mcp, mock_aio_fetcher, mock_request):
+    """Create a FastMCP client with a mocked AIO Tests fetcher."""
+    with (
+        patch(
+            "mcp_atlassian.servers.aio.get_aio_fetcher",
+            AsyncMock(return_value=mock_aio_fetcher),
+        ),
+        patch(
+            "mcp_atlassian.servers.dependencies.get_http_request",
+            return_value=mock_request,
+        ),
+    ):
+        async with Client(transport=FastMCPTransport(test_aio_mcp)) as client:
+            yield client
+
+
+@pytest.fixture
+async def read_only_client(read_only_aio_mcp, mock_aio_fetcher, mock_request):
+    """Create a FastMCP client against the read-only server."""
+    with (
+        patch(
+            "mcp_atlassian.servers.aio.get_aio_fetcher",
+            AsyncMock(return_value=mock_aio_fetcher),
+        ),
+        patch(
+            "mcp_atlassian.servers.dependencies.get_http_request",
+            return_value=mock_request,
+        ),
+    ):
+        async with Client(transport=FastMCPTransport(read_only_aio_mcp)) as client:
+            yield client
+
+
+def parse(response) -> dict:
+    """Parse the JSON payload of a tool response.
+
+    Args:
+        response: The tool call response.
+
+    Returns:
+        The decoded JSON object.
+    """
+    assert hasattr(response, "content")
+    assert len(response.content) > 0
+    assert response.content[0].type == "text"
+    return json.loads(response.content[0].text)
+
+
+@pytest.mark.anyio
+async def test_get_project(aio_client, mock_aio_fetcher):
+    """aio_get_project reports the project and its AIO Tests availability."""
+    content = parse(
+        await aio_client.call_tool("aio_get_project", {"project_key": "PROJ"})
+    )
+
+    assert content == {
+        "aio_enabled": True,
+        "project_key": "PROJ",
+        "project_id": 10010,
+        "adhoc_cycle_key": "AT-CY-1",
+    }
+    mock_aio_fetcher.get_project.assert_called_once_with("PROJ")
+
+
+@pytest.mark.anyio
+async def test_get_test_case_schema(aio_client, mock_aio_fetcher):
+    """aio_get_test_case_schema returns fields and allowed values."""
+    content = parse(
+        await aio_client.call_tool("aio_get_test_case_schema", {"project_key": "PROJ"})
+    )
+
+    assert content["project_key"] == "PROJ"
+    assert [
+        priority["name"] for priority in content["allowed_values"]["priorities"]
+    ] == ["Critical", "Medium"]
+    assert {field["name"] for field in content["custom_fields"]} == {
+        "Environment",
+        "Reviewer",
+        "Notes",
+    }
+    mock_aio_fetcher.get_test_case_schema.assert_called_once_with("PROJ")
+
+
+@pytest.mark.anyio
+async def test_search_test_cases_defaults(aio_client, mock_aio_fetcher):
+    """aio_search_test_cases forwards its defaults unchanged."""
+    content = parse(
+        await aio_client.call_tool("aio_search_test_cases", {"project_key": "PROJ"})
+    )
+
+    assert content["count"] == 1
+    assert content["test_cases"][0]["key"] == "AT-TC-17"
+    kwargs = mock_aio_fetcher.search_test_cases.call_args[1]
+    assert kwargs["title"] is None
+    assert kwargs["start_at"] == 0
+    assert kwargs["max_results"] == 50
+    assert kwargs["title_match"] == "CONTAINS"
+
+
+@pytest.mark.anyio
+async def test_search_test_cases_filters(aio_client, mock_aio_fetcher):
+    """aio_search_test_cases forwards every supported filter."""
+    await aio_client.call_tool(
+        "aio_search_test_cases",
+        {
+            "project_key": "PROJ",
+            "title": "cart",
+            "title_match": "EXACT_MATCH",
+            "statuses": ["Published"],
+            "priorities": ["Critical"],
+            "folders": ["/Regression"],
+            "tags": ["Smoke"],
+            "include_archived": False,
+            "max_results": 10,
+            "start_at": 20,
+        },
+    )
+
+    kwargs = mock_aio_fetcher.search_test_cases.call_args[1]
+    assert kwargs["title"] == "cart"
+    assert kwargs["title_match"] == "EXACT_MATCH"
+    assert kwargs["statuses"] == ["Published"]
+    assert kwargs["priorities"] == ["Critical"]
+    assert kwargs["folders"] == ["/Regression"]
+    assert kwargs["tags"] == ["Smoke"]
+    assert kwargs["include_archived"] is False
+    assert kwargs["max_results"] == 10
+    assert kwargs["start_at"] == 20
+
+
+@pytest.mark.anyio
+async def test_search_test_cases_rejects_oversized_page(aio_client):
+    """The page size is validated before the call."""
+    with pytest.raises(ToolError):
+        await aio_client.call_tool(
+            "aio_search_test_cases", {"project_key": "PROJ", "max_results": 500}
+        )
+
+
+@pytest.mark.anyio
+async def test_get_test_case(aio_client, mock_aio_fetcher):
+    """aio_get_test_case returns the full case details."""
+    content = parse(
+        await aio_client.call_tool(
+            "aio_get_test_case",
+            {"project_key": "PROJ", "test_case_id": "AT-TC-17", "version": 2},
+        )
+    )
+
+    assert content["key"] == "AT-TC-17"
+    assert len(content["steps"]) == 2
+    mock_aio_fetcher.get_test_case.assert_called_once_with(
+        "PROJ",
+        "AT-TC-17",
+        version=2,
+        include_rtf=False,
+        include_attachments=False,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_test_case_versions(aio_client, mock_aio_fetcher):
+    """aio_get_test_case_versions returns the version history."""
+    content = parse(
+        await aio_client.call_tool(
+            "aio_get_test_case_versions",
+            {"project_key": "PROJ", "test_case_id": "AT-TC-17"},
+        )
+    )
+
+    assert content["key"] == "AT-TC-17"
+    assert content["current_version"] == 2
+    assert content["versions"] == [
+        {"is_current": True, "version": 2, "id": 16557},
+        {"is_current": False, "version": 1, "id": 16556},
+    ]
+    mock_aio_fetcher.get_test_case_versions.assert_called_once_with("PROJ", "AT-TC-17")
+
+
+@pytest.mark.anyio
+async def test_create_test_case(aio_client, mock_aio_fetcher):
+    """aio_create_test_case forwards the title, steps and fields."""
+    content = parse(
+        await aio_client.call_tool(
+            "aio_create_test_case",
+            {
+                "project_key": "PROJ",
+                "title": "New case",
+                "steps": [{"step": "Login", "expected_result": "Home"}],
+                "fields": {"priority": "Critical", "folder": "/Regression"},
+            },
+        )
+    )
+
+    assert content["success"] is True
+    assert content["test_case"]["key"] == "AT-TC-17"
+    args, kwargs = mock_aio_fetcher.create_test_case.call_args
+    assert args == ("PROJ", "New case")
+    assert kwargs["priority"] == "Critical"
+    assert kwargs["folder"] == "/Regression"
+    assert kwargs["steps"] == [{"step": "Login", "expected_result": "Home"}]
+    assert kwargs["create_folder_if_missing"] is True
+
+
+@pytest.mark.anyio
+async def test_create_test_case_ignores_duplicate_title_field(
+    aio_client, mock_aio_fetcher
+):
+    """A title inside `fields` never shadows the positional title."""
+    await aio_client.call_tool(
+        "aio_create_test_case",
+        {
+            "project_key": "PROJ",
+            "title": "Real title",
+            "fields": {"title": "Other title"},
+        },
+    )
+
+    args, kwargs = mock_aio_fetcher.create_test_case.call_args
+    assert args == ("PROJ", "Real title")
+    assert "title" not in kwargs
+
+
+@pytest.mark.anyio
+async def test_update_test_case(aio_client, mock_aio_fetcher):
+    """aio_update_test_case forwards only the requested changes."""
+    content = parse(
+        await aio_client.call_tool(
+            "aio_update_test_case",
+            {
+                "project_key": "PROJ",
+                "test_case_id": "AT-TC-17",
+                "fields": {"status": "Published"},
+                "create_new_version": True,
+            },
+        )
+    )
+
+    assert content["success"] is True
+    args, kwargs = mock_aio_fetcher.update_test_case.call_args
+    assert args == ("PROJ", "AT-TC-17")
+    assert kwargs["status"] == "Published"
+    assert kwargs["create_new_version"] is True
+    assert kwargs["version"] is None
+
+
+@pytest.mark.anyio
+async def test_get_folder_hierarchy_tree(aio_client, mock_aio_fetcher):
+    """aio_get_folder_hierarchy returns a nested tree by default."""
+    content = parse(
+        await aio_client.call_tool("aio_get_folder_hierarchy", {"project_key": "PROJ"})
+    )
+
+    assert content["folder_type"] == "testcase"
+    assert [folder["name"] for folder in content["folders"]] == ["Regression", "Smoke"]
+    assert content["folders"][0]["children"][0]["path"] == "/Regression/Checkout"
+    mock_aio_fetcher.get_folder_hierarchy.assert_called_once_with("PROJ", "testcase")
+
+
+@pytest.mark.anyio
+async def test_get_folder_hierarchy_flat(aio_client, mock_aio_fetcher):
+    """The flat option returns folders with resolved paths."""
+    content = parse(
+        await aio_client.call_tool(
+            "aio_get_folder_hierarchy",
+            {"project_key": "PROJ", "folder_type": "testcycle", "flat": True},
+        )
+    )
+
+    assert [folder["path"] for folder in content["folders"]] == [
+        "/Regression",
+        "/Regression/Checkout",
+        "/Regression/Login",
+        "/Smoke",
+    ]
+    mock_aio_fetcher.flatten_folders.assert_called_once_with("PROJ", "testcycle")
+
+
+@pytest.mark.anyio
+async def test_create_folder(aio_client, mock_aio_fetcher):
+    """aio_create_folder forwards the path and folder type."""
+    content = parse(
+        await aio_client.call_tool(
+            "aio_create_folder",
+            {
+                "project_key": "PROJ",
+                "folder_path": "/Regression/Checkout",
+                "parent_folder_id": 100,
+            },
+        )
+    )
+
+    assert content["success"] is True
+    assert content["folder"]["path"] == "/Regression/Checkout"
+    mock_aio_fetcher.create_folder.assert_called_once_with(
+        "PROJ",
+        "/Regression/Checkout",
+        folder_type="testcase",
+        parent_folder_id=100,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_tags(aio_client, mock_aio_fetcher):
+    """aio_get_tags returns the project's tags."""
+    content = parse(await aio_client.call_tool("aio_get_tags", {"project_key": "PROJ"}))
+
+    assert content["tags"] == [
+        {"id": 1, "name": "AutomationEligible"},
+        {"id": 2, "name": "Smoke"},
+    ]
+    mock_aio_fetcher.get_tags.assert_called_once_with("PROJ")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "tool_name,arguments",
+    [
+        ("aio_create_test_case", {"project_key": "PROJ", "title": "New"}),
+        (
+            "aio_update_test_case",
+            {
+                "project_key": "PROJ",
+                "test_case_id": "AT-TC-17",
+                "fields": {"status": "Draft"},
+            },
+        ),
+        ("aio_create_folder", {"project_key": "PROJ", "folder_path": "New"}),
+    ],
+)
+async def test_write_tools_blocked_in_read_only_mode(
+    read_only_client, mock_aio_fetcher, tool_name, arguments
+):
+    """Write tools refuse to run in read-only mode."""
+    with pytest.raises(ToolError, match="read-only mode"):
+        await read_only_client.call_tool(tool_name, arguments)
+
+
+@pytest.mark.anyio
+async def test_tools_are_listed_when_configured(test_aio_mcp, mock_request):
+    """Every AIO Tests tool is advertised when the service is configured."""
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request",
+        return_value=mock_request,
+    ):
+        async with Client(transport=FastMCPTransport(test_aio_mcp)) as client:
+            tools = await client.list_tools()
+
+    names = {tool.name for tool in tools}
+    assert names == {
+        "aio_get_project",
+        "aio_get_test_case_schema",
+        "aio_search_test_cases",
+        "aio_get_test_case",
+        "aio_get_test_case_versions",
+        "aio_create_test_case",
+        "aio_update_test_case",
+        "aio_get_folder_hierarchy",
+        "aio_create_folder",
+        "aio_get_tags",
+    }
+
+
+@pytest.mark.anyio
+async def test_write_tools_hidden_in_read_only_mode(read_only_aio_mcp, mock_request):
+    """Read-only mode hides the write tools from the listing."""
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request",
+        return_value=mock_request,
+    ):
+        async with Client(transport=FastMCPTransport(read_only_aio_mcp)) as client:
+            tools = await client.list_tools()
+
+    names = {tool.name for tool in tools}
+    assert "aio_get_project" in names
+    assert "aio_create_test_case" not in names
+    assert "aio_update_test_case" not in names
+    assert "aio_create_folder" not in names
+
+
+@pytest.mark.anyio
+async def test_tools_hidden_when_not_configured(unconfigured_aio_mcp, mock_request):
+    """Without an AIO Tests configuration no AIO tool is advertised."""
+    with patch(
+        "mcp_atlassian.servers.dependencies.get_http_request",
+        return_value=mock_request,
+    ):
+        async with Client(transport=FastMCPTransport(unconfigured_aio_mcp)) as client:
+            tools = await client.list_tools()
+
+    assert [tool.name for tool in tools if tool.name.startswith("aio_")] == []

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -57,9 +57,15 @@ def env_scenarios():
     }
 
 
-def _assert_service_availability(result, confluence_expected, jira_expected):
+def _assert_service_availability(
+    result, confluence_expected, jira_expected, aio_expected=False
+):
     """Helper to assert service availability."""
-    assert result == {"confluence": confluence_expected, "jira": jira_expected}
+    assert result == {
+        "confluence": confluence_expected,
+        "jira": jira_expected,
+        "aio": aio_expected,
+    }
 
 
 def _assert_authentication_logs(caplog, auth_type, services):
@@ -236,7 +242,7 @@ class TestGetAvailableServices:
             result = get_available_services()
 
             assert isinstance(result, dict)
-            assert set(result.keys()) == {"confluence", "jira"}
+            assert set(result.keys()) == {"confluence", "jira", "aio"}
             assert all(isinstance(v, bool) for v in result.values())
 
     @pytest.mark.parametrize(
@@ -392,3 +398,61 @@ class TestGetAvailableServicesWithHeaders:
             _assert_service_availability(
                 result, confluence_expected=False, jira_expected=False
             )
+
+
+class TestGetAvailableServicesAIO:
+    """Test cases for AIO Tests availability detection."""
+
+    def test_not_configured_by_default(self, caplog):
+        """AIO Tests stays off unless it is explicitly configured."""
+        with MockEnvironment.clean_env():
+            result = get_available_services()
+
+            assert result["aio"] is False
+            assert "AIO Tests is not configured" in caplog.text
+
+    def test_cloud_token_enables_aio(self, caplog):
+        """An AIO Tests access token is enough to enable the service."""
+        import os
+
+        with MockEnvironment.clean_env():
+            os.environ["AIO_API_TOKEN"] = "aio-token"
+
+            result = get_available_services()
+
+            assert result["aio"] is True
+            assert "Using AIO Tests" in caplog.text
+
+    def test_jira_alone_does_not_enable_aio(self):
+        """A configured Jira instance does not imply the AIO Tests app."""
+        import os
+
+        with MockEnvironment.clean_env():
+            os.environ["JIRA_URL"] = "https://jira.company.com"
+            os.environ["JIRA_PERSONAL_TOKEN"] = "pat"
+
+            result = get_available_services()
+
+            assert result["jira"] is True
+            assert result["aio"] is False
+
+    def test_server_opt_in_flag_enables_aio(self):
+        """AIO_ENABLED opts a Server/Data Center deployment in."""
+        import os
+
+        with MockEnvironment.clean_env():
+            os.environ["JIRA_URL"] = "https://jira.company.com"
+            os.environ["JIRA_PERSONAL_TOKEN"] = "pat"
+            os.environ["AIO_ENABLED"] = "true"
+
+            result = get_available_services()
+
+            assert result["aio"] is True
+
+    def test_header_token_enables_aio(self, caplog):
+        """A per-request AIO token makes the tools available."""
+        with MockEnvironment.clean_env():
+            result = get_available_services(headers={"X-Aio-Api-Token": "user-token"})
+
+            assert result["aio"] is True
+            assert "AIO Tests authentication from header access token" in caplog.text


### PR DESCRIPTION
## Description

[AIO Tests](https://aiotests.com/) is a Jira app for test management with its own REST API. This PR adds it as a third service alongside Jira and Confluence, exposing the documented AIO MCP tool set so agents can read and write test cases, folders and tags without leaving the Jira context they already work in.

The tools are opt-in and hidden by default, so existing deployments are unaffected.

## Changes

- **New `aio` tool set** (10 tools, mounted under the `aio` prefix): `aio_get_project`, `aio_get_test_case_schema`, `aio_search_test_cases`, `aio_get_test_case`, `aio_get_test_case_versions`, `aio_create_test_case`, `aio_update_test_case`, `aio_get_folder_hierarchy`, `aio_create_folder`, `aio_get_tags`.
- **Name-or-ID lookup fields**: statuses, priorities, types, folders, tags and custom fields resolve against the project configuration, so callers can use the vocabulary they see in the UI instead of hunting for numeric IDs.
- **Deployment-aware auth**: an `AioAuth` access token on Cloud, the existing Jira credentials on Server/Data Center. Multi-user HTTP deployments can supply a per-request token via the `X-Aio-Api-Token` header.
- **Opt-in gating**: the tools stay hidden unless `AIO_API_TOKEN` is set (Cloud) or `AIO_ENABLED=true` (Server/DC).
- **Format-preserving updates**: updates round-trip the case document with `needDataInRTF` enabled so the rich-text formatting of untouched fields survives; plain-text input is escaped to match.
- **Docs and config**: `README.md`, `docs/configuration.mdx`, `docs/http-transport.mdx`, `docs/tools-reference.mdx`, `.env.example`, `smithery.yaml` and `AGENTS.md` updated.

### Known limitation

Folder rename/move/description updates are not implemented — the AIO Tests public API exposes no endpoint for them.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed <!-- not run: requires a live AIO Tests instance and credentials -->
- [ ] Manual checks performed

215 new unit tests cover the client, config, case/folder/project/tag operations, server tool registration, dependency wiring and environment gating:

```
$ uv run pytest tests/unit -q
1328 passed, 5 skipped in 5.78s
```

## Checklist

- [x] Code follows project style guidelines (linting passes). — `pre-commit run` over the changed files: ruff-format, ruff and mypy all pass.
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).
