### PR TITLE
feat(confluence): enhance inline comment retrieval

### DIFF
--- a/docs/_overrides/confluence_get_comments.yaml
+++ b/docs/_overrides/confluence_get_comments.yaml
@@ -1,0 +1,2 @@
+notes: |
+  Replies include `parent_comment_id` when Confluence provides the parent thread. Inline comments also include `marker_ref`, `original_selection`, and `resolution_status` when available.

--- a/docs/_overrides/confluence_get_inline_comments.yaml
+++ b/docs/_overrides/confluence_get_inline_comments.yaml
@@ -1,0 +1,2 @@
+notes: |
+  Each inline comment includes `parent_comment_id`, `marker_ref`, `original_selection`, and `resolution_status` when Confluence provides those values.

--- a/docs/tools/confluence-comments.mdx
+++ b/docs/tools/confluence-comments.mdx
@@ -37,6 +37,10 @@ Get comments for a specific Confluence page.
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | Confluence page ID (numeric ID, can be parsed from URL, e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' -> '123456789') |
 
+<Note>
+Replies include `parent_comment_id` when Confluence provides the parent thread. Inline comments also include `marker_ref`, `original_selection`, and `resolution_status` when available.
+</Note>
+
 ---
 
 ### Reply to Comment
@@ -72,6 +76,10 @@ Get all inline comments for a Confluence page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `page_id` | `string` | Yes | The ID of the page to get inline comments from |
+
+<Note>
+Each inline comment includes `parent_comment_id`, `marker_ref`, `original_selection`, and `resolution_status` when Confluence provides those values.
+</Note>
 
 ---
 

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -68,7 +68,12 @@ class CommentsMixin(ConfluenceClient):
 
             # Get comments with expanded content
             comments_response = self.confluence.get_page_comments(
-                content_id=page_id, expand="body.view.value,version", depth="all"
+                content_id=page_id,
+                expand=(
+                    "body.view.value,version,container,ancestors,"
+                    "extensions.inlineProperties,extensions.resolution"
+                ),
+                depth="all",
             )
 
             # Process each comment
@@ -298,7 +303,10 @@ class CommentsMixin(ConfluenceClient):
                 space_key = page.get("space", {}).get("key", "")
                 response = self.confluence.get_page_comments(
                     content_id=page_id,
-                    expand="body.view.value,version,extensions.inlineProperties",
+                    expand=(
+                        "body.view.value,version,container,ancestors,"
+                        "extensions.inlineProperties,extensions.resolution"
+                    ),
                     depth="all",
                 )
                 raw_comments = [

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -17,6 +17,35 @@ logger = logging.getLogger("mcp-atlassian")
 class CommentsMixin(ConfluenceClient):
     """Mixin for Confluence comment operations."""
 
+    def _get_all_v1_page_comments(
+        self, page_id: str, *, expand: str
+    ) -> list[dict[str, Any]]:
+        """Fetch every page of comments from the Confluence v1 API."""
+        response = self.confluence.get_page_comments(
+            content_id=page_id,
+            expand=expand,
+            depth="all",
+        )
+        results = list(response.get("results", []))
+        start = int(response.get("start", 0))
+
+        while response.get("_links", {}).get("next"):
+            page_size = int(response.get("size", len(response.get("results", []))))
+            if page_size <= 0:
+                break
+            start += page_size
+            limit = int(response.get("limit", 25))
+            response = self.confluence.get_page_comments(
+                content_id=page_id,
+                expand=expand,
+                depth="all",
+                start=start,
+                limit=limit,
+            )
+            results.extend(response.get("results", []))
+
+        return results
+
     @property
     def _v2_adapter(self) -> ConfluenceV2Adapter | None:
         """Get v2 API adapter for supported Confluence Cloud authentication.
@@ -67,18 +96,17 @@ class CommentsMixin(ConfluenceClient):
             space_key = page.get("space", {}).get("key", "")
 
             # Get comments with expanded content
-            comments_response = self.confluence.get_page_comments(
-                content_id=page_id,
+            raw_comments = self._get_all_v1_page_comments(
+                page_id,
                 expand=(
                     "body.view.value,version,container,ancestors,"
                     "extensions.inlineProperties,extensions.resolution"
                 ),
-                depth="all",
             )
 
             # Process each comment
             comment_models = []
-            for comment_data in comments_response.get("results", []):
+            for comment_data in raw_comments:
                 # Get the content based on format
                 body = comment_data["body"]["view"]["value"]
                 processed_html, processed_markdown = (
@@ -301,17 +329,16 @@ class CommentsMixin(ConfluenceClient):
                 # v1: fetch all child comments then filter by location=inline
                 page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
                 space_key = page.get("space", {}).get("key", "")
-                response = self.confluence.get_page_comments(
-                    content_id=page_id,
+                all_comments = self._get_all_v1_page_comments(
+                    page_id,
                     expand=(
                         "body.view.value,version,container,ancestors,"
                         "extensions.inlineProperties,extensions.resolution"
                     ),
-                    depth="all",
                 )
                 raw_comments = [
                     c
-                    for c in response.get("results", [])
+                    for c in all_comments
                     if c.get("extensions", {}).get("location") == "inline"
                 ]
 

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -802,8 +802,14 @@ class ConfluenceV2Adapter:
         if author := v2_response.get("author"):
             v1_compatible["author"] = author
 
-        if inline_props := v2_response.get("inlineCommentProperties"):
-            v1_compatible["inlineCommentProperties"] = inline_props
+        for field in (
+            "inlineCommentProperties",
+            "properties",
+            "resolutionStatus",
+            "parentCommentId",
+        ):
+            if field in v2_response:
+                v1_compatible[field] = v2_response[field]
 
         return v1_compatible
 

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -6,6 +6,7 @@ corresponding v1 endpoints are deprecated or unavailable.
 
 import logging
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import requests
 from requests.exceptions import HTTPError
@@ -657,14 +658,14 @@ class ConfluenceV2Adapter:
         page_id: str,
         status: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Get inline comments for a page using the v2 API.
+        """Get all inline comment threads for a page using the v2 API.
 
         Args:
             page_id: The ID of the page to get inline comments from
             status: Optional filter - "open" or "resolved"
 
         Returns:
-            List of inline comments in v1-compatible format
+            Root comments and replies in a flat, v1-compatible list
 
         Raises:
             ValueError: If the API request fails
@@ -675,12 +676,50 @@ class ConfluenceV2Adapter:
             if status:
                 params["status"] = status
 
-            response = self.session.get(url, params=params)
-            response.raise_for_status()
+            root_comments = self._get_all_comment_results(url, params=params)
+            comments: list[dict[str, Any]] = []
+            pending_parent_ids: list[str] = []
+            seen_comment_ids: set[str] = set()
 
-            data = response.json()
-            results = data.get("results", [])
-            return [self._convert_v2_inline_comment_to_v1_format(r) for r in results]
+            for root_comment in root_comments:
+                comment = dict(root_comment)
+                comment_id = comment.get("id")
+                if comment_id is not None:
+                    comment_id = str(comment_id)
+                    if comment_id in seen_comment_ids:
+                        continue
+                    seen_comment_ids.add(comment_id)
+                    pending_parent_ids.append(comment_id)
+                comments.append(comment)
+
+            parent_index = 0
+            while parent_index < len(pending_parent_ids):
+                parent_id = pending_parent_ids[parent_index]
+                parent_index += 1
+                children_url = (
+                    f"{self.base_url}/api/v2/inline-comments/{parent_id}/children"
+                )
+                children = self._get_all_comment_results(
+                    children_url,
+                    params={"body-format": "storage"},
+                )
+
+                for raw_child in children:
+                    child = dict(raw_child)
+                    child.setdefault("parentCommentId", parent_id)
+                    child_id = child.get("id")
+                    if child_id is not None:
+                        child_id = str(child_id)
+                        if child_id in seen_comment_ids:
+                            continue
+                        seen_comment_ids.add(child_id)
+                        pending_parent_ids.append(child_id)
+                    comments.append(child)
+
+            return [
+                self._convert_v2_inline_comment_to_v1_format(comment)
+                for comment in comments
+            ]
 
         except HTTPError as e:
             if e.response is not None:
@@ -701,6 +740,65 @@ class ConfluenceV2Adapter:
             logger.error(f"Error getting inline comments for page '{page_id}': {e}")
             msg = f"Failed to get inline comments for page '{page_id}': {e}"
             raise ValueError(msg) from e
+
+    @staticmethod
+    def _comment_next_cursor(
+        response: requests.Response, data: dict[str, Any]
+    ) -> str | None:
+        """Extract a Confluence v2 cursor from JSON or the Link header."""
+        next_url: str | None = None
+        links = data.get("_links")
+        if isinstance(links, dict) and isinstance(links.get("next"), str):
+            next_url = links["next"]
+
+        if not next_url:
+            response_links = getattr(response, "links", None)
+            if isinstance(response_links, dict):
+                next_link = response_links.get("next")
+                if isinstance(next_link, dict) and isinstance(
+                    next_link.get("url"), str
+                ):
+                    next_url = next_link["url"]
+
+        if not next_url:
+            return None
+
+        return parse_qs(urlparse(next_url).query).get("cursor", [None])[0]
+
+    def _get_all_comment_results(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Read every cursor page from a v2 comment collection endpoint."""
+        results: list[dict[str, Any]] = []
+        cursor: str | None = None
+        seen_cursors: set[str | None] = set()
+
+        while cursor not in seen_cursors:
+            seen_cursors.add(cursor)
+            request_params = dict(params)
+            if cursor is not None:
+                request_params["cursor"] = cursor
+
+            response = self.session.get(url, params=request_params)
+            response.raise_for_status()
+            data = response.json()
+            page_results = data.get("results", [])
+            if not isinstance(page_results, list):
+                break
+            results.extend(item for item in page_results if isinstance(item, dict))
+
+            cursor = self._comment_next_cursor(response, data)
+            if not cursor:
+                break
+        else:
+            logger.warning(
+                "Stopping comment pagination after repeated cursor '%s'", cursor
+            )
+
+        return results
 
     def create_inline_comment(
         self,

--- a/src/mcp_atlassian/models/confluence/comment.py
+++ b/src/mcp_atlassian/models/confluence/comment.py
@@ -32,6 +32,9 @@ class ConfluenceComment(ApiModel, TimestampMixin):
     type: str = "comment"  # "comment", "page", etc.
     parent_comment_id: str | None = None
     location: str | None = None  # "inline", "footer", or None
+    marker_ref: str | None = None
+    original_selection: str | None = None
+    resolution_status: str | None = None
 
     @classmethod
     def from_api_response(
@@ -60,6 +63,8 @@ class ConfluenceComment(ApiModel, TimestampMixin):
         # For title, try to extract from different locations
         title = data.get("title")
         container = data.get("container")
+        if not isinstance(container, dict):
+            container = {}
         if not title and container:
             title = container.get("title")
 
@@ -69,20 +74,89 @@ class ConfluenceComment(ApiModel, TimestampMixin):
             parent_comment_id = str(v2_parent)
         elif container and container.get("type") == "comment":
             parent_comment_id = str(container.get("id", ""))
+        elif isinstance(data.get("ancestors"), list):
+            for ancestor in reversed(data["ancestors"]):
+                if (
+                    isinstance(ancestor, dict)
+                    and ancestor.get("type") == "comment"
+                    and ancestor.get("id") is not None
+                ):
+                    parent_comment_id = str(ancestor["id"])
+                    break
 
-        # Extract location from extensions (v1 API)
-        location = data.get("extensions", {}).get("location")
+        extensions = data.get("extensions")
+        if not isinstance(extensions, dict):
+            extensions = {}
+
+        # Extract inline anchor metadata from Server/DC v1 and Cloud v2 shapes.
+        inline_properties = extensions.get("inlineProperties")
+        if not isinstance(inline_properties, dict):
+            inline_properties = {}
+        v2_inline_properties = data.get("inlineCommentProperties")
+        if not isinstance(v2_inline_properties, dict):
+            v2_inline_properties = {}
+        properties = data.get("properties")
+        if not isinstance(properties, dict):
+            properties = {}
+
+        marker_ref_value = (
+            inline_properties.get("markerRef")
+            or properties.get("inlineMarkerRef")
+            or properties.get("inline-marker-ref")
+        )
+        original_selection_value = (
+            inline_properties.get("originalSelection")
+            or properties.get("inlineOriginalSelection")
+            or properties.get("inline-original-selection")
+            or v2_inline_properties.get("textSelection")
+        )
+
+        resolution_status_value = data.get("resolutionStatus")
+        resolution = extensions.get("resolution")
+        if resolution_status_value is None and isinstance(resolution, dict):
+            resolution_status_value = resolution.get("status")
+        elif resolution_status_value is None and isinstance(resolution, str):
+            resolution_status_value = resolution
+        if resolution_status_value is None and isinstance(
+            v2_inline_properties.get("resolved"), bool
+        ):
+            resolution_status_value = (
+                "resolved" if v2_inline_properties["resolved"] else "open"
+            )
+
+        version = data.get("version")
+        if not isinstance(version, dict):
+            version = {}
+        created = (
+            data.get("created")
+            or version.get("createdAt")
+            or version.get("when")
+            or EMPTY_STRING
+        )
+        updated = (
+            data.get("updated")
+            or version.get("createdAt")
+            or version.get("when")
+            or EMPTY_STRING
+        )
 
         return cls(
             id=str(data.get("id", CONFLUENCE_DEFAULT_ID)),
             title=title,
             body=data.get("body", {}).get("view", {}).get("value", EMPTY_STRING),
-            created=data.get("created", EMPTY_STRING),
-            updated=data.get("updated", EMPTY_STRING),
+            created=str(created),
+            updated=str(updated),
             author=author,
             type=data.get("type", "comment"),
             parent_comment_id=parent_comment_id,
-            location=location,
+            location=extensions.get("location"),
+            marker_ref=(str(marker_ref_value) if marker_ref_value else None),
+            original_selection=(
+                str(original_selection_value) if original_selection_value else None
+            ),
+            resolution_status=(
+                str(resolution_status_value) if resolution_status_value else None
+            ),
         )
 
     def to_simplified_dict(self) -> dict[str, Any]:
@@ -105,5 +179,14 @@ class ConfluenceComment(ApiModel, TimestampMixin):
 
         if self.location:
             result["location"] = self.location
+
+        if self.marker_ref:
+            result["marker_ref"] = self.marker_ref
+
+        if self.original_selection:
+            result["original_selection"] = self.original_selection
+
+        if self.resolution_status:
+            result["resolution_status"] = self.resolution_status
 
         return result

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -582,6 +582,9 @@ async def get_comments(
 ) -> str:
     """Get comments for a specific Confluence page.
 
+    Replies include their parent comment ID when available. Inline comments also
+    include anchor selection, marker reference, and resolution status metadata.
+
     Args:
         ctx: The FastMCP context.
         page_id: Confluence page ID.
@@ -1387,6 +1390,9 @@ async def get_inline_comments(
     ],
 ) -> str:
     """Get all inline comments for a Confluence page.
+
+    Results include parent comment IDs plus anchor selection, marker reference,
+    and resolution status metadata when Confluence provides those fields.
 
     Args:
         ctx: The FastMCP context.

--- a/tests/fixtures/confluence_mocks.py
+++ b/tests/fixtures/confluence_mocks.py
@@ -646,7 +646,9 @@ MOCK_INLINE_COMMENT_V1_RESPONSE = {
         "location": "inline",
         "inlineProperties": {
             "originalSelection": "some text to anchor",
+            "markerRef": "marker-ref-123",
         },
+        "resolution": {"status": "open"},
     },
     "_links": {
         "webui": "/spaces/TEST/pages/12345?focusedCommentId=333444555",

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -92,7 +92,12 @@ class TestCommentsMixin:
 
         # Verify
         comments_mixin.confluence.get_page_comments.assert_called_once_with(
-            content_id=page_id, expand="body.view.value,version", depth="all"
+            content_id=page_id,
+            expand=(
+                "body.view.value,version,container,ancestors,"
+                "extensions.inlineProperties,extensions.resolution"
+            ),
+            depth="all",
         )
         assert len(result) == 1
         assert result[0].body == "Processed Markdown"
@@ -704,6 +709,53 @@ class TestConfluenceCommentModel:
         result = comment.to_simplified_dict()
         assert "location" not in result
 
+    def test_inline_metadata_from_v1_extensions(self):
+        """Inline anchor and resolution metadata survive v1 simplification."""
+        comment = ConfluenceComment.from_api_response(MOCK_INLINE_COMMENT_V1_RESPONSE)
+
+        assert comment.marker_ref == "marker-ref-123"
+        assert comment.original_selection == "some text to anchor"
+        assert comment.resolution_status == "open"
+        assert comment.created == "2024-01-03T10:00:00.000Z"
+        assert comment.to_simplified_dict()["marker_ref"] == "marker-ref-123"
+
+    def test_inline_metadata_from_v2_properties(self):
+        """Current Cloud v2 inline properties are normalized."""
+        data = {
+            "id": "456789123",
+            "body": {"view": {"value": "<p>Inline comment</p>"}},
+            "parentCommentId": "123456789",
+            "properties": {
+                "inlineMarkerRef": "cloud-marker-ref",
+                "inlineOriginalSelection": "selected cloud text",
+            },
+            "resolutionStatus": "resolved",
+        }
+
+        result = ConfluenceComment.from_api_response(data).to_simplified_dict()
+
+        assert result["parent_comment_id"] == "123456789"
+        assert result["marker_ref"] == "cloud-marker-ref"
+        assert result["original_selection"] == "selected cloud text"
+        assert result["resolution_status"] == "resolved"
+
+    def test_parent_comment_from_v1_ancestors(self):
+        """Server/DC replies use the nearest comment ancestor as their parent."""
+        data = {
+            "id": "reply-2",
+            "body": {"view": {"value": "<p>Nested reply</p>"}},
+            "container": {"id": "page-1", "type": "page"},
+            "ancestors": [
+                {"id": "page-1", "type": "page"},
+                {"id": "root-comment", "type": "comment"},
+                {"id": "reply-1", "type": "comment"},
+            ],
+        }
+
+        comment = ConfluenceComment.from_api_response(data)
+
+        assert comment.parent_comment_id == "reply-1"
+
 
 class TestGetInlineComments:
     """Tests for get_inline_comments method."""
@@ -735,10 +787,16 @@ class TestGetInlineComments:
         assert len(result) == 1
         assert result[0].location == "inline"
         assert result[0].id == "333444555"
+        assert result[0].marker_ref == "marker-ref-123"
+        assert result[0].original_selection == "some text to anchor"
+        assert result[0].resolution_status == "open"
         # Verify expanded fields were requested
         comments_mixin_dc.confluence.get_page_comments.assert_called_once_with(
             content_id=page_id,
-            expand="body.view.value,version,extensions.inlineProperties",
+            expand=(
+                "body.view.value,version,container,ancestors,"
+                "extensions.inlineProperties,extensions.resolution"
+            ),
             depth="all",
         )
 
@@ -750,10 +808,16 @@ class TestGetInlineComments:
                 "id": "444555666",
                 "type": "comment",
                 "status": "open",
+                "parentCommentId": "333444555",
                 "body": {
                     "view": {"value": "<p>v2 inline</p>", "representation": "view"}
                 },
                 "extensions": {"location": "inline"},
+                "properties": {
+                    "inlineMarkerRef": "cloud-marker-ref",
+                    "inlineOriginalSelection": "selected cloud text",
+                },
+                "resolutionStatus": "open",
                 "version": {"number": 1},
                 "_links": {},
             }
@@ -771,6 +835,10 @@ class TestGetInlineComments:
             result = comments_mixin.get_inline_comments("12345")
 
         assert len(result) == 1
+        assert result[0].parent_comment_id == "333444555"
+        assert result[0].marker_ref == "cloud-marker-ref"
+        assert result[0].original_selection == "selected cloud text"
+        assert result[0].resolution_status == "open"
         mock_adapter.get_inline_comments.assert_called_once_with("12345")
         # v1 API should not be called
         comments_mixin.confluence.get_page_comments.assert_not_called()

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -131,6 +131,41 @@ class TestCommentsMixin:
         comment = result[0]
         assert comment.body == "<p>Processed HTML</p>"
 
+    def test_get_page_comments_paginates_v1_results(self, comments_mixin):
+        """All v1 comment pages are returned when Confluence provides next."""
+        first_comment = {
+            "id": "first",
+            "body": {"view": {"value": "<p>First</p>"}},
+        }
+        second_comment = {
+            "id": "second",
+            "body": {"view": {"value": "<p>Second</p>"}},
+        }
+        comments_mixin.confluence.get_page_comments.side_effect = [
+            {
+                "results": [first_comment],
+                "start": 0,
+                "limit": 1,
+                "size": 1,
+                "_links": {"next": "/rest/api/content/12345/child/comment?start=1"},
+            },
+            {
+                "results": [second_comment],
+                "start": 1,
+                "limit": 1,
+                "size": 1,
+                "_links": {},
+            },
+        ]
+
+        result = comments_mixin.get_page_comments("12345")
+
+        assert [comment.id for comment in result] == ["first", "second"]
+        assert comments_mixin.confluence.get_page_comments.call_count == 2
+        second_call = comments_mixin.confluence.get_page_comments.call_args_list[1]
+        assert second_call.kwargs["start"] == 1
+        assert second_call.kwargs["limit"] == 1
+
     def test_get_page_comments_api_error(self, comments_mixin):
         """Test handling of API errors."""
         # Mock the API to raise an exception
@@ -842,6 +877,40 @@ class TestGetInlineComments:
         mock_adapter.get_inline_comments.assert_called_once_with("12345")
         # v1 API should not be called
         comments_mixin.confluence.get_page_comments.assert_not_called()
+
+    def test_get_inline_comments_paginates_v1_results(self, comments_mixin_dc):
+        """Server/DC inline comments include matches beyond the first page."""
+        comments_mixin_dc.confluence.get_page_by_id.return_value = {
+            "space": {"key": "TEST"}
+        }
+        footer_comment = {
+            "id": "footer",
+            "body": {"view": {"value": "<p>footer</p>"}},
+            "extensions": {"location": "footer"},
+        }
+        comments_mixin_dc.confluence.get_page_comments.side_effect = [
+            {
+                "results": [footer_comment],
+                "start": 0,
+                "limit": 1,
+                "size": 1,
+                "_links": {"next": "/rest/api/content/12345/child/comment?start=1"},
+            },
+            {
+                "results": [MOCK_INLINE_COMMENT_V1_RESPONSE],
+                "start": 1,
+                "limit": 1,
+                "size": 1,
+                "_links": {},
+            },
+        ]
+
+        result = comments_mixin_dc.get_inline_comments("12345")
+
+        assert [comment.id for comment in result] == ["333444555"]
+        second_call = comments_mixin_dc.confluence.get_page_comments.call_args_list[1]
+        assert second_call.kwargs["start"] == 1
+        assert second_call.kwargs["limit"] == 1
 
     def test_get_inline_comments_empty(self, comments_mixin_dc):
         """get_inline_comments returns empty list if no inline comments (Server/DC)."""

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -840,10 +840,9 @@ class TestGetInlineComments:
         mock_adapter = MagicMock()
         mock_adapter.get_inline_comments.return_value = [
             {
-                "id": "444555666",
+                "id": "333444555",
                 "type": "comment",
                 "status": "open",
-                "parentCommentId": "333444555",
                 "body": {
                     "view": {"value": "<p>v2 inline</p>", "representation": "view"}
                 },
@@ -855,7 +854,19 @@ class TestGetInlineComments:
                 "resolutionStatus": "open",
                 "version": {"number": 1},
                 "_links": {},
-            }
+            },
+            {
+                "id": "444555666",
+                "type": "comment",
+                "status": "open",
+                "parentCommentId": "333444555",
+                "body": {
+                    "view": {"value": "<p>v2 reply</p>", "representation": "view"}
+                },
+                "extensions": {"location": "inline"},
+                "version": {"number": 1},
+                "_links": {},
+            },
         ]
         comments_mixin.preprocessor.process_html_content.return_value = (
             "<p>v2 inline</p>",
@@ -869,11 +880,13 @@ class TestGetInlineComments:
         ):
             result = comments_mixin.get_inline_comments("12345")
 
-        assert len(result) == 1
-        assert result[0].parent_comment_id == "333444555"
+        assert len(result) == 2
+        assert result[0].parent_comment_id is None
         assert result[0].marker_ref == "cloud-marker-ref"
         assert result[0].original_selection == "selected cloud text"
         assert result[0].resolution_status == "open"
+        assert result[1].parent_comment_id == result[0].id
+        assert result[1].location == "inline"
         mock_adapter.get_inline_comments.assert_called_once_with("12345")
         # v1 API should not be called
         comments_mixin.confluence.get_page_comments.assert_not_called()

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -377,6 +377,44 @@ class TestConfluenceV2AdapterComments:
                 body="<p>Test</p>",
             )
 
+    def test_get_inline_comments_preserves_review_metadata(
+        self, v2_adapter, mock_session
+    ):
+        """Cloud v2 anchor, resolution, and thread fields survive conversion."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "id": "comment-2",
+                    "status": "current",
+                    "parentCommentId": "comment-1",
+                    "properties": {
+                        "inlineMarkerRef": "marker-ref-123",
+                        "inlineOriginalSelection": "selected text",
+                    },
+                    "resolutionStatus": "open",
+                    "body": {
+                        "storage": {
+                            "value": "<p>Review comment</p>",
+                            "representation": "storage",
+                        }
+                    },
+                    "version": {"createdAt": "2024-01-03T10:00:00.000Z"},
+                }
+            ]
+        }
+        mock_session.get.return_value = mock_response
+
+        result = v2_adapter.get_inline_comments("12345")
+
+        mock_session.get.assert_called_once_with(
+            "https://example.atlassian.net/wiki/api/v2/pages/12345/inline-comments",
+            params={"body-format": "storage"},
+        )
+        assert result[0]["parentCommentId"] == "comment-1"
+        assert result[0]["properties"]["inlineMarkerRef"] == "marker-ref-123"
+        assert result[0]["resolutionStatus"] == "open"
+
     def test_create_footer_comment_neither_param_raises(self, v2_adapter):
         """T11b: Passing neither page_id nor parent_comment_id raises ValueError."""
         with pytest.raises(ValueError, match="Either"):

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -1,6 +1,6 @@
 """Unit tests for ConfluenceV2Adapter class."""
 
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, call
 
 import pytest
 import requests
@@ -368,6 +368,148 @@ class TestConfluenceV2AdapterComments:
             session=mock_session, base_url="https://example.atlassian.net/wiki"
         )
 
+    def test_get_inline_comments_includes_nested_replies(
+        self, v2_adapter, mock_session
+    ):
+        """Cloud inline reads traverse descendants without duplicating cycles."""
+
+        def comment(comment_id: str) -> dict:
+            return {
+                "id": comment_id,
+                "status": "current",
+                "body": {
+                    "storage": {
+                        "value": f"<p>{comment_id}</p>",
+                        "representation": "storage",
+                    }
+                },
+                "version": {"number": 1},
+                "_links": {},
+            }
+
+        root_response = Mock()
+        root_response.json.return_value = {"results": [comment("root")]}
+        child_response = Mock()
+        child_response.json.return_value = {"results": [comment("child")]}
+        grandchild_response = Mock()
+        grandchild_response.json.return_value = {"results": [comment("grandchild")]}
+        cycle_response = Mock()
+        cycle_response.json.return_value = {"results": [comment("root")]}
+        mock_session.get.side_effect = [
+            root_response,
+            child_response,
+            grandchild_response,
+            cycle_response,
+        ]
+
+        result = v2_adapter.get_inline_comments("page-1")
+
+        assert [item["id"] for item in result] == ["root", "child", "grandchild"]
+        assert result[1]["parentCommentId"] == "root"
+        assert result[2]["parentCommentId"] == "child"
+        assert mock_session.get.call_args_list == [
+            call(
+                "https://example.atlassian.net/wiki/api/v2/pages/page-1/inline-comments",
+                params={"body-format": "storage"},
+            ),
+            call(
+                "https://example.atlassian.net/wiki/api/v2/inline-comments/root/children",
+                params={"body-format": "storage"},
+            ),
+            call(
+                "https://example.atlassian.net/wiki/api/v2/inline-comments/child/children",
+                params={"body-format": "storage"},
+            ),
+            call(
+                "https://example.atlassian.net/wiki/api/v2/inline-comments/"
+                "grandchild/children",
+                params={"body-format": "storage"},
+            ),
+        ]
+
+    def test_get_inline_comments_paginates_roots_and_replies(
+        self, v2_adapter, mock_session
+    ):
+        """Cloud root and child collections follow both next-link shapes."""
+
+        def response(results: list[dict], next_url: str | None = None) -> Mock:
+            item = Mock()
+            item.links = {}
+            item.json.return_value = {
+                "results": results,
+                "_links": {"next": next_url} if next_url else {},
+            }
+            return item
+
+        def get(url: str, params: dict) -> Mock:
+            cursor = params.get("cursor")
+            if url.endswith("/pages/page-1/inline-comments"):
+                if cursor == "root-next":
+                    return response([{"id": "root-2"}])
+                return response(
+                    [{"id": "root-1"}],
+                    "/wiki/api/v2/pages/page-1/inline-comments?cursor=root-next",
+                )
+            if url.endswith("/inline-comments/root-1/children"):
+                if cursor == "child-next":
+                    return response([{"id": "child-2"}])
+                item = response([{"id": "child-1"}])
+                item.links = {
+                    "next": {
+                        "url": (
+                            "https://example.atlassian.net/wiki/api/v2/"
+                            "inline-comments/root-1/children?cursor=child-next"
+                        )
+                    }
+                }
+                return item
+            return response([])
+
+        mock_session.get.side_effect = get
+
+        result = v2_adapter.get_inline_comments("page-1", status="resolved")
+
+        assert [item["id"] for item in result] == [
+            "root-1",
+            "root-2",
+            "child-1",
+            "child-2",
+        ]
+        assert result[2]["parentCommentId"] == "root-1"
+        assert result[3]["parentCommentId"] == "root-1"
+        assert (
+            call(
+                "https://example.atlassian.net/wiki/api/v2/pages/page-1/inline-comments",
+                params={
+                    "body-format": "storage",
+                    "status": "resolved",
+                    "cursor": "root-next",
+                },
+            )
+            in mock_session.get.call_args_list
+        )
+        assert (
+            call(
+                "https://example.atlassian.net/wiki/api/v2/inline-comments/"
+                "root-1/children",
+                params={"body-format": "storage", "cursor": "child-next"},
+            )
+            in mock_session.get.call_args_list
+        )
+
+    def test_get_inline_comments_fails_when_child_read_fails(
+        self, v2_adapter, mock_session
+    ):
+        """A failed child request does not return a misleading partial tree."""
+        root_response = Mock()
+        root_response.json.return_value = {"results": [{"id": "root"}]}
+        error_response = Mock(status_code=500, text="server error")
+        error_response.raise_for_status.side_effect = HTTPError(response=error_response)
+        mock_session.get.side_effect = [root_response, error_response]
+
+        with pytest.raises(ValueError, match="Failed to get inline comments"):
+            v2_adapter.get_inline_comments("page-1")
+
     def test_create_footer_comment_both_params_raises(self, v2_adapter):
         """T11a: Passing both page_id and parent_comment_id raises ValueError."""
         with pytest.raises(ValueError, match="mutually exclusive"):
@@ -381,13 +523,12 @@ class TestConfluenceV2AdapterComments:
         self, v2_adapter, mock_session
     ):
         """Cloud v2 anchor, resolution, and thread fields survive conversion."""
-        mock_response = Mock()
-        mock_response.json.return_value = {
+        root_response = Mock()
+        root_response.json.return_value = {
             "results": [
                 {
-                    "id": "comment-2",
+                    "id": "comment-1",
                     "status": "current",
-                    "parentCommentId": "comment-1",
                     "properties": {
                         "inlineMarkerRef": "marker-ref-123",
                         "inlineOriginalSelection": "selected text",
@@ -403,17 +544,31 @@ class TestConfluenceV2AdapterComments:
                 }
             ]
         }
-        mock_session.get.return_value = mock_response
+        child_response = Mock()
+        child_response.json.return_value = {
+            "results": [
+                {
+                    "id": "comment-2",
+                    "status": "current",
+                    "parentCommentId": "comment-1",
+                    "body": {"storage": {"value": "<p>Reply</p>"}},
+                }
+            ]
+        }
+        empty_response = Mock()
+        empty_response.json.return_value = {"results": []}
+        mock_session.get.side_effect = [
+            root_response,
+            child_response,
+            empty_response,
+        ]
 
         result = v2_adapter.get_inline_comments("12345")
 
-        mock_session.get.assert_called_once_with(
-            "https://example.atlassian.net/wiki/api/v2/pages/12345/inline-comments",
-            params={"body-format": "storage"},
-        )
-        assert result[0]["parentCommentId"] == "comment-1"
+        assert [comment["id"] for comment in result] == ["comment-1", "comment-2"]
         assert result[0]["properties"]["inlineMarkerRef"] == "marker-ref-123"
         assert result[0]["resolutionStatus"] == "open"
+        assert result[1]["parentCommentId"] == "comment-1"
 
     def test_create_footer_comment_neither_param_raises(self, v2_adapter):
         """T11b: Passing neither page_id nor parent_comment_id raises ValueError."""

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -242,6 +242,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
         download_content_attachments,
         get_attachments,
         get_comments,
+        get_inline_comments,
         get_labels,
         get_page,
         get_page_children,
@@ -280,6 +281,7 @@ def test_confluence_mcp(mock_confluence_fetcher, mock_base_confluence_config):
     confluence_sub_mcp.add_tool(get_page_children)
     confluence_sub_mcp.add_tool(get_space_page_tree)
     confluence_sub_mcp.add_tool(get_comments)
+    confluence_sub_mcp.add_tool(get_inline_comments)
     confluence_sub_mcp.add_tool(add_comment)
     confluence_sub_mcp.add_tool(get_labels)
     confluence_sub_mcp.add_tool(add_label)
@@ -323,6 +325,7 @@ def no_fetcher_test_confluence_mcp(mock_base_confluence_config):
         download_content_attachments,
         get_attachments,
         get_comments,
+        get_inline_comments,
         get_labels,
         get_page,
         get_page_children,
@@ -363,6 +366,7 @@ def no_fetcher_test_confluence_mcp(mock_base_confluence_config):
     confluence_sub_mcp.add_tool(get_page_children)
     confluence_sub_mcp.add_tool(get_space_page_tree)
     confluence_sub_mcp.add_tool(get_comments)
+    confluence_sub_mcp.add_tool(get_inline_comments)
     confluence_sub_mcp.add_tool(add_comment)
     confluence_sub_mcp.add_tool(get_labels)
     confluence_sub_mcp.add_tool(add_label)
@@ -704,6 +708,42 @@ async def test_get_comments(client, mock_confluence_fetcher):
     assert isinstance(result_data, list)
     assert len(result_data) > 0
     assert result_data[0]["author"] == "Test User"
+
+
+@pytest.mark.anyio
+async def test_get_inline_comments_returns_complete_flat_thread(
+    client, mock_confluence_fetcher
+):
+    """The MCP response preserves every comment and its parent link."""
+    root = MagicMock()
+    root.to_simplified_dict.return_value = {
+        "id": "root",
+        "body": "Root review comment",
+        "location": "inline",
+    }
+    reply = MagicMock()
+    reply.to_simplified_dict.return_value = {
+        "id": "reply",
+        "body": "Review reply",
+        "parent_comment_id": "root",
+        "location": "inline",
+    }
+    mock_confluence_fetcher.get_inline_comments.return_value = [root, reply]
+
+    response = await client.call_tool(
+        "confluence_get_inline_comments", {"page_id": "123456"}
+    )
+
+    mock_confluence_fetcher.get_inline_comments.assert_called_once_with("123456")
+    result_data = json.loads(response.content[0].text)
+    assert result_data["success"] is True
+    assert result_data["page_id"] == "123456"
+    assert result_data["count"] == 2
+    assert [comment["id"] for comment in result_data["comments"]] == [
+        "root",
+        "reply",
+    ]
+    assert result_data["comments"][1]["parent_comment_id"] == "root"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

`confluence_get_inline_comments` promises all inline comments, but both read paths can return incomplete review threads. Confluence Cloud's page endpoint returns only root comments, while Server/Data Center reads stop at the API's default first page. Normalization also discards the anchor, resolution, and parent metadata needed to process review feedback.

This PR makes the existing read tools complete and review-ready without changing MCP tool signatures or response structure. Results remain a flat list, with `parent_comment_id` preserving thread relationships.

Related: #1264. Complementary write-side fix: #1627.

## Changes

- Paginate Cloud root inline comments and every child collection, traversing nested replies iteratively with ID-based cycle protection.
- Fail the Cloud read if a child collection cannot be loaded instead of returning a misleading partial tree.
- Paginate Server/Data Center page comments before normalization and inline filtering.
- Normalize `marker_ref`, `original_selection`, `resolution_status`, and `parent_comment_id` across Cloud v2 and Server/Data Center v1 responses.
- Populate timestamps from version metadata when top-level timestamps are absent.
- Add adapter, fetcher, and MCP response regression coverage and document the additional review metadata.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: created a root inline comment and two successive replies on Confluence Data Center; the MCP read returned all three records with parent links, and the temporary page was removed.

Contributor verification:

- 153 focused adapter/fetcher/MCP tests passed.
- 528 Confluence unit tests passed.
- 8 integration tests passed; 15 real-data cases were skipped by configuration.
- Full UTF-8 unit run: 3871 passed, 5 skipped; four unrelated Windows-specific assertions remain (path formatting, maximum timestamp, ZIP MIME mapping, and POSIX permission bits).
- Full pre-commit and generated documentation checks passed.

Maintainer verification on 2026-08-28:

- 153 focused adapter/fetcher/MCP tests passed.
- Full unit suite: 3,875 passed. The 5 skips are unrelated opt-in real-data model tests.
- Relevant real-API integration test passed against Confluence Cloud.
- Confluence Cloud e2e: 19 passed. The 1 skip is the unrelated, plan-gated page restrictions test; the inline-comment scenario passed.
- Confluence Data Center e2e: 17 passed, including the inline-comment scenario.
- Configured Ruff checks, Ruff formatting, mypy, generated documentation checks, and `git diff --check` passed.
- All required GitHub checks pass on Python 3.10 through 3.13.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All change-related tests pass locally.
- [x] Documentation updated (if needed).
