### PR TITLE
fix(jira): preserve escaped emphasis delimiters in jira_to_markdown

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -272,9 +272,12 @@ class JiraPreprocessor(BasePreprocessor):
         # Block quotes
         output = re.sub(r"^bq\.(.*?)$", r"> \1\n", output, flags=re.MULTILINE)
 
-        # Text formatting (bold, italic)
+        # Text formatting (bold, italic). Delimiters preceded by a backslash
+        # are wiki escapes (e.g. the intraword `\_` this module's
+        # markdown_to_jira writes), not markup, so they must neither open nor
+        # close a span.
         output = re.sub(
-            r"([*_])(.*?)\1",
+            r"(?<!\\)([*_])(.*?)(?<!\\)\1",
             lambda match: (
                 ("**" if match.group(1) == "*" else "*")
                 + match.group(2)

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -251,6 +251,24 @@ def test_jira_to_markdown(preprocessor_with_jira):
     assert preprocessor_with_jira.jira_to_markdown("*bold text*") == "**bold text**"
     assert preprocessor_with_jira.jira_to_markdown("_italic text_") == "*italic text*"
 
+    # Test escaped delimiters are preserved, not paired as emphasis (issue #1610)
+    assert (
+        preprocessor_with_jira.jira_to_markdown(r"QUALITY\_GATES\_LLM\_ENABLED")
+        == r"QUALITY\_GATES\_LLM\_ENABLED"
+    )
+    assert preprocessor_with_jira.jira_to_markdown(r"foo\_bar") == r"foo\_bar"
+    assert (
+        preprocessor_with_jira.jira_to_markdown(r"my\_var\_x and her\_var")
+        == r"my\_var\_x and her\_var"
+    )
+    assert "*" not in preprocessor_with_jira.jira_to_markdown(
+        r"my\_var\_x and her\_var"
+    )
+    assert (
+        preprocessor_with_jira.jira_to_markdown(r"escaped \*stars\* stay literal")
+        == r"escaped \*stars\* stay literal"
+    )
+
     # Test code blocks
     assert preprocessor_with_jira.jira_to_markdown("{{code}}") == "`code`"
 


### PR DESCRIPTION
## Problem

`JiraPreprocessor.jira_to_markdown()` pairs emphasis delimiters positionally with `([*_])(.*?)\1`, ignoring wiki escape markers. Stored content containing escaped intraword underscores is rewritten on every read-back:

- stored wiki bytes: `QUALITY\_GATES\_LLM\_ENABLED`
- returned "markdown": `QUALITY\*GATES\*LLM\_ENABLED`

Each round-trip through any read tool rewrites `\_` to `\*`, silently corrupting content for MCP clients and any agent that treats the response as ground truth. Tracked by #1610.

## Solution

Delimiters preceded by a backslash are wiki escapes written by this module's own `markdown_to_jira` (intraword `\_` protection), not markup. The pairing regex now rejects escaped delimiters via negative lookbehind, so they can neither open nor close a span:

```python
r"(?<!\\)([*_])(.*?)(?<!\\)\1"
```

## Changes

**`src/mcp_atlassian/preprocessing/jira.py`**

| Change | Why |
|---|---|
| Emphasis regex gains `(?<!\\)` lookbehinds on open/close delimiter | Escaped delimiters are literal text, not markup |

**`tests/unit/preprocessing/test_preprocessing.py`**
- `test_jira_to_markdown` additions — escaped `\_` / `\*` sequences survive conversion unchanged; unescaped emphasis still converts

## What Does Not Change

- Unescaped emphasis conversion is byte-for-byte identical (`*bold*` → `**bold**`, `_italic_` → `*italic*`)
- Write path (`markdown_to_jira`) untouched
- No new dependencies; no API/config changes

## Breaking Changes

None.

## Regression Tests

**Fails before the fix** (`tests/unit/preprocessing/test_preprocessing.py::test_jira_to_markdown`, against `436b37e`):

```
E       AssertionError: assert 'QUALITY\\*GA...LLM\\_ENABLED' == 'QUALITY\\_GA...LLM\\_ENABLED'
E         - QUALITY\_GATES\_LLM\_ENABLED
E         + QUALITY\*GATES\*LLM\_ENABLED
```

Result: **FAIL** before, **PASS** after this commit.

## Test Plan

- [x] `pytest tests/unit/preprocessing/ -q` — 173 passed
- [x] `pytest tests/unit -q` — full suite green on the combined stack

Fixes #1610
