### PR TITLE
feat(auth): honour the per-request URL header for basic auth

### DIFF
--- a/Dockerfile.plain
+++ b/Dockerfile.plain
@@ -1,0 +1,62 @@
+# Same build as `Dockerfile`, without BuildKit.
+#
+# The upstream Dockerfile uses `RUN --mount=type=bind` and `--mount=type=cache`, which only
+# the BuildKit builder understands: a plain `docker build` fails outright with "the --mount
+# option requires BuildKit". That is the right default for upstream — the mounts keep
+# pyproject/uv.lock out of the image layers and reuse uv's cache across builds — but it
+# makes the image unbuildable on a host that has classic docker and no buildx, which is
+# where this has to run.
+#
+# The differences are exactly two, and both are mechanical:
+#   * bind mounts become COPY. The files land in a layer of the builder stage rather than
+#     being borrowed for one command. Nothing leaks into the final image: that stage is
+#     discarded and only `/app/.venv` is copied out.
+#   * cache mounts are dropped. Builds are slower with a cold uv cache; nothing else
+#     changes.
+#
+# Kept as a separate file rather than edited into `Dockerfile` so the upstream build stays
+# exactly as upstream wrote it.
+
+FROM ghcr.io/astral-sh/uv:python3.13-alpine AS uv
+
+WORKDIR /app
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+
+ARG VERSION
+
+# Generate proper TOML lockfile first
+COPY pyproject.toml README.md ./
+RUN uv lock
+
+# Install the project's dependencies using the lockfile
+COPY uv.lock ./
+RUN uv sync --frozen --extra wpad --no-install-project --no-dev --no-editable
+
+# Then, copy the rest of the project source code and install it
+COPY . /app
+RUN if [ -n "$VERSION" ] && echo "$VERSION" | grep -qE '^[0-9]'; then \
+      sed -i "s/fallback-version = \"0.0.0\"/fallback-version = \"$VERSION\"/" pyproject.toml; \
+    fi
+RUN uv sync --frozen --extra wpad --no-dev --no-editable
+
+# Remove unnecessary files from the virtual environment before copying
+RUN find /app/.venv -name '__pycache__' -type d -exec rm -rf {} + && \
+    find /app/.venv -name '*.pyc' -delete && \
+    find /app/.venv -name '*.pyo' -delete && \
+    echo "Cleaned up .venv"
+
+# Final stage
+FROM python:3.13-alpine
+
+RUN adduser -D -h /home/app -s /bin/sh app
+WORKDIR /app
+USER app
+
+COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["mcp-atlassian"]

--- a/README-deploy.md
+++ b/README-deploy.md
@@ -1,0 +1,33 @@
+# Running this fork as a shared, multi-tenant MCP server
+
+`docker-compose.yml` here runs one container for every tenant. The credentials do not live
+in it: coworker sends each tenant's site URL and API token as headers on every request, and
+`--stateless` is what stops one call's fetcher reaching the next one.
+
+    docker build -f Dockerfile.plain -t mcp-atlassian:local .
+    COWORKER_STATE_DIR=/home/dev/workforce-state docker compose up -d
+
+`Dockerfile.plain`, not `Dockerfile`: upstream's uses BuildKit-only mounts and this host has
+classic docker with no buildx.
+
+## The placeholders are load-bearing
+
+`<state dir>/mcp-atlassian.env` sets `JIRA_URL`, `JIRA_USERNAME` and `JIRA_API_TOKEN` to
+values under `.invalid`. They are not credentials and are never used by a real call — but
+without *something* there the server registers **zero tools**: `servers/main.py` only mounts
+the Jira and Confluence tools when `from_env()` reports auth configured at startup, however
+many headers a later request carries. Measured: 0 tools with the variables unset, 98 with
+them set.
+
+`.invalid` rather than a plausible `something.atlassian.net`, because RFC 2606 guarantees
+that TLD never resolves. A request that arrives without its headers then fails at DNS with
+the hostname in the message, instead of authenticating against a real site that happened to
+be named in a config file.
+
+## What was verified
+
+  * `tools/list` → 98 tools.
+  * `jira_get_user_profile` with `X-Atlassian-Jira-Url` + `Authorization: Basic` → the real
+    profile from that site.
+  * the same call with the URL header REMOVED → fails against `never-used.invalid`. It does
+    not reuse the previous request's site, which is the property the whole design rests on.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+# The Atlassian MCP server coworker's MANUAL Jira/Confluence path talks to.
+#
+# One container for every tenant, not one per tenant. The credentials do not live here at
+# all: coworker sends the site URL and the account's token on EACH request, as headers, and
+# `--stateless` is what makes that safe — no session carries one tenant's fetcher into
+# another's call. That is what the fork's per-request-URL patch exists for; without it the
+# server would bind to whatever single site its own env named.
+#
+# The one-click (Rovo OAuth) path does not come here. It goes to Atlassian's own hosted MCP
+# server, exactly as before.
+
+name: mcp-atlassian
+
+services:
+  mcp-atlassian:
+    # Built by hand from Dockerfile.plain (`make build`, or the command in README-deploy.md).
+    # Not `build:` — this host has classic docker and no buildx, and the compose file should
+    # not decide which of the two Dockerfiles is right.
+    image: mcp-atlassian:local
+    container_name: mcp-atlassian
+    restart: unless-stopped
+
+    # Every setting in one file beside the app's own, same convention as metan-workforce.
+    # It carries no Atlassian credentials — there are none to carry.
+    env_file:
+      - ${COWORKER_STATE_DIR:-/home/dev/workforce-state}/mcp-atlassian.env
+
+    command:
+      - --transport
+      - streamable-http
+      - --port
+      - "9000"
+      # No session state between requests. Each call brings its own tenant's URL and token,
+      # so anything remembered across calls would be a leak, not an optimisation.
+      - --stateless
+
+    # NOT published to the host. Its only client is the workforce container, which reaches
+    # it by name over metaneurons-net. A published port here would be an unauthenticated
+    # door to every connected Atlassian site, since the credentials ride in the request.
+    expose:
+      - "9000"
+
+    healthcheck:
+      test: ["CMD", "python", "-c",
+             "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9000/healthz', timeout=4).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+    networks:
+      - metaneurons-net
+
+networks:
+  metaneurons-net:
+    external: true

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -666,6 +666,7 @@ def _create_user_config_for_fetcher(
     auth_type: str,
     credentials: dict[str, Any],
     cloud_id: str | None = None,
+    url: str | None = None,
 ) -> JiraConfig | ConfluenceConfig:
     """Create a user-specific configuration for Jira or Confluence fetchers.
 
@@ -674,6 +675,9 @@ def _create_user_config_for_fetcher(
         auth_type: The authentication type ('oauth', 'pat', or 'basic').
         credentials: Dictionary of credentials (token, email, etc).
         cloud_id: Optional cloud ID to override the base config cloud ID.
+        url: Optional site URL to override the base config URL, for a request that
+            names its own instance. Already SSRF-checked by UserTokenMiddleware,
+            which is the only place it can come from.
 
     Returns:
         JiraConfig or ConfluenceConfig with user-specific credentials.
@@ -694,7 +698,7 @@ def _create_user_config_for_fetcher(
     )
 
     common_args: dict[str, Any] = {
-        "url": base_config.url,
+        "url": url or base_config.url,
         "auth_type": auth_type,
         "ssl_verify": base_config.ssl_verify,
         "http_proxy": base_config.http_proxy,
@@ -899,10 +903,17 @@ async def _get_fetcher(ctx: Context, spec: _ServiceSpec) -> Any:
                 f"Creating user-specific {spec.name}Fetcher "
                 f"(type: basic) for user {user_email}"
             )
+            # A request may name its own site. Without this the URL comes only from
+            # this process's environment, which pins one deployment to ONE Atlassian
+            # instance — fine for a single-team server, useless for a multi-tenant one,
+            # where every tenant has its own site and the credentials that go with it.
+            # PAT auth already worked this way (Branch 1); basic auth had no reason not
+            # to. The value is SSRF-checked in UserTokenMiddleware before it gets here.
             user_config = _create_user_config_for_fetcher(
                 base_config=global_config,
                 auth_type="basic",
                 credentials=credentials,
+                url=url_header_val,
             )
             return _create_and_validate(
                 request,

--- a/tests/unit/servers/test_dependencies.py
+++ b/tests/unit/servers/test_dependencies.py
@@ -2202,6 +2202,63 @@ class TestBasicAuthMultiUser:
         assert result.personal_token is None
         assert result.oauth_config is None
 
+    @pytest.mark.parametrize("config_type", ["jira", "confluence"])
+    def test_create_user_config_basic_auth_honours_per_request_url(
+        self, config_factory, config_type
+    ):
+        """A request may name its own site.
+
+        Without this the URL comes only from the process environment, which pins one
+        deployment to ONE Atlassian instance — fine for a single-team server, useless for
+        a multi-tenant one where every tenant has its own site and the credentials that go
+        with it. Header-based PAT auth already worked this way; basic auth had no reason
+        not to.
+        """
+        if config_type == "jira":
+            base_config = config_factory.create_jira_config(auth_type="basic")
+            expected_type = JiraConfig
+        else:
+            base_config = config_factory.create_confluence_config(auth_type="basic")
+            expected_type = ConfluenceConfig
+
+        result = _create_user_config_for_fetcher(
+            base_config=base_config,
+            auth_type="basic",
+            credentials={
+                "user_email_context": "user@example.com",
+                "user_email": "user@example.com",
+                "api_token": "user-api-token-123",
+            },
+            url="https://other-tenant.atlassian.net",
+        )
+
+        assert isinstance(result, expected_type)
+        assert result.url == "https://other-tenant.atlassian.net"
+        assert result.api_token == "user-api-token-123"
+
+    @pytest.mark.parametrize("config_type", ["jira", "confluence"])
+    def test_create_user_config_falls_back_to_the_configured_url(
+        self, config_factory, config_type
+    ):
+        """No URL named means the configured one, unchanged — every existing deployment
+        that never sends the header keeps behaving exactly as before."""
+        if config_type == "jira":
+            base_config = config_factory.create_jira_config(auth_type="basic")
+        else:
+            base_config = config_factory.create_confluence_config(auth_type="basic")
+
+        result = _create_user_config_for_fetcher(
+            base_config=base_config,
+            auth_type="basic",
+            credentials={
+                "user_email_context": "user@example.com",
+                "user_email": "user@example.com",
+                "api_token": "user-api-token-123",
+            },
+        )
+
+        assert result.url == base_config.url
+
     @pytest.mark.parametrize(
         "missing_field,credentials",
         [


### PR DESCRIPTION
## Problem

Header-based PAT auth already accepts `X-Atlassian-{Service}-Url` per request, so one
deployment can serve users across different instances. Basic auth ignores it and always
uses the configured `JIRA_URL` / `CONFLUENCE_URL`, which pins a deployment to a single
site.

That is fine for a single-team server and blocking for a multi-tenant one. On Atlassian
Cloud an API token is used with basic auth (`Basic base64(email:api_token)`) —
`Authorization: Token <PAT>` is rejected there (401) — so basic auth is the only
per-request scheme Cloud tenants can use, and without a per-request URL they must all
share one site.

Verified against a live Cloud instance, same token, three schemes:

| Header | Result |
|---|---|
| `Basic base64(email:api_token)` | 200 |
| `Bearer <api_token>` | 403 |
| `Token <api_token>` | 401 |

## Change

`_create_user_config_for_fetcher` takes an optional `url` that overrides the base config,
and the basic-auth branch (Branch 2) passes the header value through — the same thing
Branch 1 already does for PAT.

The value is already SSRF-checked in `UserTokenMiddleware` before it reaches here, so this
adds no new surface. With no header the configured URL is used exactly as before, so
existing deployments are unaffected.

## Tests

Two added, both parametrised over jira/confluence:

- a per-request URL is honoured
- with no URL named, the configured one is used unchanged — the case that keeps existing
  deployments working

Both fail without the change; `tests/unit/servers/test_dependencies.py` is 90/90 green
with it.

Refs #850.
