### PR TITLE
fix(jira): name the failing argument in update_issue parse errors

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -160,11 +160,13 @@ def _parse_visibility(
 
 def _parse_additional_fields(
     additional_fields: dict[str, Any] | str | None,
+    param_name: str = "additional_fields",
 ) -> dict[str, Any]:
     """Parse additional_fields from dict or JSON string.
 
     Args:
         additional_fields: Dict, JSON string, or None.
+        param_name: Argument name used in error messages.
 
     Returns:
         Parsed dict of additional fields.
@@ -180,13 +182,11 @@ def _parse_additional_fields(
         try:
             parsed = json.loads(additional_fields)
             if not isinstance(parsed, dict):
-                raise ValueError(
-                    "Parsed additional_fields is not a JSON object (dict)."
-                )
+                raise ValueError(f"{param_name} is not a JSON object (dict).")
             return parsed
         except json.JSONDecodeError as e:
-            raise ValueError(f"additional_fields is not valid JSON: {e}") from e
-    raise ValueError("additional_fields must be a dictionary or JSON string.")
+            raise ValueError(f"{param_name} is not valid JSON: {e}") from e
+    raise ValueError(f"{param_name} must be a dictionary or JSON string.")
 
 
 def _parse_request_field_values(
@@ -2121,7 +2121,7 @@ async def update_issue(
         ValueError: If in read-only mode or Jira client unavailable, or invalid input.
     """
     jira = await get_jira_fetcher(ctx)
-    update_fields = _parse_additional_fields(fields)
+    update_fields = _parse_additional_fields(fields, param_name="fields")
 
     return_fields_list: str | list[str] | None = return_fields
     if return_fields and return_fields != "*all":
@@ -2998,7 +2998,7 @@ async def transition_issue(
         raise ValueError("issue_key and transition_id are required.")
 
     # Parse fields from JSON string
-    update_fields = _parse_additional_fields(fields)
+    update_fields = _parse_additional_fields(fields, param_name="fields")
 
     available_transitions = jira.get_available_transitions(issue_key)
     resolved_transition_id = resolve_transition(available_transitions, transition_id)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2399,6 +2399,24 @@ async def test_update_issue_accepts_json_string_additional_fields(
 
 
 @pytest.mark.anyio
+async def test_update_issue_plain_text_fields_error_names_fields(jira_client):
+    """Regression: invalid plain-text fields must blame fields,
+    not additional_fields — both arguments share one parser whose
+    error previously hardcoded the additional_fields name."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_update_issue",
+            {
+                "issue_key": "TEST-123",
+                "fields": "plain markdown text, not JSON",
+            },
+        )
+    message = str(excinfo.value)
+    assert "fields is not valid JSON" in message
+    assert "additional_fields" not in message
+
+
+@pytest.mark.anyio
 async def test_update_issue_additional_fields_invalid_json(jira_client):
     """Test that invalid JSON additional_fields raises ToolError."""
     with pytest.raises(ToolError) as excinfo:

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2612,6 +2612,24 @@ async def test_transition_issue_still_accepts_numeric_id(
 
 
 @pytest.mark.anyio
+async def test_transition_issue_plain_text_fields_error_names_fields(jira_client):
+    """Invalid transition fields errors name the fields argument."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_transition_issue",
+            {
+                "issue_key": "TEST-123",
+                "transition_id": "31",
+                "fields": "plain text, not JSON",
+            },
+        )
+
+    message = str(excinfo.value)
+    assert "fields is not valid JSON" in message
+    assert "additional_fields" not in message
+
+
+@pytest.mark.anyio
 async def test_transition_issue_unknown_name_raises_with_options(
     jira_client, mock_jira_fetcher
 ):


### PR DESCRIPTION
## Problem

`jira_update_issue` parses both its `fields` and `additional_fields` arguments with the same helper (`_parse_additional_fields`), whose `ValueError` always names `additional_fields`. A caller that passes plain text (for example, Markdown) in `fields` is therefore told that the wrong argument failed:

```
Error calling tool 'update_issue': additional_fields is not valid JSON: Expecting value: line 1 column 1 (char 0)
```

The same misleading attribution affects the `fields` argument of `jira_transition_issue`.

## Solution

Parameterize the argument name used by the shared parser and pass `"fields"` from the update and transition call sites.

## Changes

- `_parse_additional_fields(..., param_name="additional_fields")` now uses the actual argument name in validation errors.
- `jira_update_issue` and `jira_transition_issue` identify invalid `fields` input correctly.
- Regression tests cover both tool paths.

## What Does Not Change

- Valid-input behavior is unchanged.
- Empty and whitespace-only strings remain validation errors.
- There are no tool-schema, API, or dependency changes.

## Verification

- [x] Focused Jira parser regressions: 4 passed
- [x] `uv run pytest tests/unit -q`: 3842 passed, 5 skipped
- [x] Ruff format and lint checks on the changed test file
- [x] `uv run python scripts/generate_tool_docs.py --check`

## Related

Fixes the server-side half of internal ticket AIDEV-482. See also #1466 and #1140 for prior work on `update_issue` ergonomics.
