### PR TITLE
docs(jira): clarify Jira Cloud transition comment screen dependency (#1623)

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -188,7 +188,7 @@ Transition a Jira issue to a new status.
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `transition_id` | `string` | Yes | ID or name of the transition to perform (case-insensitive name match, e.g. 'In Progress', 'Done'). Use the jira_get_transitions tool first to see the available transitions for the issue. Example values: '11', '21', '31', 'In Progress' |
 | `fields` | `string` | No | (Optional) JSON string of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: '`{"resolution": {"name": "Fixed"}}`' |
-| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be customer-visible on JSM and cannot be forced internal): transition without a comment, then post an internal note with jira_add_comment(public=false). |
+| `comment` | `string` | No | (Optional) Comment to add during the transition in Markdown format. This will be visible in the issue history. Rejected for projects listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be customer-visible on JSM and cannot be forced internal): transition without a comment, then post an internal note with jira_add_comment(public=false). On Jira Cloud, the workflow transition's screen must include a Comment field; if Jira omits the comment, add it separately with jira_add_comment. |
 **Example:**
 
 ```json

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -127,11 +127,19 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
         """
         Transition a Jira issue to a new status.
 
+        Note on Jira Cloud comments:
+            On Jira Cloud, comments bundled in the transition request (`update.comment`)
+            are only recorded if the destination status's transition screen includes
+            a Comment field. If the comment is omitted after transition, call `add_comment`
+            directly to add it (#1623).
+
         Args:
             issue_key: The key of the issue to transition
             transition_id: The ID of the transition to perform
                 (integer preferred, string accepted)
             fields: Optional fields to set during the transition
+            comment: Optional comment to add during transition (Markdown format)
+                (Note: On Jira Cloud, requires the transition screen to expose the comment field)
             comment: Optional comment to add during the transition.
                 Rejected for projects listed in
                 JIRA_INTERNAL_ONLY_PROJECTS: a transition comment is a

--- a/src/mcp_atlassian/jira/transitions.py
+++ b/src/mcp_atlassian/jira/transitions.py
@@ -129,17 +129,15 @@ class TransitionsMixin(JiraClient, IssueOperationsProto, UsersOperationsProto):
 
         Note on Jira Cloud comments:
             On Jira Cloud, comments bundled in the transition request (`update.comment`)
-            are only recorded if the destination status's transition screen includes
-            a Comment field. If the comment is omitted after transition, call `add_comment`
-            directly to add it (#1623).
+            are only recorded if the workflow transition's screen includes a Comment
+            field. If the comment is omitted after transition, call `add_comment`
+            directly to add it.
 
         Args:
             issue_key: The key of the issue to transition
             transition_id: The ID of the transition to perform
                 (integer preferred, string accepted)
             fields: Optional fields to set during the transition
-            comment: Optional comment to add during transition (Markdown format)
-                (Note: On Jira Cloud, requires the transition screen to expose the comment field)
             comment: Optional comment to add during the transition.
                 Rejected for projects listed in
                 JIRA_INTERNAL_ONLY_PROJECTS: a transition comment is a

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2981,7 +2981,9 @@ async def transition_issue(
                 "listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be "
                 "customer-visible on JSM and cannot be forced internal): transition "
                 "without a comment, then post an internal note with "
-                "jira_add_comment(public=false)."
+                "jira_add_comment(public=false). On Jira Cloud, the workflow "
+                "transition's screen must include a Comment field; if Jira omits "
+                "the comment, add it separately with jira_add_comment."
             ),
         ),
     ] = None,

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2615,6 +2615,21 @@ async def test_transition_issue_resolves_name_to_id(jira_client, mock_jira_fetch
 
 
 @pytest.mark.anyio
+async def test_transition_issue_comment_schema_warns_about_cloud_screen():
+    """The MCP schema documents Jira Cloud's transition-screen dependency."""
+    import mcp_atlassian.servers.jira as jira_server
+
+    tools = {tool.name: tool for tool in await jira_server.jira_mcp.list_tools()}
+
+    description = tools["transition_issue"].parameters["properties"]["comment"][
+        "description"
+    ]
+
+    assert "workflow transition's screen must include a Comment field" in description
+    assert "jira_add_comment" in description
+
+
+@pytest.mark.anyio
 async def test_transition_issue_still_accepts_numeric_id(
     jira_client, mock_jira_fetcher
 ):


### PR DESCRIPTION
## Summary

Fixes #1623.

Clarifies both the lower-level `transition_issue` docstring and the `jira_transition_issue` MCP parameter documentation that, on Jira Cloud, bundled transition comments (`update.comment`) require the workflow transition screen to include a Comment field. If Jira omits the comment, callers should use `jira_add_comment` to record it separately.

Regenerates the MCP tool reference and adds a schema regression test so the warning remains visible to tool callers.

## Test Plan

- `uv run pytest tests/unit/jira/test_transitions.py -q` (30 passed)
- `uv run pytest tests/unit/servers/test_jira_server.py -q -k transition_issue` (4 passed)
- `uv run pytest tests/unit/test_generate_tool_docs.py -q` (28 passed)
- `uv run python scripts/generate_tool_docs.py --check`
- Repository-equivalent Ruff, format, and mypy checks on changed Python files