### PR TITLE
feat(jira): add inline status lozenge support in markdown_to_adf

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -51,7 +51,7 @@ Create a new Jira issue with optional Epic link or parent for subtasks.
 | `summary` | `string` | Yes | Summary/title of the issue |
 | `issue_type` | `string` | Yes | Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). The available types depend on your project configuration. For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields. |
 | `assignee` | `string` | No | (Optional) Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...') |
-| `description` | `string` | No | Issue description in Markdown format. On Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. |
+| `description` | `string` | No | Issue description in Markdown format. On Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section and '`{status:color=green\|title=Done}`' for an inline status lozenge. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API') |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to set. Examples: - Set priority: `{"priority": {"name": "High"}}` - Add labels: `{"labels": ["frontend", "urgent"]}` - Link to parent (for any issue type): `{"parent": "PROJ-123"}` - Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}` - Set Fix Version/s: `{"fixVersions": [{"id": "10020"}]}` - Custom fields: `{"customfield_10010": "value"}` |
 **Example:**
@@ -81,7 +81,7 @@ Update an issue and optionally transition, comment, and log work.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `fields` | `string` | No | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format; on Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section. Example: '`{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}`' |
+| `fields` | `string` | No | JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). For 'description', provide text in Markdown format; on Jira Cloud, use '`{expand:Title}`...`{expand}`' for a collapsible section and '`{status:color=green\|title=Done}`' for an inline status lozenge. Example: '`{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\nMarkdown text"}`' |
 | `additional_fields` | `string` | No | (Optional) JSON string of additional fields to update. Use this for custom fields or more complex updates. Link to epic: `{"epicKey": "EPIC-123"}` or `{"epic_link": "EPIC-123"}`. |
 | `components` | `string` | No | (Optional) Comma-separated list of component names (e.g., 'Frontend,API') |
 | `attachments` | `string` | No | (Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt'] |

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -17,6 +17,9 @@ _JIRA_ISSUE_KEY_RE = re.compile(
     r"([A-Z][A-Z0-9_]+-\d+(?:-\d+)*)"
     r"(?![A-Za-z0-9_/-])"
 )
+_VALID_STATUS_COLORS = frozenset(
+    {"neutral", "purple", "blue", "red", "yellow", "green"}
+)
 
 
 def _append_text_nodes(
@@ -69,8 +72,9 @@ def _parse_inline_formatting(
     """Parse inline Markdown formatting into ADF inline nodes.
 
     Handles: bold (**), italic (*), inline code (`), links ([text](url)),
-    strikethrough (~~), and Jira-flavored user mentions
-    ([~accountid:ACCOUNT_ID] or @[Display Name](accountid:ACCOUNT_ID)).
+    strikethrough (~~), Jira-flavored user mentions
+    ([~accountid:ACCOUNT_ID] or @[Display Name](accountid:ACCOUNT_ID)), and
+    status lozenges ({status:color=green|title=Done}).
 
     Bare Jira issue keys are converted to links when ``jira_base_url`` is set.
 
@@ -79,6 +83,9 @@ def _parse_inline_formatting(
     are symmetric. The display-name syntax also includes the mention text in
     the ADF node.
 
+    The {status:...} syntax follows Jira wiki markup conventions. ``color`` is
+    optional and falls back to "neutral" when omitted or unrecognized.
+
     Args:
         text: Raw text potentially containing inline Markdown formatting.
         jira_base_url: Jira base URL used to link bare issue keys.
@@ -86,19 +93,23 @@ def _parse_inline_formatting(
     Returns:
         List of ADF inline nodes (text nodes with optional marks, plus
         mention nodes when [~accountid:...] or
-        @[Display Name](accountid:...) is present).
+        @[Display Name](accountid:...) is present, plus status nodes when
+        {status:...} is present).
     """
     if not text:
         return []
 
     nodes: list[dict[str, Any]] = []
     # Pattern order matters: mention before link, bold before italic,
-    # code before others.
+    # code before others. Status sits after code so a backticked
+    # `{status:...}` stays literal.
     inline_re = re.compile(
         r"\[~accountid:(?P<wiki_mention_id>[^\]]+)\]"
         r"|@\[(?P<display_mention_text>[^\]]+)\]"
         r"\(accountid:(?P<display_mention_id>[^)]+)\)"
         r"|`(?P<code_inner>[^`]+)`"
+        r"|\{status:(?:color=(?P<status_color>\w+)\|)?"
+        r"title=(?P<status_title>[^}]+)\}"
         r"|\*\*(?P<bold_inner>.+?)\*\*"
         r"|~~(?P<strike_inner>.+?)~~"
         r"|\[(?P<link_text>[^\]]+)\]\((?P<link_href>[^)]+)\)"
@@ -135,6 +146,20 @@ def _parse_inline_formatting(
                     "type": "text",
                     "text": m.group("code_inner"),
                     "marks": [{"type": "code"}],
+                }
+            )
+        elif m.group("status_title") is not None:
+            color = (m.group("status_color") or "neutral").lower()
+            if color not in _VALID_STATUS_COLORS:
+                color = "neutral"
+            nodes.append(
+                {
+                    "type": "status",
+                    "attrs": {
+                        "text": m.group("status_title"),
+                        "color": color,
+                        "style": "",
+                    },
                 }
             )
         elif m.group("bold_inner") is not None:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -1759,7 +1759,9 @@ async def create_issue(
         Field(
             description=(
                 "Issue description in Markdown format. On Jira Cloud, use "
-                "'{expand:Title}...{expand}' for a collapsible section."
+                "'{expand:Title}...{expand}' for a collapsible section and "
+                "'{status:color=green|title=Done}' for an inline status "
+                "lozenge."
             ),
             default=None,
         ),
@@ -2005,7 +2007,9 @@ async def update_issue(
             description=(
                 "JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). "
                 "For 'description', provide text in Markdown format; on Jira Cloud, "
-                "use '{expand:Title}...{expand}' for a collapsible section. "
+                "use '{expand:Title}...{expand}' for a collapsible section "
+                "and '{status:color=green|title=Done}' for an inline status "
+                "lozenge. "
                 'Example: \'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\\nMarkdown text"}\''
             ),
             default=None,

--- a/tests/e2e/cloud/test_adf_write.py
+++ b/tests/e2e/cloud/test_adf_write.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+import requests
 from fastmcp import Client
 from fastmcp.client import FastMCPTransport
 from mcp.types import CallToolResult, TextContent
@@ -88,6 +89,20 @@ async def _read_issue_description(mcp_client: Client, issue_key: str) -> str:
     assert not result.is_error
     data = json.loads(result.content[0].text)
     return data.get("description", "")
+
+
+def _read_raw_issue_description(
+    cloud_instance: CloudInstanceInfo, issue_key: str
+) -> dict[str, Any]:
+    """Read an issue description directly from Jira as raw ADF."""
+    response = requests.get(
+        f"{cloud_instance.jira_url}/rest/api/3/issue/{issue_key}",
+        params={"fields": "description"},
+        auth=(cloud_instance.username, cloud_instance.api_token),
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()["fields"]["description"]
 
 
 async def _delete_issue(mcp_client: Client, issue_key: str) -> None:
@@ -265,11 +280,21 @@ class TestADFCreateIssue:
             ),
         )
         try:
-            desc = await _read_issue_description(mcp_client, key)
-            # Cloud renders status nodes, which read back as [text].
-            assert "[Done]" in desc
-            assert "[Blocked]" in desc
-            assert "Rollout is" in desc
+            desc = _read_raw_issue_description(cloud_instance, key)
+            statuses = [
+                node
+                for block in desc["content"]
+                for node in block.get("content", [])
+                if node.get("type") == "status"
+            ]
+            assert [status["attrs"]["text"] for status in statuses] == [
+                "Done",
+                "Blocked",
+            ]
+            assert [status["attrs"]["color"] for status in statuses] == [
+                "green",
+                "red",
+            ]
         finally:
             await _delete_issue(mcp_client, key)
 

--- a/tests/e2e/cloud/test_adf_write.py
+++ b/tests/e2e/cloud/test_adf_write.py
@@ -250,6 +250,29 @@ class TestADFCreateIssue:
         finally:
             await _delete_issue(mcp_client, key)
 
+    async def test_create_issue_status(
+        self,
+        mcp_client: Client,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """Status syntax creates content accepted and returned by Jira Cloud."""
+        key = await _create_issue_with_description(
+            mcp_client,
+            cloud_instance.project_key,
+            (
+                "Rollout is {status:color=green|title=Done} "
+                "and rollback is {status:color=red|title=Blocked}."
+            ),
+        )
+        try:
+            desc = await _read_issue_description(mcp_client, key)
+            # Cloud renders status nodes, which read back as [text].
+            assert "[Done]" in desc
+            assert "[Blocked]" in desc
+            assert "Rollout is" in desc
+        finally:
+            await _delete_issue(mcp_client, key)
+
     async def test_create_issue_mixed(
         self,
         mcp_client: Client,

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -973,6 +973,93 @@ class TestMarkdownToAdfPanels:
         assert types == ["heading", "panel", "bulletList"]
 
 
+class TestMarkdownToAdfStatus:
+    """Tests for inline status lozenge support in markdown_to_adf."""
+
+    def _inline_nodes(self, markdown: str) -> list[dict[str, Any]]:
+        """Helper: return the inline nodes of the first paragraph."""
+        result = markdown_to_adf(markdown)
+        return result["content"][0]["content"]
+
+    @pytest.mark.parametrize(
+        "color",
+        ["neutral", "purple", "blue", "red", "yellow", "green"],
+    )
+    def test_all_valid_colors(self, color: str) -> None:
+        """Every supported color is passed through to the status node."""
+        nodes = self._inline_nodes(f"{{status:color={color}|title=Done}}")
+        assert nodes[0]["type"] == "status"
+        assert nodes[0]["attrs"] == {"text": "Done", "color": color, "style": ""}
+
+    def test_color_is_optional(self) -> None:
+        """Omitting color defaults to neutral."""
+        nodes = self._inline_nodes("{status:title=In Progress}")
+        assert nodes[0]["type"] == "status"
+        assert nodes[0]["attrs"]["color"] == "neutral"
+        assert nodes[0]["attrs"]["text"] == "In Progress"
+
+    def test_unknown_color_becomes_neutral(self) -> None:
+        """An unrecognized color does not produce an invalid ADF node."""
+        nodes = self._inline_nodes("{status:color=chartreuse|title=Blocked}")
+        assert nodes[0]["attrs"]["color"] == "neutral"
+        assert nodes[0]["attrs"]["text"] == "Blocked"
+
+    def test_color_is_case_insensitive(self) -> None:
+        """Color matching is not case sensitive."""
+        nodes = self._inline_nodes("{status:color=GREEN|title=Done}")
+        assert nodes[0]["attrs"]["color"] == "green"
+
+    def test_status_alongside_surrounding_text(self) -> None:
+        """Text before and after a lozenge is preserved."""
+        nodes = self._inline_nodes("Ticket is {status:color=green|title=Done} now")
+        assert [n["type"] for n in nodes] == ["text", "status", "text"]
+        assert nodes[0]["text"] == "Ticket is "
+        assert nodes[2]["text"] == " now"
+
+    def test_multiple_statuses_in_one_line(self) -> None:
+        """Several lozenges can appear in the same paragraph."""
+        nodes = self._inline_nodes(
+            "{status:color=red|title=Blocked} then {status:color=green|title=Done}"
+        )
+        statuses = [n for n in nodes if n["type"] == "status"]
+        assert [s["attrs"]["text"] for s in statuses] == ["Blocked", "Done"]
+        assert [s["attrs"]["color"] for s in statuses] == ["red", "green"]
+
+    def test_status_with_inline_formatting(self) -> None:
+        """Lozenges coexist with bold and inline code."""
+        nodes = self._inline_nodes("**bold** {status:color=blue|title=Review} `code`")
+        types = [n["type"] for n in nodes]
+        assert "status" in types
+        assert any(n.get("marks") == [{"type": "strong"}] for n in nodes)
+        assert any(n.get("marks") == [{"type": "code"}] for n in nodes)
+
+    def test_backticked_status_stays_literal(self) -> None:
+        """A lozenge inside inline code is not converted."""
+        nodes = self._inline_nodes("`{status:color=red|title=Blocked}`")
+        assert [n["type"] for n in nodes] == ["text"]
+        assert nodes[0]["marks"] == [{"type": "code"}]
+        assert nodes[0]["text"] == "{status:color=red|title=Blocked}"
+
+    def test_malformed_status_is_left_as_text(self) -> None:
+        """A lozenge missing its title is not converted."""
+        nodes = self._inline_nodes("{status:color=red}")
+        assert all(n["type"] != "status" for n in nodes)
+
+    def test_status_in_list_item(self) -> None:
+        """Lozenges work inside list items, not just paragraphs."""
+        result = markdown_to_adf("- item {status:color=yellow|title=WIP}")
+        item = result["content"][0]["content"][0]
+        inline = item["content"][0]["content"]
+        assert any(n["type"] == "status" for n in inline)
+
+    def test_round_trip_through_adf_to_text(self) -> None:
+        """A written lozenge is readable again via the ADF read path."""
+        adf = markdown_to_adf("Rollout is {status:color=green|title=Done} today")
+        text = adf_to_text(adf)
+        assert "[Done]" in text
+        assert "Rollout is" in text
+
+
 class TestMarkdownToJiraDispatch:
     """Tests for _markdown_to_jira Cloud/Server dispatch."""
 


### PR DESCRIPTION
## Description

`adf_to_text` already reads `status` nodes back out as `[text]`, but there's no way to write one. So you can read a lozenge, you just can't create it.

This adds `{status:color=green|title=Done}` to the markdown converter. Same brace style as `{expand:Title}` from #1309

## Changes

- `{status:color=X|title=Y}` becomes an ADF `status` node
- `color` is optional, falls back to `neutral` if it's missing or something I didn't expect, so a typo can't emit an invalid node
- Sits after inline code in `inline_re` so a backticked `` `{status:...}` `` stays literal
- Documented on `jira_create_issue` / `jira_update_issue`, regenerated `docs/tools/jira-issues.mdx`

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: `round-tripped it locally, lozenges come back as [Done] / [Blocked]`

Unit tests in `TestMarkdownToAdfStatus` cover the colors, the neutral fallback, mixed inline formatting, backticked literals, and malformed input.

Added `test_create_issue_status` next to the existing expand one in `tests/e2e/cloud/test_adf_write.py`, since that seemed to be the useful part last time. Creates a real issue with two lozenges, checks they survive the round trip, deletes it after.

Full unit suite passes locally.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).

