### PR TITLE
fix(confluence): preserve inline comment replies

### DIFF
--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -284,7 +284,7 @@ class CommentsMixin(ConfluenceClient):
             A tuple containing the owning page ID and ``"inline"`` or ``"footer"``.
 
         Raises:
-            ValueError: If the parent response contains no page reference.
+            ValueError: If no page reference exists or ancestry is cyclic.
         """
         current_id = comment_id
         visited: set[str] = set()
@@ -317,6 +317,9 @@ class CommentsMixin(ConfluenceClient):
             if not comment_parent_id:
                 break
             current_id = comment_parent_id
+        else:
+            message = f"Cyclic comment ancestry detected for '{comment_id}'"
+            raise ValueError(message)
 
         if not page_id:
             message = f"Could not resolve page for parent comment {comment_id}"

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -192,32 +192,49 @@ class CommentsMixin(ConfluenceClient):
 
             v2_adapter = self._v2_adapter
             if v2_adapter:
-                response = v2_adapter.create_footer_comment(
-                    parent_comment_id=comment_id, body=content
-                )
+                location = v2_adapter.get_comment_thread_location(comment_id)
+                if location == "inline":
+                    response = v2_adapter.create_inline_comment(
+                        parent_comment_id=comment_id, body=content
+                    )
+                else:
+                    response = v2_adapter.create_footer_comment(
+                        parent_comment_id=comment_id, body=content
+                    )
                 space_key = ""
             else:
-                # v1 API: thread replies under the parent page with ancestors,
-                # not as a direct child of the parent comment.
-                page_id = self._resolve_page_id_for_parent_comment(comment_id)
-                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
-                space_key = page.get("space", {}).get("key", "")
-                data: dict[str, Any] = {
-                    "type": "comment",
-                    "container": {
-                        "id": page_id,
-                        "type": "page",
-                    },
-                    "ancestors": [{"id": comment_id}],
-                    "body": {
-                        "storage": {
-                            "value": content,
-                            "representation": "storage",
+                page_id, location = self._resolve_parent_comment_context(comment_id)
+                inline_adapter = self._inline_v2_adapter
+                if location == "inline" and inline_adapter:
+                    response = inline_adapter.create_inline_comment(
+                        parent_comment_id=comment_id, body=content
+                    )
+                    space_key = ""
+                else:
+                    # v1 API: thread replies under the parent page with ancestors,
+                    # not as a direct child of the parent comment.
+                    page = self.confluence.get_page_by_id(
+                        page_id=page_id, expand="space"
+                    )
+                    space_key = page.get("space", {}).get("key", "")
+                    data: dict[str, Any] = {
+                        "type": "comment",
+                        "container": {
+                            "id": page_id,
+                            "type": "page",
                         },
-                    },
-                }
-                response = self.confluence.post("rest/api/content/", data=data)
-                space_key = ""
+                        "ancestors": [{"id": comment_id}],
+                        "body": {
+                            "storage": {
+                                "value": content,
+                                "representation": "storage",
+                            },
+                        },
+                    }
+                    if location == "inline":
+                        data["extensions"] = {"location": "inline"}
+                    response = self.confluence.post("rest/api/content/", data=data)
+                    space_key = ""
 
             if not response:
                 logger.error("Failed to reply to comment: empty response")
@@ -245,34 +262,66 @@ class CommentsMixin(ConfluenceClient):
         page_id = reference.get("id")
         return str(page_id) if page_id is not None else None
 
-    def _resolve_page_id_for_parent_comment(self, comment_id: str) -> str:
-        """Resolve the page containing a parent comment, including nested replies.
+    @staticmethod
+    def _comment_id_from_reference(reference: Any) -> str | None:
+        """Return a comment ID from an expanded Confluence content reference."""
+        if not isinstance(reference, dict) or reference.get("type") != "comment":
+            return None
+
+        comment_id = reference.get("id")
+        return str(comment_id) if comment_id is not None else None
+
+    def _resolve_parent_comment_context(self, comment_id: str) -> tuple[str, str]:
+        """Resolve the owning page and thread location for a v1 comment.
+
+        Older clients can create footer-typed replies beneath an inline root, so
+        parent comments are followed until the thread root is reached.
 
         Args:
             comment_id: The ID of the parent comment.
 
         Returns:
-            The page ID that owns the comment thread.
+            A tuple containing the owning page ID and ``"inline"`` or ``"footer"``.
 
         Raises:
             ValueError: If the parent response contains no page reference.
         """
-        parent = self.confluence.get_page_by_id(
-            page_id=comment_id, expand="container,ancestors"
-        )
+        current_id = comment_id
+        visited: set[str] = set()
+        page_id: str | None = None
 
-        page_id = self._page_id_from_reference(parent.get("container"))
-        if page_id:
-            return page_id
+        while current_id not in visited:
+            visited.add(current_id)
+            parent = self.confluence.get_page_by_id(
+                page_id=current_id,
+                expand="container,ancestors,extensions.location",
+            )
 
-        ancestors = parent.get("ancestors")
-        if isinstance(ancestors, list):
-            for ancestor in reversed(ancestors):
-                page_id = self._page_id_from_reference(ancestor)
-                if page_id:
-                    return page_id
+            container = parent.get("container")
+            page_id = page_id or self._page_id_from_reference(container)
+            ancestors = parent.get("ancestors")
+            comment_parent_id = self._comment_id_from_reference(container)
+            if isinstance(ancestors, list):
+                for ancestor in reversed(ancestors):
+                    page_id = page_id or self._page_id_from_reference(ancestor)
+                    comment_parent_id = (
+                        comment_parent_id or self._comment_id_from_reference(ancestor)
+                    )
 
-        raise ValueError(f"Could not resolve page for parent comment {comment_id}")
+            if parent.get("extensions", {}).get("location") == "inline":
+                if not page_id:
+                    message = f"Could not resolve page for parent comment {comment_id}"
+                    raise ValueError(message)
+                return page_id, "inline"
+
+            if not comment_parent_id:
+                break
+            current_id = comment_parent_id
+
+        if not page_id:
+            message = f"Could not resolve page for parent comment {comment_id}"
+            raise ValueError(message)
+        return page_id, "footer"
 
     def get_inline_comments(
         self, page_id: str, *, return_markdown: bool = True

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -702,22 +702,83 @@ class ConfluenceV2Adapter:
             msg = f"Failed to get inline comments for page '{page_id}': {e}"
             raise ValueError(msg) from e
 
+    def _get_comment_if_exists(
+        self, comment_id: str, endpoint: str
+    ) -> dict[str, Any] | None:
+        """Return a v2 comment, or None when it does not exist at an endpoint."""
+        url = f"{self.base_url}/api/v2/{endpoint}/{comment_id}"
+        response = self.session.get(url, params={"body-format": "storage"})
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            if response.status_code == 404:
+                return None
+            raise
+        return response.json()
+
+    def get_comment_thread_location(self, comment_id: str) -> str:
+        """Determine whether a Cloud comment thread is inline or footer.
+
+        Footer replies created under an inline thread by older clients are traced
+        through ``parentCommentId`` until the thread root is found.
+
+        Args:
+            comment_id: The comment whose thread location should be resolved.
+
+        Returns:
+            ``"inline"`` or ``"footer"``.
+
+        Raises:
+            ValueError: If the comment cannot be found or its ancestry is cyclic.
+        """
+        current_id = comment_id
+        visited: set[str] = set()
+
+        try:
+            while current_id not in visited:
+                visited.add(current_id)
+
+                if self._get_comment_if_exists(current_id, "inline-comments"):
+                    return "inline"
+
+                footer_comment = self._get_comment_if_exists(
+                    current_id, "footer-comments"
+                )
+                if not footer_comment:
+                    message = f"Comment '{current_id}' was not found"
+                    raise ValueError(message)
+
+                parent_id = footer_comment.get("parentCommentId")
+                if not parent_id:
+                    return "footer"
+                current_id = str(parent_id)
+        except (requests.RequestException, TypeError) as e:
+            message = (
+                f"Failed to determine comment thread location for '{comment_id}': {e}"
+            )
+            raise ValueError(message) from e
+
+        message = f"Cyclic comment ancestry detected for '{comment_id}'"
+        raise ValueError(message)
+
     def create_inline_comment(
         self,
         *,
-        page_id: str,
         body: str,
-        text_selection: str,
+        page_id: str | None = None,
+        parent_comment_id: str | None = None,
+        text_selection: str | None = None,
         text_selection_match_count: int = 1,
         text_selection_match_index: int = 0,
         representation: str = "storage",
     ) -> dict[str, Any]:
-        """Create an inline comment anchored to a text selection using the v2 API.
+        """Create an inline comment or reply using the v2 API.
 
         Args:
-            page_id: The ID of the page to add the inline comment to
             body: The comment content
-            text_selection: The text on the page to anchor the comment to
+            page_id: The page ID for a new inline comment
+            parent_comment_id: The parent inline comment ID for a reply
+            text_selection: The text to anchor a new inline comment to
             text_selection_match_count: Total number of times the text
                 appears on the page
             text_selection_match_index: Zero-based index of which occurrence
@@ -728,21 +789,32 @@ class ConfluenceV2Adapter:
             The created inline comment data in v1-compatible format
 
         Raises:
-            ValueError: If creation fails
+            ValueError: If arguments are invalid or creation fails
         """
+        if page_id and parent_comment_id:
+            raise ValueError("page_id and parent_comment_id are mutually exclusive")
+        if not page_id and not parent_comment_id:
+            raise ValueError("Either page_id or parent_comment_id must be provided")
+        if page_id and not text_selection:
+            raise ValueError("text_selection is required for a new inline comment")
+
         try:
             data: dict[str, Any] = {
-                "pageId": page_id,
                 "body": {
                     "representation": representation,
                     "value": body,
                 },
-                "inlineCommentProperties": {
+            }
+
+            if parent_comment_id:
+                data["parentCommentId"] = parent_comment_id
+            else:
+                data["pageId"] = page_id
+                data["inlineCommentProperties"] = {
                     "textSelection": text_selection,
                     "textSelectionMatchCount": text_selection_match_count,
                     "textSelectionMatchIndex": text_selection_match_index,
-                },
-            }
+                }
 
             url = f"{self.base_url}/api/v2/inline-comments"
             response = self.session.post(url, json=data)
@@ -804,6 +876,9 @@ class ConfluenceV2Adapter:
 
         if inline_props := v2_response.get("inlineCommentProperties"):
             v1_compatible["inlineCommentProperties"] = inline_props
+
+        if parent_id := v2_response.get("parentCommentId"):
+            v1_compatible["parentCommentId"] = parent_id
 
         return v1_compatible
 

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -566,6 +566,7 @@ class TestConfluenceCloudComments:
         cloud_instance: CloudInstanceInfo,
         resource_tracker: CloudResourceTracker,
     ) -> None:
+        """Cloud inline threads keep replies on the inline endpoint."""
         uid = uuid.uuid4().hex[:8]
         anchor = f"cloud inline anchor {uid}"
         page = confluence_fetcher.create_page(
@@ -587,6 +588,16 @@ class TestConfluenceCloudComments:
 
         comments = confluence_fetcher.get_inline_comments(page.id)
         assert any(inline_comment.id == comment.id for inline_comment in comments)
+
+        reply_content = f"Cloud E2E inline reply {uid}"
+        reply = confluence_fetcher.reply_to_comment(
+            comment_id=comment.id,
+            content=reply_content,
+        )
+        assert reply is not None
+        assert reply.location == "inline"
+        assert reply.parent_comment_id == comment.id
+        assert reply_content in reply.body
 
 
 class TestConfluenceDateLozenge:

--- a/tests/e2e/test_confluence_dc_operations.py
+++ b/tests/e2e/test_confluence_dc_operations.py
@@ -422,6 +422,7 @@ class TestConfluenceDCComments:
         dc_instance: DCInstanceInfo,
         resource_tracker: DCResourceTracker,
     ) -> None:
+        """Server/DC inline threads keep replies inline and readable."""
         uid = uuid.uuid4().hex[:8]
         anchor = f"inline anchor {uid}"
         page = confluence_fetcher.create_page(
@@ -443,3 +444,15 @@ class TestConfluenceDCComments:
 
         comments = confluence_fetcher.get_inline_comments(page.id)
         assert any(inline_comment.id == comment.id for inline_comment in comments)
+
+        reply_content = f"E2E inline reply {uid}"
+        reply = confluence_fetcher.reply_to_comment(
+            comment_id=comment.id,
+            content=reply_content,
+        )
+        assert reply is not None
+        assert reply.location == "inline"
+        assert reply_content in reply.body
+
+        comments = confluence_fetcher.get_inline_comments(page.id)
+        assert any(inline_comment.id == reply.id for inline_comment in comments)

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -551,6 +551,34 @@ class TestReplyToComment:
         payload = comments_mixin_dc.confluence.post.call_args.kwargs["data"]
         assert payload["extensions"] == {"location": "inline"}
 
+    def test_cyclic_v1_reply_ancestry_is_rejected(self, comments_mixin_dc):
+        """Cyclic Server/DC ancestry must not fall back to a footer reply."""
+        comments_mixin_dc.confluence.get_page_by_id.side_effect = [
+            {
+                "id": "comment-a",
+                "type": "comment",
+                "container": {"id": "987654321", "type": "page"},
+                "ancestors": [{"id": "comment-b", "type": "comment"}],
+                "extensions": {"location": "footer"},
+            },
+            {
+                "id": "comment-b",
+                "type": "comment",
+                "container": {"id": "987654321", "type": "page"},
+                "ancestors": [{"id": "comment-a", "type": "comment"}],
+                "extensions": {"location": "footer"},
+            },
+        ]
+
+        with pytest.raises(
+            ValueError,
+            match="Cyclic comment ancestry detected for 'comment-a'",
+        ):
+            comments_mixin_dc._resolve_parent_comment_context("comment-a")
+
+        assert comments_mixin_dc.confluence.get_page_by_id.call_count == 2
+        comments_mixin_dc.confluence.post.assert_not_called()
+
     def test_reply_with_html_content(self, comments_mixin):
         """Reply with HTML content skips markdown conversion."""
         comments_mixin.confluence.get_page_by_id.side_effect = [

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -330,7 +330,10 @@ class TestReplyToComment:
         assert result is not None
         assert result.parent_comment_id == "456789123"
         assert comments_mixin.confluence.get_page_by_id.call_args_list == [
-            call(page_id="456789123", expand="container,ancestors"),
+            call(
+                page_id="456789123",
+                expand="container,ancestors,extensions.location",
+            ),
             call(page_id="987654321", expand="space"),
         ]
         comments_mixin.confluence.post.assert_called_once_with(
@@ -359,6 +362,7 @@ class TestReplyToComment:
                     {"id": "parent-comment", "type": "comment"},
                 ],
             },
+            MOCK_PARENT_COMMENT_V1_RESPONSE,
             {"id": "987654321", "space": {"key": "TEST"}},
         ]
         comments_mixin.confluence.post.return_value = MOCK_COMMENT_REPLY_V1_RESPONSE
@@ -397,6 +401,7 @@ class TestReplyToComment:
 
         # Mock v2 adapter
         mock_adapter = MagicMock()
+        mock_adapter.get_comment_thread_location.return_value = "footer"
         mock_adapter.create_footer_comment.return_value = {
             "id": "222333444",
             "type": "comment",
@@ -434,6 +439,117 @@ class TestReplyToComment:
             parent_comment_id="456789123",
             body="<p>This is a v2 reply</p>",
         )
+
+    def test_reply_to_inline_comment_v2_cloud(self, comments_mixin):
+        """Cloud replies use the inline endpoint for an inline thread."""
+        comments_mixin.config.auth_type = "oauth"
+        mock_adapter = MagicMock()
+        mock_adapter.get_comment_thread_location.return_value = "inline"
+        mock_adapter.create_inline_comment.return_value = {
+            **MOCK_INLINE_COMMENT_V1_RESPONSE,
+            "container": {"id": "456789123", "type": "comment"},
+        }
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>This is an inline reply</p>"
+        )
+
+        with patch.object(
+            type(comments_mixin),
+            "_v2_adapter",
+            new_callable=lambda: property(lambda self: mock_adapter),
+        ):
+            result = comments_mixin.reply_to_comment(
+                "456789123", "This is an inline reply"
+            )
+
+        assert result is not None
+        assert result.location == "inline"
+        mock_adapter.create_inline_comment.assert_called_once_with(
+            parent_comment_id="456789123",
+            body="<p>This is an inline reply</p>",
+        )
+        mock_adapter.create_footer_comment.assert_not_called()
+
+    def test_reply_to_inline_comment_v1_server_dc(self, comments_mixin_dc):
+        """Server/DC replies preserve the inline thread location."""
+        comments_mixin_dc.confluence.get_page_by_id.side_effect = [
+            {
+                **MOCK_PARENT_COMMENT_V1_RESPONSE,
+                "extensions": {"location": "inline"},
+            },
+            {"id": "987654321", "space": {"key": "TEST"}},
+        ]
+        comments_mixin_dc.confluence.post.return_value = {
+            **MOCK_COMMENT_REPLY_V1_RESPONSE,
+            "extensions": {"location": "inline"},
+        }
+
+        result = comments_mixin_dc.reply_to_comment(
+            "456789123", "This is an inline reply"
+        )
+
+        assert result is not None
+        assert result.location == "inline"
+        payload = comments_mixin_dc.confluence.post.call_args.kwargs["data"]
+        assert payload["extensions"] == {"location": "inline"}
+
+    def test_reply_to_inline_comment_cloud_basic_uses_v2(self, comments_mixin):
+        """Cloud Basic detects the thread via v1 and writes through v2."""
+        comments_mixin.confluence.get_page_by_id.return_value = {
+            **MOCK_PARENT_COMMENT_V1_RESPONSE,
+            "extensions": {"location": "inline"},
+        }
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>Inline reply</p>"
+        )
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.return_value = {
+            **MOCK_INLINE_COMMENT_V1_RESPONSE,
+            "container": {"id": "456789123", "type": "comment"},
+        }
+
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=lambda: property(lambda self: mock_adapter),
+        ):
+            result = comments_mixin.reply_to_comment("456789123", "Inline reply")
+
+        assert result is not None
+        mock_adapter.create_inline_comment.assert_called_once_with(
+            parent_comment_id="456789123",
+            body="<p>Inline reply</p>",
+        )
+        comments_mixin.confluence.post.assert_not_called()
+
+    def test_nested_v1_reply_inherits_inline_root(self, comments_mixin_dc):
+        """A legacy footer-typed child still inherits its inline root."""
+        comments_mixin_dc.confluence.get_page_by_id.side_effect = [
+            {
+                "id": "legacy-child",
+                "type": "comment",
+                "container": {"id": "987654321", "type": "page"},
+                "ancestors": [{"id": "inline-root", "type": "comment"}],
+                "extensions": {"location": "footer"},
+            },
+            {
+                "id": "inline-root",
+                "type": "comment",
+                "container": {"id": "987654321", "type": "page"},
+                "extensions": {"location": "inline"},
+            },
+            {"id": "987654321", "space": {"key": "TEST"}},
+        ]
+        comments_mixin_dc.confluence.post.return_value = {
+            **MOCK_COMMENT_REPLY_V1_RESPONSE,
+            "extensions": {"location": "inline"},
+        }
+
+        result = comments_mixin_dc.reply_to_comment("legacy-child", "Nested reply")
+
+        assert result is not None
+        payload = comments_mixin_dc.confluence.post.call_args.kwargs["data"]
+        assert payload["extensions"] == {"location": "inline"}
 
     def test_reply_with_html_content(self, comments_mixin):
         """Reply with HTML content skips markdown conversion."""

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -522,3 +522,92 @@ class TestConfluenceV2AdapterComments:
         assert payload["pageId"] == "12345"
         assert "parentCommentId" not in payload
         assert result["id"] == "333444555"
+
+    def test_create_inline_comment_reply(self, v2_adapter, mock_session):
+        """Inline replies use parentCommentId without anchor properties."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "id": "444555777",
+            "status": "current",
+            "parentCommentId": "444555666",
+            "pageId": "12345",
+            "body": {
+                "storage": {
+                    "value": "<p>Inline reply</p>",
+                    "representation": "storage",
+                }
+            },
+            "version": {"number": 1},
+            "_links": {},
+        }
+        mock_session.post.return_value = mock_response
+
+        result = v2_adapter.create_inline_comment(
+            parent_comment_id="444555666", body="<p>Inline reply</p>"
+        )
+
+        mock_session.post.assert_called_once_with(
+            "https://example.atlassian.net/wiki/api/v2/inline-comments",
+            json={
+                "parentCommentId": "444555666",
+                "body": {
+                    "representation": "storage",
+                    "value": "<p>Inline reply</p>",
+                },
+            },
+        )
+        assert result["parentCommentId"] == "444555666"
+        assert result["extensions"]["location"] == "inline"
+
+    def test_get_comment_thread_location_inline(self, v2_adapter, mock_session):
+        """An inline comment is identified with one request."""
+        inline_response = Mock()
+        inline_response.json.return_value = {"id": "inline-root"}
+        mock_session.get.return_value = inline_response
+
+        result = v2_adapter.get_comment_thread_location("inline-root")
+
+        assert result == "inline"
+        mock_session.get.assert_called_once_with(
+            "https://example.atlassian.net/wiki/api/v2/inline-comments/inline-root",
+            params={"body-format": "storage"},
+        )
+
+    def test_get_comment_thread_location_footer(self, v2_adapter, mock_session):
+        """A top-level footer comment resolves as a footer thread."""
+        inline_not_found = Mock(status_code=404)
+        inline_not_found.raise_for_status.side_effect = HTTPError(
+            response=inline_not_found
+        )
+        footer_response = Mock()
+        footer_response.json.return_value = {"id": "footer-root"}
+        mock_session.get.side_effect = [inline_not_found, footer_response]
+
+        result = v2_adapter.get_comment_thread_location("footer-root")
+
+        assert result == "footer"
+
+    def test_get_comment_thread_location_traces_inline_root(
+        self, v2_adapter, mock_session
+    ):
+        """A legacy footer-typed child inherits its inline root location."""
+        child_inline_not_found = Mock(status_code=404)
+        child_inline_not_found.raise_for_status.side_effect = HTTPError(
+            response=child_inline_not_found
+        )
+        child_footer = Mock()
+        child_footer.json.return_value = {
+            "id": "legacy-child",
+            "parentCommentId": "inline-root",
+        }
+        root_inline = Mock()
+        root_inline.json.return_value = {"id": "inline-root"}
+        mock_session.get.side_effect = [
+            child_inline_not_found,
+            child_footer,
+            root_inline,
+        ]
+
+        result = v2_adapter.get_comment_thread_location("legacy-child")
+
+        assert result == "inline"


### PR DESCRIPTION
## Description

`confluence_reply_to_comment` currently routes Cloud OAuth/PAT replies through the footer-comment endpoint and does not preserve an inline thread's location on Server/Data Center. Replies to inline review comments can therefore be stored as footer comments even when their parent link is valid.

This PR resolves the thread type before creating a reply and follows legacy reply ancestry back to the thread root. It does not change the MCP tool signature.

Independently mergeable. Complementary read-side retrieval and metadata enhancement: #1626. Related: #1264.

## Changes

- Route Cloud inline replies through `POST /api/v2/inline-comments` with `parentCommentId`.
- Preserve `extensions.location = inline` on Server/Data Center replies.
- Trace nested comment ancestry so legacy children inherit the root thread type.
- Preserve Cloud inline reply parent metadata and cover Cloud/Server paths with focused unit and E2E regressions.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual checks performed: created inline and footer replies on Confluence Data Center and verified their locations and parent links.

Verification includes 76 targeted unit tests, the full Confluence unit suite, integration tests, pre-commit, and generated documentation checks. Real-service Cloud and Server/Data Center E2E regressions are included; local execution requires the corresponding test credentials and instances.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All change-related tests pass locally.
- [x] Documentation updated (not needed; no tool signature or registration changed).
