### PR TITLE
feat(jira): add jira_get_current_user tool and upstream fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -233,8 +233,8 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 #   confluence_pages, confluence_comments
 # Example: TOOLSETS=default                      # Only core tools (~35 tools)
 # Example: TOOLSETS=default,jira_agile           # Core + agile tools
-# Example: TOOLSETS=all                          # All 25 toolsets (99 tools)
-# If unset, all toolsets are enabled (99 tools). Set TOOLSETS=all explicitly to
+# Example: TOOLSETS=all                          # All 25 toolsets (101 tools)
+# If unset, all toolsets are enabled (101 tools). Set TOOLSETS=all explicitly to
 # preserve this behavior — in v0.22.0, the default will change to core toolsets only.
 # Unknown names are silently ignored; if ALL names are unknown, no tools are enabled (fail-closed).
 #TOOLSETS=

--- a/.env.example
+++ b/.env.example
@@ -233,8 +233,8 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 #   confluence_pages, confluence_comments
 # Example: TOOLSETS=default                      # Only core tools (~35 tools)
 # Example: TOOLSETS=default,jira_agile           # Core + agile tools
-# Example: TOOLSETS=all                          # All 25 toolsets (98 tools)
-# If unset, all toolsets are enabled (98 tools). Set TOOLSETS=all explicitly to
+# Example: TOOLSETS=all                          # All 25 toolsets (99 tools)
+# If unset, all toolsets are enabled (99 tools). Set TOOLSETS=all explicitly to
 # preserve this behavior — in v0.22.0, the default will change to core toolsets only.
 # Unknown names are silently ignored; if ALL names are unknown, no tools are enabled (fail-closed).
 #TOOLSETS=

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**98 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**99 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**99 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**101 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs.json
+++ b/docs.json
@@ -3,7 +3,7 @@
   "theme": "mint",
   "name": "MCP Atlassian",
   "metadata": {
-    "og:description": "MCP server for Atlassian Jira and Confluence — all 98 tools enabled by default"
+    "og:description": "MCP server for Atlassian Jira and Confluence — all 99 tools enabled by default"
   },
   "seo": {
     "indexHiddenPages": false

--- a/docs.json
+++ b/docs.json
@@ -3,7 +3,7 @@
   "theme": "mint",
   "name": "MCP Atlassian",
   "metadata": {
-    "og:description": "MCP server for Atlassian Jira and Confluence — all 99 tools enabled by default"
+    "og:description": "MCP server for Atlassian Jira and Confluence — all 101 tools enabled by default"
   },
   "seo": {
     "indexHiddenPages": false

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 99 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 101 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **99 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **101 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -73,7 +73,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `jira_transitions` | Yes | `jira_get_transitions`, `jira_transition_issue` |
 | `jira_projects` | No | `jira_get_project_issue_types`, `jira_get_create_fields`, `jira_get_project_versions`, `jira_get_project_components`, `jira_get_all_projects`, `jira_search_projects`, `jira_get_project_fields`, `jira_create_version`, `jira_batch_create_versions`, `jira_update_version` |
 | `jira_agile` | No | `jira_get_agile_boards`, `jira_get_board_issues`, `jira_get_sprints_from_board`, `jira_get_sprint_issues`, `jira_create_sprint`, `jira_update_sprint`, `jira_add_issues_to_sprint`, `jira_move_issues_to_backlog` |
-| `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_create_remote_issue_link`, `jira_remove_issue_link` |
+| `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_get_remote_issue_links`, `jira_create_remote_issue_link`, `jira_delete_remote_issue_link`, `jira_remove_issue_link` |
 | `jira_worklog` | No | `jira_get_worklog`, `jira_add_worklog` |
 | `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images` |
 | `jira_users` | No | `jira_get_current_user`, `jira_get_user_profile`, `jira_search_assignable_users` |
@@ -111,7 +111,7 @@ TOOLSETS=default,jira_agile,jira_attachments
 # Enable deprecated tools only while migrating to their replacements:
 TOOLSETS=legacy
 
-# Enable all toolsets (99 tools)
+# Enable all toolsets (101 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 98 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 99 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **98 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **99 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -76,7 +76,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `jira_links` | No | `jira_get_link_types`, `jira_link_to_epic`, `jira_create_issue_link`, `jira_create_remote_issue_link`, `jira_remove_issue_link` |
 | `jira_worklog` | No | `jira_get_worklog`, `jira_add_worklog` |
 | `jira_attachments` | No | `jira_download_attachments`, `jira_get_issue_images` |
-| `jira_users` | No | `jira_get_user_profile`, `jira_search_assignable_users` |
+| `jira_users` | No | `jira_get_current_user`, `jira_get_user_profile`, `jira_search_assignable_users` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
 | `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues`, `jira_get_request_types`, `jira_get_request_type_fields`, `jira_create_customer_request` |
 | `jira_forms` | No | `jira_get_issue_proforma_forms`, `jira_get_proforma_form_details`, `jira_update_proforma_form_answers` |
@@ -111,7 +111,7 @@ TOOLSETS=default,jira_agile,jira_attachments
 # Enable deprecated tools only while migrating to their replacements:
 TOOLSETS=legacy
 
-# Enable all toolsets (98 tools)
+# Enable all toolsets (99 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -74,6 +74,8 @@ Add a worklog entry to a Jira issue.
 | `started` | `string` | No | (Optional) Start time in ISO format. If not provided, the current time will be used. Example: '2023-08-01T12:00:00.000+0000' |
 | `original_estimate` | `string` | No | (Optional) New value for the original estimate |
 | `remaining_estimate` | `string` | No | (Optional) New value for the remaining estimate |
+| `attributes` | `string` | No | (Optional) Custom worklog attributes (e.g. Tempo attributes) as JSON string |
+| `additional_fields` | `string` | No | (Optional) Extra fields to pass in the worklog creation payload as JSON string |
 
 ---
 

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -104,6 +104,18 @@ Only available on Jira Cloud.
 
 ---
 
+### Get Current User
+
+Retrieve the profile of the user the current credentials belong to.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `expand` | `string` | No | (Optional) Comma-separated sections to expand on the returned user, e.g. 'groups' or 'groups,applicationRoles'. Recognised sections are included verbatim in the response. |
+
+---
+
 ### Get User Profile
 
 Retrieve profile information for a specific Jira user.

--- a/docs/tools/jira-links-versions.mdx
+++ b/docs/tools/jira-links-versions.mdx
@@ -77,7 +77,35 @@ Create a remote issue link (web link or Confluence link) for a Jira issue.
 | `title` | `string` | Yes | The title/name of the link (e.g., 'Documentation Page', 'Confluence Page') |
 | `summary` | `string` | No | (Optional) Description of the link |
 | `relationship` | `string` | No | (Optional) Relationship description (e.g., 'causes', 'relates to', 'documentation') |
+| `global_id` | `string` | No | (Optional) Unique global identifier for the remote link (e.g., Confluence globalId or external URL ID) |
 | `icon_url` | `string` | No | (Optional) URL to a 16x16 icon for the link |
+
+---
+
+### Get Remote Issue Links
+
+Retrieve all remote links (web links, Confluence links) for a Jira issue.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | The key of the issue (e.g., 'PROJ-123', 'ACV2-642') |
+
+---
+
+### Delete Remote Issue Link
+
+Delete a remote issue link from a Jira issue.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_key` | `string` | Yes | The key of the issue containing the link (e.g., 'PROJ-123') |
+| `link_id` | `string` | Yes | The ID of the remote link to delete (obtained from get_remote_issue_links) |
 
 ---
 

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -68,6 +68,7 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
         "jira_get_worklog",
         "jira_add_worklog",
         "jira_batch_get_changelogs",
+        "jira_get_current_user",
         "jira_get_user_profile",
         "jira_search_assignable_users",
         "jira_get_issue_watchers",

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -81,6 +81,8 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
         "jira_remove_issue_link",
         "jira_link_to_epic",
         "jira_create_remote_issue_link",
+        "jira_get_remote_issue_links",
+        "jira_delete_remote_issue_link",
         "jira_get_project_versions",
         "jira_get_project_components",
         "jira_create_version",

--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -108,7 +108,7 @@ class CommentsMixin(ConfluenceClient):
             comment_models = []
             for comment_data in raw_comments:
                 # Get the content based on format
-                body = comment_data["body"]["view"]["value"]
+                body = comment_data.get("body", {}).get("view", {}).get("value", "")
                 processed_html, processed_markdown = (
                     self.preprocessor.process_html_content(
                         body, space_key=space_key, confluence_client=self.confluence

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -638,6 +638,20 @@ class PagesMixin(ConfluenceClient):
             logger.debug("Full exception details:", exc_info=True)
             return None
 
+    def _check_space_filter(self, space_key: str) -> None:
+        """Enforce CONFLUENCE_SPACES_FILTER boundary check."""
+        if self.config.spaces_filter:
+            allowed = {
+                s.strip().upper()
+                for s in self.config.spaces_filter.split(",")
+                if s.strip()
+            }
+            if space_key.upper() not in allowed:
+                raise ValueError(
+                    f"Access to space '{space_key}' is restricted by "
+                    f"CONFLUENCE_SPACES_FILTER ({self.config.spaces_filter})."
+                )
+
     def get_space_pages(
         self,
         space_key: str,
@@ -659,6 +673,7 @@ class PagesMixin(ConfluenceClient):
         Returns:
             List of ConfluencePage models containing page content and metadata
         """
+        self._check_space_filter(space_key)
         pages = self.confluence.get_all_pages_from_space(
             space_key, start=start, limit=limit, expand="body.storage"
         )
@@ -1241,6 +1256,7 @@ class PagesMixin(ConfluenceClient):
             Exception: If there is an error fetching pages
         """
         try:
+            self._check_space_filter(space_key)
             limit = clamp_limit(limit, context="confluence.get_space_page_tree")
 
             # Paginate using the raw API to access _links.next for reliable

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -1215,11 +1215,10 @@ class ConfluenceV2Adapter:
         version: int,
         expand: str | None = None,
     ) -> dict[str, Any]:
-        """Get a specific version of a page using the versions API.
+        """Get a specific version of a page.
 
-        Note: The v2 API uses version IDs, not version numbers. We need to:
-        1. List all versions to find the version ID for the given version number
-        2. Fetch the specific version using its version ID
+        The page endpoint serves a previously published version directly when
+        given its version *number*, so no version id lookup is involved.
 
         Args:
             page_id: The ID of page
@@ -1233,24 +1232,8 @@ class ConfluenceV2Adapter:
             ValueError: If page retrieval fails or version not found
         """
         try:
-            # Step 1: Get all versions to find the version ID
-            versions_list = self.get_page_versions_list(page_id)
-
-            # Find the version with the matching version number
-            version_id = None
-            for ver in versions_list:
-                if ver.get("number") == version:
-                    version_id = ver.get("id")
-                    break
-
-            if not version_id:
-                raise ValueError(f"Version {version} not found for page '{page_id}'")
-
-            # Step 2: Fetch the specific version using its version ID
-            url = f"{self.base_url}/api/v2/versions/{version_id}"
-
-            # Convert v1 expand parameters to v2 format
-            params = {"body-format": "storage"}
+            url = f"{self.base_url}/api/v2/pages/{page_id}"
+            params: dict[str, Any] = {"body-format": "storage", "version": version}
 
             response = self.session.get(url, params=params)
             response.raise_for_status()

--- a/src/mcp_atlassian/jira/comments.py
+++ b/src/mcp_atlassian/jira/comments.py
@@ -135,12 +135,18 @@ class CommentsMixin(JiraClient):
                 body_text = (
                     adf_to_text(body_raw) if isinstance(body_raw, dict) else body_raw
                 )
+                author_dict = comment.get("author") or {}
+                author_name = (
+                    author_dict.get("displayName", "Unknown")
+                    if isinstance(author_dict, dict)
+                    else "Unknown"
+                )
                 processed_comment = {
                     "id": comment.get("id"),
                     "body": self._clean_text(body_text or ""),
                     "created": str(parse_date(comment.get("created"))),
                     "updated": str(parse_date(comment.get("updated"))),
-                    "author": comment.get("author", {}).get("displayName", "Unknown"),
+                    "author": author_name,
                 }
                 processed_comments.append(processed_comment)
 
@@ -425,11 +431,17 @@ class CommentsMixin(JiraClient):
             body_text = (
                 adf_to_text(body_raw) if isinstance(body_raw, dict) else body_raw
             )
+            author_dict = result.get("author") or {}
+            author_name = (
+                author_dict.get("displayName", "Unknown")
+                if isinstance(author_dict, dict)
+                else "Unknown"
+            )
             return {
                 "id": result.get("id"),
                 "body": self._clean_text(body_text or ""),
                 "created": str(parse_date(result.get("created"))),
-                "author": result.get("author", {}).get("displayName", "Unknown"),
+                "author": author_name,
             }
         except Exception as e:
             logger.error(f"Error adding comment to issue {issue_key}: {str(e)}")
@@ -580,11 +592,17 @@ class CommentsMixin(JiraClient):
             body_text = (
                 adf_to_text(body_raw) if isinstance(body_raw, dict) else body_raw
             )
+            author_dict = result.get("author") or {}
+            author_name = (
+                author_dict.get("displayName", "Unknown")
+                if isinstance(author_dict, dict)
+                else "Unknown"
+            )
             return {
                 "id": result.get("id"),
                 "body": self._clean_text(body_text or ""),
                 "updated": str(parse_date(result.get("updated"))),
-                "author": result.get("author", {}).get("displayName", "Unknown"),
+                "author": author_name,
             }
         except Exception as e:
             logger.error(

--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -158,7 +158,12 @@ class DevelopmentMixin(JiraClient):
         # Use _session.get() directly: the dev-status endpoint is a plugin-specific
         # path (/rest/dev-status/1.0/...) not covered by the standard Jira client
         # wrappers. No higher-level wrapper method exists for this non-standard endpoint.
-        url = f"{self.config.url}/rest/dev-status/1.0/issue/detail"
+        base_url = (
+            self.jira.url.rstrip("/")
+            if hasattr(self.jira, "url") and self.jira.url
+            else self.config.url.rstrip("/")
+        )
+        url = f"{base_url}/rest/dev-status/1.0/issue/detail"
         http_response = self.jira._session.get(
             url, params=params, verify=self.config.ssl_verify
         )
@@ -391,7 +396,12 @@ class DevelopmentMixin(JiraClient):
             A deterministic list of case-sensitive application type values.
         """
         fallback_types = list(_COMMON_APPLICATION_TYPES)
-        url = f"{self.config.url}/rest/dev-status/1.0/issue/summary"
+        base_url = (
+            self.jira.url.rstrip("/")
+            if hasattr(self.jira, "url") and self.jira.url
+            else self.config.url.rstrip("/")
+        )
+        url = f"{base_url}/rest/dev-status/1.0/issue/summary"
         params = {"issueId": str(issue_id)}
 
         try:

--- a/src/mcp_atlassian/jira/epics.py
+++ b/src/mcp_atlassian/jira/epics.py
@@ -24,6 +24,22 @@ class EpicsMixin(
 ):
     """Mixin for Jira epic operations."""
 
+    def _is_epic_issue_type(self, issue_type: str) -> bool:
+        """Check if an issue type is an Epic, handling localized names."""
+        epic_names = {
+            "epic",  # English
+            "에픽",  # Korean
+            "エピック",  # Japanese
+            "史诗",  # Chinese (Simplified)
+            "史詩",  # Chinese (Traditional)
+            "épica",  # Spanish/Portuguese
+            "épique",  # French
+            "epik",  # Turkish
+            "эпик",  # Russian
+            "епік",  # Ukrainian
+        }
+        return issue_type.lower() in epic_names or "epic" in issue_type.lower()
+
     def _try_discover_fields_from_existing_epic(
         self, field_ids: dict[str, str]
     ) -> None:
@@ -326,7 +342,7 @@ class EpicsMixin(
             fields = epic.get("fields", {})
             issue_type = fields.get("issuetype", {}).get("name", "").lower()
 
-            if issue_type != "epic":
+            if not self._is_epic_issue_type(issue_type):
                 error_msg = f"Error linking issue to epic: {epic_key} is not an Epic"
                 raise ValueError(error_msg)
 
@@ -461,12 +477,8 @@ class EpicsMixin(
             issuetype_data = fields_data.get("issuetype", {})
             issue_type_name = issuetype_data.get("name", "")
 
-            # Check if it's an Epic by looking for "epic" in the name (case-insensitive)
-            # This handles localized names like "에픽", "エピック", etc.
-            if "epic" not in issue_type_name.lower() and issue_type_name not in [
-                "에픽",
-                "エピック",
-            ]:
+            # Check if it's an Epic, handling localized names
+            if not self._is_epic_issue_type(issue_type_name):
                 # Try to verify via JQL as a fallback
                 is_epic = False
                 try:

--- a/src/mcp_atlassian/jira/forms.py
+++ b/src/mcp_atlassian/jira/forms.py
@@ -54,7 +54,7 @@ class FormsMixin(JiraClient):
             return forms
 
         except HTTPError as e:
-            if e.response.status_code == 404:
+            if e.response is not None and e.response.status_code == 404:
                 # No forms found for this issue
                 return []
             raise handle_forms_http_error(e, "getting forms", issue_key) from e
@@ -98,7 +98,7 @@ class FormsMixin(JiraClient):
             return form
 
         except HTTPError as e:
-            if e.response.status_code == 404:
+            if e.response is not None and e.response.status_code == 404:
                 return None
             raise handle_forms_http_error(
                 e, "getting form details", f"{issue_key}/{form_id}"

--- a/src/mcp_atlassian/jira/forms_common.py
+++ b/src/mcp_atlassian/jira/forms_common.py
@@ -35,7 +35,7 @@ def handle_forms_http_error(
         ValueError: For 404 not found errors
         Exception: For other HTTP errors
     """
-    status_code = error.response.status_code
+    status_code = error.response.status_code if error.response is not None else None
 
     if status_code == 403:
         error_msg = f"Insufficient permissions for {operation}: {resource_id}"

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -1875,8 +1875,9 @@ class IssuesMixin(
 
         # Prepare issues for bulk creation
         issue_updates = []
-        for issue_data in issues:
+        for raw_issue in issues:
             try:
+                issue_data = dict(raw_issue)
                 # Extract and validate required fields
                 project_key = issue_data.pop("project_key", None)
                 summary = issue_data.pop("summary", None)

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -983,6 +983,29 @@ class IssuesMixin(
                 f"Try using the exact custom field ID (e.g., customfield_10014)."
             )
 
+    def _validate_parent_clear_supported(self, value: Any) -> None:
+        """Reject parent clearing on Jira Server/Data Center.
+
+        Jira Cloud accepts ``{"parent": null}`` for clearing a parent. Jira
+        Server/Data Center rejects the same request shape, so users must
+        update the Epic Link custom field directly instead.
+
+        Args:
+            value: The requested parent value.
+
+        Raises:
+            ValueError: If the value requests a parent clear on Server/DC.
+        """
+        if (value is None or value == "") and not self.config.is_cloud:
+            raise ValueError(
+                "Clearing an issue's parent with parent=None, parent='', or "
+                '{"parent": null} is supported only on Jira Cloud. Jira '
+                "Server/Data Center rejects this parent update format. To "
+                "clear an Epic Link on Server/DC, update its custom field "
+                'directly, for example {"customfield_10014": null}, using '
+                "the field ID returned by jira_search_fields."
+            )
+
     def _add_assignee_to_fields(self, fields: dict[str, Any], assignee: str) -> None:
         """
         Add assignee to issue fields.
@@ -1196,6 +1219,16 @@ class IssuesMixin(
             kwargs_mutable = dict(kwargs)
             self._prepare_epic_link_fields(update_fields, kwargs_mutable)
 
+            # Jira Server/Data Center rejects the Cloud parent-clearing
+            # payload. Validate before any update or follow-up REST request.
+            if "parent" in kwargs_mutable:
+                self._validate_parent_clear_supported(kwargs_mutable["parent"])
+            elif "parent" in update_fields:
+                parent_value = update_fields["parent"]
+                self._validate_parent_clear_supported(parent_value)
+                if parent_value == "":
+                    update_fields["parent"] = None
+
             # Process kwargs
             for key, value in kwargs_mutable.items():
                 if key == "status":
@@ -1238,7 +1271,10 @@ class IssuesMixin(
                                 f"Could not update assignee: {str(e)}"
                             ) from e
                 elif key == "parent":
-                    if isinstance(value, dict) and value.get("key"):
+                    # Jira Cloud accepts an explicit null to clear the parent.
+                    if value is None or value == "":
+                        update_fields["parent"] = None
+                    elif isinstance(value, dict) and value.get("key"):
                         update_fields["parent"] = {"key": str(value["key"])}
                     elif isinstance(value, str) and value:
                         update_fields["parent"] = {"key": value}

--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -260,6 +260,51 @@ class LinksMixin(JiraClient):
             raise Exception(msg) from e
 
     @handle_auth_errors("Jira API")
+    def delete_remote_issue_link(self, issue_key: str, link_id: str) -> dict[str, Any]:
+        """Delete a remote link (web link, Confluence link) from an issue.
+
+        Args:
+            issue_key: The issue key (e.g., 'PROJ-123')
+            link_id: The ID of the remote link to delete
+
+        Returns:
+            Dictionary confirming removal of the remote link
+
+        Raises:
+            ValueError: If issue_key or link_id is empty
+            MCPAtlassianAuthenticationError: If authentication fails (401/403)
+            Exception: If there is an error deleting the remote link
+        """
+        if not issue_key:
+            raise ValueError("Issue key is required")
+        if not link_id:
+            raise ValueError("Link ID is required")
+
+        try:
+            if self.config.is_cloud:
+                endpoint = f"rest/api/3/issue/{issue_key}/remotelink/{link_id}"
+            else:
+                endpoint = f"rest/api/2/issue/{issue_key}/remotelink/{link_id}"
+            self.jira.delete(endpoint)
+            return {
+                "success": True,
+                "message": f"Remote link {link_id} deleted from issue {issue_key}",
+                "issue_key": issue_key,
+                "link_id": link_id,
+            }
+        except HTTPError:
+            raise  # let decorator handle auth errors
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(
+                f"Error deleting remote link {link_id} from {issue_key}: {error_msg}",
+                exc_info=True,
+            )
+            raise Exception(
+                f"Error deleting remote link {link_id} from {issue_key}: {error_msg}"
+            ) from e
+
+    @handle_auth_errors("Jira API")
     def remove_issue_link(self, link_id: str) -> dict[str, Any]:
         """
         Remove a link between two issues.

--- a/src/mcp_atlassian/jira/search.py
+++ b/src/mcp_atlassian/jira/search.py
@@ -165,6 +165,8 @@ class SearchMixin(JiraClient, IssueOperationsProto):
                         raise TypeError(msg)
 
                     issues = response.get("issues", [])
+                    if not issues:
+                        break
                     all_issues.extend(issues)
 
                     names = response.get("names")

--- a/src/mcp_atlassian/jira/sla.py
+++ b/src/mcp_atlassian/jira/sla.py
@@ -1,7 +1,7 @@
 """Module for Jira SLA calculations."""
 
 import logging
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from ..models.jira.metrics import IssueDatesResponse
@@ -604,6 +604,11 @@ class SLAMixin(JiraClient, MetricsOperationsProto):
         Returns:
             Duration in minutes
         """
+        if start.tzinfo is None and end.tzinfo is not None:
+            start = start.replace(tzinfo=timezone.utc)
+        elif end.tzinfo is None and start.tzinfo is not None:
+            end = end.replace(tzinfo=timezone.utc)
+
         if not working_hours_only:
             # Simple calendar time calculation
             delta = end - start
@@ -638,6 +643,11 @@ class SLAMixin(JiraClient, MetricsOperationsProto):
         Returns:
             Working minutes between start and end
         """
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+
         if end <= start:
             return 0
 

--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from requests.exceptions import HTTPError
 from unidecode import unidecode
@@ -598,3 +598,43 @@ class UsersMixin(JiraClient):
             raise Exception(
                 f"Error processing user profile for '{identifier}': {str(e)}"
             ) from e
+
+    @handle_auth_errors("Jira API")
+    def get_current_user_profile(self, expand: str | None = None) -> dict[str, Any]:
+        """Retrieve the profile of the currently authenticated user.
+
+        Calls the Jira ``/myself`` endpoint, which resolves the user from the
+        request credentials. This is BYOT-friendly: each request's own token
+        determines the returned identity.
+
+        Args:
+            expand: Optional comma-separated sections to expand, e.g.
+                ``"groups,applicationRoles"``. Recognised sections are returned
+                verbatim alongside the simplified user fields.
+
+        Returns:
+            Simplified user dict, plus any requested expand sections.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: For other API errors or an unexpected response shape.
+        """
+        try:
+            logger.debug("Calling /myself to get the current user profile.")
+            params = {"expand": expand} if expand else None
+            user_data = self.jira.get(self.jira.resource_url("myself"), params=params)
+            if not isinstance(user_data, dict):
+                raise ValueError(
+                    "Current user lookup via /myself returned unexpected type: "
+                    f"{type(user_data)}."
+                )
+            result = JiraUser.from_api_response(user_data).to_simplified_dict()
+            for section in ("groups", "applicationRoles"):
+                if section in user_data:
+                    result[section] = user_data[section]
+            return result
+        except HTTPError:
+            raise  # decorator handles 401/403; other HTTP errors propagate
+        except Exception as e:
+            logger.exception("Unexpected error getting current user profile:")
+            raise Exception(f"Error processing current user profile: {str(e)}") from e

--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -149,6 +149,12 @@ class WorklogMixin(JiraClient):
                 if isinstance(comment_raw, dict)
                 else comment_raw
             )
+            author_dict = result.get("author") or {}
+            author_name = (
+                author_dict.get("displayName", "Unknown")
+                if isinstance(author_dict, dict)
+                else "Unknown"
+            )
             return {
                 "id": result.get("id"),
                 "comment": self._clean_text(comment_text or ""),
@@ -157,7 +163,7 @@ class WorklogMixin(JiraClient):
                 "started": str(parse_date(result.get("started", ""))),
                 "time_spent": result.get("timeSpent", ""),
                 "time_spent_seconds": result.get("timeSpentSeconds", 0),
-                "author": result.get("author", {}).get("displayName", "Unknown"),
+                "author": author_name,
                 "original_estimate_updated": original_estimate_updated,
                 "remaining_estimate_updated": remaining_estimate_updated,
             }
@@ -237,18 +243,28 @@ class WorklogMixin(JiraClient):
 
                 page = result.get("worklogs", [])
                 for worklog in page:
+                    comment_raw = worklog.get("comment", "")
+                    comment_text = (
+                        adf_to_text(comment_raw)
+                        if isinstance(comment_raw, dict)
+                        else comment_raw
+                    )
+                    page_author_dict = worklog.get("author") or {}
+                    page_author_name = (
+                        page_author_dict.get("displayName", "Unknown")
+                        if isinstance(page_author_dict, dict)
+                        else "Unknown"
+                    )
                     worklogs.append(
                         {
                             "id": worklog.get("id"),
-                            "comment": self._clean_text(worklog.get("comment", "")),
+                            "comment": self._clean_text(comment_text or ""),
                             "created": str(parse_date(worklog.get("created", ""))),
                             "updated": str(parse_date(worklog.get("updated", ""))),
                             "started": str(parse_date(worklog.get("started", ""))),
                             "time_spent": worklog.get("timeSpent", ""),
                             "time_spent_seconds": worklog.get("timeSpentSeconds", 0),
-                            "author": worklog.get("author", {}).get(
-                                "displayName", "Unknown"
-                            ),
+                            "author": page_author_name,
                         }
                     )
 

--- a/src/mcp_atlassian/jira/worklog.py
+++ b/src/mcp_atlassian/jira/worklog.py
@@ -70,6 +70,8 @@ class WorklogMixin(JiraClient):
         started: str | None = None,
         original_estimate: str | None = None,
         remaining_estimate: str | None = None,
+        attributes: dict[str, Any] | None = None,
+        additional_fields: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """
         Add a worklog entry to a Jira issue.
@@ -81,6 +83,8 @@ class WorklogMixin(JiraClient):
             started: Optional ISO8601 date time string for when work began
             original_estimate: Optional new value for the original estimate
             remaining_estimate: Optional new value for the remaining estimate
+            attributes: Optional dictionary of worklog attributes (e.g., Tempo)
+            additional_fields: Optional dictionary of additional fields
 
         Returns:
             Response data if successful
@@ -117,6 +121,10 @@ class WorklogMixin(JiraClient):
                 worklog_data["comment"] = comment
             if started:
                 worklog_data["started"] = started
+            if attributes:
+                worklog_data["attributes"] = attributes
+            if additional_fields:
+                worklog_data.update(additional_fields)
 
             # Step 3: Prepare query parameters for remaining estimate
             params = {}

--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -430,11 +430,11 @@ def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, An
                 table_rows.append(lines[i])
                 i += 1
 
-            # Parse rows, skip separator (|---|---|)
+            # Parse rows, skip separator (|---|---|) at index 1
             data_rows: list[list[str]] = []
-            for row_line in table_rows:
+            for row_idx, row_line in enumerate(table_rows):
                 cells = [c.strip() for c in row_line.strip("|").split("|")]
-                if all(re.match(r"^:?-+:?$", c) for c in cells if c):
+                if row_idx == 1 and all(re.match(r"^:?-+:?$", c) for c in cells if c):
                     continue
                 data_rows.append(cells)
 

--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -24,6 +24,20 @@ def _convert_panel(params: str | None, content: str) -> str:
     return f"\n{content}\n"
 
 
+def _contains_html_outside_code(text: str) -> bool:
+    """Return whether source text contains HTML outside protected code spans."""
+    code_patterns = (
+        r"\{code(?::[a-z]+)?\}[\s\S]*?\{code\}",
+        r"\{noformat\}[\s\S]*?\{noformat\}",
+        r"\{\{[^}]+\}\}",
+        r"```[^\n]*\n[\s\S]*?\n```",
+        r"`[^`]+`",
+    )
+    for pattern in code_patterns:
+        text = re.sub(pattern, "", text, flags=re.MULTILINE)
+    return re.search(r"<[^>]+>", text) is not None
+
+
 class JiraPreprocessor(BasePreprocessor):
     """Handles text preprocessing for Jira content."""
 
@@ -142,11 +156,15 @@ class JiraPreprocessor(BasePreprocessor):
 
         # Convert markup only if translation is enabled
         if not self.disable_translation:
+            source_had_html = _contains_html_outside_code(text)
+
             # First convert any Jira markup to Markdown
             text = self.jira_to_markdown(text)
 
-            # Then convert any remaining HTML to markdown
-            text = self._convert_html_to_markdown(text)
+            # Then convert HTML that came from the source. Tags emitted by
+            # jira_to_markdown must not trigger whole-document conversion.
+            if source_had_html:
+                text = self._convert_html_to_markdown(text)
 
         return text.strip()
 
@@ -309,14 +327,15 @@ class JiraPreprocessor(BasePreprocessor):
             output,
         )
 
-        # Inserted text
-        output = re.sub(r"\+([^+]*)\+", r"<ins>\1</ins>", output)
+        # Inserted text. Delimiters glued to word characters are prose
+        # (e.g. version numbers "3.13+"), not markup.
+        output = re.sub(r"(?<!\w)\+([^+\n]+)\+(?!\w)", r"<ins>\1</ins>", output)
 
         # Superscript
         output = re.sub(r"\^([^^]*)\^", r"<sup>\1</sup>", output)
 
-        # Subscript
-        output = re.sub(r"~([^~]*)~", r"<sub>\1</sub>", output)
+        # Subscript (must not match Jira user mentions [~username])
+        output = re.sub(r"(?<!\[)~([^~\[\]\n]+)~(?!\])", r"<sub>\1</sub>", output)
 
         # Strikethrough
         output = re.sub(r"-([^-]*)-", r"-\1-", output)
@@ -355,7 +374,7 @@ class JiraPreprocessor(BasePreprocessor):
 
         # Links
         output = re.sub(r"\[([^|]+)\|(.+?)\]", r"[\1](\2)", output)
-        output = re.sub(r"\[(.+?)\]([^\(])", r"\1\2", output)
+        output = re.sub(r"\[(?!~)(.+?)\]([^\(])", r"\1\2", output)
 
         # Colored text
         output = re.sub(

--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -24,6 +24,30 @@ def _convert_panel(params: str | None, content: str) -> str:
     return f"\n{content}\n"
 
 
+def _convert_callout_macro(macro_type: str, params: str | None, content: str) -> str:
+    """Convert Jira {info}, {note}, {warning}, {tip} macros to Markdown callouts."""
+    title = ""
+    if params:
+        title_match = re.search(r"title=([^|}]+)", params)
+        if title_match:
+            title = title_match.group(1).strip()
+    content = content.strip()
+    alert_type = {
+        "info": "NOTE",
+        "note": "NOTE",
+        "tip": "TIP",
+        "warning": "WARNING",
+    }.get(macro_type.lower(), "NOTE")
+
+    lines = content.split("\n")
+    formatted_lines = [f"> [!{alert_type}]"]
+    if title:
+        formatted_lines.append(f"> **{title}**")
+    for line in lines:
+        formatted_lines.append(f"> {line}")
+    return "\n" + "\n".join(formatted_lines) + "\n"
+
+
 def _contains_html_outside_code(text: str) -> bool:
     """Return whether source text contains HTML outside protected code spans."""
     code_patterns = (
@@ -358,6 +382,27 @@ class JiraPreprocessor(BasePreprocessor):
             flags=re.MULTILINE,
         )
 
+        # Macro callouts: {info}, {note}, {warning}, {tip}
+        output = re.sub(
+            r"\{(info|note|warning|tip)(?::([^}]*))?\}([\s\S]*?)\{\1\}",
+            lambda match: _convert_callout_macro(
+                match.group(1), match.group(2), match.group(3)
+            ),
+            output,
+            flags=re.MULTILINE | re.IGNORECASE,
+        )
+
+        # Expand macro: {expand:title}content{expand}
+        output = re.sub(
+            r"\{expand(?::([^}]*))?\}([\s\S]*?)\{expand\}",
+            lambda match: (
+                f"\n{{expand{(':' + match.group(1).strip()) if match.group(1) else ''}}}\n"
+                f"{match.group(2).strip()}\n{{expand}}\n"
+            ),
+            output,
+            flags=re.MULTILINE | re.IGNORECASE,
+        )
+
         # Images with alt text
         output = re.sub(
             r"!([^|\n\s]+)\|([^\n!]*)alt=([^\n!\,]+?)"
@@ -374,7 +419,7 @@ class JiraPreprocessor(BasePreprocessor):
 
         # Links
         output = re.sub(r"\[([^|]+)\|(.+?)\]", r"[\1](\2)", output)
-        output = re.sub(r"\[(?!~)(.+?)\]([^\(])", r"\1\2", output)
+        output = re.sub(r"\[(?!~|!)(.+?)\]([^\(])", r"\1\2", output)
 
         # Colored text
         output = re.sub(

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2708,6 +2708,20 @@ async def add_worklog(
     remaining_estimate: Annotated[
         str | None, Field(description="(Optional) New value for the remaining estimate")
     ] = None,
+    attributes: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Custom worklog attributes (e.g. Tempo attributes) as JSON string"
+            )
+        ),
+    ] = None,
+    additional_fields: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Extra fields to pass in the worklog creation payload as JSON string"
+        ),
+    ] = None,
 ) -> str:
     """Add a worklog entry to a Jira issue.
 
@@ -2719,6 +2733,8 @@ async def add_worklog(
         started: Optional start time in ISO format.
         original_estimate: Optional new original estimate.
         remaining_estimate: Optional new remaining estimate.
+        attributes: Optional worklog attributes as JSON string.
+        additional_fields: Optional additional fields as JSON string.
 
 
     Returns:
@@ -2728,6 +2744,8 @@ async def add_worklog(
         ValueError: If in read-only mode or Jira client unavailable.
     """
     jira = await get_jira_fetcher(ctx)
+    parsed_attributes = json.loads(attributes) if attributes else None
+    parsed_additional = json.loads(additional_fields) if additional_fields else None
     # add_worklog returns dict
     worklog_result = jira.add_worklog(
         issue_key=issue_key,
@@ -2736,6 +2754,8 @@ async def add_worklog(
         started=started,
         original_estimate=original_estimate,
         remaining_estimate=remaining_estimate,
+        attributes=parsed_attributes,
+        additional_fields=parsed_additional,
     )
     result = {"message": "Worklog added successfully", "worklog": worklog_result}
     return json.dumps(result, indent=2, ensure_ascii=False)
@@ -2882,6 +2902,43 @@ async def create_issue_link(
 
 
 @jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_links"},
+    annotations={"title": "Get Remote Issue Links", "readOnlyHint": True},
+)
+async def get_remote_issue_links(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="The key of the issue (e.g., 'PROJ-123', 'ACV2-642')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+) -> str:
+    """Retrieve all remote links (web links, Confluence links) for a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: The issue key (e.g., 'PROJ-123').
+
+    Returns:
+        JSON string containing the list of remote links for the issue.
+
+    Raises:
+        ValueError: If issue_key is missing or Jira client is unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    if not issue_key:
+        raise ValueError("issue_key is required.")
+    remote_links = jira.get_remote_issue_links(issue_key)
+    return json.dumps(
+        {"success": True, "issue_key": issue_key, "remote_links": remote_links},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@jira_mcp.tool(
     tags={"jira", "write", "toolset:jira_links"},
     annotations={"title": "Create Remote Issue Link", "destructiveHint": False},
 )
@@ -2916,6 +2973,12 @@ async def create_remote_issue_link(
             description="(Optional) Relationship description (e.g., 'causes', 'relates to', 'documentation')"
         ),
     ] = None,
+    global_id: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Unique global identifier for the remote link (e.g., Confluence globalId or external URL ID)"
+        ),
+    ] = None,
     icon_url: Annotated[
         str | None, Field(description="(Optional) URL to a 16x16 icon for the link")
     ] = None,
@@ -2932,6 +2995,7 @@ async def create_remote_issue_link(
         title: The title/name that will be displayed for the link.
         summary: Optional description of what the link is for.
         relationship: Optional relationship description.
+        global_id: Optional unique global identifier for the link.
         icon_url: Optional URL to a 16x16 icon for the link.
 
     Returns:
@@ -2960,12 +3024,58 @@ async def create_remote_issue_link(
     if icon_url:
         link_object["icon"] = {"url16x16": icon_url, "title": title}
 
-    link_data = {"object": link_object}
+    link_data: dict[str, Any] = {"object": link_object}
 
     if relationship:
         link_data["relationship"] = relationship
 
+    if global_id:
+        link_data["globalId"] = global_id
+
     result = jira.create_remote_issue_link(issue_key, link_data)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_links"},
+    annotations={"title": "Delete Remote Issue Link", "destructiveHint": True},
+)
+@check_write_access
+async def delete_remote_issue_link(
+    ctx: Context,
+    issue_key: Annotated[
+        str,
+        Field(
+            description="The key of the issue containing the link (e.g., 'PROJ-123')",
+            pattern=ISSUE_KEY_PATTERN,
+        ),
+    ],
+    link_id: Annotated[
+        str,
+        Field(
+            description="The ID of the remote link to delete (obtained from get_remote_issue_links)"
+        ),
+    ],
+) -> str:
+    """Delete a remote issue link from a Jira issue.
+
+    Args:
+        ctx: The FastMCP context.
+        issue_key: The issue key containing the link.
+        link_id: The ID of the remote link to delete.
+
+    Returns:
+        JSON string confirming deletion.
+
+    Raises:
+        ValueError: If required parameters are missing, in read-only mode, or Jira client unavailable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    if not issue_key:
+        raise ValueError("issue_key is required.")
+    if not link_id:
+        raise ValueError("link_id is required.")
+    result = jira.delete_remote_issue_link(issue_key, link_id)
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -264,6 +264,68 @@ def _parse_attachments(
 
 @jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_users"},
+    annotations={"title": "Get Current User", "readOnlyHint": True},
+)
+async def get_current_user(
+    ctx: Context,
+    expand: Annotated[
+        str | None,
+        Field(
+            description=(
+                "(Optional) Comma-separated sections to expand on the returned "
+                "user, e.g. 'groups' or 'groups,applicationRoles'. Recognised "
+                "sections are included verbatim in the response."
+            ),
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Retrieve the profile of the user the current credentials belong to.
+
+    Calls ``/rest/api/2/myself``, so the identity is resolved from the token
+    used for this request. Works on Jira Cloud, Server/Data Center, and Jira
+    Service Management, and needs no "Browse Users" permission.
+
+    Use this to answer "who am I?", to obtain the caller's own ``account_id``
+    (Cloud) or ``name`` / ``key`` (Server/DC) before setting assignee,
+    reporter, or watcher fields, or to confirm which account a token maps to
+    in BYOT deployments. Use ``get_user_profile`` instead when you need to
+    look up somebody else by email, username, key, or account ID.
+
+    Args:
+        ctx: The FastMCP context.
+        expand: Optional comma-separated sections to expand (e.g. 'groups').
+
+    Returns:
+        JSON string representing the current Jira user profile object, or an
+        error object.
+
+    Raises:
+        ValueError: If the Jira client is not configured or available.
+    """
+    jira = await get_jira_fetcher(ctx)
+    try:
+        user = jira.get_current_user_profile(expand=expand)
+        response_data = {"success": True, "user": user}
+    except Exception as e:
+        error_message = ""
+        log_level = logging.ERROR
+        if isinstance(e, MCPAtlassianAuthenticationError):
+            error_message = f"Authentication/Permission Error: {str(e)}"
+        elif isinstance(e, OSError | HTTPError):
+            error_message = f"Network or API Error: {str(e)}"
+        else:
+            error_message = (
+                "An unexpected error occurred while fetching the current user."
+            )
+            logger.exception("Unexpected error in get_current_user:")
+        logger.log(log_level, f"get_current_user failed: {error_message}")
+        response_data = {"success": False, "error": str(e)}
+    return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_users"},
     annotations={"title": "Get User Profile", "readOnlyHint": True},
 )
 async def get_user_profile(

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 98 tools into 25 named toolsets controlled via the TOOLSETS env var.
+Groups 99 tools into 25 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -1,6 +1,6 @@
 """Toolset definitions and filtering utilities for MCP Atlassian.
 
-Groups 99 tools into 25 named toolsets controlled via the TOOLSETS env var.
+Groups 101 tools into 25 named toolsets controlled via the TOOLSETS env var.
 Supports 'all', 'default', and comma-separated toolset names.
 """
 

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -131,6 +131,37 @@ class TestCommentsMixin:
         comment = result[0]
         assert comment.body == "<p>Processed HTML</p>"
 
+    def test_get_page_comments_with_missing_body(self, comments_mixin):
+        """Test get_page_comments safely parses comments missing body or view keys without dropping results."""
+        comments_mixin.confluence.get_page_comments.return_value = {
+            "results": [
+                {
+                    "id": "1",
+                    "version": {"number": 1},
+                },
+                {
+                    "id": "2",
+                    "body": {},
+                    "version": {"number": 1},
+                },
+                {
+                    "id": "3",
+                    "body": {"view": {"value": "<p>Valid</p>"}},
+                    "version": {"number": 1},
+                },
+            ]
+        }
+        comments_mixin.preprocessor.process_html_content.return_value = (
+            "<p>Valid</p>",
+            "Valid",
+        )
+
+        result = comments_mixin.get_page_comments("12345")
+        assert len(result) == 3
+        assert result[0].id == "1"
+        assert result[1].id == "2"
+        assert result[2].id == "3"
+
     def test_get_page_comments_paginates_v1_results(self, comments_mixin):
         """All v1 comment pages are returned when Confluence provides next."""
         first_comment = {

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -3886,3 +3886,22 @@ class TestUpdatePageSection:
             )
 
         pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
+
+    def test_get_space_pages_respects_spaces_filter(self, pages_mixin):
+        """get_space_pages raises ValueError when space_key is not in CONFLUENCE_SPACES_FILTER."""
+        pages_mixin.config.spaces_filter = "DEV,TEAM"
+
+        with pytest.raises(ValueError, match="restricted by CONFLUENCE_SPACES_FILTER"):
+            pages_mixin.get_space_pages("SECRET")
+
+        # Allowed space succeeds
+        pages_mixin.confluence.get_all_pages_from_space.return_value = []
+        result = pages_mixin.get_space_pages("DEV")
+        assert result == []
+
+    def test_get_space_page_tree_respects_spaces_filter(self, pages_mixin):
+        """get_space_page_tree raises Exception when space_key is not in CONFLUENCE_SPACES_FILTER."""
+        pages_mixin.config.spaces_filter = "DEV,TEAM"
+
+        with pytest.raises(Exception, match="restricted by CONFLUENCE_SPACES_FILTER"):
+            pages_mixin.get_space_page_tree("SECRET")

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -715,3 +715,67 @@ class TestConfluenceV2AdapterComments:
         assert payload["pageId"] == "12345"
         assert "parentCommentId" not in payload
         assert result["id"] == "333444555"
+
+
+class TestConfluenceV2AdapterPageVersion:
+    """`get_page_by_version` must ask the page endpoint for the version (#1373)."""
+
+    @pytest.fixture
+    def mock_session(self):
+        return MagicMock(spec=requests.Session)
+
+    @pytest.fixture
+    def v2_adapter(self, mock_session):
+        return ConfluenceV2Adapter(
+            session=mock_session, base_url="https://example.atlassian.net/wiki"
+        )
+
+    def _page_response(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "id": "123456",
+            "status": "current",
+            "title": "Test Page",
+            "spaceId": "789",
+            "version": {
+                "number": 3,
+                "createdAt": "2024-01-02T10:00:00.000Z",
+                "authorId": "author-id",
+                "message": "third revision",
+            },
+            "body": {
+                "storage": {"value": "<p>v3 content</p>", "representation": "storage"}
+            },
+        }
+        return response
+
+    def _space_response(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"key": "TEST"}
+        return response
+
+    def test_requests_version_from_page_endpoint(self, v2_adapter, mock_session):
+        mock_session.get.side_effect = [self._page_response(), self._space_response()]
+
+        result = v2_adapter.get_page_by_version("123456", 3)
+
+        url, kwargs = (
+            mock_session.get.call_args_list[0][0],
+            mock_session.get.call_args_list[0][1],
+        )
+        assert url[0] == "https://example.atlassian.net/wiki/api/v2/pages/123456"
+        assert kwargs["params"]["version"] == 3
+        assert kwargs["params"]["body-format"] == "storage"
+        assert result["body"]["storage"]["value"] == "<p>v3 content</p>"
+        assert result["version"]["number"] == 3
+
+    def test_does_not_call_the_versions_endpoints(self, v2_adapter, mock_session):
+        """PageVersion objects carry no id, so the two-step lookup can never work."""
+        mock_session.get.side_effect = [self._page_response(), self._space_response()]
+
+        v2_adapter.get_page_by_version("123456", 3)
+
+        requested = [call[0][0] for call in mock_session.get.call_args_list]
+        assert not any("/versions" in url for url in requested)

--- a/tests/unit/jira/test_comments.py
+++ b/tests/unit/jira/test_comments.py
@@ -134,6 +134,22 @@ class TestCommentsMixin:
             result[2]["author"] == "Unknown"
         )  # Should use Unknown when only name is available
 
+    def test_get_issue_comments_with_none_author(self, comments_mixin):
+        """Test get_issue_comments handles author: None without AttributeError."""
+        comments_mixin.jira.issue_get_comments.return_value = {
+            "comments": [
+                {
+                    "id": "10001",
+                    "body": "Comment from deleted user",
+                    "created": "2024-01-01T10:00:00.000+0000",
+                    "author": None,
+                }
+            ]
+        }
+        result = comments_mixin.get_issue_comments("TEST-123")
+        assert len(result) == 1
+        assert result[0]["author"] == "Unknown"
+
     def test_get_issue_comments_with_empty_response(self, comments_mixin):
         """Test get_issue_comments with an empty response."""
         # Setup mock response with no comments

--- a/tests/unit/jira/test_development.py
+++ b/tests/unit/jira/test_development.py
@@ -526,3 +526,20 @@ class TestDevelopmentMixin:
         assert pr["destination"] == ""
         assert pr["author"] == ""
         assert pr["reviewers"] == []
+
+    def test_dev_info_url_uses_jira_url(self, development_mixin):
+        """Test that dev-status API calls use self.jira.url rather than config.url directly."""
+        development_mixin.jira.url = "https://api.atlassian.com/ex/jira/cloud-id-123"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"detail": []}
+        development_mixin.jira._session.get.return_value = mock_response
+
+        development_mixin._fetch_dev_info_for_app_type(
+            "TEST-1", "1001", "stash", "pullrequest"
+        )
+        call_url = development_mixin.jira._session.get.call_args[0][0]
+        assert (
+            call_url
+            == "https://api.atlassian.com/ex/jira/cloud-id-123/rest/dev-status/1.0/issue/detail"
+        )

--- a/tests/unit/jira/test_epics.py
+++ b/tests/unit/jira/test_epics.py
@@ -580,6 +580,33 @@ class TestEpicsMixin:
         ):
             epics_mixin.link_issue_to_epic("TEST-123", "TEST-456")
 
+    @pytest.mark.parametrize(
+        "localized_epic_name",
+        ["épique", "эпик", "エピック", "에픽", "史诗", "epik", "Épica"],
+    )
+    def test_link_issue_to_epic_multilingual(
+        self, epics_mixin: EpicsMixin, localized_epic_name: str
+    ):
+        """Test link_issue_to_epic recognizes non-English localized epic issue types."""
+        epics_mixin.jira.get_issue.side_effect = [
+            {"key": "TEST-123"},
+            {
+                "key": "EPIC-456",
+                "fields": {"issuetype": {"name": localized_epic_name}},
+            },
+        ]
+        epics_mixin.get_issue = MagicMock(
+            return_value=JiraIssue(key="TEST-123", id="123456")
+        )
+        epics_mixin.get_field_ids_to_epic = MagicMock(return_value={})
+        epics_mixin.jira.update_issue.return_value = None
+
+        result = epics_mixin.link_issue_to_epic("TEST-123", "EPIC-456")
+        assert result.key == "TEST-123"
+        epics_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123", update={"fields": {"parent": {"key": "EPIC-456"}}}
+        )
+
     def test_link_issue_to_epic_all_methods_fail(self, epics_mixin: EpicsMixin):
         """Test link_issue_to_epic when all linking methods fail."""
         # Setup mocks

--- a/tests/unit/jira/test_forms.py
+++ b/tests/unit/jira/test_forms.py
@@ -1,0 +1,79 @@
+"""Tests for Jira ProForma form operations."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from requests.exceptions import HTTPError
+
+from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
+from mcp_atlassian.jira.config import JiraConfig
+from mcp_atlassian.jira.forms import FormsMixin
+from mcp_atlassian.jira.forms_common import handle_forms_http_error
+
+
+@pytest.fixture
+def mock_config():
+    """Fixture to create a mock JiraConfig instance."""
+    config = MagicMock(spec=JiraConfig)
+    config.url = "https://test.atlassian.net"
+    config.auth_type = "pat"
+    return config
+
+
+@pytest.fixture
+def forms_mixin(mock_config):
+    """Fixture to create a FormsMixin instance for testing."""
+    mixin = FormsMixin(config=mock_config)
+    mixin.jira = MagicMock()
+    return mixin
+
+
+def test_get_issue_forms_404_empty_list(forms_mixin):
+    """Test get_issue_forms returns empty list on 404 HTTPError."""
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    error = HTTPError(response=mock_response)
+    forms_mixin.jira.get.side_effect = error
+
+    assert forms_mixin.get_issue_forms("TEST-123") == []
+
+
+def test_get_issue_forms_http_error_no_response(forms_mixin):
+    """Test get_issue_forms handles HTTPError when response is None."""
+    error = HTTPError()
+    error.response = None
+    forms_mixin.jira.get.side_effect = error
+
+    with pytest.raises(Exception):
+        forms_mixin.get_issue_forms("TEST-123")
+
+
+def test_get_form_details_404_returns_none(forms_mixin):
+    """Test get_form_details returns None on 404 HTTPError."""
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    error = HTTPError(response=mock_response)
+    forms_mixin.jira.get.side_effect = error
+
+    assert forms_mixin.get_form_details("TEST-123", "i1") is None
+
+
+def test_get_form_details_http_error_no_response(forms_mixin):
+    """Test get_form_details handles HTTPError when response is None."""
+    error = HTTPError()
+    error.response = None
+    forms_mixin.jira.get.side_effect = error
+
+    with pytest.raises(Exception):
+        forms_mixin.get_form_details("TEST-123", "i1")
+
+
+def test_handle_forms_http_error_without_response():
+    """Test handle_forms_http_error does not crash when error.response is None."""
+    error = HTTPError()
+    error.response = None
+
+    exc = handle_forms_http_error(error, "testing", "TEST-123")
+    assert isinstance(exc, Exception)
+    assert not isinstance(exc, MCPAtlassianAuthenticationError)
+    assert not isinstance(exc, ValueError)

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1723,6 +1723,14 @@ class TestIssuesMixin:
         assert len(result) == 0
         assert not issues_mixin.jira.create_issues.called
 
+        # Verify input dictionaries were not mutated
+        assert issues[0]["project_key"] == "TEST"
+        assert issues[0]["summary"] == "Test Issue 1"
+        assert issues[0]["issue_type"] == "Task"
+        assert issues[1]["project_key"] == "TEST"
+        assert issues[1]["summary"] == "Test Issue 2"
+        assert issues[1]["issue_type"] == "Bug"
+
     def test_batch_create_issues_missing_required_fields(
         self, issues_mixin: IssuesMixin
     ):

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1300,6 +1300,147 @@ class TestIssuesMixin:
         assert "priority" in fields
         assert fields["priority"] is None
 
+    def test_update_issue_set_parent_with_string_key(self, issues_mixin: IssuesMixin):
+        """Test setting a parent via a plain issue key string."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Task"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        issues_mixin.update_issue(issue_key="TEST-123", parent="EPIC-1")
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123", update={"fields": {"parent": {"key": "EPIC-1"}}}
+        )
+
+    def test_update_issue_set_parent_with_dict(self, issues_mixin: IssuesMixin):
+        """Test setting a parent via an already-shaped {"key": ...} dict."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Task"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        issues_mixin.update_issue(issue_key="TEST-123", parent={"key": "EPIC-2"})
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123", update={"fields": {"parent": {"key": "EPIC-2"}}}
+        )
+
+    @pytest.mark.parametrize("parent_value", [None, ""])
+    @pytest.mark.parametrize("input_style", ["keyword", "fields"])
+    def test_update_issue_clear_parent_on_cloud(
+        self,
+        issues_mixin: IssuesMixin,
+        parent_value: None | str,
+        input_style: str,
+    ):
+        """Cloud sends an explicit null when clearing an issue parent."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Task"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        if input_style == "keyword":
+            document = issues_mixin.update_issue(
+                issue_key="TEST-123", parent=parent_value
+            )
+        else:
+            document = issues_mixin.update_issue(
+                issue_key="TEST-123", fields={"parent": parent_value}
+            )
+
+        issues_mixin.jira.update_issue.assert_called_once_with(
+            issue_key="TEST-123", update={"fields": {"parent": None}}
+        )
+        assert document.key == "TEST-123"
+
+    @pytest.mark.parametrize("parent_value", [None, ""])
+    def test_update_issue_clear_parent_on_server_dc(
+        self, issues_mixin: IssuesMixin, parent_value: None | str
+    ):
+        """Server/DC rejects parent clearing before making an update request."""
+        issues_mixin.config.url = "https://jira.example.com"
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Task"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        with pytest.raises(ValueError, match="supported only on Jira Cloud"):
+            issues_mixin.update_issue(issue_key="TEST-123", parent=parent_value)
+
+        issues_mixin.jira.update_issue.assert_not_called()
+        issues_mixin.jira.get_issue.assert_not_called()
+
+    @pytest.mark.parametrize("parent_value", [None, ""])
+    def test_update_issue_clear_parent_in_fields_on_server_dc(
+        self, issues_mixin: IssuesMixin, parent_value: None | str
+    ):
+        """Server/DC rejects a JSON ``{"parent": null}`` field update early."""
+        issues_mixin.config.url = "https://jira.example.com"
+
+        with pytest.raises(ValueError, match="customfield_10014"):
+            issues_mixin.update_issue(
+                issue_key="TEST-123", fields={"parent": parent_value}
+            )
+
+        issues_mixin.jira.update_issue.assert_not_called()
+        issues_mixin.jira.get_issue.assert_not_called()
+
+    def test_update_issue_invalid_parent_value_is_skipped(
+        self, issues_mixin: IssuesMixin, caplog
+    ):
+        """A genuinely invalid parent value is still warned about and skipped."""
+        issue_data = {
+            "id": "12345",
+            "key": "TEST-123",
+            "fields": {
+                "summary": "Test Issue",
+                "description": "This is a test",
+                "status": {"name": "Open"},
+                "issuetype": {"name": "Task"},
+            },
+        }
+        issues_mixin.jira.get_issue.return_value = issue_data
+        issues_mixin.jira.issue_get_comments.return_value = {"comments": []}
+
+        issues_mixin.update_issue(issue_key="TEST-123", parent=123)
+
+        # No fields to update, so the PUT is skipped entirely.
+        issues_mixin.jira.update_issue.assert_not_called()
+        assert "Invalid parent value for issue TEST-123" in caplog.text
+
     def test_delete_issue(self, issues_mixin: IssuesMixin):
         """Test deleting an issue."""
         # Call the method

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -363,3 +363,34 @@ class TestLinksMixin:
 
         with pytest.raises(MCPAtlassianAuthenticationError):
             links_mixin.get_remote_issue_links("PROJ-123")
+
+    @pytest.mark.parametrize(
+        ("url", "api_version"),
+        [
+            pytest.param("https://test.atlassian.net", "3", id="cloud"),
+            pytest.param("https://jira.example.com", "2", id="server"),
+        ],
+    )
+    def test_delete_remote_issue_link_success(
+        self, jira_config_factory, mock_atlassian_jira, url: str, api_version: str
+    ):
+        """Test successful deletion of a remote issue link on Cloud and Server."""
+        config = jira_config_factory(url=url)
+        mixin = LinksMixin(config=config)
+        mixin.jira = mock_atlassian_jira
+
+        result = mixin.delete_remote_issue_link("PROJ-123", "10050")
+
+        assert result["success"] is True
+        assert result["link_id"] == "10050"
+        mixin.jira.delete.assert_called_once_with(
+            f"rest/api/{api_version}/issue/PROJ-123/remotelink/10050"
+        )
+
+    def test_delete_remote_issue_link_missing_args(self, links_mixin):
+        """Test validation when issue_key or link_id is missing."""
+        with pytest.raises(ValueError, match="Issue key is required"):
+            links_mixin.delete_remote_issue_link("", "10050")
+
+        with pytest.raises(ValueError, match="Link ID is required"):
+            links_mixin.delete_remote_issue_link("PROJ-123", "")

--- a/tests/unit/jira/test_search.py
+++ b/tests/unit/jira/test_search.py
@@ -1356,3 +1356,18 @@ class TestSearchFilterAndInjectionRegression:
             "config allowlist must still be applied even when a projects_filter arg "
             f"is supplied; JQL was {sent_jql!r}"
         )
+
+    def test_search_issues_v3_pagination_terminates_on_empty_issues(
+        self, search_mixin: SearchMixin
+    ):
+        """Test v3 pagination loop safely terminates if API returns empty issues list with nextPageToken."""
+        search_mixin.config.is_cloud = True
+        search_mixin.config.projects_filter = None
+        search_mixin.jira.post.return_value = {
+            "issues": [],
+            "nextPageToken": "infinite-token-loop",
+        }
+
+        result = search_mixin.search_issues("project = TEST", limit=50)
+        assert len(result.issues) == 0
+        assert search_mixin.jira.post.call_count == 1

--- a/tests/unit/jira/test_sla.py
+++ b/tests/unit/jira/test_sla.py
@@ -695,3 +695,58 @@ class TestStatusCategoryCaching:
 
         # API should only be called once across all issues
         assert sla_mixin.jira.get_all_statuses.call_count == 1
+
+    def test_naive_datetime_handling_in_sla_calculations(self, sla_mixin: SLAMixin):
+        """Test SLA calculations do not raise TypeError when naive datetimes are mixed with aware."""
+        config = SLAConfig(default_metrics=["lead_time", "cycle_time"])
+        # Explicit naive created datetime (tzinfo=None)
+        naive_created = datetime(2023, 1, 1, 10, 0, tzinfo=timezone.utc).replace(
+            tzinfo=None
+        )
+        naive_resolved = datetime(2023, 1, 2, 10, 0, tzinfo=timezone.utc).replace(
+            tzinfo=None
+        )
+
+        # 1. Test _calculate_duration with naive start and aware end (calendar time)
+        aware_end = datetime(2023, 1, 2, 10, 0, tzinfo=timezone.utc)
+        duration = sla_mixin._calculate_duration(
+            naive_created, aware_end, working_hours_only=False, sla_config=config
+        )
+        assert duration == 1440
+
+        # 2. Test _calculate_duration with working hours
+        wh_config = SLAConfig(
+            default_metrics=["lead_time"],
+            working_hours_only=True,
+            working_hours_start="09:00",
+            working_hours_end="17:00",
+            timezone="UTC",
+        )
+        wh_duration = sla_mixin._calculate_duration(
+            naive_created, aware_end, working_hours_only=True, sla_config=wh_config
+        )
+        assert wh_duration >= 0
+
+        # 3. Test _calculate_lead_time when issue is unresolved (resolution_date=None, now() is aware)
+        issue_dates_unresolved = IssueDatesResponse(
+            issue_key="TEST-1",
+            created=naive_created,
+            resolution_date=None,
+        )
+        lead_time = sla_mixin._calculate_lead_time(
+            issue_dates_unresolved, working_hours_only=False, sla_config=config
+        )
+        assert lead_time.value_minutes > 0
+        assert lead_time.is_resolved is False
+
+        # 4. Test _calculate_cycle_time with naive dates
+        issue_dates_resolved = IssueDatesResponse(
+            issue_key="TEST-2",
+            created=naive_created,
+            resolution_date=naive_resolved,
+        )
+        cycle_time = sla_mixin._calculate_cycle_time(
+            issue_dates_resolved, working_hours_only=False, sla_config=config
+        )
+        assert cycle_time.calculated is True
+        assert cycle_time.value_minutes == 1440

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -52,6 +52,61 @@ class TestUsersMixin:
         # Verify self.jira.myself was called
         users_mixin.jira.myself.assert_called_once()
 
+    def test_get_current_user_profile_from_api(self, users_mixin):
+        """get_current_user_profile returns simplified fields from /myself."""
+        users_mixin.jira.resource_url = MagicMock(return_value="rest/api/2/myself")
+        users_mixin.jira.get = MagicMock(
+            return_value={
+                "name": "jdoe",
+                "key": "JIRAUSER12345",
+                "displayName": "John Doe",
+                "emailAddress": "john.doe@example.com",
+            }
+        )
+
+        user = users_mixin.get_current_user_profile()
+
+        users_mixin.jira.get.assert_called_once_with("rest/api/2/myself", params=None)
+        assert user["name"] == "jdoe"
+        assert user["key"] == "JIRAUSER12345"
+        assert user["display_name"] == "John Doe"
+        assert user["email"] == "john.doe@example.com"
+
+    def test_get_current_user_profile_with_expand(self, users_mixin):
+        """expand is forwarded to the API and known sections are returned."""
+        users_mixin.jira.resource_url = MagicMock(return_value="rest/api/2/myself")
+        users_mixin.jira.get = MagicMock(
+            return_value={
+                "accountId": "5b10ac8d82e05b22cc7d4ef5",
+                "displayName": "John Doe",
+                "groups": {"size": 1, "items": [{"name": "jira-users"}]},
+                "applicationRoles": {
+                    "size": 1,
+                    "items": [{"key": "jira-software", "name": "Jira Software"}],
+                },
+            }
+        )
+
+        user = users_mixin.get_current_user_profile(expand="groups")
+
+        users_mixin.jira.get.assert_called_once_with(
+            "rest/api/2/myself", params={"expand": "groups"}
+        )
+        assert user["account_id"] == "5b10ac8d82e05b22cc7d4ef5"
+        assert user["groups"] == {"size": 1, "items": [{"name": "jira-users"}]}
+        assert user["applicationRoles"] == {
+            "size": 1,
+            "items": [{"key": "jira-software", "name": "Jira Software"}],
+        }
+
+    def test_get_current_user_profile_unexpected_type(self, users_mixin):
+        """A non-dict /myself response raises an error."""
+        users_mixin.jira.resource_url = MagicMock(return_value="rest/api/2/myself")
+        users_mixin.jira.get = MagicMock(return_value=["not", "a", "dict"])
+
+        with pytest.raises(Exception, match="Error processing current user profile"):
+            users_mixin.get_current_user_profile()
+
     def test_get_current_user_account_id_data_center_timestamp_issue(self, users_mixin):
         """Test that get_current_user_account_id handles Jira Data Center with problematic timestamps."""
         # Ensure no cached value

--- a/tests/unit/jira/test_worklog.py
+++ b/tests/unit/jira/test_worklog.py
@@ -510,3 +510,82 @@ class TestWorklogMixin:
         server_worklog_mixin.jira.resource_url.assert_called_with("issue")
         server_worklog_mixin._post_api3.assert_not_called()
         assert result["id"] == "10003"
+
+    def test_get_worklogs_with_adf_comment(self, worklog_mixin):
+        """Test get_worklogs properly parses ADF comment dictionaries without raising TypeError."""
+        mock_result = {
+            "total": 1,
+            "worklogs": [
+                {
+                    "id": "10004",
+                    "comment": {
+                        "type": "doc",
+                        "version": 1,
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [
+                                    {"type": "text", "text": "ADF logged work"}
+                                ],
+                            }
+                        ],
+                    },
+                    "created": "2024-01-01T10:00:00.000+0000",
+                    "updated": "2024-01-01T10:30:00.000+0000",
+                    "started": "2024-01-01T09:00:00.000+0000",
+                    "timeSpent": "1h",
+                    "timeSpentSeconds": 3600,
+                    "author": {"displayName": "Test User"},
+                }
+            ],
+        }
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
+        worklog_mixin.jira.get.return_value = mock_result
+
+        result = worklog_mixin.get_worklogs("TEST-123")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "10004"
+        assert result[0]["comment"] == "ADF logged work"
+
+    def test_worklog_with_none_author(self, worklog_mixin):
+        """Test that get_worklogs and add_worklog gracefully handle author=None."""
+        mock_get_result = {
+            "total": 1,
+            "worklogs": [
+                {
+                    "id": "10005",
+                    "comment": "Work with no author",
+                    "created": "2024-01-01T10:00:00.000+0000",
+                    "updated": "2024-01-01T10:30:00.000+0000",
+                    "started": "2024-01-01T09:00:00.000+0000",
+                    "timeSpent": "30m",
+                    "timeSpentSeconds": 1800,
+                    "author": None,
+                }
+            ],
+        }
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
+        worklog_mixin.jira.get.return_value = mock_get_result
+
+        get_res = worklog_mixin.get_worklogs("TEST-123")
+        assert len(get_res) == 1
+        assert get_res[0]["author"] == "Unknown"
+
+        mock_add_result = {
+            "id": "10006",
+            "comment": "New work",
+            "created": "2024-01-01T10:00:00.000+0000",
+            "updated": "2024-01-01T10:00:00.000+0000",
+            "started": "2024-01-01T09:00:00.000+0000",
+            "timeSpent": "1h",
+            "timeSpentSeconds": 3600,
+            "author": None,
+        }
+        worklog_mixin.jira.post.return_value = mock_add_result
+        add_res = worklog_mixin.add_worklog("TEST-123", "1h", comment="New work")
+        assert add_res["author"] == "Unknown"

--- a/tests/unit/jira/test_worklog.py
+++ b/tests/unit/jira/test_worklog.py
@@ -258,6 +258,34 @@ class TestWorklogMixin:
         assert result["original_estimate_updated"] is False
         assert result["remaining_estimate_updated"] is False
 
+    def test_add_worklog_with_attributes_and_additional_fields(self, worklog_mixin):
+        """Test add_worklog passes custom attributes and additional fields."""
+        mock_result = {
+            "id": "10001",
+            "timeSpent": "2h",
+            "timeSpentSeconds": 7200,
+        }
+        worklog_mixin.jira.post.return_value = mock_result
+        worklog_mixin.jira.resource_url.return_value = (
+            "https://jira.example.com/rest/api/2/issue"
+        )
+
+        custom_attrs = {"_Account_": {"value": "DEV-100"}}
+        extra_fields = {"visibility": {"type": "group", "value": "developers"}}
+
+        result = worklog_mixin.add_worklog(
+            "TEST-123",
+            "2h",
+            attributes=custom_attrs,
+            additional_fields=extra_fields,
+        )
+
+        call_data = worklog_mixin.jira.post.call_args[1]["data"]
+        assert call_data["attributes"] == custom_attrs
+        assert call_data["visibility"] == {"type": "group", "value": "developers"}
+        assert call_data["timeSpentSeconds"] == 7200
+        assert result["id"] == "10001"
+
     def test_add_worklog_with_original_estimate(self, worklog_mixin):
         """Test add_worklog with original estimate update."""
         # Setup mocks

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -816,6 +816,20 @@ class TestMarkdownToAdf:
         # Should have 2 rows: header + 1 data (separator skipped)
         assert len(table["content"]) == 2
 
+    def test_table_with_dash_only_data_row(self):
+        """Data rows containing '-' (N/A) are not skipped as separators (#1629)."""
+        md = "| Metric | Value |\n| --- | --- |\n| Test | - |\n| - | - |"
+        result = markdown_to_adf(md)
+        table = next(n for n in result["content"] if n["type"] == "table")
+        # Should have 3 rows: 1 header row + 2 data rows
+        assert len(table["content"]) == 3
+        # Last row should contain the '-' text in its cells
+        last_row = table["content"][2]
+        assert last_row["type"] == "tableRow"
+        assert len(last_row["content"]) == 2
+        assert last_row["content"][0]["content"][0]["content"][0]["text"] == "-"
+        assert last_row["content"][1]["content"][0]["content"][0]["text"] == "-"
+
     # -- Roundtrip ----------------------------------------------------------
 
     def test_roundtrip(self):

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -347,6 +347,35 @@ For more information, see [our website|https://example.com].
     assert "[our website](https://example.com)" in converted
 
 
+def test_jira_to_markdown_callout_macros(preprocessor_with_jira):
+    """Test {info}, {note}, {warning}, {tip} macro conversions."""
+    info_text = "{info:title=Important Note}\nThis is informational.\n{info}"
+    converted_info = preprocessor_with_jira.jira_to_markdown(info_text)
+    assert "> [!NOTE]" in converted_info
+    assert "> **Important Note**" in converted_info
+    assert "> This is informational." in converted_info
+
+    warning_text = "{warning}\nBeware of dragons!\n{warning}"
+    converted_warning = preprocessor_with_jira.jira_to_markdown(warning_text)
+    assert "> [!WARNING]" in converted_warning
+    assert "> Beware of dragons!" in converted_warning
+
+    tip_text = "{tip:title=ProTip}\nUse shortcuts.\n{tip}"
+    converted_tip = preprocessor_with_jira.jira_to_markdown(tip_text)
+    assert "> [!TIP]" in converted_tip
+    assert "> **ProTip**" in converted_tip
+    assert "> Use shortcuts." in converted_tip
+
+
+def test_jira_to_markdown_expand_macro(preprocessor_with_jira):
+    """Test {expand:Title} macro conversion."""
+    expand_text = "{expand:Click to view details}\nNested detail text\n{expand}"
+    converted = preprocessor_with_jira.jira_to_markdown(expand_text)
+    assert "{expand:Click to view details}" in converted
+    assert "Nested detail text" in converted
+    assert "{expand}" in converted
+
+
 def test_jira_to_markdown_citation(preprocessor_with_jira):
     """Test citation markup conversion and that unmatched ?? does not cause ReDoS."""
     # Matched citation

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -147,10 +147,45 @@ def test_clean_jira_text_smart_links(preprocessor_with_jira):
     confluence_url = (
         f"{base_url}/wiki/spaces/PROJ/pages/987654321/Example+Meeting+Notes"
     )
-    processed_url = f"{base_url}/wiki/spaces/PROJ/pages/987654321/ExampleMeetingNotes"
+    # Literal plus signs in the URL are preserved; only the display
+    # title has them replaced with spaces.
+    processed_url = f"{base_url}/wiki/spaces/PROJ/pages/987654321/Example+Meeting+Notes"
     text = f"[Meeting Notes|{confluence_url}|smart-link]"
     cleaned = preprocessor_with_jira.clean_jira_text(text)
     assert cleaned == f"[Example Meeting Notes]({processed_url})"
+
+
+def test_clean_jira_text_stray_plus_no_markdown_escaping(
+    preprocessor_with_jira,
+):
+    """Bold prose plus unpaired plus signs must survive the read path
+    without markdownify escaping every emphasis delimiter."""
+    wiki = "*Ticket:* done\r\n\r\nPython 3.13+ and 2.6+ differ"
+    out = preprocessor_with_jira.clean_jira_text(wiki)
+    assert "**Ticket:**" in out
+    assert "\\*" not in out
+    assert "3.13+" in out and "2.6+" in out
+
+
+def test_clean_jira_text_generated_html_does_not_trigger_html_conversion(
+    preprocessor_with_jira,
+):
+    """Tags emitted by Jira conversion must not reprocess Markdown prose."""
+    wiki = "*Ticket:* {{<b>literal</b>}} +new note+"
+
+    assert preprocessor_with_jira.clean_jira_text(wiki) == (
+        "**Ticket:** `<b>literal</b>` <ins>new note</ins>"
+    )
+
+
+def test_clean_jira_text_preserves_server_dc_mentions(
+    preprocessor_with_jira,
+):
+    """Jira Server/DC [~username] mentions must not have brackets stripped."""
+    wiki = "Please review [~john.doe] and [~jane_smith]"
+    out = preprocessor_with_jira.clean_jira_text(wiki)
+    assert "[~john.doe]" in out
+    assert "[~jane_smith]" in out
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -3522,6 +3522,8 @@ async def test_add_worklog(jira_client, mock_jira_fetcher):
         started=None,
         original_estimate=None,
         remaining_estimate=None,
+        attributes=None,
+        additional_fields=None,
     )
 
     result = json.loads(response.content[0].text)

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -262,7 +262,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 63, f"Expected 63 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 64, f"Expected 64 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -262,7 +262,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 64, f"Expected 64 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 66, f"Expected 66 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Summary

This PR introduces high-value enhancements, bug fixes, and additional tool capabilities for both Jira and Confluence MCP servers:

### New Features & Tools (101 tools total)
- **Jira Remote Issue Links (CRUD)**: Added `jira_get_remote_issue_links` and `jira_delete_remote_issue_link` tools, along with `global_id` support in `jira_create_remote_issue_link`.
- **Jira Current User Tool**: Added `jira_get_current_user` tool backed by Jira's `/myself` endpoint (`PR #1571`).
- **Jira Wiki Macros Conversion**: Converted `{info}`, `{note}`, `{warning}`, `{tip}`, and `{expand}` macros to GitHub callouts (`> [!NOTE]`, `> [!WARNING]`, etc.).
- **Custom Worklog Attributes**: Added `attributes` and `additional_fields` parameters to `add_worklog` (supporting Tempo worklog attributes).
- **Confluence Spaces Filter Enforcement**: Added strict boundary validation on `get_space_pages` and `get_space_page_tree` against `CONFLUENCE_SPACES_FILTER`.
- **Multilingual Epic Type Detection**: Extended `_is_epic_issue_type` to support non-English localized Jira instances (French, German, Spanish, Japanese, Korean, Chinese, Russian, Ukrainian).

### Bug Fixes & Improvements
- **Confluence v2 Version Retrieval**: Fixed `get_page_by_version` to call the direct version endpoint (`PR #1593`).
- **Clear Issue Parent**: Supported explicit `parent=None` or `""` in `jira_update_issue` on Cloud (`PR #1518`).
- **Table Data Preservation**: Preserved single-dash `-` data cells in Markdown-to-ADF table conversion (`Issue #1629`).
- **Mentions & Formatting**: Protected Server/DC `[~username]` mentions and literal `+` signs in Jira preprocessing (`PR #1615`).

## Verification
- `pre-commit run --all-files`: Passed (Ruff + Mypy strict mode)
- `scripts/generate_tool_docs.py --check`: Passed (all 101 tools mapped and documented)
- `pytest`: All 3,938 tests passing