### PR TITLE
fix(jira): stop prose plus signs corrupting markdown read-back

### DIFF
--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -468,12 +468,6 @@ class BasePreprocessor:
         Protects markdown code spans (fenced and inline) from being
         interpreted as HTML by BeautifulSoup before conversion.
         """
-        # Only engage the HTML converter when the source text itself had
-        # HTML. Tags our own converter emitted (e.g. <ins> from
-        # jira_to_markdown) must not trigger a whole-document markdownify
-        # pass that escapes every markdown character in prose.
-        had_html = bool(re.search(r"<[^>]+>", text))
-
         # Protect fenced code blocks and inline code from HTML parsing
         code_blocks: list[str] = []
         inline_codes: list[str] = []
@@ -493,7 +487,7 @@ class BasePreprocessor:
             "HTMLCVTINLINE",
         )
 
-        if had_html and re.search(r"<[^>]+>", text):
+        if re.search(r"<[^>]+>", text):
             try:
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=UserWarning)

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -468,6 +468,12 @@ class BasePreprocessor:
         Protects markdown code spans (fenced and inline) from being
         interpreted as HTML by BeautifulSoup before conversion.
         """
+        # Only engage the HTML converter when the source text itself had
+        # HTML. Tags our own converter emitted (e.g. <ins> from
+        # jira_to_markdown) must not trigger a whole-document markdownify
+        # pass that escapes every markdown character in prose.
+        had_html = bool(re.search(r"<[^>]+>", text))
+
         # Protect fenced code blocks and inline code from HTML parsing
         code_blocks: list[str] = []
         inline_codes: list[str] = []
@@ -487,7 +493,7 @@ class BasePreprocessor:
             "HTMLCVTINLINE",
         )
 
-        if re.search(r"<[^>]+>", text):
+        if had_html and re.search(r"<[^>]+>", text):
             try:
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=UserWarning)

--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -309,8 +309,9 @@ class JiraPreprocessor(BasePreprocessor):
             output,
         )
 
-        # Inserted text
-        output = re.sub(r"\+([^+]*)\+", r"<ins>\1</ins>", output)
+        # Inserted text. Delimiters glued to word characters are prose
+        # (e.g. version numbers "3.13+"), not markup.
+        output = re.sub(r"(?<!\w)\+([^+\n]+)\+(?!\w)", r"<ins>\1</ins>", output)
 
         # Superscript
         output = re.sub(r"\^([^^]*)\^", r"<sup>\1</sup>", output)

--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -24,6 +24,20 @@ def _convert_panel(params: str | None, content: str) -> str:
     return f"\n{content}\n"
 
 
+def _contains_html_outside_code(text: str) -> bool:
+    """Return whether source text contains HTML outside protected code spans."""
+    code_patterns = (
+        r"\{code(?::[a-z]+)?\}[\s\S]*?\{code\}",
+        r"\{noformat\}[\s\S]*?\{noformat\}",
+        r"\{\{[^}]+\}\}",
+        r"```[^\n]*\n[\s\S]*?\n```",
+        r"`[^`]+`",
+    )
+    for pattern in code_patterns:
+        text = re.sub(pattern, "", text, flags=re.MULTILINE)
+    return re.search(r"<[^>]+>", text) is not None
+
+
 class JiraPreprocessor(BasePreprocessor):
     """Handles text preprocessing for Jira content."""
 
@@ -142,11 +156,15 @@ class JiraPreprocessor(BasePreprocessor):
 
         # Convert markup only if translation is enabled
         if not self.disable_translation:
+            source_had_html = _contains_html_outside_code(text)
+
             # First convert any Jira markup to Markdown
             text = self.jira_to_markdown(text)
 
-            # Then convert any remaining HTML to markdown
-            text = self._convert_html_to_markdown(text)
+            # Then convert HTML that came from the source. Tags emitted by
+            # jira_to_markdown must not trigger whole-document conversion.
+            if source_had_html:
+                text = self._convert_html_to_markdown(text)
 
         return text.strip()
 

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -147,10 +147,25 @@ def test_clean_jira_text_smart_links(preprocessor_with_jira):
     confluence_url = (
         f"{base_url}/wiki/spaces/PROJ/pages/987654321/Example+Meeting+Notes"
     )
-    processed_url = f"{base_url}/wiki/spaces/PROJ/pages/987654321/ExampleMeetingNotes"
+    # Literal plus signs in the URL are preserved; only the display
+    # title has them replaced with spaces.
+    processed_url = f"{base_url}/wiki/spaces/PROJ/pages/987654321/Example+Meeting+Notes"
     text = f"[Meeting Notes|{confluence_url}|smart-link]"
     cleaned = preprocessor_with_jira.clean_jira_text(text)
     assert cleaned == f"[Example Meeting Notes]({processed_url})"
+
+
+def test_clean_jira_text_stray_plus_no_markdown_escaping(
+    preprocessor_with_jira,
+):
+    """Bold prose plus unpaired plus signs must survive the read path
+    without markdownify escaping every emphasis delimiter (issue found via
+    INFRA-3939 comment round-trip)."""
+    wiki = "*Ticket:* done\r\n\r\nPython 3.13+ and 2.6+ differ"
+    out = preprocessor_with_jira.clean_jira_text(wiki)
+    assert "**Ticket:**" in out
+    assert "\\*" not in out
+    assert "3.13+" in out and "2.6+" in out
 
 
 @pytest.mark.parametrize(
@@ -267,6 +282,18 @@ def test_jira_to_markdown(preprocessor_with_jira):
     assert (
         preprocessor_with_jira.jira_to_markdown(r"escaped \*stars\* stay literal")
         == r"escaped \*stars\* stay literal"
+    )
+
+    # Unpaired plus signs in prose (version numbers) must not open an
+    # inserted-text span, and must not trigger whole-document HTML conversion
+    assert (
+        preprocessor_with_jira.jira_to_markdown("Python 3.13+ and 2.6+ differ")
+        == "Python 3.13+ and 2.6+ differ"
+    )
+    # Genuine inserted-text markup still converts
+    assert (
+        preprocessor_with_jira.jira_to_markdown("+new note+ added")
+        == "<ins>new note</ins> added"
     )
 
     # Test code blocks

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -168,6 +168,17 @@ def test_clean_jira_text_stray_plus_no_markdown_escaping(
     assert "3.13+" in out and "2.6+" in out
 
 
+def test_clean_jira_text_generated_html_does_not_trigger_html_conversion(
+    preprocessor_with_jira,
+):
+    """Tags emitted by Jira conversion must not reprocess Markdown prose."""
+    wiki = "*Ticket:* {{<b>literal</b>}} +new note+"
+
+    assert preprocessor_with_jira.clean_jira_text(wiki) == (
+        "**Ticket:** `<b>literal</b>` <ins>new note</ins>"
+    )
+
+
 @pytest.mark.parametrize(
     ("issue_key", "expected"),
     [


### PR DESCRIPTION
## Problem

Unpaired plus signs in Jira prose, especially version numbers such as `Python 3.13+` and `urllib3 2.6+`, could be paired across text by the inserted-text rule. That emitted an `<ins>` tag, triggered whole-document HTML conversion, escaped existing Markdown characters, and removed the plus signs from read responses.

The HTML guard also checked content only after `jira_to_markdown()`. Converter-generated tags therefore still looked like source HTML, so the guard did not prevent the second conversion.

## Solution

1. Inserted-text delimiters adjacent to word characters are treated as prose: `(?<!\w)\+([^+\n]+)\+(?!\w)`.
2. `clean_jira_text()` records whether the original Jira source contains HTML outside protected code spans before Jira markup conversion.
3. Whole-document HTML conversion runs only when HTML came from that original source. Tags emitted by Jira conversion remain valid inline HTML in the Markdown result.

## Changes

- `src/mcp_atlassian/preprocessing/jira.py`
  - Preserve unpaired version-number plus signs.
  - Detect source HTML without mistaking Jira or Markdown code spans for HTML.
  - Keep converter-generated `<ins>`, `<cite>`, `<sup>`, and `<sub>` tags from triggering a second conversion.
- `tests/unit/preprocessing/test_preprocessing.py`
  - Cover stray plus signs alongside Markdown emphasis.
  - Cover literal plus signs in smart-link URLs.
  - Prove generated HTML does not trigger conversion, including when literal HTML appears inside a code span.
  - Preserve genuine inserted-text markup.

## Verification

- `uv run pytest tests/unit/preprocessing/ -q`: 175 passed
- `uv run pytest tests/unit/ -q`: 3842 passed, 5 repository-standard skips
- `uv run pytest 'tests/e2e/test_jira_auth_matrix.py::TestJiraReadOperations::test_get_issue[basic]' --dc-e2e -vv`: 1 passed, no skips
- `uv run python scripts/generate_tool_docs.py --check`: passed
- Ruff check and format check on changed Jira/test files: passed
- mypy hook on changed Jira/test files: passed

A broader DC run reached 102 passed, 1 failed, and 1 skipped. The failure is an unrelated JSM fixture problem: the pre-seeded `JSMDC-2` issue returns 403 from the service-desk comment endpoint.

Related: #1610
