### PR TITLE
fix(jira): treat empty additional_fields as unset

### DIFF
--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -160,11 +160,13 @@ def _parse_visibility(
 
 def _parse_additional_fields(
     additional_fields: dict[str, Any] | str | None,
+    param_name: str = "additional_fields",
 ) -> dict[str, Any]:
     """Parse additional_fields from dict or JSON string.
 
     Args:
         additional_fields: Dict, JSON string, or None.
+        param_name: Argument name used in error messages.
 
     Returns:
         Parsed dict of additional fields.
@@ -180,13 +182,11 @@ def _parse_additional_fields(
         try:
             parsed = json.loads(additional_fields)
             if not isinstance(parsed, dict):
-                raise ValueError(
-                    "Parsed additional_fields is not a JSON object (dict)."
-                )
+                raise ValueError(f"{param_name} is not a JSON object (dict).")
             return parsed
         except json.JSONDecodeError as e:
-            raise ValueError(f"additional_fields is not valid JSON: {e}") from e
-    raise ValueError("additional_fields must be a dictionary or JSON string.")
+            raise ValueError(f"{param_name} is not valid JSON: {e}") from e
+    raise ValueError(f"{param_name} must be a dictionary or JSON string.")
 
 
 def _parse_request_field_values(
@@ -2121,7 +2121,7 @@ async def update_issue(
         ValueError: If in read-only mode or Jira client unavailable, or invalid input.
     """
     jira = await get_jira_fetcher(ctx)
-    update_fields = _parse_additional_fields(fields)
+    update_fields = _parse_additional_fields(fields, param_name="fields")
 
     return_fields_list: str | list[str] | None = return_fields
     if return_fields and return_fields != "*all":
@@ -2998,7 +2998,7 @@ async def transition_issue(
         raise ValueError("issue_key and transition_id are required.")
 
     # Parse fields from JSON string
-    update_fields = _parse_additional_fields(fields)
+    update_fields = _parse_additional_fields(fields, param_name="fields")
 
     available_transitions = jira.get_available_transitions(issue_key)
     resolved_transition_id = resolve_transition(available_transitions, transition_id)

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -195,6 +195,10 @@ def _parse_request_field_values(
     request_field_values: dict[str, Any] | str,
 ) -> dict[str, Any]:
     """Parse request_field_values from dict or JSON string."""
+    if isinstance(request_field_values, str) and not request_field_values.strip():
+        raise ValueError(
+            "request_field_values is not valid JSON: value must not be blank."
+        )
     try:
         return _parse_additional_fields(request_field_values)
     except ValueError as e:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -179,6 +179,8 @@ def _parse_additional_fields(
     if isinstance(additional_fields, dict):
         return additional_fields
     if isinstance(additional_fields, str):
+        if not additional_fields.strip():
+            return {}
         try:
             parsed = json.loads(additional_fields)
             if not isinstance(parsed, dict):

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2399,6 +2399,24 @@ async def test_update_issue_accepts_json_string_additional_fields(
 
 
 @pytest.mark.anyio
+async def test_update_issue_plain_text_fields_error_names_fields(jira_client):
+    """Regression: invalid plain-text fields must blame fields,
+    not additional_fields — both arguments share one parser whose
+    error previously hardcoded the additional_fields name."""
+    with pytest.raises(ToolError) as excinfo:
+        await jira_client.call_tool(
+            "jira_update_issue",
+            {
+                "issue_key": "TEST-123",
+                "fields": "plain markdown text, not JSON",
+            },
+        )
+    message = str(excinfo.value)
+    assert "fields is not valid JSON" in message
+    assert "additional_fields" not in message
+
+
+@pytest.mark.anyio
 async def test_update_issue_additional_fields_invalid_json(jira_client):
     """Test that invalid JSON additional_fields raises ToolError."""
     with pytest.raises(ToolError) as excinfo:

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -906,6 +906,25 @@ async def test_create_customer_request(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("request_field_values", ["", " \t\n"])
+async def test_create_customer_request_rejects_blank_field_values(
+    jira_client, mock_jira_fetcher, request_field_values
+):
+    """Customer requests require non-blank request field values."""
+    with pytest.raises(ToolError, match="request_field_values is not valid JSON"):
+        await jira_client.call_tool(
+            "jira_create_customer_request",
+            {
+                "service_desk_id": "4",
+                "request_type_id": "23",
+                "request_field_values": request_field_values,
+            },
+        )
+
+    mock_jira_fetcher.create_customer_request.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_create_customer_request_with_attachments(jira_client, mock_jira_fetcher):
     """Customer request tool should forward parsed base64 attachments."""
     mock_jira_fetcher.create_customer_request.return_value = JiraCustomerRequest(
@@ -1079,18 +1098,19 @@ async def test_create_issue_accepts_json_string(jira_client, mock_jira_fetcher):
     )
 
 
+@pytest.mark.parametrize("additional_fields", ["", " \t\n"])
 @pytest.mark.anyio
-async def test_create_issue_additional_fields_empty_string(
-    jira_client, mock_jira_fetcher
+async def test_create_issue_additional_fields_blank_string(
+    jira_client, mock_jira_fetcher, additional_fields
 ):
-    """Test that empty string additional_fields is treated as unset."""
+    """Test that blank additional_fields is treated as unset."""
     await jira_client.call_tool(
         "jira_create_issue",
         {
             "project_key": "TEST",
             "summary": "Test issue",
             "issue_type": "Task",
-            "additional_fields": "",
+            "additional_fields": additional_fields,
         },
     )
     assert "labels" not in mock_jira_fetcher.create_issue.call_args[1]
@@ -2447,17 +2467,18 @@ async def test_update_issue_additional_fields_non_dict_json(jira_client):
     assert "not a JSON object" in str(excinfo.value)
 
 
+@pytest.mark.parametrize("additional_fields", ["", " \t\n"])
 @pytest.mark.anyio
-async def test_update_issue_additional_fields_empty_string(
-    jira_client, mock_jira_fetcher
+async def test_update_issue_additional_fields_blank_string(
+    jira_client, mock_jira_fetcher, additional_fields
 ):
-    """Test that empty string additional_fields is treated as unset."""
+    """Test that blank additional_fields is treated as unset."""
     response = await jira_client.call_tool(
         "jira_update_issue",
         {
             "issue_key": "TEST-123",
             "fields": '{"summary": "Updated"}',
-            "additional_fields": "",
+            "additional_fields": additional_fields,
         },
     )
     content = json.loads(response.content[0].text)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -1080,19 +1080,20 @@ async def test_create_issue_accepts_json_string(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
-async def test_create_issue_additional_fields_empty_string(jira_client):
-    """Test that empty string additional_fields raises ToolError."""
-    with pytest.raises(ToolError) as excinfo:
-        await jira_client.call_tool(
-            "jira_create_issue",
-            {
-                "project_key": "TEST",
-                "summary": "Test issue",
-                "issue_type": "Task",
-                "additional_fields": "",
-            },
-        )
-    assert "not valid JSON" in str(excinfo.value)
+async def test_create_issue_additional_fields_empty_string(
+    jira_client, mock_jira_fetcher
+):
+    """Test that empty string additional_fields is treated as unset."""
+    await jira_client.call_tool(
+        "jira_create_issue",
+        {
+            "project_key": "TEST",
+            "summary": "Test issue",
+            "issue_type": "Task",
+            "additional_fields": "",
+        },
+    )
+    assert "labels" not in mock_jira_fetcher.create_issue.call_args[1]
 
 
 @pytest.mark.anyio
@@ -2447,18 +2448,21 @@ async def test_update_issue_additional_fields_non_dict_json(jira_client):
 
 
 @pytest.mark.anyio
-async def test_update_issue_additional_fields_empty_string(jira_client):
-    """Test that empty string additional_fields raises ToolError."""
-    with pytest.raises(ToolError) as excinfo:
-        await jira_client.call_tool(
-            "jira_update_issue",
-            {
-                "issue_key": "TEST-123",
-                "fields": '{"summary": "Updated"}',
-                "additional_fields": "",
-            },
-        )
-    assert "not valid JSON" in str(excinfo.value)
+async def test_update_issue_additional_fields_empty_string(
+    jira_client, mock_jira_fetcher
+):
+    """Test that empty string additional_fields is treated as unset."""
+    response = await jira_client.call_tool(
+        "jira_update_issue",
+        {
+            "issue_key": "TEST-123",
+            "fields": '{"summary": "Updated"}',
+            "additional_fields": "",
+        },
+    )
+    content = json.loads(response.content[0].text)
+    assert content["message"] == "Issue updated successfully"
+    assert "labels" not in mock_jira_fetcher.update_issue.call_args[1]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Problem

`jira_update_issue`, `jira_create_issue`, and `jira_transition_issue` accept `fields` / `additional_fields` as optional string parameters, but passing an empty or whitespace-only string raises an opaque JSON error. Omitting the parameter succeeds, while serializing the absent optional value as `""` fails.

## Solution

Treat empty and whitespace-only optional `fields` / `additional_fields` strings as `{}`. Genuinely invalid non-empty JSON still raises.

The parser is also shared by `jira_create_customer_request`. Its `request_field_values` argument is required, so this PR explicitly preserves strict rejection of empty and whitespace-only values on that path.

## Changes

- Normalize blank optional Jira issue and transition field strings to an empty dictionary.
- Preserve required customer-request field validation.
- Keep parameter-specific parse errors from the stacked #1618 change.
- Add regression coverage for both empty and whitespace-only strings.

## Behavior

- Optional `fields=""` and `additional_fields=""` are treated as unset.
- Required `request_field_values=""` remains invalid.
- Non-empty invalid JSON and non-object JSON remain invalid.
- No API schema or dependency changes.

## Verification

- `uv run pytest tests/unit/servers/test_jira_server.py -q` — 212 passed
- `uv run pytest tests/unit/ -q` — 3845 passed, 5 pre-existing skips
- Focused blank-input regression selection — 6 passed
- Ruff check, Ruff format check, and mypy — passed on changed files
- `uv run python scripts/generate_tool_docs.py --check` — passed; generated docs unchanged
- `tests/integration/` contains only environment-gated cases in this checkout (23 skipped); the changed validation runs before any Jira API call

## Related

Stacked on #1618 (error attribution fix). Internal ticket AIDEV-482.
