### PR TITLE
fix(confluence): support v5 page reads

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -331,7 +331,11 @@ class PagesMixin(ConfluenceClient):
             if not properties:
                 return None
 
-            results = properties.get("results", [])
+            results = (
+                properties
+                if isinstance(properties, list)
+                else properties.get("results", [])
+            )
             for prop in results:
                 key = prop.get("key", "")
                 if key in ("emoji-title-published", "emoji-title-draft"):
@@ -489,7 +493,11 @@ class PagesMixin(ConfluenceClient):
             if not properties:
                 return None
 
-            results = properties.get("results", [])
+            results = (
+                properties
+                if isinstance(properties, list)
+                else properties.get("results", [])
+            )
             for prop in results:
                 key = prop.get("key", "")
                 if key in ("content-appearance-published", "content-appearance-draft"):
@@ -569,8 +577,10 @@ class PagesMixin(ConfluenceClient):
         try:
             # Directly try to find the page by title
             page = self.confluence.get_page_by_title(
-                space=space_key, title=title, expand="body.storage,version"
+                space_key, title, expand="body.storage,version"
             )
+            if isinstance(page, dict) and isinstance(page.get("results"), list):
+                page = page["results"][0] if page["results"] else None
 
             if not page:
                 logger.warning(
@@ -650,7 +660,7 @@ class PagesMixin(ConfluenceClient):
             List of ConfluencePage models containing page content and metadata
         """
         pages = self.confluence.get_all_pages_from_space(
-            space=space_key, start=start, limit=limit, expand="body.storage"
+            space_key, start=start, limit=limit, expand="body.storage"
         )
 
         page_models = []

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -193,13 +193,40 @@ class TestPagesMixin:
 
         # Verify API calls
         pages_mixin.confluence.get_page_by_title.assert_called_once_with(
-            space=space_key, title=title, expand="body.storage,version"
+            space_key, title, expand="body.storage,version"
         )
 
         # Verify result
         assert result.id == "987654321"
         assert result.title == title
         assert result.content == "Processed Markdown"
+
+    def test_get_page_by_title_supports_v5_space_key(self, pages_mixin):
+        """Use the positional space argument accepted by v4 and v5."""
+        page = {
+            "id": "987654321",
+            "title": "Example Page",
+            "space": {"key": "DEMO"},
+            "body": {"storage": {"value": "<p>Example content</p>"}},
+            "version": {"number": 1},
+        }
+
+        def get_page_by_title_v5(space_key, title, **kwargs):
+            assert space_key == "DEMO"
+            assert title == "Example Page"
+            assert kwargs == {"expand": "body.storage,version"}
+            return {"results": [page]}
+
+        pages_mixin.confluence.get_page_by_title.side_effect = get_page_by_title_v5
+        pages_mixin.preprocessor.process_html_content.return_value = (
+            "<p>Processed HTML</p>",
+            "Processed Markdown",
+        )
+
+        result = pages_mixin.get_page_by_title("DEMO", "Example Page")
+
+        assert result is not None
+        assert result.id == "987654321"
 
     def test_get_page_by_title_preserves_raw_storage(self, pages_mixin):
         """Test raw storage is preserved when a page is looked up by title."""
@@ -237,7 +264,7 @@ class TestPagesMixin:
         # Assert
         assert result is None
         pages_mixin.confluence.get_page_by_title.assert_called_once_with(
-            space="NONEXISTENT", title="Page Title", expand="body.storage,version"
+            "NONEXISTENT", "Page Title", expand="body.storage,version"
         )
 
     def test_get_page_by_title_page_not_found(self, pages_mixin):
@@ -251,7 +278,7 @@ class TestPagesMixin:
         # Assert
         assert result is None
         pages_mixin.confluence.get_page_by_title.assert_called_once_with(
-            space="PROJ", title="Nonexistent Page", expand="body.storage,version"
+            "PROJ", "Nonexistent Page", expand="body.storage,version"
         )
 
     def test_get_page_by_title_error_handling(self, pages_mixin):
@@ -278,7 +305,7 @@ class TestPagesMixin:
 
         # Assert
         pages_mixin.confluence.get_all_pages_from_space.assert_called_once_with(
-            space=space_key, start=0, limit=10, expand="body.storage"
+            space_key, start=0, limit=10, expand="body.storage"
         )
 
         # Verify results
@@ -298,6 +325,37 @@ class TestPagesMixin:
         # Verify the second page
         assert results[1].id == "987654321"  # Second page ID from mock
         assert results[1].title == "Example Meeting Notes"
+
+    def test_get_space_pages_supports_v5_space_key(self, pages_mixin):
+        """Use the positional space argument accepted by v4 and v5."""
+
+        def get_all_pages_from_space_v5(space_key, **kwargs):
+            assert space_key == "PROJ"
+            assert kwargs == {
+                "start": 0,
+                "limit": 10,
+                "expand": "body.storage",
+            }
+            return [
+                {
+                    "id": "123456789",
+                    "title": "Example Page",
+                    "body": {"storage": {"value": "<p>Example content</p>"}},
+                }
+            ]
+
+        pages_mixin.confluence.get_all_pages_from_space.side_effect = (
+            get_all_pages_from_space_v5
+        )
+        pages_mixin.preprocessor.process_html_content.return_value = (
+            "<p>Processed HTML</p>",
+            "Processed Markdown",
+        )
+
+        results = pages_mixin.get_space_pages("PROJ")
+
+        assert len(results) == 1
+        assert results[0].id == "123456789"
 
     def test_create_page_success(self, pages_mixin):
         """Test creating a new page."""
@@ -2280,6 +2338,17 @@ class TestPageEmoji:
         assert result == "🚀"
         pages_mixin.confluence.get_page_properties.assert_called_once_with("123456")
 
+    def test_get_page_emoji_supports_v5_property_list(self, pages_mixin):
+        """Read page properties when the client returns the v5 list shape."""
+        pages_mixin.confluence.get_page_properties.return_value = [
+            {
+                "key": "emoji-title-published",
+                "value": {"fallback": "🚀"},
+            }
+        ]
+
+        assert pages_mixin._get_page_emoji("123456") == "🚀"
+
     def test_get_page_emoji_draft_fallback(self, pages_mixin):
         """Test getting page emoji from draft when published not available."""
         pages_mixin.confluence.get_page_properties.return_value = {
@@ -2953,6 +3022,17 @@ class TestPageWidth:
 
             mock_get.assert_called_once_with(page_id)
             assert result == "full-width"
+
+    def test_get_page_width_supports_v5_property_list(self, pages_mixin):
+        """Read page properties when the client returns the v5 list shape."""
+        pages_mixin.confluence.get_page_properties.return_value = [
+            {
+                "key": "content-appearance-published",
+                "value": "full-width",
+            }
+        ]
+
+        assert pages_mixin._get_page_width("page_full_width_123") == "full-width"
 
     def test_get_page_width_fixed_width(self, pages_mixin):
         """Test getting max page layout."""


### PR DESCRIPTION
## Description

I updated Confluence page reads to work with the v5 client response shapes:

- pass the shared space argument positionally for title and space-page reads
- unwrap title lookup result envelopes
- read page properties returned as either a result envelope or a list

The existing `<5.0.0` dependency ceiling remains unchanged. This fixes the
known reader compatibility paths without representing the package as fully v5
compatible.

Fixes #1601

## Verification

- `uv run pytest` (3849 passed, 242 skipped)

## Maintainer verification

- `uv run pytest tests/unit/ -q` (3849 passed, 5 skipped)
- `uv run pytest tests/e2e/test_confluence_dc_operations.py --dc-e2e -q` with atlassian-python-api 4.0.7 (17 passed)
- `.venv/bin/pytest tests/e2e/test_confluence_dc_operations.py --dc-e2e -q` with atlassian-python-api 5.0.3 forced locally (17 passed)
- live DC title lookup and space-page reads with atlassian-python-api 5.0.3
- `uv run pytest tests/e2e/cloud/test_confluence_cloud_operations.py --cloud-e2e -q` with atlassian-python-api 4.0.7 (19 passed, 1 unrelated site-capability skip)
- targeted Cloud page-property reads (2 passed, no skips)
- live Cloud title lookup and space-page reads with atlassian-python-api 4.0.7
- `uv run python scripts/generate_tool_docs.py --check`
