### PR TITLE
feat(jira): add consolidated Assets discovery for Server/DC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -233,8 +233,8 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 #   confluence_pages, confluence_comments
 # Example: TOOLSETS=default                      # Only core tools (~35 tools)
 # Example: TOOLSETS=default,jira_agile           # Core + agile tools
-# Example: TOOLSETS=all                          # All 25 toolsets (98 tools)
-# If unset, all toolsets are enabled (98 tools). Set TOOLSETS=all explicitly to
+# Example: TOOLSETS=all                          # All 26 toolsets (107 tools)
+# If unset, all toolsets are enabled (107 tools). Set TOOLSETS=all explicitly to
 # preserve this behavior — in v0.22.0, the default will change to core toolsets only.
 # Unknown names are silently ignored; if ALL names are unknown, no tools are enabled (fail-closed).
 #TOOLSETS=
@@ -252,6 +252,14 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # 4ME-123). An invalid regex is ignored and the default is kept.
 #JIRA_ISSUE_KEY_PATTERN=^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$
 #JIRA_PROJECT_KEY_PATTERN=^[A-Z][A-Z0-9_]+$
+
+# --- Jira Assets (Insight) — Server/Data Center only ---
+# REST base path used by the jira_assets toolset (off by default; enable with
+# TOOLSETS=default,jira_assets or TOOLSETS=all). JSM Data Center 5.3+ serves the
+# Assets API at rest/assets/1.0 (default). Set rest/insight/1.0 for legacy
+# Insight installs (JSM 5.2 and earlier); the legacy base also switches object
+# search to iql/objects. Leading/trailing slashes are ignored.
+#JIRA_ASSETS_API_BASE=rest/assets/1.0
 
 # --- Confluence Cloud attachment download workaround ---
 # Confluence Cloud removed the legacy /download/attachments/... endpoint that an

--- a/.env.example
+++ b/.env.example
@@ -233,8 +233,8 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 #   confluence_pages, confluence_comments
 # Example: TOOLSETS=default                      # Only core tools (~35 tools)
 # Example: TOOLSETS=default,jira_agile           # Core + agile tools
-# Example: TOOLSETS=all                          # All 26 toolsets (107 tools)
-# If unset, all toolsets are enabled (107 tools). Set TOOLSETS=all explicitly to
+# Example: TOOLSETS=all                          # All 26 toolsets (99 tools)
+# If unset, all toolsets are enabled (99 tools). Set TOOLSETS=all explicitly to
 # preserve this behavior — in v0.22.0, the default will change to core toolsets only.
 # Unknown names are silently ignored; if ALL names are unknown, no tools are enabled (fail-closed).
 #TOOLSETS=
@@ -254,11 +254,11 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 #JIRA_PROJECT_KEY_PATTERN=^[A-Z][A-Z0-9_]+$
 
 # --- Jira Assets (Insight) — Server/Data Center only ---
-# REST base path used by the jira_assets toolset (off by default; enable with
-# TOOLSETS=default,jira_assets or TOOLSETS=all). JSM Data Center 5.3+ serves the
-# Assets API at rest/assets/1.0 (default). Set rest/insight/1.0 for legacy
-# Insight installs (JSM 5.2 and earlier); the legacy base also switches object
-# search to iql/objects. Leading/trailing slashes are ignored.
+# REST base path used by jira_discover and jira_get_issue(include="assets").
+# The jira_assets discovery toolset is off by default; enable it with
+# TOOLSETS=default,jira_assets or TOOLSETS=all. JSM Data Center 5.3+ serves
+# Assets at rest/assets/1.0 (default). Set rest/insight/1.0 for legacy Insight
+# installs (JSM 5.2 and earlier). Leading/trailing slashes are ignored.
 #JIRA_ASSETS_API_BASE=rest/assets/1.0
 
 # --- Confluence Cloud attachment download workaround ---

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**107 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**99 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Documentation is also available in [llms.txt format](https://llmstxt.org/), whic
 | `jira_update_issue` - Update issues | `confluence_update_page` - Update pages |
 | `jira_transition_issue` - Change status | `confluence_add_comment` - Add comments |
 
-**98 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
+**107 tools total** — See [Tools Reference](https://mcp-atlassian.soomiles.com/docs/tools-reference) for the complete list.
 
 ## Security
 

--- a/docs.json
+++ b/docs.json
@@ -3,7 +3,7 @@
   "theme": "mint",
   "name": "MCP Atlassian",
   "metadata": {
-    "og:description": "MCP server for Atlassian Jira and Confluence — all 107 tools enabled by default"
+    "og:description": "MCP server for Atlassian Jira and Confluence — all 99 tools enabled by default"
   },
   "seo": {
     "indexHiddenPages": false

--- a/docs.json
+++ b/docs.json
@@ -3,7 +3,7 @@
   "theme": "mint",
   "name": "MCP Atlassian",
   "metadata": {
-    "og:description": "MCP server for Atlassian Jira and Confluence — all 98 tools enabled by default"
+    "og:description": "MCP server for Atlassian Jira and Confluence — all 107 tools enabled by default"
   },
   "seo": {
     "indexHiddenPages": false
@@ -78,7 +78,8 @@
               "docs/tools/jira-links-versions",
               "docs/tools/jira-attachments",
               "docs/tools/jira-service-desk",
-              "docs/tools/jira-forms-metrics"
+              "docs/tools/jira-forms-metrics",
+              "docs/tools/jira-assets"
             ]
           },
           {

--- a/docs/_overrides/jira_get_issue.yaml
+++ b/docs/_overrides/jira_get_issue.yaml
@@ -5,4 +5,4 @@ tips: |
 
   Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`. If a display name conflicts with another output key, that custom field keeps its raw ID so no value is lost.
 platform_notes: |
-  Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
+  Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs. The `assets` include is available only on Jira Service Management Server/Data Center and returns up to 100 objects connected to the issue.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -199,14 +199,16 @@ JIRA_PROJECT_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*$
 
 ### Jira Assets (Server/Data Center)
 
-The `jira_assets` toolset wraps the Assets (formerly Insight) REST API on Jira
-Service Management Server/Data Center. It is disabled by default; enable it with
-`TOOLSETS=default,jira_assets` (or `all`). The tools are hidden automatically when
-connected to Jira Cloud, whose workspace-scoped Assets API is not supported.
+The `jira_assets` toolset enables Assets discovery through the consolidated
+`jira_discover` tool on Jira Service Management Server/Data Center. It is disabled
+by default; enable it with `TOOLSETS=default,jira_assets` (or `all`). The tool is
+hidden automatically when connected to Jira Cloud, whose workspace-scoped Assets
+API is not supported. `jira_get_issue` can also inline connected objects with
+`include="assets"` on Server/Data Center.
 
 | Variable | Description |
 |----------|-------------|
-| `JIRA_ASSETS_API_BASE` | REST base path for the Assets API (default: `rest/assets/1.0`, JSM Data Center 5.3+). Set to `rest/insight/1.0` for legacy Insight installs (JSM 5.2 and earlier); object search then uses `iql/objects` instead of `aql/objects`. Leading/trailing slashes are ignored. |
+| `JIRA_ASSETS_API_BASE` | REST base path for Assets discovery and issue enrichment (default: `rest/assets/1.0`, JSM Data Center 5.3+). Set to `rest/insight/1.0` for legacy Insight installs (JSM 5.2 and earlier). Leading/trailing slashes are ignored. |
 
 ```bash
 TOOLSETS=default,jira_assets

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -197,6 +197,22 @@ JIRA_ISSUE_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*-\d+(?:-\d+)*$
 JIRA_PROJECT_KEY_PATTERN=^[A-Z0-9][A-Z0-9_]*$
 ```
 
+### Jira Assets (Server/Data Center)
+
+The `jira_assets` toolset wraps the Assets (formerly Insight) REST API on Jira
+Service Management Server/Data Center. It is disabled by default; enable it with
+`TOOLSETS=default,jira_assets` (or `all`). The tools are hidden automatically when
+connected to Jira Cloud, whose workspace-scoped Assets API is not supported.
+
+| Variable | Description |
+|----------|-------------|
+| `JIRA_ASSETS_API_BASE` | REST base path for the Assets API (default: `rest/assets/1.0`, JSM Data Center 5.3+). Set to `rest/insight/1.0` for legacy Insight installs (JSM 5.2 and earlier); object search then uses `iql/objects` instead of `aql/objects`. Leading/trailing slashes are ignored. |
+
+```bash
+TOOLSETS=default,jira_assets
+JIRA_ASSETS_API_BASE=rest/insight/1.0
+```
+
 ### Server Options
 
 | Variable | Description |

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 107 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 99 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **107 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **99 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -33,7 +33,7 @@ MCP Atlassian provides **107 tools** for interacting with Jira and Confluence. T
     ProForma forms, SLA, dates, development info
   </Card>
   <Card title="Assets" icon="boxes-stacked" href="/docs/tools/jira-assets">
-    Assets (Insight) schemas, objects, AQL search (Server/DC)
+    Consolidated Assets discovery (Server/DC)
   </Card>
 </CardGroup>
 
@@ -82,7 +82,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `jira_users` | No | `jira_get_user_profile`, `jira_search_assignable_users` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
 | `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues`, `jira_get_request_types`, `jira_get_request_type_fields`, `jira_create_customer_request` |
-| `jira_assets` | No | `jira_list_asset_schemas`, `jira_list_asset_object_types`, `jira_get_asset_object_type_attributes`, `jira_search_assets`, `jira_get_asset_object`, `jira_get_asset_object_history`, `jira_get_asset_connected_tickets`, `jira_create_asset_object`, `jira_update_asset_object` |
+| `jira_assets` | No | `jira_discover` |
 | `jira_forms` | No | `jira_get_issue_proforma_forms`, `jira_get_proforma_form_details`, `jira_update_proforma_form_answers` |
 | `jira_metrics` | No | `jira_get_issue_dates`, `jira_get_issue_sla` |
 | `jira_development` | No | `jira_get_issue_development_info`, `jira_get_issues_development_info` |
@@ -115,7 +115,7 @@ TOOLSETS=default,jira_agile,jira_attachments
 # Enable deprecated tools only while migrating to their replacements:
 TOOLSETS=legacy
 
-# Enable all toolsets (107 tools)
+# Enable all toolsets (99 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools-reference.mdx
+++ b/docs/tools-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Tools Reference"
-description: "Overview of all 98 MCP tools for Jira and Confluence — organized by category with quick links"
+description: "Overview of all 107 MCP tools for Jira and Confluence — organized by category with quick links"
 ---
 
-MCP Atlassian provides **98 tools** for interacting with Jira and Confluence. Tools are organized by category below.
+MCP Atlassian provides **107 tools** for interacting with Jira and Confluence. Tools are organized by category below.
 
 ## Jira Tools
 
@@ -31,6 +31,9 @@ MCP Atlassian provides **98 tools** for interacting with Jira and Confluence. To
   </Card>
   <Card title="Forms & Metrics" icon="chart-line" href="/docs/tools/jira-forms-metrics">
     ProForma forms, SLA, dates, development info
+  </Card>
+  <Card title="Assets" icon="boxes-stacked" href="/docs/tools/jira-assets">
+    Assets (Insight) schemas, objects, AQL search (Server/DC)
   </Card>
 </CardGroup>
 
@@ -63,7 +66,7 @@ MCP Atlassian provides **98 tools** for interacting with Jira and Confluence. To
 
 Toolsets group related tools for easier management via `TOOLSETS` env var or `--toolsets` flag.
 
-**Jira Toolsets (16):**
+**Jira Toolsets (17):**
 
 | Toolset | Core | Tools |
 |---------|:----:|-------|
@@ -79,6 +82,7 @@ Toolsets group related tools for easier management via `TOOLSETS` env var or `--
 | `jira_users` | No | `jira_get_user_profile`, `jira_search_assignable_users` |
 | `jira_watchers` | No | `jira_get_issue_watchers`, `jira_add_watcher`, `jira_remove_watcher` |
 | `jira_service_desk` | No | `jira_get_service_desk_for_project`, `jira_get_service_desk_queues`, `jira_get_queue_issues`, `jira_get_request_types`, `jira_get_request_type_fields`, `jira_create_customer_request` |
+| `jira_assets` | No | `jira_list_asset_schemas`, `jira_list_asset_object_types`, `jira_get_asset_object_type_attributes`, `jira_search_assets`, `jira_get_asset_object`, `jira_get_asset_object_history`, `jira_get_asset_connected_tickets`, `jira_create_asset_object`, `jira_update_asset_object` |
 | `jira_forms` | No | `jira_get_issue_proforma_forms`, `jira_get_proforma_form_details`, `jira_update_proforma_form_answers` |
 | `jira_metrics` | No | `jira_get_issue_dates`, `jira_get_issue_sla` |
 | `jira_development` | No | `jira_get_issue_development_info`, `jira_get_issues_development_info` |
@@ -111,7 +115,7 @@ TOOLSETS=default,jira_agile,jira_attachments
 # Enable deprecated tools only while migrating to their replacements:
 TOOLSETS=legacy
 
-# Enable all toolsets (98 tools)
+# Enable all toolsets (107 tools)
 TOOLSETS=all
 
 # Command line

--- a/docs/tools/jira-assets.mdx
+++ b/docs/tools/jira-assets.mdx
@@ -1,0 +1,122 @@
+---
+title: "Jira Assets"
+description: "Assets (Insight) schemas, object types, objects, and AQL search on Server/Data Center"
+---
+
+### List Asset Schemas
+
+List Jira Assets (Insight) object schemas.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name_filter` | `string` | No | Optional case-insensitive substring to filter schemas by name. Leave empty to list all schemas. |
+
+---
+
+### List Asset Object Types
+
+List the object types within an Assets object schema.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `schema_id` | `string` | Yes | Object schema ID (e.g., '3'), from list_asset_schemas |
+
+---
+
+### Get Asset Object Type Attributes
+
+Get attribute definitions for an Assets object type.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `object_type_id` | `string` | Yes | Object type ID (e.g., '42') |
+
+---
+
+### Search Assets with AQL
+
+Search Jira Assets objects using AQL (Assets Query Language).
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `aql` | `string` | Yes | AQL/IQL query string. Examples: objectType = "Person"; objectType = "Hardware" AND "Status" = "Active"; "Assigned To" IS EMPTY |
+| `page` | `integer` | No | 1-based page number |
+| `results_per_page` | `integer` | No | Results per page (1-100) |
+| `include_attributes` | `boolean` | No | Include attribute values in results |
+| `schema_id` | `string` | No | Optional object schema ID to restrict the search to (from jira_list_asset_schemas). Leave empty to search all schemas. |
+
+---
+
+### Get Asset Object
+
+Get a single Assets object with its resolved attribute values.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
+
+---
+
+### Get Asset Object History
+
+Get the change history for an Assets object.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
+
+---
+
+### Get Asset Connected Tickets
+
+Get Jira issues connected to an Assets object.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
+
+---
+
+### Create Asset Object
+
+Create a new Jira Assets object.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `object_type_id` | `string` | Yes | Object type ID to create the object under |
+| `attributes` | `object` | Yes | Mapping of attribute ID (as string) to value, e.g. `{"142": "Jane Doe", "143": "jane.doe@example.com"}`. Use jira_get_asset_object_type_attributes to resolve attribute names to IDs first. Lists are accepted for multi-value attributes. |
+
+---
+
+### Update Asset Object
+
+Update an existing Jira Assets object.
+
+<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
+| `attributes` | `object` | Yes | Mapping of attribute ID (as string) to new value. Only the supplied attributes are sent; other attributes are not included in the request. |
+
+---

--- a/docs/tools/jira-assets.mdx
+++ b/docs/tools/jira-assets.mdx
@@ -1,122 +1,19 @@
 ---
 title: "Jira Assets"
-description: "Assets (Insight) schemas, object types, objects, and AQL search on Server/Data Center"
+description: "Consolidated Assets (Insight) discovery on Server/Data Center"
 ---
 
-### List Asset Schemas
+### Discover Jira Resources
 
-List Jira Assets (Insight) object schemas.
+Discover Jira Assets schemas, object types, or attributes.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name_filter` | `string` | No | Optional case-insensitive substring to filter schemas by name. Leave empty to list all schemas. |
-
----
-
-### List Asset Object Types
-
-List the object types within an Assets object schema.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `schema_id` | `string` | Yes | Object schema ID (e.g., '3'), from list_asset_schemas |
-
----
-
-### Get Asset Object Type Attributes
-
-Get attribute definitions for an Assets object type.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `object_type_id` | `string` | Yes | Object type ID (e.g., '42') |
-
----
-
-### Search Assets with AQL
-
-Search Jira Assets objects using AQL (Assets Query Language).
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `aql` | `string` | Yes | AQL/IQL query string. Examples: objectType = "Person"; objectType = "Hardware" AND "Status" = "Active"; "Assigned To" IS EMPTY |
-| `page` | `integer` | No | 1-based page number |
-| `results_per_page` | `integer` | No | Results per page (1-100) |
-| `include_attributes` | `boolean` | No | Include attribute values in results |
-| `schema_id` | `string` | No | Optional object schema ID to restrict the search to (from jira_list_asset_schemas). Leave empty to search all schemas. |
-
----
-
-### Get Asset Object
-
-Get a single Assets object with its resolved attribute values.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
-
----
-
-### Get Asset Object History
-
-Get the change history for an Assets object.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
-
----
-
-### Get Asset Connected Tickets
-
-Get Jira issues connected to an Assets object.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
-
----
-
-### Create Asset Object
-
-Create a new Jira Assets object.
-
-<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `object_type_id` | `string` | Yes | Object type ID to create the object under |
-| `attributes` | `object` | Yes | Mapping of attribute ID (as string) to value, e.g. `{"142": "Jane Doe", "143": "jane.doe@example.com"}`. Use jira_get_asset_object_type_attributes to resolve attribute names to IDs first. Lists are accepted for multi-value attributes. |
-
----
-
-### Update Asset Object
-
-Update an existing Jira Assets object.
-
-<Note>This is a **write** tool. Disabled when `READ_ONLY_MODE=true`.</Note>
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `object_id` | `string` | Yes | Object ID (e.g., '1234') or object key (e.g., 'HW-42') |
-| `attributes` | `object` | Yes | Mapping of attribute ID (as string) to new value. Only the supplied attributes are sent; other attributes are not included in the request. |
+| `resource` | `string` | Yes | Resource to discover: asset_schemas, asset_object_types, or asset_attributes. |
+| `schema_id` | `string` | No | Object schema ID required when resource=asset_object_types. |
+| `object_type_id` | `string` | No | Object type ID required when resource=asset_attributes. |
+| `name_filter` | `string` | No | Optional case-insensitive name filter for schemas or object types. |
 
 ---

--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -17,7 +17,7 @@ Get details of a specific Jira issue.
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
-| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response, avoiding extra tool calls. Supported: all, remote_links, transitions, watchers, changelog, comments, worklogs |
+| `include` | `string` | No | (Optional) Comma-separated sections to inline in the response, avoiding extra tool calls. Supported: all, remote_links, transitions, watchers, changelog, comments, worklogs, assets (Assets is Server/Data Center only) |
 | `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The 'names' expansion is added automatically. Standard fields are unaffected. |
 **Example:**
 
@@ -32,7 +32,7 @@ Set `use_display_names: true` to get human-readable keys for custom fields inste
 </Tip>
 
 <Warning>
-Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs.
+Custom field IDs differ between Cloud and Server/DC. Use `jira_search_fields` to discover field IDs. The `assets` include is available only on Jira Service Management Server/Data Center and returns up to 100 objects connected to the issue.
 </Warning>
 
 ---

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -110,15 +110,7 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
         "jira_get_issues_development_info",
     ],
     "jira-assets": [
-        "jira_list_asset_schemas",
-        "jira_list_asset_object_types",
-        "jira_get_asset_object_type_attributes",
-        "jira_search_assets",
-        "jira_get_asset_object",
-        "jira_get_asset_object_history",
-        "jira_get_asset_connected_tickets",
-        "jira_create_asset_object",
-        "jira_update_asset_object",
+        "jira_discover",
     ],
     "confluence-pages": [
         "confluence_get_page",
@@ -208,8 +200,7 @@ CATEGORY_META: dict[str, dict[str, str]] = {
     "jira-assets": {
         "title": "Jira Assets",
         "description": (
-            "Assets (Insight) schemas, object types, objects, and AQL search "
-            "on Server/Data Center"
+            "Consolidated Assets (Insight) discovery on Server/Data Center"
         ),
     },
     "confluence-pages": {

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -109,6 +109,17 @@ CATEGORY_TOOLS: dict[str, list[str]] = {
         "jira_get_issue_development_info",
         "jira_get_issues_development_info",
     ],
+    "jira-assets": [
+        "jira_list_asset_schemas",
+        "jira_list_asset_object_types",
+        "jira_get_asset_object_type_attributes",
+        "jira_search_assets",
+        "jira_get_asset_object",
+        "jira_get_asset_object_history",
+        "jira_get_asset_connected_tickets",
+        "jira_create_asset_object",
+        "jira_update_asset_object",
+    ],
     "confluence-pages": [
         "confluence_get_page",
         "confluence_create_page",
@@ -193,6 +204,13 @@ CATEGORY_META: dict[str, dict[str, str]] = {
     "jira-forms-metrics": {
         "title": "Jira Forms & Metrics",
         "description": ("ProForma forms, SLA metrics, dates, and development info"),
+    },
+    "jira-assets": {
+        "title": "Jira Assets",
+        "description": (
+            "Assets (Insight) schemas, object types, objects, and AQL search "
+            "on Server/Data Center"
+        ),
     },
     "confluence-pages": {
         "title": "Confluence Pages",

--- a/scripts/templates/tools_reference.mdx.j2
+++ b/scripts/templates/tools_reference.mdx.j2
@@ -33,7 +33,7 @@ MCP Atlassian provides **{{ counts.total_tools }} tools** for interacting with J
     ProForma forms, SLA, dates, development info
   </Card>
   <Card title="Assets" icon="boxes-stacked" href="/docs/tools/jira-assets">
-    Assets (Insight) schemas, objects, AQL search (Server/DC)
+    Consolidated Assets discovery (Server/DC)
   </Card>
 </CardGroup>
 

--- a/scripts/templates/tools_reference.mdx.j2
+++ b/scripts/templates/tools_reference.mdx.j2
@@ -32,6 +32,9 @@ MCP Atlassian provides **{{ counts.total_tools }} tools** for interacting with J
   <Card title="Forms & Metrics" icon="chart-line" href="/docs/tools/jira-forms-metrics">
     ProForma forms, SLA, dates, development info
   </Card>
+  <Card title="Assets" icon="boxes-stacked" href="/docs/tools/jira-assets">
+    Assets (Insight) schemas, objects, AQL search (Server/DC)
+  </Card>
 </CardGroup>
 
 ## Confluence Tools

--- a/src/mcp_atlassian/jira/__init__.py
+++ b/src/mcp_atlassian/jira/__init__.py
@@ -8,6 +8,7 @@ This module provides various Jira API client implementations.
 # Re-export the Jira class for backward compatibility
 from atlassian.jira import Jira
 
+from .assets import AssetsMixin
 from .attachments import AttachmentsMixin
 from .boards import BoardsMixin
 from .client import JiraClient
@@ -37,6 +38,7 @@ from .worklog import WorklogMixin
 
 class JiraFetcher(
     ProjectsMixin,
+    AssetsMixin,
     FieldsMixin,
     FieldOptionsMixin,
     FormsApiMixin,  # Use new Forms REST API instead of FormsMixin
@@ -82,6 +84,7 @@ class JiraFetcher(
     - MetricsMixin: Issue metrics and date operations
     - QueuesMixin: Service Desk queue read operations (Server/DC)
     - SLAMixin: SLA calculations
+    - AssetsMixin: Jira Assets (Insight) operations (Server/DC)
 
     The class structure is designed to maintain backward compatibility while
     improving code organization and maintainability.
@@ -91,6 +94,7 @@ class JiraFetcher(
 
 
 __all__ = [
+    "AssetsMixin",
     "JiraFetcher",
     "JiraConfig",
     "JiraClient",

--- a/src/mcp_atlassian/jira/assets.py
+++ b/src/mcp_atlassian/jira/assets.py
@@ -1,19 +1,4 @@
-"""Module for Jira Assets (Insight) operations on Server/Data Center.
-
-Wraps the Insight/Assets REST API exposed by Jira Service Management
-Data Center. This is a DIFFERENT API surface from Jira Cloud's native
-Assets API (workspace-scoped, served from
-api.atlassian.com/jsm/assets/workspace/{workspaceId}/v1).
-
-Base path is configurable because Atlassian renamed the app (JSM 5.3):
-  - JSM DC >= 5.3 / Assets app:      rest/assets/1.0   (documented, default)
-  - JSM DC <= 5.2 / Insight app:     rest/insight/1.0  (legacy)
-
-Set JIRA_ASSETS_API_BASE to override (read into JiraConfig.assets_api_base).
-The object search endpoint follows the base path: the Assets API serves
-``aql/objects?qlQuery=`` while the legacy Insight API serves
-``iql/objects?iql=``. Everything else is identical between the two.
-"""
+"""Jira Assets (Insight) discovery for Server/Data Center."""
 
 import logging
 from typing import Any
@@ -27,11 +12,11 @@ __all__ = ["DEFAULT_ASSETS_API_BASE", "AssetsMixin"]
 
 
 class AssetsMixin(JiraClient):
-    """Mixin for Jira Assets / Insight operations (Server/Data Center)."""
+    """Mixin for the Server/Data Center Assets discovery API."""
 
     @property
     def _assets_base(self) -> str:
-        """Return the Assets/Insight REST base path, without trailing slash."""
+        """Return the Assets/Insight REST base path without a trailing slash."""
         base = getattr(self.config, "assets_api_base", None)
         if not isinstance(base, str) or not base.strip("/"):
             return DEFAULT_ASSETS_API_BASE
@@ -39,11 +24,11 @@ class AssetsMixin(JiraClient):
 
     @property
     def _uses_legacy_insight_api(self) -> bool:
-        """True when the configured base path targets the legacy Insight API."""
+        """Return whether the configured base targets the legacy Insight API."""
         return "insight" in self._assets_base.lower().split("/")
 
     def _ensure_server_mode(self) -> None:
-        """Assets endpoints here target Server/Data Center only."""
+        """Reject this Data Center API surface when configured for Jira Cloud."""
         if self.config.is_cloud:
             raise NotImplementedError(
                 "This Assets implementation targets the Insight/Assets REST API "
@@ -52,30 +37,20 @@ class AssetsMixin(JiraClient):
             )
 
     def _assets_get(self, path: str, params: dict[str, Any] | None = None) -> Any:
-        """GET against the Assets API."""
+        """Send a GET request to the configured Assets API."""
         self._ensure_server_mode()
         return self.jira.get(f"{self._assets_base}/{path.lstrip('/')}", params=params)
 
-    def _assets_post(self, path: str, json_body: dict[str, Any]) -> Any:
-        """POST against the Assets API."""
-        self._ensure_server_mode()
-        return self.jira.post(f"{self._assets_base}/{path.lstrip('/')}", data=json_body)
-
-    def _assets_put(self, path: str, json_body: dict[str, Any]) -> Any:
-        """PUT against the Assets API."""
-        self._ensure_server_mode()
-        return self.jira.put(f"{self._assets_base}/{path.lstrip('/')}", data=json_body)
-
-    # ------------------------------------------------------------------
-    # Schema / structure discovery
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _numeric_id(value: str, name: str) -> str:
+        """Normalize and validate an Assets numeric path ID."""
+        normalized = str(value).strip()
+        if not normalized.isdigit():
+            raise ValueError(f"{name} must be a numeric ID")
+        return normalized
 
     def list_asset_schemas(self) -> list[dict[str, Any]]:
-        """List all object schemas visible to the authenticated user.
-
-        Returns:
-            List of simplified schema dicts (id, name, key, description).
-        """
+        """List object schemas visible to the authenticated user."""
         response = self._assets_get("objectschema/list")
         if not isinstance(response, dict):
             logger.error("Unexpected objectschema/list payload: %s", type(response))
@@ -87,418 +62,151 @@ class AssetsMixin(JiraClient):
 
         return [
             {
-                "id": str(s.get("id", "")),
-                "name": s.get("name"),
-                "key": s.get("objectSchemaKey"),
-                "description": s.get("description"),
-                "object_count": s.get("objectCount"),
-                "object_type_count": s.get("objectTypeCount"),
+                "id": str(schema.get("id", "")),
+                "name": schema.get("name"),
+                "key": schema.get("objectSchemaKey"),
+                "description": schema.get("description"),
+                "object_count": schema.get("objectCount"),
+                "object_type_count": schema.get("objectTypeCount"),
             }
-            for s in schemas
-            if isinstance(s, dict)
+            for schema in schemas
+            if isinstance(schema, dict)
         ]
 
     def list_asset_object_types(self, schema_id: str) -> list[dict[str, Any]]:
-        """List object types in a schema as a flat list.
-
-        Args:
-            schema_id: The object schema ID (e.g. '3').
-
-        Returns:
-            List of simplified object type dicts.
-        """
-        if not schema_id or not str(schema_id).strip():
-            raise ValueError("schema_id is required")
-
-        response = self._assets_get(
-            f"objectschema/{str(schema_id).strip()}/objecttypes/flat"
-        )
+        """List the object types in a schema as a flat list."""
+        normalized_id = self._numeric_id(schema_id, "schema_id")
+        response = self._assets_get(f"objectschema/{normalized_id}/objecttypes/flat")
         if not isinstance(response, list):
             logger.error("Unexpected objecttypes/flat payload: %s", type(response))
             return []
 
         return [
             {
-                "id": str(t.get("id", "")),
-                "name": t.get("name"),
-                "description": t.get("description"),
+                "id": str(object_type.get("id", "")),
+                "name": object_type.get("name"),
+                "description": object_type.get("description"),
                 "parent_object_type_id": (
-                    str(t.get("parentObjectTypeId"))
-                    if t.get("parentObjectTypeId") is not None
+                    str(object_type.get("parentObjectTypeId"))
+                    if object_type.get("parentObjectTypeId") is not None
                     else None
                 ),
-                "object_count": t.get("objectCount"),
+                "object_count": object_type.get("objectCount"),
             }
-            for t in response
-            if isinstance(t, dict)
+            for object_type in response
+            if isinstance(object_type, dict)
         ]
 
     def get_asset_object_type_attributes(
         self, object_type_id: str
     ) -> list[dict[str, Any]]:
-        """Get the attribute definitions for an object type.
-
-        This is the schema you need before creating or updating objects,
-        because writes are keyed by numeric attribute ID, not by name.
-
-        Args:
-            object_type_id: The object type ID (e.g. '42').
-
-        Returns:
-            List of attribute definition dicts.
-        """
-        if not object_type_id or not str(object_type_id).strip():
-            raise ValueError("object_type_id is required")
-
-        response = self._assets_get(
-            f"objecttype/{str(object_type_id).strip()}/attributes"
-        )
+        """Get the attribute definitions for an object type."""
+        normalized_id = self._numeric_id(object_type_id, "object_type_id")
+        response = self._assets_get(f"objecttype/{normalized_id}/attributes")
         if not isinstance(response, list):
-            logger.error("Unexpected objecttype attributes payload: %s", type(response))
+            logger.error(
+                "Unexpected object type attributes payload: %s", type(response)
+            )
             return []
 
         results = []
-        for attr in response:
-            if not isinstance(attr, dict):
+        for attribute in response:
+            if not isinstance(attribute, dict):
                 continue
-            ref_type = attr.get("referenceObjectType") or {}
+            reference_type = attribute.get("referenceObjectType") or {}
             results.append(
                 {
-                    "id": str(attr.get("id", "")),
-                    "name": attr.get("name"),
-                    "type": attr.get("type"),
-                    "default_type": (attr.get("defaultType") or {}).get("name"),
-                    "editable": attr.get("editable"),
-                    "required": attr.get("minimumCardinality", 0) > 0,
+                    "id": str(attribute.get("id", "")),
+                    "name": attribute.get("name"),
+                    "type": attribute.get("type"),
+                    "default_type": (attribute.get("defaultType") or {}).get("name"),
+                    "editable": attribute.get("editable"),
+                    "required": attribute.get("minimumCardinality", 0) > 0,
                     "reference_object_type_id": (
-                        str(ref_type.get("id")) if ref_type.get("id") else None
+                        str(reference_type.get("id"))
+                        if reference_type.get("id")
+                        else None
                     ),
-                    "reference_object_type_name": ref_type.get("name"),
+                    "reference_object_type_name": reference_type.get("name"),
                 }
             )
         return results
-
-    # ------------------------------------------------------------------
-    # Object read
-    # ------------------------------------------------------------------
 
     def search_assets_aql(
         self,
         aql: str,
         page: int = 1,
         results_per_page: int = 25,
-        include_attributes: bool = True,
-        schema_id: str | None = None,
     ) -> dict[str, Any]:
-        """Search Assets objects using AQL/IQL.
-
-        Args:
-            aql: The AQL query string, e.g. 'objectType = "Person"
-                AND "Email" LIKE "@example.com"'.
-            page: 1-based page number.
-            results_per_page: Objects per page (1-100 recommended).
-            include_attributes: Whether to return attribute values.
-            schema_id: Optional object schema ID to restrict the search to.
-
-        Returns:
-            Dict with objects list and pagination metadata.
-        """
+        """Search Assets for outcome-oriented Jira issue enrichment."""
         if not aql or not aql.strip():
             raise ValueError("aql query string is required")
 
-        # The Assets API (rest/assets) searches via aql/objects?qlQuery=;
-        # the legacy Insight API (rest/insight) via iql/objects?iql=.
         if self._uses_legacy_insight_api:
-            path, query_param = "iql/objects", "iql"
+            path, query_parameter = "iql/objects", "iql"
         else:
-            path, query_param = "aql/objects", "qlQuery"
+            path, query_parameter = "aql/objects", "qlQuery"
 
         params: dict[str, Any] = {
-            query_param: aql.strip(),
+            query_parameter: aql.strip(),
             "page": max(1, int(page)),
             "resultPerPage": max(1, min(int(results_per_page), 100)),
-            "includeAttributes": str(bool(include_attributes)).lower(),
-            # objectTypeAttributes (attribute names) are only returned when
-            # explicitly requested; without them values would be keyed by ID.
+            "includeAttributes": "true",
             "includeTypeAttributes": "true",
         }
-        if schema_id is not None and str(schema_id).strip():
-            params["objectSchemaId"] = str(schema_id).strip()
-
         response = self._assets_get(path, params=params)
         if not isinstance(response, dict):
             logger.error("Unexpected %s payload: %s", path, type(response))
             return {"objects": [], "total": 0, "page": page}
 
         objects = response.get("objectEntries", [])
-        type_attrs = response.get("objectTypeAttributes", [])
-        attr_names = {
-            str(a.get("id")): a.get("name") for a in type_attrs if isinstance(a, dict)
+        if not isinstance(objects, list):
+            objects = []
+        type_attributes = response.get("objectTypeAttributes", [])
+        if not isinstance(type_attributes, list):
+            type_attributes = []
+        attribute_names = {
+            str(attribute.get("id")): attribute.get("name")
+            for attribute in type_attributes
+            if isinstance(attribute, dict)
         }
 
         return {
             "objects": [
-                self._simplify_object(o, attr_names)
-                for o in objects
-                if isinstance(o, dict)
+                self._simplify_object(obj, attribute_names)
+                for obj in objects
+                if isinstance(obj, dict)
             ],
             "total": response.get("totalFilterCount", len(objects)),
             "page": response.get("pageNumber", page),
-            # In the Insight/Assets API pageObjectSize is the number of objects
-            # per page and pageSize is the total number of pages.
             "page_size": response.get("pageObjectSize"),
             "total_pages": response.get("pageSize"),
         }
 
-    def _resolve_object_id(self, object_id: str) -> str:
-        """Return the numeric object ID for an ID or object key.
-
-        The object endpoints only accept numeric IDs, so an object key
-        (e.g. 'HW-42') is resolved through an AQL lookup first.
-        """
-        if not object_id or not str(object_id).strip():
-            raise ValueError("object_id is required")
-
-        oid = str(object_id).strip()
-        if oid.isdigit():
-            return oid
-        if '"' in oid or "\\" in oid:
-            raise ValueError(f"Invalid object key: {oid!r}")
-
-        result = self.search_assets_aql(
-            f'Key = "{oid}"', results_per_page=1, include_attributes=False
-        )
-        for obj in result.get("objects", []):
-            if obj.get("id"):
-                return str(obj["id"])
-        raise ValueError(f"Assets object not found for key {oid!r}")
-
-    def get_asset_object(self, object_id: str) -> dict[str, Any]:
-        """Get a single Assets object with its attributes.
-
-        Args:
-            object_id: The object ID (e.g. '1234') or object key (e.g. 'HW-42').
-
-        Returns:
-            Simplified object dict.
-        """
-        oid = self._resolve_object_id(object_id)
-        obj = self._assets_get(f"object/{oid}")
-        if not isinstance(obj, dict):
-            logger.error("Unexpected object payload: %s", type(obj))
-            return {}
-
-        # The object response normally embeds each attribute's definition
-        # (objectTypeAttribute.name). Fall back to the object type definition
-        # only when a name is missing.
-        attr_names: dict[str, str] = {}
-        object_type = obj.get("objectType") or {}
-        type_id = object_type.get("id")
-        if type_id is not None and not self._attribute_names_embedded(obj):
-            try:
-                defs = self.get_asset_object_type_attributes(str(type_id))
-                attr_names = {d["id"]: d["name"] for d in defs if d.get("id")}
-            except Exception as e:  # noqa: BLE001 - degrade gracefully
-                logger.warning(
-                    "Could not resolve attribute names for object type %s: %s",
-                    type_id,
-                    e,
-                )
-
-        return self._simplify_object(obj, attr_names)
-
-    def get_asset_object_history(self, object_id: str) -> list[dict[str, Any]]:
-        """Get the change history for an Assets object.
-
-        Args:
-            object_id: The object ID or object key.
-
-        Returns:
-            List of history entry dicts.
-        """
-        oid = self._resolve_object_id(object_id)
-        response = self._assets_get(f"object/{oid}/history")
-        if not isinstance(response, list):
-            return []
-
-        return [
-            {
-                "id": str(h.get("id", "")),
-                "actor": (h.get("actor") or {}).get("displayName"),
-                "created": h.get("created"),
-                "type": h.get("type"),
-                "affected_attribute": h.get("affectedAttribute"),
-                "old_value": h.get("oldValue"),
-                "new_value": h.get("newValue"),
-            }
-            for h in response
-            if isinstance(h, dict)
-        ]
-
-    def get_asset_object_connected_tickets(self, object_id: str) -> dict[str, Any]:
-        """Get Jira issues connected to an Assets object.
-
-        Args:
-            object_id: The object ID or object key.
-
-        Returns:
-            Dict with connected ticket data.
-        """
-        oid = self._resolve_object_id(object_id)
-        response = self._assets_get(f"objectconnectedtickets/{oid}/tickets")
-        if not isinstance(response, dict):
-            return {"tickets": []}
-        return response
-
-    # ------------------------------------------------------------------
-    # Object write
-    # ------------------------------------------------------------------
-
-    def create_asset_object(
-        self,
-        object_type_id: str,
-        attributes: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Create a new Assets object.
-
-        Args:
-            object_type_id: The object type ID to create under.
-            attributes: Mapping of attribute ID (as string) to value, e.g.
-                {"142": "Jane Doe", "143": "jane.doe@example.com"}.
-                Use get_asset_object_type_attributes() to resolve names to IDs.
-
-        Returns:
-            Simplified created object dict.
-        """
-        if not object_type_id or not str(object_type_id).strip():
-            raise ValueError("object_type_id is required")
-        if not attributes:
-            raise ValueError("attributes mapping is required")
-
-        payload = {
-            "objectTypeId": str(object_type_id).strip(),
-            "attributes": self._build_attribute_payload(attributes),
-        }
-
-        result = self._assets_post("object/create", payload)
-        if not isinstance(result, dict):
-            logger.error("Unexpected create response: %s", type(result))
-            return {}
-        return self._simplify_object(result, {})
-
-    def update_asset_object(
-        self,
-        object_id: str,
-        attributes: dict[str, Any],
-        object_type_id: str | None = None,
-    ) -> dict[str, Any]:
-        """Update an existing Assets object.
-
-        Only the supplied attributes are sent. The REST reference does not
-        state how omitted attributes are treated; in practice Insight leaves
-        them unchanged.
-
-        The documented update request body carries the object's type ID
-        alongside the attributes. When it is not supplied it is read from
-        the object itself first.
-
-        Args:
-            object_id: The object ID or object key to update.
-            attributes: Mapping of attribute ID (as string) to new value.
-            object_type_id: The object's type ID. Looked up when omitted.
-
-        Returns:
-            Simplified updated object dict.
-        """
-        if not attributes:
-            raise ValueError("attributes mapping is required")
-
-        oid = self._resolve_object_id(object_id)
-        payload: dict[str, Any] = {
-            "attributes": self._build_attribute_payload(attributes)
-        }
-
-        type_id = str(object_type_id).strip() if object_type_id else ""
-        if not type_id:
-            current = self._assets_get(f"object/{oid}")
-            if isinstance(current, dict):
-                found = (current.get("objectType") or {}).get("id")
-                type_id = str(found) if found is not None else ""
-        if type_id:
-            payload["objectTypeId"] = type_id
-        else:
-            logger.warning(
-                "Could not determine object type for object %s; sending update "
-                "without objectTypeId",
-                oid,
-            )
-
-        result = self._assets_put(f"object/{oid}", payload)
-        if not isinstance(result, dict):
-            logger.error("Unexpected update response: %s", type(result))
-            return {}
-        return self._simplify_object(result, {})
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _build_attribute_payload(
-        attributes: dict[str, Any],
-    ) -> list[dict[str, Any]]:
-        """Convert a flat {attr_id: value} mapping to the Insight write format.
-
-        Values may be scalars or lists (for multi-value attributes).
-        """
-        payload = []
-        for attr_id, value in attributes.items():
-            values = value if isinstance(value, list) else [value]
-            payload.append(
-                {
-                    "objectTypeAttributeId": str(attr_id),
-                    "objectAttributeValues": [
-                        {"value": "" if v is None else str(v)} for v in values
-                    ],
-                }
-            )
-        return payload
-
-    @staticmethod
-    def _attribute_names_embedded(obj: dict[str, Any]) -> bool:
-        """Return True when every attribute carries its definition name."""
-        for attr in obj.get("attributes", []) or []:
-            if not isinstance(attr, dict):
-                continue
-            if not (attr.get("objectTypeAttribute") or {}).get("name"):
-                return False
-        return True
-
     @staticmethod
     def _simplify_object(
-        obj: dict[str, Any], attr_names: dict[str, str]
+        obj: dict[str, Any], attribute_names: dict[str, str]
     ) -> dict[str, Any]:
-        """Flatten an Insight object response into a readable dict."""
+        """Flatten an Assets object response into a readable dictionary."""
         object_type = obj.get("objectType") or {}
-
         attributes: dict[str, Any] = {}
-        for attr in obj.get("attributes", []) or []:
-            if not isinstance(attr, dict):
+        for attribute in obj.get("attributes", []) or []:
+            if not isinstance(attribute, dict):
                 continue
-            attr_id = str(attr.get("objectTypeAttributeId", ""))
-            # Prefer the name embedded in the response when present,
-            # otherwise fall back to the resolved lookup table.
-            embedded = attr.get("objectTypeAttribute") or {}
-            name = embedded.get("name") or attr_names.get(attr_id) or attr_id
+            attribute_id = str(attribute.get("objectTypeAttributeId", ""))
+            embedded = attribute.get("objectTypeAttribute") or {}
+            name = (
+                embedded.get("name")
+                or attribute_names.get(attribute_id)
+                or attribute_id
+            )
 
             values = []
-            for v in attr.get("objectAttributeValues", []) or []:
-                if not isinstance(v, dict):
+            for value in attribute.get("objectAttributeValues", []) or []:
+                if not isinstance(value, dict):
                     continue
-                # Referenced objects carry a nested object; scalars carry
-                # displayValue or value.
-                referenced = v.get("referencedObject")
-                if referenced and isinstance(referenced, dict):
+                referenced = value.get("referencedObject")
+                if isinstance(referenced, dict):
                     values.append(
                         {
                             "id": str(referenced.get("id", "")),
@@ -507,7 +215,7 @@ class AssetsMixin(JiraClient):
                         }
                     )
                 else:
-                    values.append(v.get("displayValue", v.get("value")))
+                    values.append(value.get("displayValue", value.get("value")))
 
             if len(values) == 1:
                 attributes[name] = values[0]

--- a/src/mcp_atlassian/jira/assets.py
+++ b/src/mcp_atlassian/jira/assets.py
@@ -1,0 +1,528 @@
+"""Module for Jira Assets (Insight) operations on Server/Data Center.
+
+Wraps the Insight/Assets REST API exposed by Jira Service Management
+Data Center. This is a DIFFERENT API surface from Jira Cloud's native
+Assets API (workspace-scoped, served from
+api.atlassian.com/jsm/assets/workspace/{workspaceId}/v1).
+
+Base path is configurable because Atlassian renamed the app (JSM 5.3):
+  - JSM DC >= 5.3 / Assets app:      rest/assets/1.0   (documented, default)
+  - JSM DC <= 5.2 / Insight app:     rest/insight/1.0  (legacy)
+
+Set JIRA_ASSETS_API_BASE to override (read into JiraConfig.assets_api_base).
+The object search endpoint follows the base path: the Assets API serves
+``aql/objects?qlQuery=`` while the legacy Insight API serves
+``iql/objects?iql=``. Everything else is identical between the two.
+"""
+
+import logging
+from typing import Any
+
+from .client import JiraClient
+from .config import DEFAULT_ASSETS_API_BASE
+
+logger = logging.getLogger("mcp-jira")
+
+__all__ = ["DEFAULT_ASSETS_API_BASE", "AssetsMixin"]
+
+
+class AssetsMixin(JiraClient):
+    """Mixin for Jira Assets / Insight operations (Server/Data Center)."""
+
+    @property
+    def _assets_base(self) -> str:
+        """Return the Assets/Insight REST base path, without trailing slash."""
+        base = getattr(self.config, "assets_api_base", None)
+        if not isinstance(base, str) or not base.strip("/"):
+            return DEFAULT_ASSETS_API_BASE
+        return base.strip().strip("/")
+
+    @property
+    def _uses_legacy_insight_api(self) -> bool:
+        """True when the configured base path targets the legacy Insight API."""
+        return "insight" in self._assets_base.lower().split("/")
+
+    def _ensure_server_mode(self) -> None:
+        """Assets endpoints here target Server/Data Center only."""
+        if self.config.is_cloud:
+            raise NotImplementedError(
+                "This Assets implementation targets the Insight/Assets REST API "
+                "on Jira Server/Data Center. Jira Cloud uses a different "
+                "workspace-scoped Assets API and is not supported here."
+            )
+
+    def _assets_get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        """GET against the Assets API."""
+        self._ensure_server_mode()
+        return self.jira.get(f"{self._assets_base}/{path.lstrip('/')}", params=params)
+
+    def _assets_post(self, path: str, json_body: dict[str, Any]) -> Any:
+        """POST against the Assets API."""
+        self._ensure_server_mode()
+        return self.jira.post(f"{self._assets_base}/{path.lstrip('/')}", data=json_body)
+
+    def _assets_put(self, path: str, json_body: dict[str, Any]) -> Any:
+        """PUT against the Assets API."""
+        self._ensure_server_mode()
+        return self.jira.put(f"{self._assets_base}/{path.lstrip('/')}", data=json_body)
+
+    # ------------------------------------------------------------------
+    # Schema / structure discovery
+    # ------------------------------------------------------------------
+
+    def list_asset_schemas(self) -> list[dict[str, Any]]:
+        """List all object schemas visible to the authenticated user.
+
+        Returns:
+            List of simplified schema dicts (id, name, key, description).
+        """
+        response = self._assets_get("objectschema/list")
+        if not isinstance(response, dict):
+            logger.error("Unexpected objectschema/list payload: %s", type(response))
+            return []
+
+        schemas = response.get("objectschemas", [])
+        if not isinstance(schemas, list):
+            return []
+
+        return [
+            {
+                "id": str(s.get("id", "")),
+                "name": s.get("name"),
+                "key": s.get("objectSchemaKey"),
+                "description": s.get("description"),
+                "object_count": s.get("objectCount"),
+                "object_type_count": s.get("objectTypeCount"),
+            }
+            for s in schemas
+            if isinstance(s, dict)
+        ]
+
+    def list_asset_object_types(self, schema_id: str) -> list[dict[str, Any]]:
+        """List object types in a schema as a flat list.
+
+        Args:
+            schema_id: The object schema ID (e.g. '3').
+
+        Returns:
+            List of simplified object type dicts.
+        """
+        if not schema_id or not str(schema_id).strip():
+            raise ValueError("schema_id is required")
+
+        response = self._assets_get(
+            f"objectschema/{str(schema_id).strip()}/objecttypes/flat"
+        )
+        if not isinstance(response, list):
+            logger.error("Unexpected objecttypes/flat payload: %s", type(response))
+            return []
+
+        return [
+            {
+                "id": str(t.get("id", "")),
+                "name": t.get("name"),
+                "description": t.get("description"),
+                "parent_object_type_id": (
+                    str(t.get("parentObjectTypeId"))
+                    if t.get("parentObjectTypeId") is not None
+                    else None
+                ),
+                "object_count": t.get("objectCount"),
+            }
+            for t in response
+            if isinstance(t, dict)
+        ]
+
+    def get_asset_object_type_attributes(
+        self, object_type_id: str
+    ) -> list[dict[str, Any]]:
+        """Get the attribute definitions for an object type.
+
+        This is the schema you need before creating or updating objects,
+        because writes are keyed by numeric attribute ID, not by name.
+
+        Args:
+            object_type_id: The object type ID (e.g. '42').
+
+        Returns:
+            List of attribute definition dicts.
+        """
+        if not object_type_id or not str(object_type_id).strip():
+            raise ValueError("object_type_id is required")
+
+        response = self._assets_get(
+            f"objecttype/{str(object_type_id).strip()}/attributes"
+        )
+        if not isinstance(response, list):
+            logger.error("Unexpected objecttype attributes payload: %s", type(response))
+            return []
+
+        results = []
+        for attr in response:
+            if not isinstance(attr, dict):
+                continue
+            ref_type = attr.get("referenceObjectType") or {}
+            results.append(
+                {
+                    "id": str(attr.get("id", "")),
+                    "name": attr.get("name"),
+                    "type": attr.get("type"),
+                    "default_type": (attr.get("defaultType") or {}).get("name"),
+                    "editable": attr.get("editable"),
+                    "required": attr.get("minimumCardinality", 0) > 0,
+                    "reference_object_type_id": (
+                        str(ref_type.get("id")) if ref_type.get("id") else None
+                    ),
+                    "reference_object_type_name": ref_type.get("name"),
+                }
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Object read
+    # ------------------------------------------------------------------
+
+    def search_assets_aql(
+        self,
+        aql: str,
+        page: int = 1,
+        results_per_page: int = 25,
+        include_attributes: bool = True,
+        schema_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Search Assets objects using AQL/IQL.
+
+        Args:
+            aql: The AQL query string, e.g. 'objectType = "Person"
+                AND "Email" LIKE "@example.com"'.
+            page: 1-based page number.
+            results_per_page: Objects per page (1-100 recommended).
+            include_attributes: Whether to return attribute values.
+            schema_id: Optional object schema ID to restrict the search to.
+
+        Returns:
+            Dict with objects list and pagination metadata.
+        """
+        if not aql or not aql.strip():
+            raise ValueError("aql query string is required")
+
+        # The Assets API (rest/assets) searches via aql/objects?qlQuery=;
+        # the legacy Insight API (rest/insight) via iql/objects?iql=.
+        if self._uses_legacy_insight_api:
+            path, query_param = "iql/objects", "iql"
+        else:
+            path, query_param = "aql/objects", "qlQuery"
+
+        params: dict[str, Any] = {
+            query_param: aql.strip(),
+            "page": max(1, int(page)),
+            "resultPerPage": max(1, min(int(results_per_page), 100)),
+            "includeAttributes": str(bool(include_attributes)).lower(),
+            # objectTypeAttributes (attribute names) are only returned when
+            # explicitly requested; without them values would be keyed by ID.
+            "includeTypeAttributes": "true",
+        }
+        if schema_id is not None and str(schema_id).strip():
+            params["objectSchemaId"] = str(schema_id).strip()
+
+        response = self._assets_get(path, params=params)
+        if not isinstance(response, dict):
+            logger.error("Unexpected %s payload: %s", path, type(response))
+            return {"objects": [], "total": 0, "page": page}
+
+        objects = response.get("objectEntries", [])
+        type_attrs = response.get("objectTypeAttributes", [])
+        attr_names = {
+            str(a.get("id")): a.get("name") for a in type_attrs if isinstance(a, dict)
+        }
+
+        return {
+            "objects": [
+                self._simplify_object(o, attr_names)
+                for o in objects
+                if isinstance(o, dict)
+            ],
+            "total": response.get("totalFilterCount", len(objects)),
+            "page": response.get("pageNumber", page),
+            # In the Insight/Assets API pageObjectSize is the number of objects
+            # per page and pageSize is the total number of pages.
+            "page_size": response.get("pageObjectSize"),
+            "total_pages": response.get("pageSize"),
+        }
+
+    def _resolve_object_id(self, object_id: str) -> str:
+        """Return the numeric object ID for an ID or object key.
+
+        The object endpoints only accept numeric IDs, so an object key
+        (e.g. 'HW-42') is resolved through an AQL lookup first.
+        """
+        if not object_id or not str(object_id).strip():
+            raise ValueError("object_id is required")
+
+        oid = str(object_id).strip()
+        if oid.isdigit():
+            return oid
+        if '"' in oid or "\\" in oid:
+            raise ValueError(f"Invalid object key: {oid!r}")
+
+        result = self.search_assets_aql(
+            f'Key = "{oid}"', results_per_page=1, include_attributes=False
+        )
+        for obj in result.get("objects", []):
+            if obj.get("id"):
+                return str(obj["id"])
+        raise ValueError(f"Assets object not found for key {oid!r}")
+
+    def get_asset_object(self, object_id: str) -> dict[str, Any]:
+        """Get a single Assets object with its attributes.
+
+        Args:
+            object_id: The object ID (e.g. '1234') or object key (e.g. 'HW-42').
+
+        Returns:
+            Simplified object dict.
+        """
+        oid = self._resolve_object_id(object_id)
+        obj = self._assets_get(f"object/{oid}")
+        if not isinstance(obj, dict):
+            logger.error("Unexpected object payload: %s", type(obj))
+            return {}
+
+        # The object response normally embeds each attribute's definition
+        # (objectTypeAttribute.name). Fall back to the object type definition
+        # only when a name is missing.
+        attr_names: dict[str, str] = {}
+        object_type = obj.get("objectType") or {}
+        type_id = object_type.get("id")
+        if type_id is not None and not self._attribute_names_embedded(obj):
+            try:
+                defs = self.get_asset_object_type_attributes(str(type_id))
+                attr_names = {d["id"]: d["name"] for d in defs if d.get("id")}
+            except Exception as e:  # noqa: BLE001 - degrade gracefully
+                logger.warning(
+                    "Could not resolve attribute names for object type %s: %s",
+                    type_id,
+                    e,
+                )
+
+        return self._simplify_object(obj, attr_names)
+
+    def get_asset_object_history(self, object_id: str) -> list[dict[str, Any]]:
+        """Get the change history for an Assets object.
+
+        Args:
+            object_id: The object ID or object key.
+
+        Returns:
+            List of history entry dicts.
+        """
+        oid = self._resolve_object_id(object_id)
+        response = self._assets_get(f"object/{oid}/history")
+        if not isinstance(response, list):
+            return []
+
+        return [
+            {
+                "id": str(h.get("id", "")),
+                "actor": (h.get("actor") or {}).get("displayName"),
+                "created": h.get("created"),
+                "type": h.get("type"),
+                "affected_attribute": h.get("affectedAttribute"),
+                "old_value": h.get("oldValue"),
+                "new_value": h.get("newValue"),
+            }
+            for h in response
+            if isinstance(h, dict)
+        ]
+
+    def get_asset_object_connected_tickets(self, object_id: str) -> dict[str, Any]:
+        """Get Jira issues connected to an Assets object.
+
+        Args:
+            object_id: The object ID or object key.
+
+        Returns:
+            Dict with connected ticket data.
+        """
+        oid = self._resolve_object_id(object_id)
+        response = self._assets_get(f"objectconnectedtickets/{oid}/tickets")
+        if not isinstance(response, dict):
+            return {"tickets": []}
+        return response
+
+    # ------------------------------------------------------------------
+    # Object write
+    # ------------------------------------------------------------------
+
+    def create_asset_object(
+        self,
+        object_type_id: str,
+        attributes: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Create a new Assets object.
+
+        Args:
+            object_type_id: The object type ID to create under.
+            attributes: Mapping of attribute ID (as string) to value, e.g.
+                {"142": "Jane Doe", "143": "jane.doe@example.com"}.
+                Use get_asset_object_type_attributes() to resolve names to IDs.
+
+        Returns:
+            Simplified created object dict.
+        """
+        if not object_type_id or not str(object_type_id).strip():
+            raise ValueError("object_type_id is required")
+        if not attributes:
+            raise ValueError("attributes mapping is required")
+
+        payload = {
+            "objectTypeId": str(object_type_id).strip(),
+            "attributes": self._build_attribute_payload(attributes),
+        }
+
+        result = self._assets_post("object/create", payload)
+        if not isinstance(result, dict):
+            logger.error("Unexpected create response: %s", type(result))
+            return {}
+        return self._simplify_object(result, {})
+
+    def update_asset_object(
+        self,
+        object_id: str,
+        attributes: dict[str, Any],
+        object_type_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing Assets object.
+
+        Only the supplied attributes are sent. The REST reference does not
+        state how omitted attributes are treated; in practice Insight leaves
+        them unchanged.
+
+        The documented update request body carries the object's type ID
+        alongside the attributes. When it is not supplied it is read from
+        the object itself first.
+
+        Args:
+            object_id: The object ID or object key to update.
+            attributes: Mapping of attribute ID (as string) to new value.
+            object_type_id: The object's type ID. Looked up when omitted.
+
+        Returns:
+            Simplified updated object dict.
+        """
+        if not attributes:
+            raise ValueError("attributes mapping is required")
+
+        oid = self._resolve_object_id(object_id)
+        payload: dict[str, Any] = {
+            "attributes": self._build_attribute_payload(attributes)
+        }
+
+        type_id = str(object_type_id).strip() if object_type_id else ""
+        if not type_id:
+            current = self._assets_get(f"object/{oid}")
+            if isinstance(current, dict):
+                found = (current.get("objectType") or {}).get("id")
+                type_id = str(found) if found is not None else ""
+        if type_id:
+            payload["objectTypeId"] = type_id
+        else:
+            logger.warning(
+                "Could not determine object type for object %s; sending update "
+                "without objectTypeId",
+                oid,
+            )
+
+        result = self._assets_put(f"object/{oid}", payload)
+        if not isinstance(result, dict):
+            logger.error("Unexpected update response: %s", type(result))
+            return {}
+        return self._simplify_object(result, {})
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_attribute_payload(
+        attributes: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Convert a flat {attr_id: value} mapping to the Insight write format.
+
+        Values may be scalars or lists (for multi-value attributes).
+        """
+        payload = []
+        for attr_id, value in attributes.items():
+            values = value if isinstance(value, list) else [value]
+            payload.append(
+                {
+                    "objectTypeAttributeId": str(attr_id),
+                    "objectAttributeValues": [
+                        {"value": "" if v is None else str(v)} for v in values
+                    ],
+                }
+            )
+        return payload
+
+    @staticmethod
+    def _attribute_names_embedded(obj: dict[str, Any]) -> bool:
+        """Return True when every attribute carries its definition name."""
+        for attr in obj.get("attributes", []) or []:
+            if not isinstance(attr, dict):
+                continue
+            if not (attr.get("objectTypeAttribute") or {}).get("name"):
+                return False
+        return True
+
+    @staticmethod
+    def _simplify_object(
+        obj: dict[str, Any], attr_names: dict[str, str]
+    ) -> dict[str, Any]:
+        """Flatten an Insight object response into a readable dict."""
+        object_type = obj.get("objectType") or {}
+
+        attributes: dict[str, Any] = {}
+        for attr in obj.get("attributes", []) or []:
+            if not isinstance(attr, dict):
+                continue
+            attr_id = str(attr.get("objectTypeAttributeId", ""))
+            # Prefer the name embedded in the response when present,
+            # otherwise fall back to the resolved lookup table.
+            embedded = attr.get("objectTypeAttribute") or {}
+            name = embedded.get("name") or attr_names.get(attr_id) or attr_id
+
+            values = []
+            for v in attr.get("objectAttributeValues", []) or []:
+                if not isinstance(v, dict):
+                    continue
+                # Referenced objects carry a nested object; scalars carry
+                # displayValue or value.
+                referenced = v.get("referencedObject")
+                if referenced and isinstance(referenced, dict):
+                    values.append(
+                        {
+                            "id": str(referenced.get("id", "")),
+                            "label": referenced.get("label"),
+                            "object_key": referenced.get("objectKey"),
+                        }
+                    )
+                else:
+                    values.append(v.get("displayValue", v.get("value")))
+
+            if len(values) == 1:
+                attributes[name] = values[0]
+            elif values:
+                attributes[name] = values
+
+        return {
+            "id": str(obj.get("id", "")),
+            "object_key": obj.get("objectKey"),
+            "label": obj.get("label"),
+            "object_type_id": (
+                str(object_type.get("id")) if object_type.get("id") else None
+            ),
+            "object_type_name": object_type.get("name"),
+            "created": obj.get("created"),
+            "updated": obj.get("updated"),
+            "attributes": attributes,
+        }

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -39,6 +39,19 @@ def normalize_project_key(raw: str) -> str:
     return raw.translate(_INVISIBLE_CHARS).strip().upper()
 
 
+DEFAULT_ASSETS_API_BASE = "rest/assets/1.0"
+
+
+def _parse_assets_api_base(raw: str | None) -> str:
+    """Normalize JIRA_ASSETS_API_BASE to a base path without surrounding slashes.
+
+    Unset, empty, or slash-only values fall back to the default.
+    """
+    if raw is None:
+        return DEFAULT_ASSETS_API_BASE
+    return raw.strip().strip("/") or DEFAULT_ASSETS_API_BASE
+
+
 def _parse_internal_only_projects(raw: str | None) -> frozenset[str]:
     """Parse JIRA_INTERNAL_ONLY_PROJECTS into a set of normalized project keys.
 
@@ -191,6 +204,9 @@ class JiraConfig:
     )  # Project keys where jira_add_comment/jira_edit_comment enforce
     # internal-only (non-customer-visible) comments. See
     # JIRA_INTERNAL_ONLY_PROJECTS. Empty by default (guard disabled).
+    assets_api_base: str = DEFAULT_ASSETS_API_BASE  # Assets/Insight REST base
+    # path on Server/DC (rest/assets/1.0, or rest/insight/1.0 on legacy
+    # Insight installs). See JIRA_ASSETS_API_BASE.
 
     @property
     def is_cloud(self) -> bool:
@@ -337,6 +353,9 @@ class JiraConfig:
             os.getenv("JIRA_INTERNAL_ONLY_PROJECTS")
         )
 
+        # Assets (Insight) REST base path, Server/DC only
+        assets_api_base = _parse_assets_api_base(os.getenv("JIRA_ASSETS_API_BASE"))
+
         # Proxy settings
         proxy_settings = get_proxy_settings_from_env("JIRA")
 
@@ -382,6 +401,7 @@ class JiraConfig:
             client_key_password=client_key_password,
             timeout=timeout,
             internal_only_projects=internal_only_projects,
+            assets_api_base=assets_api_base,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -4,7 +4,7 @@ import asyncio
 import base64
 import json
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context
 from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent
@@ -60,6 +60,7 @@ _GET_ISSUE_INCLUDE_SECTIONS = frozenset(
         "changelog",
         "comments",
         "worklogs",
+        "assets",
     }
 )
 _GET_ISSUE_INCLUDE_OUTPUT_KEYS: dict[str, str] = {
@@ -69,6 +70,7 @@ _GET_ISSUE_INCLUDE_OUTPUT_KEYS: dict[str, str] = {
     "changelog": "changelogs",
     "comments": "comments",
     "worklogs": "worklogs",
+    "assets": "assets",
 }
 _GET_ISSUE_INCLUDE_ALIASES = {
     "comment": "comments",
@@ -636,7 +638,8 @@ async def get_issue(
                 "(Optional) Comma-separated sections to inline "
                 "in the response, avoiding extra tool calls. "
                 "Supported: all, remote_links, transitions, "
-                "watchers, changelog, comments, worklogs"
+                "watchers, changelog, comments, worklogs, assets "
+                "(Assets is Server/Data Center only)"
             ),
             default=None,
         ),
@@ -658,7 +661,7 @@ async def get_issue(
 
     Includes Epic links and relationship information. Use the
     ``include`` parameter to inline enrichments (remote_links,
-    transitions, watchers, changelog, comments, worklogs) so that
+    transitions, watchers, changelog, comments, worklogs, assets) so that
     separate tool calls are not needed.
 
     Args:
@@ -746,6 +749,18 @@ async def get_issue(
             result["worklogs"] = jira.get_worklogs(issue_key)
         except Exception:  # noqa: BLE001
             result["worklogs"] = []
+
+    if "assets" in include_sections:
+        result["assets"] = []
+        if not jira.config.is_cloud:
+            try:
+                asset_result = jira.search_assets_aql(
+                    f'object HAVING connectedTickets(key = "{issue_key}")',
+                    results_per_page=100,
+                )
+                result["assets"] = asset_result["objects"]
+            except Exception:  # noqa: BLE001
+                result["assets"] = []
 
     return json.dumps(result, indent=2, ensure_ascii=False)
 
@@ -4686,368 +4701,104 @@ async def get_cross_project_dependencies(
 
 
 # ----------------------------------------------------------------------
-# Jira Assets (Insight) — Server/Data Center only
-# ----------------------------------------------------------------------
-
-
-# ----------------------------------------------------------------------
-# Discovery
+# Jira Assets (Insight) discovery — Server/Data Center only
 # ----------------------------------------------------------------------
 
 
 @jira_mcp.tool(
     tags={"jira", "read", "toolset:jira_assets", "server_only"},
-    annotations={"title": "List Asset Schemas", "readOnlyHint": True},
+    annotations={"title": "Discover Jira Resources", "readOnlyHint": True},
 )
-async def list_asset_schemas(
+async def discover(
     ctx: Context,
+    resource: Annotated[
+        Literal[
+            "asset_schemas",
+            "asset_object_types",
+            "asset_attributes",
+        ],
+        Field(
+            description=(
+                "Resource to discover: asset_schemas, asset_object_types, "
+                "or asset_attributes."
+            )
+        ),
+    ],
+    schema_id: Annotated[
+        str | None,
+        Field(
+            description=("Object schema ID required when resource=asset_object_types."),
+            default=None,
+        ),
+    ] = None,
+    object_type_id: Annotated[
+        str | None,
+        Field(
+            description=("Object type ID required when resource=asset_attributes."),
+            default=None,
+        ),
+    ] = None,
     name_filter: Annotated[
         str,
         Field(
             description=(
-                "Optional case-insensitive substring to filter schemas by name. "
-                "Leave empty to list all schemas."
+                "Optional case-insensitive name filter for schemas or object types."
             ),
             default="",
         ),
     ] = "",
 ) -> str:
-    """
-    List Jira Assets (Insight) object schemas.
+    """Discover Jira Assets schemas, object types, or attributes.
 
-    Start here when exploring Assets: schemas are the top-level containers
-    that hold object types, which in turn hold objects.
-
-    Server/Data Center only.
-
-    Args:
-        ctx: The FastMCP context.
-        name_filter: Optional substring to filter schema names.
-
-    Returns:
-        JSON string with the list of object schemas.
-    """
-    jira = await get_jira_fetcher(ctx)
-    schemas = jira.list_asset_schemas()
-    if name_filter:
-        needle = name_filter.strip().lower()
-        schemas = [s for s in schemas if needle in str(s.get("name") or "").lower()]
-    return json.dumps({"schemas": schemas}, indent=2, ensure_ascii=False)
-
-
-@jira_mcp.tool(
-    tags={"jira", "read", "toolset:jira_assets", "server_only"},
-    annotations={"title": "List Asset Object Types", "readOnlyHint": True},
-)
-async def list_asset_object_types(
-    ctx: Context,
-    schema_id: Annotated[
-        str,
-        Field(description="Object schema ID (e.g., '3'), from list_asset_schemas"),
-    ],
-) -> str:
-    """
-    List the object types within an Assets object schema.
-
-    Server/Data Center only.
+    This is the consolidated discovery entry point for Assets on Jira Service
+    Management Server/Data Center. Start with asset_schemas, then use the
+    returned schema ID for asset_object_types and an object type ID for
+    asset_attributes.
 
     Args:
         ctx: The FastMCP context.
-        schema_id: The object schema ID.
+        resource: Assets resource kind to discover.
+        schema_id: Schema ID for object-type discovery.
+        object_type_id: Object type ID for attribute discovery.
+        name_filter: Optional name substring for schema or object-type results.
 
     Returns:
-        JSON string with a flat list of object types.
+        JSON string containing the requested discovery results.
     """
     jira = await get_jira_fetcher(ctx)
-    types = jira.list_asset_object_types(schema_id=schema_id)
-    return json.dumps(
-        {"schema_id": schema_id, "object_types": types}, indent=2, ensure_ascii=False
-    )
+    needle = name_filter.strip().lower()
 
+    if resource == "asset_schemas":
+        schemas = jira.list_asset_schemas()
+        if needle:
+            schemas = [
+                schema
+                for schema in schemas
+                if needle in str(schema.get("name") or "").lower()
+            ]
+        result: dict[str, Any] = {"resource": resource, "schemas": schemas}
+    elif resource == "asset_object_types":
+        if not schema_id:
+            raise ValueError("schema_id is required for asset_object_types")
+        object_types = jira.list_asset_object_types(schema_id)
+        if needle:
+            object_types = [
+                object_type
+                for object_type in object_types
+                if needle in str(object_type.get("name") or "").lower()
+            ]
+        result = {
+            "resource": resource,
+            "schema_id": schema_id,
+            "object_types": object_types,
+        }
+    else:
+        if not object_type_id:
+            raise ValueError("object_type_id is required for asset_attributes")
+        result = {
+            "resource": resource,
+            "object_type_id": object_type_id,
+            "attributes": jira.get_asset_object_type_attributes(object_type_id),
+        }
 
-@jira_mcp.tool(
-    tags={"jira", "read", "toolset:jira_assets", "server_only"},
-    annotations={"title": "Get Asset Object Type Attributes", "readOnlyHint": True},
-)
-async def get_asset_object_type_attributes(
-    ctx: Context,
-    object_type_id: Annotated[
-        str,
-        Field(description="Object type ID (e.g., '42')"),
-    ],
-) -> str:
-    """
-    Get attribute definitions for an Assets object type.
-
-    Call this before creating or updating objects: Assets writes are keyed
-    by numeric attribute ID, not by attribute name, and this tool provides
-    the name-to-ID mapping.
-
-    Server/Data Center only.
-
-    Args:
-        ctx: The FastMCP context.
-        object_type_id: The object type ID.
-
-    Returns:
-        JSON string with attribute definitions including IDs, types, and
-        whether each attribute is required or editable.
-    """
-    jira = await get_jira_fetcher(ctx)
-    attrs = jira.get_asset_object_type_attributes(object_type_id=object_type_id)
-    return json.dumps(
-        {"object_type_id": object_type_id, "attributes": attrs},
-        indent=2,
-        ensure_ascii=False,
-    )
-
-
-# ----------------------------------------------------------------------
-# Read
-# ----------------------------------------------------------------------
-
-
-@jira_mcp.tool(
-    tags={"jira", "read", "toolset:jira_assets", "server_only"},
-    annotations={"title": "Search Assets with AQL", "readOnlyHint": True},
-)
-async def search_assets(
-    ctx: Context,
-    aql: Annotated[
-        str,
-        Field(
-            description=(
-                "AQL/IQL query string. Examples: "
-                'objectType = "Person"; '
-                'objectType = "Hardware" AND "Status" = "Active"; '
-                '"Assigned To" IS EMPTY'
-            )
-        ),
-    ],
-    page: Annotated[
-        int,
-        Field(description="1-based page number", default=1, ge=1),
-    ] = 1,
-    results_per_page: Annotated[
-        int,
-        Field(description="Results per page (1-100)", default=25, ge=1, le=100),
-    ] = 25,
-    include_attributes: Annotated[
-        bool,
-        Field(description="Include attribute values in results", default=True),
-    ] = True,
-    schema_id: Annotated[
-        str,
-        Field(
-            description=(
-                "Optional object schema ID to restrict the search to "
-                "(from jira_list_asset_schemas). Leave empty to search all schemas."
-            ),
-            default="",
-        ),
-    ] = "",
-) -> str:
-    """
-    Search Jira Assets objects using AQL (Assets Query Language).
-
-    This is the primary read tool for Assets. Set include_attributes=false
-    for large result sets where only labels and IDs are needed.
-
-    Server/Data Center only.
-
-    Args:
-        ctx: The FastMCP context.
-        aql: The AQL query string.
-        page: 1-based page number.
-        results_per_page: Number of objects per page.
-        include_attributes: Whether to return full attribute values.
-        schema_id: Optional object schema ID to limit the search.
-
-    Returns:
-        JSON string with matching objects and pagination metadata.
-    """
-    jira = await get_jira_fetcher(ctx)
-    result = jira.search_assets_aql(
-        aql=aql,
-        page=page,
-        results_per_page=results_per_page,
-        include_attributes=include_attributes,
-        schema_id=schema_id or None,
-    )
     return json.dumps(result, indent=2, ensure_ascii=False)
-
-
-@jira_mcp.tool(
-    tags={"jira", "read", "toolset:jira_assets", "server_only"},
-    annotations={"title": "Get Asset Object", "readOnlyHint": True},
-)
-async def get_asset_object(
-    ctx: Context,
-    object_id: Annotated[
-        str,
-        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
-    ],
-) -> str:
-    """
-    Get a single Assets object with its resolved attribute values.
-
-    Server/Data Center only.
-
-    Args:
-        ctx: The FastMCP context.
-        object_id: The object ID or object key.
-
-    Returns:
-        JSON string with the object and its attributes.
-    """
-    jira = await get_jira_fetcher(ctx)
-    obj = jira.get_asset_object(object_id=object_id)
-    return json.dumps(obj, indent=2, ensure_ascii=False)
-
-
-@jira_mcp.tool(
-    tags={"jira", "read", "toolset:jira_assets", "server_only"},
-    annotations={"title": "Get Asset Object History", "readOnlyHint": True},
-)
-async def get_asset_object_history(
-    ctx: Context,
-    object_id: Annotated[
-        str,
-        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
-    ],
-) -> str:
-    """
-    Get the change history for an Assets object.
-
-    Useful for auditing: who changed which attribute, when,
-    and what the previous value was.
-
-    Server/Data Center only.
-
-    Args:
-        ctx: The FastMCP context.
-        object_id: The object ID or object key.
-
-    Returns:
-        JSON string with the object's change history entries.
-    """
-    jira = await get_jira_fetcher(ctx)
-    history = jira.get_asset_object_history(object_id=object_id)
-    return json.dumps(
-        {"object_id": object_id, "history": history}, indent=2, ensure_ascii=False
-    )
-
-
-@jira_mcp.tool(
-    tags={"jira", "read", "toolset:jira_assets", "server_only"},
-    annotations={"title": "Get Asset Connected Tickets", "readOnlyHint": True},
-)
-async def get_asset_connected_tickets(
-    ctx: Context,
-    object_id: Annotated[
-        str,
-        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
-    ],
-) -> str:
-    """
-    Get Jira issues connected to an Assets object.
-
-    Server/Data Center only.
-
-    Args:
-        ctx: The FastMCP context.
-        object_id: The object ID or object key.
-
-    Returns:
-        JSON string with connected ticket data.
-    """
-    jira = await get_jira_fetcher(ctx)
-    result = jira.get_asset_object_connected_tickets(object_id=object_id)
-    return json.dumps(result, indent=2, ensure_ascii=False)
-
-
-# ----------------------------------------------------------------------
-# Write
-# ----------------------------------------------------------------------
-
-
-@jira_mcp.tool(
-    tags={"jira", "write", "toolset:jira_assets", "server_only"},
-    annotations={"title": "Create Asset Object", "readOnlyHint": False},
-)
-@check_write_access
-async def create_asset_object(
-    ctx: Context,
-    object_type_id: Annotated[
-        str,
-        Field(description="Object type ID to create the object under"),
-    ],
-    attributes: Annotated[
-        dict,
-        Field(
-            description=(
-                "Mapping of attribute ID (as string) to value, e.g. "
-                '{"142": "Jane Doe", "143": "jane.doe@example.com"}. '
-                "Use jira_get_asset_object_type_attributes to resolve "
-                "attribute names to IDs first. Lists are accepted for "
-                "multi-value attributes."
-            )
-        ),
-    ],
-) -> str:
-    """
-    Create a new Jira Assets object.
-
-    Server/Data Center only. Requires write access (not read-only mode).
-
-    Args:
-        ctx: The FastMCP context.
-        object_type_id: The object type ID.
-        attributes: Attribute ID to value mapping.
-
-    Returns:
-        JSON string with the created object.
-    """
-    jira = await get_jira_fetcher(ctx)
-    obj = jira.create_asset_object(object_type_id=object_type_id, attributes=attributes)
-    return json.dumps(obj, indent=2, ensure_ascii=False)
-
-
-@jira_mcp.tool(
-    tags={"jira", "write", "toolset:jira_assets", "server_only"},
-    annotations={"title": "Update Asset Object", "readOnlyHint": False},
-)
-@check_write_access
-async def update_asset_object(
-    ctx: Context,
-    object_id: Annotated[
-        str,
-        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
-    ],
-    attributes: Annotated[
-        dict,
-        Field(
-            description=(
-                "Mapping of attribute ID (as string) to new value. "
-                "Only the supplied attributes are sent; other attributes "
-                "are not included in the request."
-            )
-        ),
-    ],
-) -> str:
-    """
-    Update an existing Jira Assets object.
-
-    Server/Data Center only. Requires write access (not read-only mode).
-
-    Args:
-        ctx: The FastMCP context.
-        object_id: The object ID or object key.
-        attributes: Attribute ID to new value mapping.
-
-    Returns:
-        JSON string with the updated object.
-    """
-    jira = await get_jira_fetcher(ctx)
-    obj = jira.update_asset_object(object_id=object_id, attributes=attributes)
-    return json.dumps(obj, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -4683,3 +4683,371 @@ async def get_cross_project_dependencies(
         max_issues=max_issues,
     )
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+# ----------------------------------------------------------------------
+# Jira Assets (Insight) — Server/Data Center only
+# ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
+# Discovery
+# ----------------------------------------------------------------------
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_assets", "server_only"},
+    annotations={"title": "List Asset Schemas", "readOnlyHint": True},
+)
+async def list_asset_schemas(
+    ctx: Context,
+    name_filter: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional case-insensitive substring to filter schemas by name. "
+                "Leave empty to list all schemas."
+            ),
+            default="",
+        ),
+    ] = "",
+) -> str:
+    """
+    List Jira Assets (Insight) object schemas.
+
+    Start here when exploring Assets: schemas are the top-level containers
+    that hold object types, which in turn hold objects.
+
+    Server/Data Center only.
+
+    Args:
+        ctx: The FastMCP context.
+        name_filter: Optional substring to filter schema names.
+
+    Returns:
+        JSON string with the list of object schemas.
+    """
+    jira = await get_jira_fetcher(ctx)
+    schemas = jira.list_asset_schemas()
+    if name_filter:
+        needle = name_filter.strip().lower()
+        schemas = [s for s in schemas if needle in str(s.get("name") or "").lower()]
+    return json.dumps({"schemas": schemas}, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_assets", "server_only"},
+    annotations={"title": "List Asset Object Types", "readOnlyHint": True},
+)
+async def list_asset_object_types(
+    ctx: Context,
+    schema_id: Annotated[
+        str,
+        Field(description="Object schema ID (e.g., '3'), from list_asset_schemas"),
+    ],
+) -> str:
+    """
+    List the object types within an Assets object schema.
+
+    Server/Data Center only.
+
+    Args:
+        ctx: The FastMCP context.
+        schema_id: The object schema ID.
+
+    Returns:
+        JSON string with a flat list of object types.
+    """
+    jira = await get_jira_fetcher(ctx)
+    types = jira.list_asset_object_types(schema_id=schema_id)
+    return json.dumps(
+        {"schema_id": schema_id, "object_types": types}, indent=2, ensure_ascii=False
+    )
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_assets", "server_only"},
+    annotations={"title": "Get Asset Object Type Attributes", "readOnlyHint": True},
+)
+async def get_asset_object_type_attributes(
+    ctx: Context,
+    object_type_id: Annotated[
+        str,
+        Field(description="Object type ID (e.g., '42')"),
+    ],
+) -> str:
+    """
+    Get attribute definitions for an Assets object type.
+
+    Call this before creating or updating objects: Assets writes are keyed
+    by numeric attribute ID, not by attribute name, and this tool provides
+    the name-to-ID mapping.
+
+    Server/Data Center only.
+
+    Args:
+        ctx: The FastMCP context.
+        object_type_id: The object type ID.
+
+    Returns:
+        JSON string with attribute definitions including IDs, types, and
+        whether each attribute is required or editable.
+    """
+    jira = await get_jira_fetcher(ctx)
+    attrs = jira.get_asset_object_type_attributes(object_type_id=object_type_id)
+    return json.dumps(
+        {"object_type_id": object_type_id, "attributes": attrs},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+# ----------------------------------------------------------------------
+# Read
+# ----------------------------------------------------------------------
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_assets", "server_only"},
+    annotations={"title": "Search Assets with AQL", "readOnlyHint": True},
+)
+async def search_assets(
+    ctx: Context,
+    aql: Annotated[
+        str,
+        Field(
+            description=(
+                "AQL/IQL query string. Examples: "
+                'objectType = "Person"; '
+                'objectType = "Hardware" AND "Status" = "Active"; '
+                '"Assigned To" IS EMPTY'
+            )
+        ),
+    ],
+    page: Annotated[
+        int,
+        Field(description="1-based page number", default=1, ge=1),
+    ] = 1,
+    results_per_page: Annotated[
+        int,
+        Field(description="Results per page (1-100)", default=25, ge=1, le=100),
+    ] = 25,
+    include_attributes: Annotated[
+        bool,
+        Field(description="Include attribute values in results", default=True),
+    ] = True,
+    schema_id: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional object schema ID to restrict the search to "
+                "(from jira_list_asset_schemas). Leave empty to search all schemas."
+            ),
+            default="",
+        ),
+    ] = "",
+) -> str:
+    """
+    Search Jira Assets objects using AQL (Assets Query Language).
+
+    This is the primary read tool for Assets. Set include_attributes=false
+    for large result sets where only labels and IDs are needed.
+
+    Server/Data Center only.
+
+    Args:
+        ctx: The FastMCP context.
+        aql: The AQL query string.
+        page: 1-based page number.
+        results_per_page: Number of objects per page.
+        include_attributes: Whether to return full attribute values.
+        schema_id: Optional object schema ID to limit the search.
+
+    Returns:
+        JSON string with matching objects and pagination metadata.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.search_assets_aql(
+        aql=aql,
+        page=page,
+        results_per_page=results_per_page,
+        include_attributes=include_attributes,
+        schema_id=schema_id or None,
+    )
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_assets", "server_only"},
+    annotations={"title": "Get Asset Object", "readOnlyHint": True},
+)
+async def get_asset_object(
+    ctx: Context,
+    object_id: Annotated[
+        str,
+        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
+    ],
+) -> str:
+    """
+    Get a single Assets object with its resolved attribute values.
+
+    Server/Data Center only.
+
+    Args:
+        ctx: The FastMCP context.
+        object_id: The object ID or object key.
+
+    Returns:
+        JSON string with the object and its attributes.
+    """
+    jira = await get_jira_fetcher(ctx)
+    obj = jira.get_asset_object(object_id=object_id)
+    return json.dumps(obj, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_assets", "server_only"},
+    annotations={"title": "Get Asset Object History", "readOnlyHint": True},
+)
+async def get_asset_object_history(
+    ctx: Context,
+    object_id: Annotated[
+        str,
+        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
+    ],
+) -> str:
+    """
+    Get the change history for an Assets object.
+
+    Useful for auditing: who changed which attribute, when,
+    and what the previous value was.
+
+    Server/Data Center only.
+
+    Args:
+        ctx: The FastMCP context.
+        object_id: The object ID or object key.
+
+    Returns:
+        JSON string with the object's change history entries.
+    """
+    jira = await get_jira_fetcher(ctx)
+    history = jira.get_asset_object_history(object_id=object_id)
+    return json.dumps(
+        {"object_id": object_id, "history": history}, indent=2, ensure_ascii=False
+    )
+
+
+@jira_mcp.tool(
+    tags={"jira", "read", "toolset:jira_assets", "server_only"},
+    annotations={"title": "Get Asset Connected Tickets", "readOnlyHint": True},
+)
+async def get_asset_connected_tickets(
+    ctx: Context,
+    object_id: Annotated[
+        str,
+        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
+    ],
+) -> str:
+    """
+    Get Jira issues connected to an Assets object.
+
+    Server/Data Center only.
+
+    Args:
+        ctx: The FastMCP context.
+        object_id: The object ID or object key.
+
+    Returns:
+        JSON string with connected ticket data.
+    """
+    jira = await get_jira_fetcher(ctx)
+    result = jira.get_asset_object_connected_tickets(object_id=object_id)
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+# ----------------------------------------------------------------------
+# Write
+# ----------------------------------------------------------------------
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_assets", "server_only"},
+    annotations={"title": "Create Asset Object", "readOnlyHint": False},
+)
+@check_write_access
+async def create_asset_object(
+    ctx: Context,
+    object_type_id: Annotated[
+        str,
+        Field(description="Object type ID to create the object under"),
+    ],
+    attributes: Annotated[
+        dict,
+        Field(
+            description=(
+                "Mapping of attribute ID (as string) to value, e.g. "
+                '{"142": "Jane Doe", "143": "jane.doe@example.com"}. '
+                "Use jira_get_asset_object_type_attributes to resolve "
+                "attribute names to IDs first. Lists are accepted for "
+                "multi-value attributes."
+            )
+        ),
+    ],
+) -> str:
+    """
+    Create a new Jira Assets object.
+
+    Server/Data Center only. Requires write access (not read-only mode).
+
+    Args:
+        ctx: The FastMCP context.
+        object_type_id: The object type ID.
+        attributes: Attribute ID to value mapping.
+
+    Returns:
+        JSON string with the created object.
+    """
+    jira = await get_jira_fetcher(ctx)
+    obj = jira.create_asset_object(object_type_id=object_type_id, attributes=attributes)
+    return json.dumps(obj, indent=2, ensure_ascii=False)
+
+
+@jira_mcp.tool(
+    tags={"jira", "write", "toolset:jira_assets", "server_only"},
+    annotations={"title": "Update Asset Object", "readOnlyHint": False},
+)
+@check_write_access
+async def update_asset_object(
+    ctx: Context,
+    object_id: Annotated[
+        str,
+        Field(description="Object ID (e.g., '1234') or object key (e.g., 'HW-42')"),
+    ],
+    attributes: Annotated[
+        dict,
+        Field(
+            description=(
+                "Mapping of attribute ID (as string) to new value. "
+                "Only the supplied attributes are sent; other attributes "
+                "are not included in the request."
+            )
+        ),
+    ],
+) -> str:
+    """
+    Update an existing Jira Assets object.
+
+    Server/Data Center only. Requires write access (not read-only mode).
+
+    Args:
+        ctx: The FastMCP context.
+        object_id: The object ID or object key.
+        attributes: Attribute ID to new value mapping.
+
+    Returns:
+        JSON string with the updated object.
+    """
+    jira = await get_jira_fetcher(ctx)
+    obj = jira.update_asset_object(object_id=object_id, attributes=attributes)
+    return json.dumps(obj, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -317,6 +317,8 @@ class AtlassianMCP(ErrorPreservingFastMCP[MainAppContext]):
         tool_tags = tool_obj.tags
         if "cloud_only" in tool_tags and "jira" in tool_tags:
             return ctx["jira_is_cloud"] is not False
+        if "server_only" in tool_tags and "jira" in tool_tags:
+            return ctx["jira_is_cloud"] is not True
         return True
 
     def _is_tool_enabled(

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -85,6 +85,11 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Jira Service Management requests, queues, and service desks",
         default=False,
     ),
+    "jira_assets": ToolsetDefinition(
+        name="jira_assets",
+        description="Jira Assets (Insight) objects, schemas, and AQL search (Server/DC)",
+        default=False,
+    ),
     "jira_forms": ToolsetDefinition(
         name="jira_forms",
         description="ProForma form operations",

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -87,7 +87,7 @@ JIRA_TOOLSETS: dict[str, ToolsetDefinition] = {
     ),
     "jira_assets": ToolsetDefinition(
         name="jira_assets",
-        description="Jira Assets (Insight) objects, schemas, and AQL search (Server/DC)",
+        description="Jira Assets (Insight) discovery (Server/DC)",
         default=False,
     ),
     "jira_forms": ToolsetDefinition(

--- a/tests/e2e/cloud/test_jira_issue_include.py
+++ b/tests/e2e/cloud/test_jira_issue_include.py
@@ -10,14 +10,16 @@ import json
 import os
 import uuid
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastmcp import Client
+from fastmcp import Client, FastMCP
 from fastmcp.client import FastMCPTransport
-from mcp.types import CallToolResult, TextContent
+from fastmcp.client.client import CallToolResult
+from mcp.types import TextContent
 
 from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.config import JiraConfig
 from mcp_atlassian.servers import main_mcp
 
 from .conftest import CloudInstanceInfo, CloudResourceTracker
@@ -126,6 +128,39 @@ class TestGetIssueIncludeEnrichments:
 
         watchers = jira_fetcher.get_issue_watchers(issue.key)
         assert isinstance(watchers, dict)
+
+    @pytest.mark.anyio
+    async def test_assets_include_is_empty_on_cloud(self) -> None:
+        """Cloud issue reads should not call the Server/DC Assets API."""
+        issue_key = os.environ["CLOUD_E2E_JSM_ISSUE_KEY"]
+        config = JiraConfig(
+            url=os.environ["CLOUD_E2E_JIRA_URL"],
+            username=os.environ["CLOUD_E2E_USERNAME"],
+            api_token=os.environ["CLOUD_E2E_API_TOKEN"],
+            auth_type="basic",
+        )
+        fetcher = JiraFetcher(config=config)
+
+        from mcp_atlassian.servers.jira import get_issue
+
+        root_mcp = FastMCP(name="CloudAssetsIncludeRoot")
+        jira_mcp = FastMCP(name="CloudAssetsIncludeJira")
+        jira_mcp.add_tool(get_issue)
+        root_mcp.mount(jira_mcp, namespace="jira")
+
+        with patch(
+            "mcp_atlassian.servers.jira.get_jira_fetcher",
+            AsyncMock(return_value=fetcher),
+        ):
+            async with Client(transport=FastMCPTransport(root_mcp)) as client:
+                response = await client.call_tool(
+                    "jira_get_issue",
+                    {"issue_key": issue_key, "include": "assets"},
+                )
+
+        content = json.loads(response.content[0].text)
+        assert content["key"] == issue_key
+        assert content["assets"] == []
 
     @pytest.mark.anyio
     async def test_get_issue_include_all_tool(

--- a/tests/e2e/test_jira_dc_operations.py
+++ b/tests/e2e/test_jira_dc_operations.py
@@ -435,3 +435,33 @@ class TestJiraDCJSMComments:
         finally:
             for comment_id in comment_ids:
                 _delete_dc_comment(jsm_jira_fetcher, issue_key, comment_id)
+
+
+class TestJiraDCAssets:
+    """Verify the consolidated Assets paths against the JSM DC instance."""
+
+    @pytest.mark.parametrize(
+        "api_base",
+        ["rest/assets/1.0", "rest/insight/1.0"],
+        ids=["assets", "legacy-insight"],
+    )
+    def test_assets_discovery_and_issue_enrichment_query(
+        self,
+        jsm_jira_fetcher: JiraFetcher,
+        api_base: str,
+    ) -> None:
+        """Both supported prefixes should discover and search without errors."""
+        original_base = jsm_jira_fetcher.config.assets_api_base
+        jsm_jira_fetcher.config.assets_api_base = api_base
+        try:
+            assert isinstance(jsm_jira_fetcher.list_asset_schemas(), list)
+
+            issue_key = os.environ.get("DC_E2E_JSM_ISSUE_KEY", "JSMDC-2")
+            result = jsm_jira_fetcher.search_assets_aql(
+                f'object HAVING connectedTickets(key = "{issue_key}")',
+                results_per_page=100,
+            )
+            assert isinstance(result["objects"], list)
+            assert isinstance(result["total"], int)
+        finally:
+            jsm_jira_fetcher.config.assets_api_base = original_base

--- a/tests/unit/jira/test_assets.py
+++ b/tests/unit/jira/test_assets.py
@@ -1,4 +1,4 @@
-"""Tests for Jira Assets (Insight) operations on Server/Data Center."""
+"""Tests for Jira Assets (Insight) discovery on Server/Data Center."""
 
 from unittest.mock import MagicMock
 
@@ -17,11 +17,6 @@ def assets_fetcher(jira_fetcher: JiraFetcher) -> JiraFetcher:
     fetcher.config.is_cloud = False
     fetcher.config.assets_api_base = DEFAULT_ASSETS_API_BASE
     return fetcher
-
-
-# ----------------------------------------------------------------------
-# Cloud guard and base path
-# ----------------------------------------------------------------------
 
 
 def test_assets_raise_on_cloud(assets_fetcher: JiraFetcher):
@@ -53,19 +48,6 @@ def test_assets_base_path_from_config(assets_fetcher: JiraFetcher):
     assert called_path == "rest/insight/1.0/objectschema/list"
 
 
-def test_assets_base_path_falls_back_when_config_lacks_field(
-    assets_fetcher: JiraFetcher,
-):
-    """Configs built without the field (e.g. header-based) use the default."""
-    del assets_fetcher.config.assets_api_base
-    assets_fetcher.jira.get = MagicMock(return_value={"objectschemas": []})
-
-    assets_fetcher.list_asset_schemas()
-
-    called_path = assets_fetcher.jira.get.call_args[0][0]
-    assert called_path == f"{DEFAULT_ASSETS_API_BASE}/objectschema/list"
-
-
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
@@ -91,13 +73,8 @@ def test_config_reads_assets_api_base_from_env(monkeypatch, raw, expected):
     assert config.assets_api_base == expected
 
 
-# ----------------------------------------------------------------------
-# Discovery
-# ----------------------------------------------------------------------
-
-
 def test_list_asset_schemas(assets_fetcher: JiraFetcher):
-    """Schema list should be flattened to simplified dicts."""
+    """Schema discovery should return simplified dictionaries."""
     assets_fetcher.jira.get = MagicMock(
         return_value={
             "objectschemas": [
@@ -108,64 +85,53 @@ def test_list_asset_schemas(assets_fetcher: JiraFetcher):
                     "description": "Physical assets",
                     "objectCount": 120,
                     "objectTypeCount": 4,
-                },
-                {"id": 2, "name": "People", "objectSchemaKey": "PPL"},
+                }
             ]
         }
     )
 
-    result = assets_fetcher.list_asset_schemas()
-
-    assert len(result) == 2
-    assert result[0] == {
-        "id": "1",
-        "name": "Hardware",
-        "key": "HW",
-        "description": "Physical assets",
-        "object_count": 120,
-        "object_type_count": 4,
-    }
-    assert result[1]["id"] == "2"
-    assert result[1]["key"] == "PPL"
-
-
-def test_list_asset_schemas_unexpected_payload(assets_fetcher: JiraFetcher):
-    """A non-dict payload should degrade to an empty list."""
-    assets_fetcher.jira.get = MagicMock(return_value="unexpected")
-
-    assert assets_fetcher.list_asset_schemas() == []
+    assert assets_fetcher.list_asset_schemas() == [
+        {
+            "id": "1",
+            "name": "Hardware",
+            "key": "HW",
+            "description": "Physical assets",
+            "object_count": 120,
+            "object_type_count": 4,
+        }
+    ]
 
 
 def test_list_asset_object_types(assets_fetcher: JiraFetcher):
-    """Object types should be returned flat with parent references."""
+    """Object-type discovery should return a flat simplified list."""
     assets_fetcher.jira.get = MagicMock(
         return_value=[
-            {"id": 10, "name": "Laptop", "parentObjectTypeId": 5, "objectCount": 40},
-            {"id": 5, "name": "Device", "objectCount": 0},
+            {"id": 10, "name": "Laptop", "parentObjectTypeId": 5, "objectCount": 40}
         ]
     )
 
     result = assets_fetcher.list_asset_object_types("1")
 
-    called_path, called_kwargs = assets_fetcher.jira.get.call_args
-    assert called_path[0].endswith("objectschema/1/objecttypes/flat")
-    assert called_kwargs.get("params") is None
+    assert assets_fetcher.jira.get.call_args[0][0].endswith(
+        "objectschema/1/objecttypes/flat"
+    )
     assert result[0]["parent_object_type_id"] == "5"
-    assert result[1]["parent_object_type_id"] is None
 
 
-def test_list_asset_object_types_requires_schema_id(assets_fetcher: JiraFetcher):
-    """An empty schema ID should be rejected before any request is made."""
+def test_list_asset_object_types_rejects_non_numeric_id(
+    assets_fetcher: JiraFetcher,
+):
+    """Schema IDs must not be able to alter the REST path."""
     assets_fetcher.jira.get = MagicMock()
 
-    with pytest.raises(ValueError, match="schema_id"):
-        assets_fetcher.list_asset_object_types("  ")
+    with pytest.raises(ValueError, match="schema_id must be a numeric ID"):
+        assets_fetcher.list_asset_object_types("1/attributes")
 
     assets_fetcher.jira.get.assert_not_called()
 
 
 def test_get_asset_object_type_attributes(assets_fetcher: JiraFetcher):
-    """Attribute definitions should expose IDs, cardinality and references."""
+    """Attribute discovery should expose IDs, cardinality, and references."""
     assets_fetcher.jira.get = MagicMock(
         return_value=[
             {
@@ -189,21 +155,14 @@ def test_get_asset_object_type_attributes(assets_fetcher: JiraFetcher):
 
     result = assets_fetcher.get_asset_object_type_attributes("10")
 
-    assert result[0]["id"] == "100"
     assert result[0]["required"] is True
     assert result[0]["default_type"] == "Text"
-    assert result[1]["required"] is False
     assert result[1]["reference_object_type_id"] == "7"
     assert result[1]["reference_object_type_name"] == "Person"
 
 
-# ----------------------------------------------------------------------
-# Read
-# ----------------------------------------------------------------------
-
-
-def test_search_assets_aql(assets_fetcher: JiraFetcher):
-    """AQL search should send correct params and resolve attribute names."""
+def test_search_assets_aql_for_issue_include(assets_fetcher: JiraFetcher):
+    """The internal Assets search should resolve names and pagination."""
     assets_fetcher.jira.get = MagicMock(
         return_value={
             "objectEntries": [
@@ -212,387 +171,42 @@ def test_search_assets_aql(assets_fetcher: JiraFetcher):
                     "objectKey": "HW-501",
                     "label": "Laptop 501",
                     "objectType": {"id": 10, "name": "Laptop"},
-                    "created": "2024-01-01T00:00:00.000Z",
-                    "updated": "2024-02-01T00:00:00.000Z",
                     "attributes": [
                         {
                             "objectTypeAttributeId": 100,
-                            "objectAttributeValues": [
-                                {"value": "Laptop 501", "displayValue": "Laptop 501"}
-                            ],
-                        },
-                        {
-                            "objectTypeAttributeId": 101,
-                            "objectAttributeValues": [
-                                {
-                                    "referencedObject": {
-                                        "id": 42,
-                                        "label": "Example User",
-                                        "objectKey": "PPL-42",
-                                    }
-                                }
-                            ],
-                        },
-                        {
-                            "objectTypeAttributeId": 102,
-                            "objectAttributeValues": [
-                                {"displayValue": "Red"},
-                                {"displayValue": "Blue"},
-                            ],
-                        },
+                            "objectAttributeValues": [{"displayValue": "Laptop 501"}],
+                        }
                     ],
                 }
             ],
-            "objectTypeAttributes": [
-                {"id": 100, "name": "Name"},
-                {"id": 101, "name": "Owner"},
-                {"id": 102, "name": "Tags"},
-            ],
+            "objectTypeAttributes": [{"id": 100, "name": "Name"}],
             "totalFilterCount": 1,
-            "pageNumber": 2,
+            "pageNumber": 1,
             "pageSize": 1,
-            "pageObjectSize": 1,
+            "pageObjectSize": 100,
         }
     )
 
     result = assets_fetcher.search_assets_aql(
-        'objectType = "Laptop"', page=2, results_per_page=50
+        'object HAVING connectedTickets(key = "TEST-123")', results_per_page=100
     )
 
-    called_path, called_kwargs = assets_fetcher.jira.get.call_args
-    assert called_path[0] == f"{DEFAULT_ASSETS_API_BASE}/aql/objects"
-    assert called_kwargs["params"] == {
-        "qlQuery": 'objectType = "Laptop"',
-        "page": 2,
-        "resultPerPage": 50,
-        "includeAttributes": "true",
-        "includeTypeAttributes": "true",
-    }
-
+    assert assets_fetcher.jira.get.call_args[1]["params"]["qlQuery"] == (
+        'object HAVING connectedTickets(key = "TEST-123")'
+    )
+    assert result["objects"][0]["attributes"] == {"Name": "Laptop 501"}
     assert result["total"] == 1
-    assert result["page"] == 2
-    assert result["page_size"] == 1
-    assert result["total_pages"] == 1
-    obj = result["objects"][0]
-    assert obj["id"] == "501"
-    assert obj["object_key"] == "HW-501"
-    assert obj["object_type_name"] == "Laptop"
-    assert obj["attributes"]["Name"] == "Laptop 501"
-    assert obj["attributes"]["Owner"] == {
-        "id": "42",
-        "label": "Example User",
-        "object_key": "PPL-42",
-    }
-    assert obj["attributes"]["Tags"] == ["Red", "Blue"]
 
 
-def test_search_assets_aql_legacy_insight_endpoint(assets_fetcher: JiraFetcher):
-    """A rest/insight base should search via iql/objects with the iql param."""
+def test_search_assets_aql_uses_legacy_insight_endpoint(
+    assets_fetcher: JiraFetcher,
+):
+    """The legacy Insight base should use iql/objects and its iql parameter."""
     assets_fetcher.config.assets_api_base = "rest/insight/1.0"
     assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
 
-    assets_fetcher.search_assets_aql('objectType = "Laptop"')
+    assets_fetcher.search_assets_aql("objectType = Laptop")
 
     called_path, called_kwargs = assets_fetcher.jira.get.call_args
     assert called_path[0] == "rest/insight/1.0/iql/objects"
-    assert called_kwargs["params"]["iql"] == 'objectType = "Laptop"'
-    assert "qlQuery" not in called_kwargs["params"]
-    assert called_kwargs["params"]["includeTypeAttributes"] == "true"
-
-
-def test_search_assets_aql_clamps_page_size(assets_fetcher: JiraFetcher):
-    """Page size should be clamped to the 1-100 range."""
-    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
-
-    assets_fetcher.search_assets_aql("objectType = X", page=0, results_per_page=500)
-
-    params = assets_fetcher.jira.get.call_args[1]["params"]
-    assert params["page"] == 1
-    assert params["resultPerPage"] == 100
-
-
-def test_search_assets_aql_requires_query(assets_fetcher: JiraFetcher):
-    """An empty AQL string should be rejected."""
-    with pytest.raises(ValueError, match="aql"):
-        assets_fetcher.search_assets_aql("   ")
-
-
-def test_get_asset_object_resolves_attribute_names(assets_fetcher: JiraFetcher):
-    """Single-object reads should resolve names via the object type definition."""
-    assets_fetcher.jira.get = MagicMock(
-        side_effect=[
-            # object/501
-            {
-                "id": 501,
-                "objectKey": "HW-501",
-                "label": "Laptop 501",
-                "objectType": {"id": 10, "name": "Laptop"},
-                "attributes": [
-                    {
-                        "objectTypeAttributeId": 100,
-                        "objectAttributeValues": [{"displayValue": "Laptop 501"}],
-                    }
-                ],
-            },
-            # objecttype/10/attributes
-            [{"id": 100, "name": "Name", "minimumCardinality": 1}],
-        ]
-    )
-
-    result = assets_fetcher.get_asset_object("501")
-
-    assert assets_fetcher.jira.get.call_count == 2
-    assert result["id"] == "501"
-    assert result["attributes"] == {"Name": "Laptop 501"}
-
-
-def test_get_asset_object_uses_embedded_attribute_names(assets_fetcher: JiraFetcher):
-    """When the response embeds attribute definitions no lookup is needed."""
-    assets_fetcher.jira.get = MagicMock(
-        return_value={
-            "id": 501,
-            "objectKey": "HW-501",
-            "objectType": {"id": 10, "name": "Laptop"},
-            "attributes": [
-                {
-                    "objectTypeAttributeId": 100,
-                    "objectTypeAttribute": {"id": 100, "name": "Name"},
-                    "objectAttributeValues": [{"displayValue": "Laptop 501"}],
-                }
-            ],
-        }
-    )
-
-    result = assets_fetcher.get_asset_object("501")
-
-    assert assets_fetcher.jira.get.call_count == 1
-    assert result["attributes"] == {"Name": "Laptop 501"}
-
-
-def test_get_asset_object_resolves_object_key(assets_fetcher: JiraFetcher):
-    """An object key is resolved to its numeric ID via an AQL lookup."""
-    assets_fetcher.jira.get = MagicMock(
-        side_effect=[
-            # aql/objects?qlQuery=Key = "HW-501"
-            {"objectEntries": [{"id": 501, "objectKey": "HW-501"}]},
-            # object/501
-            {"id": 501, "objectKey": "HW-501", "attributes": []},
-        ]
-    )
-
-    result = assets_fetcher.get_asset_object("HW-501")
-
-    lookup_path, lookup_kwargs = assets_fetcher.jira.get.call_args_list[0]
-    assert lookup_path[0].endswith("aql/objects")
-    assert lookup_kwargs["params"]["qlQuery"] == 'Key = "HW-501"'
-    assert lookup_kwargs["params"]["includeAttributes"] == "false"
-    assert assets_fetcher.jira.get.call_args_list[1][0][0].endswith("object/501")
-    assert result["id"] == "501"
-
-
-def test_get_asset_object_unknown_key(assets_fetcher: JiraFetcher):
-    """An object key that matches nothing should raise."""
-    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
-
-    with pytest.raises(ValueError, match="HW-999"):
-        assets_fetcher.get_asset_object("HW-999")
-
-
-def test_get_asset_object_rejects_quoted_object_key(
-    assets_fetcher: JiraFetcher,
-):
-    """Keys that would break out of the AQL literal are rejected."""
-    assets_fetcher.jira.get = MagicMock()
-
-    with pytest.raises(ValueError, match="Invalid object key"):
-        assets_fetcher.get_asset_object('HW-1" OR Key != "')
-
-    assets_fetcher.jira.get.assert_not_called()
-
-
-def test_get_asset_object_degrades_without_type_lookup(assets_fetcher: JiraFetcher):
-    """If the attribute lookup fails, raw attribute IDs should be used as keys."""
-    assets_fetcher.jira.get = MagicMock(
-        side_effect=[
-            {
-                "id": 501,
-                "objectType": {"id": 10, "name": "Laptop"},
-                "attributes": [
-                    {
-                        "objectTypeAttributeId": 100,
-                        "objectAttributeValues": [{"displayValue": "Laptop 501"}],
-                    }
-                ],
-            },
-            RuntimeError("permission denied"),
-        ]
-    )
-
-    result = assets_fetcher.get_asset_object("501")
-
-    assert result["attributes"] == {"100": "Laptop 501"}
-
-
-def test_get_asset_object_history(assets_fetcher: JiraFetcher):
-    """History entries should be flattened."""
-    assets_fetcher.jira.get = MagicMock(
-        return_value=[
-            {
-                "id": 1,
-                "actor": {"displayName": "Example User"},
-                "created": "2024-03-01T00:00:00.000Z",
-                "type": 1,
-                "affectedAttribute": "Owner",
-                "oldValue": "A",
-                "newValue": "B",
-            }
-        ]
-    )
-
-    result = assets_fetcher.get_asset_object_history("501")
-
-    assert assets_fetcher.jira.get.call_args[0][0].endswith("object/501/history")
-    assert result[0]["actor"] == "Example User"
-    assert result[0]["old_value"] == "A"
-    assert result[0]["new_value"] == "B"
-
-
-def test_get_asset_object_connected_tickets(assets_fetcher: JiraFetcher):
-    """Connected tickets should be returned as-is from the API."""
-    payload = {"tickets": [{"key": "SUP-1"}]}
-    assets_fetcher.jira.get = MagicMock(return_value=payload)
-
-    result = assets_fetcher.get_asset_object_connected_tickets("501")
-
-    assert assets_fetcher.jira.get.call_args[0][0].endswith(
-        "objectconnectedtickets/501/tickets"
-    )
-    assert result == payload
-
-
-# ----------------------------------------------------------------------
-# Write
-# ----------------------------------------------------------------------
-
-
-def test_create_asset_object_payload(assets_fetcher: JiraFetcher):
-    """Create should build the Insight attribute payload correctly."""
-    assets_fetcher.jira.post = MagicMock(
-        return_value={
-            "id": 600,
-            "objectKey": "HW-600",
-            "label": "New Laptop",
-            "objectType": {"id": 10, "name": "Laptop"},
-            "attributes": [],
-        }
-    )
-
-    result = assets_fetcher.create_asset_object(
-        "10", {"100": "New Laptop", "102": ["Red", "Blue"], "103": None}
-    )
-
-    called_path, called_kwargs = assets_fetcher.jira.post.call_args
-    assert called_path[0].endswith("object/create")
-    assert called_kwargs["data"] == {
-        "objectTypeId": "10",
-        "attributes": [
-            {
-                "objectTypeAttributeId": "100",
-                "objectAttributeValues": [{"value": "New Laptop"}],
-            },
-            {
-                "objectTypeAttributeId": "102",
-                "objectAttributeValues": [{"value": "Red"}, {"value": "Blue"}],
-            },
-            {
-                "objectTypeAttributeId": "103",
-                "objectAttributeValues": [{"value": ""}],
-            },
-        ],
-    }
-    assert result["id"] == "600"
-    assert result["object_key"] == "HW-600"
-
-
-def test_create_asset_object_requires_attributes(assets_fetcher: JiraFetcher):
-    """Create should reject an empty attribute mapping."""
-    assets_fetcher.jira.post = MagicMock()
-
-    with pytest.raises(ValueError, match="attributes"):
-        assets_fetcher.create_asset_object("10", {})
-
-    assets_fetcher.jira.post.assert_not_called()
-
-
-def test_update_asset_object(assets_fetcher: JiraFetcher):
-    """Update should PUT the supplied attributes plus the resolved type ID."""
-    assets_fetcher.jira.get = MagicMock(
-        return_value={"id": 501, "objectType": {"id": 10, "name": "Laptop"}}
-    )
-    assets_fetcher.jira.put = MagicMock(
-        return_value={
-            "id": 501,
-            "objectKey": "HW-501",
-            "objectType": {"id": 10, "name": "Laptop"},
-            "attributes": [],
-        }
-    )
-
-    result = assets_fetcher.update_asset_object("501", {"101": "PPL-43"})
-
-    # The type ID is read from the object before the update.
-    assert assets_fetcher.jira.get.call_args[0][0].endswith("object/501")
-    called_path, called_kwargs = assets_fetcher.jira.put.call_args
-    assert called_path[0].endswith("object/501")
-    assert called_kwargs["data"] == {
-        "attributes": [
-            {
-                "objectTypeAttributeId": "101",
-                "objectAttributeValues": [{"value": "PPL-43"}],
-            }
-        ],
-        "objectTypeId": "10",
-    }
-    assert result["id"] == "501"
-
-
-def test_update_asset_object_with_explicit_type_skips_lookup(
-    assets_fetcher: JiraFetcher,
-):
-    """Passing object_type_id should avoid the extra GET."""
-    assets_fetcher.jira.get = MagicMock()
-    assets_fetcher.jira.put = MagicMock(return_value={"id": 501, "attributes": []})
-
-    assets_fetcher.update_asset_object("501", {"101": "x"}, object_type_id="10")
-
-    assets_fetcher.jira.get.assert_not_called()
-    assert assets_fetcher.jira.put.call_args[1]["data"]["objectTypeId"] == "10"
-
-
-def test_update_asset_object_without_resolvable_type(assets_fetcher: JiraFetcher):
-    """If the type cannot be resolved the update is still attempted."""
-    assets_fetcher.jira.get = MagicMock(return_value="unexpected")
-    assets_fetcher.jira.put = MagicMock(return_value={"id": 501, "attributes": []})
-
-    assets_fetcher.update_asset_object("501", {"101": "x"})
-
-    assert "objectTypeId" not in assets_fetcher.jira.put.call_args[1]["data"]
-
-
-def test_search_assets_aql_schema_filter(assets_fetcher: JiraFetcher):
-    """schema_id should be passed through as objectSchemaId."""
-    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
-
-    assets_fetcher.search_assets_aql("objectType = X", schema_id=" 3 ")
-
-    params = assets_fetcher.jira.get.call_args[1]["params"]
-    assert params["objectSchemaId"] == "3"
-
-
-def test_search_assets_aql_omits_empty_schema_filter(assets_fetcher: JiraFetcher):
-    """An empty schema_id should not add objectSchemaId."""
-    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
-
-    assets_fetcher.search_assets_aql("objectType = X", schema_id="  ")
-
-    assert "objectSchemaId" not in assets_fetcher.jira.get.call_args[1]["params"]
+    assert called_kwargs["params"]["iql"] == "objectType = Laptop"

--- a/tests/unit/jira/test_assets.py
+++ b/tests/unit/jira/test_assets.py
@@ -1,0 +1,598 @@
+"""Tests for Jira Assets (Insight) operations on Server/Data Center."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+from mcp_atlassian.jira.assets import DEFAULT_ASSETS_API_BASE
+from mcp_atlassian.jira.config import JiraConfig
+
+
+@pytest.fixture
+def assets_fetcher(jira_fetcher: JiraFetcher) -> JiraFetcher:
+    """Create a Jira fetcher configured for Server/DC Assets testing."""
+    fetcher = jira_fetcher
+    fetcher.config = MagicMock()
+    fetcher.config.is_cloud = False
+    fetcher.config.assets_api_base = DEFAULT_ASSETS_API_BASE
+    return fetcher
+
+
+# ----------------------------------------------------------------------
+# Cloud guard and base path
+# ----------------------------------------------------------------------
+
+
+def test_assets_raise_on_cloud(assets_fetcher: JiraFetcher):
+    """Assets operations should refuse to run against Jira Cloud."""
+    assets_fetcher.config.is_cloud = True
+
+    with pytest.raises(NotImplementedError, match="Server/Data Center"):
+        assets_fetcher.list_asset_schemas()
+
+
+def test_assets_default_base_path(assets_fetcher: JiraFetcher):
+    """Requests should target rest/assets/1.0 by default."""
+    assets_fetcher.jira.get = MagicMock(return_value={"objectschemas": []})
+
+    assets_fetcher.list_asset_schemas()
+
+    called_path = assets_fetcher.jira.get.call_args[0][0]
+    assert called_path == f"{DEFAULT_ASSETS_API_BASE}/objectschema/list"
+
+
+def test_assets_base_path_from_config(assets_fetcher: JiraFetcher):
+    """JiraConfig.assets_api_base should drive the REST base path."""
+    assets_fetcher.config.assets_api_base = "rest/insight/1.0"
+    assets_fetcher.jira.get = MagicMock(return_value={"objectschemas": []})
+
+    assets_fetcher.list_asset_schemas()
+
+    called_path = assets_fetcher.jira.get.call_args[0][0]
+    assert called_path == "rest/insight/1.0/objectschema/list"
+
+
+def test_assets_base_path_falls_back_when_config_lacks_field(
+    assets_fetcher: JiraFetcher,
+):
+    """Configs built without the field (e.g. header-based) use the default."""
+    del assets_fetcher.config.assets_api_base
+    assets_fetcher.jira.get = MagicMock(return_value={"objectschemas": []})
+
+    assets_fetcher.list_asset_schemas()
+
+    called_path = assets_fetcher.jira.get.call_args[0][0]
+    assert called_path == f"{DEFAULT_ASSETS_API_BASE}/objectschema/list"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, DEFAULT_ASSETS_API_BASE),
+        ("", DEFAULT_ASSETS_API_BASE),
+        ("/", DEFAULT_ASSETS_API_BASE),
+        ("rest/insight/1.0", "rest/insight/1.0"),
+        ("/rest/insight/1.0/", "rest/insight/1.0"),
+        ("  rest/insight/1.0  ", "rest/insight/1.0"),
+    ],
+)
+def test_config_reads_assets_api_base_from_env(monkeypatch, raw, expected):
+    """JIRA_ASSETS_API_BASE is normalized into JiraConfig.assets_api_base."""
+    monkeypatch.setenv("JIRA_URL", "https://jira.example.com")
+    monkeypatch.setenv("JIRA_PERSONAL_TOKEN", "token")
+    if raw is None:
+        monkeypatch.delenv("JIRA_ASSETS_API_BASE", raising=False)
+    else:
+        monkeypatch.setenv("JIRA_ASSETS_API_BASE", raw)
+
+    config = JiraConfig.from_env()
+
+    assert config.assets_api_base == expected
+
+
+# ----------------------------------------------------------------------
+# Discovery
+# ----------------------------------------------------------------------
+
+
+def test_list_asset_schemas(assets_fetcher: JiraFetcher):
+    """Schema list should be flattened to simplified dicts."""
+    assets_fetcher.jira.get = MagicMock(
+        return_value={
+            "objectschemas": [
+                {
+                    "id": 1,
+                    "name": "Hardware",
+                    "objectSchemaKey": "HW",
+                    "description": "Physical assets",
+                    "objectCount": 120,
+                    "objectTypeCount": 4,
+                },
+                {"id": 2, "name": "People", "objectSchemaKey": "PPL"},
+            ]
+        }
+    )
+
+    result = assets_fetcher.list_asset_schemas()
+
+    assert len(result) == 2
+    assert result[0] == {
+        "id": "1",
+        "name": "Hardware",
+        "key": "HW",
+        "description": "Physical assets",
+        "object_count": 120,
+        "object_type_count": 4,
+    }
+    assert result[1]["id"] == "2"
+    assert result[1]["key"] == "PPL"
+
+
+def test_list_asset_schemas_unexpected_payload(assets_fetcher: JiraFetcher):
+    """A non-dict payload should degrade to an empty list."""
+    assets_fetcher.jira.get = MagicMock(return_value="unexpected")
+
+    assert assets_fetcher.list_asset_schemas() == []
+
+
+def test_list_asset_object_types(assets_fetcher: JiraFetcher):
+    """Object types should be returned flat with parent references."""
+    assets_fetcher.jira.get = MagicMock(
+        return_value=[
+            {"id": 10, "name": "Laptop", "parentObjectTypeId": 5, "objectCount": 40},
+            {"id": 5, "name": "Device", "objectCount": 0},
+        ]
+    )
+
+    result = assets_fetcher.list_asset_object_types("1")
+
+    called_path, called_kwargs = assets_fetcher.jira.get.call_args
+    assert called_path[0].endswith("objectschema/1/objecttypes/flat")
+    assert called_kwargs.get("params") is None
+    assert result[0]["parent_object_type_id"] == "5"
+    assert result[1]["parent_object_type_id"] is None
+
+
+def test_list_asset_object_types_requires_schema_id(assets_fetcher: JiraFetcher):
+    """An empty schema ID should be rejected before any request is made."""
+    assets_fetcher.jira.get = MagicMock()
+
+    with pytest.raises(ValueError, match="schema_id"):
+        assets_fetcher.list_asset_object_types("  ")
+
+    assets_fetcher.jira.get.assert_not_called()
+
+
+def test_get_asset_object_type_attributes(assets_fetcher: JiraFetcher):
+    """Attribute definitions should expose IDs, cardinality and references."""
+    assets_fetcher.jira.get = MagicMock(
+        return_value=[
+            {
+                "id": 100,
+                "name": "Name",
+                "type": 0,
+                "defaultType": {"name": "Text"},
+                "editable": True,
+                "minimumCardinality": 1,
+            },
+            {
+                "id": 101,
+                "name": "Owner",
+                "type": 1,
+                "editable": True,
+                "minimumCardinality": 0,
+                "referenceObjectType": {"id": 7, "name": "Person"},
+            },
+        ]
+    )
+
+    result = assets_fetcher.get_asset_object_type_attributes("10")
+
+    assert result[0]["id"] == "100"
+    assert result[0]["required"] is True
+    assert result[0]["default_type"] == "Text"
+    assert result[1]["required"] is False
+    assert result[1]["reference_object_type_id"] == "7"
+    assert result[1]["reference_object_type_name"] == "Person"
+
+
+# ----------------------------------------------------------------------
+# Read
+# ----------------------------------------------------------------------
+
+
+def test_search_assets_aql(assets_fetcher: JiraFetcher):
+    """AQL search should send correct params and resolve attribute names."""
+    assets_fetcher.jira.get = MagicMock(
+        return_value={
+            "objectEntries": [
+                {
+                    "id": 501,
+                    "objectKey": "HW-501",
+                    "label": "Laptop 501",
+                    "objectType": {"id": 10, "name": "Laptop"},
+                    "created": "2024-01-01T00:00:00.000Z",
+                    "updated": "2024-02-01T00:00:00.000Z",
+                    "attributes": [
+                        {
+                            "objectTypeAttributeId": 100,
+                            "objectAttributeValues": [
+                                {"value": "Laptop 501", "displayValue": "Laptop 501"}
+                            ],
+                        },
+                        {
+                            "objectTypeAttributeId": 101,
+                            "objectAttributeValues": [
+                                {
+                                    "referencedObject": {
+                                        "id": 42,
+                                        "label": "Example User",
+                                        "objectKey": "PPL-42",
+                                    }
+                                }
+                            ],
+                        },
+                        {
+                            "objectTypeAttributeId": 102,
+                            "objectAttributeValues": [
+                                {"displayValue": "Red"},
+                                {"displayValue": "Blue"},
+                            ],
+                        },
+                    ],
+                }
+            ],
+            "objectTypeAttributes": [
+                {"id": 100, "name": "Name"},
+                {"id": 101, "name": "Owner"},
+                {"id": 102, "name": "Tags"},
+            ],
+            "totalFilterCount": 1,
+            "pageNumber": 2,
+            "pageSize": 1,
+            "pageObjectSize": 1,
+        }
+    )
+
+    result = assets_fetcher.search_assets_aql(
+        'objectType = "Laptop"', page=2, results_per_page=50
+    )
+
+    called_path, called_kwargs = assets_fetcher.jira.get.call_args
+    assert called_path[0] == f"{DEFAULT_ASSETS_API_BASE}/aql/objects"
+    assert called_kwargs["params"] == {
+        "qlQuery": 'objectType = "Laptop"',
+        "page": 2,
+        "resultPerPage": 50,
+        "includeAttributes": "true",
+        "includeTypeAttributes": "true",
+    }
+
+    assert result["total"] == 1
+    assert result["page"] == 2
+    assert result["page_size"] == 1
+    assert result["total_pages"] == 1
+    obj = result["objects"][0]
+    assert obj["id"] == "501"
+    assert obj["object_key"] == "HW-501"
+    assert obj["object_type_name"] == "Laptop"
+    assert obj["attributes"]["Name"] == "Laptop 501"
+    assert obj["attributes"]["Owner"] == {
+        "id": "42",
+        "label": "Example User",
+        "object_key": "PPL-42",
+    }
+    assert obj["attributes"]["Tags"] == ["Red", "Blue"]
+
+
+def test_search_assets_aql_legacy_insight_endpoint(assets_fetcher: JiraFetcher):
+    """A rest/insight base should search via iql/objects with the iql param."""
+    assets_fetcher.config.assets_api_base = "rest/insight/1.0"
+    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
+
+    assets_fetcher.search_assets_aql('objectType = "Laptop"')
+
+    called_path, called_kwargs = assets_fetcher.jira.get.call_args
+    assert called_path[0] == "rest/insight/1.0/iql/objects"
+    assert called_kwargs["params"]["iql"] == 'objectType = "Laptop"'
+    assert "qlQuery" not in called_kwargs["params"]
+    assert called_kwargs["params"]["includeTypeAttributes"] == "true"
+
+
+def test_search_assets_aql_clamps_page_size(assets_fetcher: JiraFetcher):
+    """Page size should be clamped to the 1-100 range."""
+    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
+
+    assets_fetcher.search_assets_aql("objectType = X", page=0, results_per_page=500)
+
+    params = assets_fetcher.jira.get.call_args[1]["params"]
+    assert params["page"] == 1
+    assert params["resultPerPage"] == 100
+
+
+def test_search_assets_aql_requires_query(assets_fetcher: JiraFetcher):
+    """An empty AQL string should be rejected."""
+    with pytest.raises(ValueError, match="aql"):
+        assets_fetcher.search_assets_aql("   ")
+
+
+def test_get_asset_object_resolves_attribute_names(assets_fetcher: JiraFetcher):
+    """Single-object reads should resolve names via the object type definition."""
+    assets_fetcher.jira.get = MagicMock(
+        side_effect=[
+            # object/501
+            {
+                "id": 501,
+                "objectKey": "HW-501",
+                "label": "Laptop 501",
+                "objectType": {"id": 10, "name": "Laptop"},
+                "attributes": [
+                    {
+                        "objectTypeAttributeId": 100,
+                        "objectAttributeValues": [{"displayValue": "Laptop 501"}],
+                    }
+                ],
+            },
+            # objecttype/10/attributes
+            [{"id": 100, "name": "Name", "minimumCardinality": 1}],
+        ]
+    )
+
+    result = assets_fetcher.get_asset_object("501")
+
+    assert assets_fetcher.jira.get.call_count == 2
+    assert result["id"] == "501"
+    assert result["attributes"] == {"Name": "Laptop 501"}
+
+
+def test_get_asset_object_uses_embedded_attribute_names(assets_fetcher: JiraFetcher):
+    """When the response embeds attribute definitions no lookup is needed."""
+    assets_fetcher.jira.get = MagicMock(
+        return_value={
+            "id": 501,
+            "objectKey": "HW-501",
+            "objectType": {"id": 10, "name": "Laptop"},
+            "attributes": [
+                {
+                    "objectTypeAttributeId": 100,
+                    "objectTypeAttribute": {"id": 100, "name": "Name"},
+                    "objectAttributeValues": [{"displayValue": "Laptop 501"}],
+                }
+            ],
+        }
+    )
+
+    result = assets_fetcher.get_asset_object("501")
+
+    assert assets_fetcher.jira.get.call_count == 1
+    assert result["attributes"] == {"Name": "Laptop 501"}
+
+
+def test_get_asset_object_resolves_object_key(assets_fetcher: JiraFetcher):
+    """An object key is resolved to its numeric ID via an AQL lookup."""
+    assets_fetcher.jira.get = MagicMock(
+        side_effect=[
+            # aql/objects?qlQuery=Key = "HW-501"
+            {"objectEntries": [{"id": 501, "objectKey": "HW-501"}]},
+            # object/501
+            {"id": 501, "objectKey": "HW-501", "attributes": []},
+        ]
+    )
+
+    result = assets_fetcher.get_asset_object("HW-501")
+
+    lookup_path, lookup_kwargs = assets_fetcher.jira.get.call_args_list[0]
+    assert lookup_path[0].endswith("aql/objects")
+    assert lookup_kwargs["params"]["qlQuery"] == 'Key = "HW-501"'
+    assert lookup_kwargs["params"]["includeAttributes"] == "false"
+    assert assets_fetcher.jira.get.call_args_list[1][0][0].endswith("object/501")
+    assert result["id"] == "501"
+
+
+def test_get_asset_object_unknown_key(assets_fetcher: JiraFetcher):
+    """An object key that matches nothing should raise."""
+    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
+
+    with pytest.raises(ValueError, match="HW-999"):
+        assets_fetcher.get_asset_object("HW-999")
+
+
+def test_get_asset_object_rejects_quoted_object_key(
+    assets_fetcher: JiraFetcher,
+):
+    """Keys that would break out of the AQL literal are rejected."""
+    assets_fetcher.jira.get = MagicMock()
+
+    with pytest.raises(ValueError, match="Invalid object key"):
+        assets_fetcher.get_asset_object('HW-1" OR Key != "')
+
+    assets_fetcher.jira.get.assert_not_called()
+
+
+def test_get_asset_object_degrades_without_type_lookup(assets_fetcher: JiraFetcher):
+    """If the attribute lookup fails, raw attribute IDs should be used as keys."""
+    assets_fetcher.jira.get = MagicMock(
+        side_effect=[
+            {
+                "id": 501,
+                "objectType": {"id": 10, "name": "Laptop"},
+                "attributes": [
+                    {
+                        "objectTypeAttributeId": 100,
+                        "objectAttributeValues": [{"displayValue": "Laptop 501"}],
+                    }
+                ],
+            },
+            RuntimeError("permission denied"),
+        ]
+    )
+
+    result = assets_fetcher.get_asset_object("501")
+
+    assert result["attributes"] == {"100": "Laptop 501"}
+
+
+def test_get_asset_object_history(assets_fetcher: JiraFetcher):
+    """History entries should be flattened."""
+    assets_fetcher.jira.get = MagicMock(
+        return_value=[
+            {
+                "id": 1,
+                "actor": {"displayName": "Example User"},
+                "created": "2024-03-01T00:00:00.000Z",
+                "type": 1,
+                "affectedAttribute": "Owner",
+                "oldValue": "A",
+                "newValue": "B",
+            }
+        ]
+    )
+
+    result = assets_fetcher.get_asset_object_history("501")
+
+    assert assets_fetcher.jira.get.call_args[0][0].endswith("object/501/history")
+    assert result[0]["actor"] == "Example User"
+    assert result[0]["old_value"] == "A"
+    assert result[0]["new_value"] == "B"
+
+
+def test_get_asset_object_connected_tickets(assets_fetcher: JiraFetcher):
+    """Connected tickets should be returned as-is from the API."""
+    payload = {"tickets": [{"key": "SUP-1"}]}
+    assets_fetcher.jira.get = MagicMock(return_value=payload)
+
+    result = assets_fetcher.get_asset_object_connected_tickets("501")
+
+    assert assets_fetcher.jira.get.call_args[0][0].endswith(
+        "objectconnectedtickets/501/tickets"
+    )
+    assert result == payload
+
+
+# ----------------------------------------------------------------------
+# Write
+# ----------------------------------------------------------------------
+
+
+def test_create_asset_object_payload(assets_fetcher: JiraFetcher):
+    """Create should build the Insight attribute payload correctly."""
+    assets_fetcher.jira.post = MagicMock(
+        return_value={
+            "id": 600,
+            "objectKey": "HW-600",
+            "label": "New Laptop",
+            "objectType": {"id": 10, "name": "Laptop"},
+            "attributes": [],
+        }
+    )
+
+    result = assets_fetcher.create_asset_object(
+        "10", {"100": "New Laptop", "102": ["Red", "Blue"], "103": None}
+    )
+
+    called_path, called_kwargs = assets_fetcher.jira.post.call_args
+    assert called_path[0].endswith("object/create")
+    assert called_kwargs["data"] == {
+        "objectTypeId": "10",
+        "attributes": [
+            {
+                "objectTypeAttributeId": "100",
+                "objectAttributeValues": [{"value": "New Laptop"}],
+            },
+            {
+                "objectTypeAttributeId": "102",
+                "objectAttributeValues": [{"value": "Red"}, {"value": "Blue"}],
+            },
+            {
+                "objectTypeAttributeId": "103",
+                "objectAttributeValues": [{"value": ""}],
+            },
+        ],
+    }
+    assert result["id"] == "600"
+    assert result["object_key"] == "HW-600"
+
+
+def test_create_asset_object_requires_attributes(assets_fetcher: JiraFetcher):
+    """Create should reject an empty attribute mapping."""
+    assets_fetcher.jira.post = MagicMock()
+
+    with pytest.raises(ValueError, match="attributes"):
+        assets_fetcher.create_asset_object("10", {})
+
+    assets_fetcher.jira.post.assert_not_called()
+
+
+def test_update_asset_object(assets_fetcher: JiraFetcher):
+    """Update should PUT the supplied attributes plus the resolved type ID."""
+    assets_fetcher.jira.get = MagicMock(
+        return_value={"id": 501, "objectType": {"id": 10, "name": "Laptop"}}
+    )
+    assets_fetcher.jira.put = MagicMock(
+        return_value={
+            "id": 501,
+            "objectKey": "HW-501",
+            "objectType": {"id": 10, "name": "Laptop"},
+            "attributes": [],
+        }
+    )
+
+    result = assets_fetcher.update_asset_object("501", {"101": "PPL-43"})
+
+    # The type ID is read from the object before the update.
+    assert assets_fetcher.jira.get.call_args[0][0].endswith("object/501")
+    called_path, called_kwargs = assets_fetcher.jira.put.call_args
+    assert called_path[0].endswith("object/501")
+    assert called_kwargs["data"] == {
+        "attributes": [
+            {
+                "objectTypeAttributeId": "101",
+                "objectAttributeValues": [{"value": "PPL-43"}],
+            }
+        ],
+        "objectTypeId": "10",
+    }
+    assert result["id"] == "501"
+
+
+def test_update_asset_object_with_explicit_type_skips_lookup(
+    assets_fetcher: JiraFetcher,
+):
+    """Passing object_type_id should avoid the extra GET."""
+    assets_fetcher.jira.get = MagicMock()
+    assets_fetcher.jira.put = MagicMock(return_value={"id": 501, "attributes": []})
+
+    assets_fetcher.update_asset_object("501", {"101": "x"}, object_type_id="10")
+
+    assets_fetcher.jira.get.assert_not_called()
+    assert assets_fetcher.jira.put.call_args[1]["data"]["objectTypeId"] == "10"
+
+
+def test_update_asset_object_without_resolvable_type(assets_fetcher: JiraFetcher):
+    """If the type cannot be resolved the update is still attempted."""
+    assets_fetcher.jira.get = MagicMock(return_value="unexpected")
+    assets_fetcher.jira.put = MagicMock(return_value={"id": 501, "attributes": []})
+
+    assets_fetcher.update_asset_object("501", {"101": "x"})
+
+    assert "objectTypeId" not in assets_fetcher.jira.put.call_args[1]["data"]
+
+
+def test_search_assets_aql_schema_filter(assets_fetcher: JiraFetcher):
+    """schema_id should be passed through as objectSchemaId."""
+    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
+
+    assets_fetcher.search_assets_aql("objectType = X", schema_id=" 3 ")
+
+    params = assets_fetcher.jira.get.call_args[1]["params"]
+    assert params["objectSchemaId"] == "3"
+
+
+def test_search_assets_aql_omits_empty_schema_filter(assets_fetcher: JiraFetcher):
+    """An empty schema_id should not add objectSchemaId."""
+    assets_fetcher.jira.get = MagicMock(return_value={"objectEntries": []})
+
+    assets_fetcher.search_assets_aql("objectType = X", schema_id="  ")
+
+    assert "objectSchemaId" not in assets_fetcher.jira.get.call_args[1]["params"]

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -88,6 +88,13 @@ def mock_jira_fetcher():
     mock_fetcher.get_available_transitions.return_value = []
     mock_fetcher.get_issue_watchers.return_value = {"watchCount": 0, "watchers": []}
     mock_fetcher.get_worklogs.return_value = []
+    mock_fetcher.search_assets_aql.return_value = {
+        "objects": [],
+        "total": 0,
+        "page": 1,
+        "page_size": 100,
+        "total_pages": 0,
+    }
 
     # Configure search_issues to return fixture data
     def mock_search_issues(jql, **kwargs):
@@ -630,6 +637,24 @@ async def jira_client(test_jira_mcp, mock_jira_fetcher, mock_request):
         ),
     ):
         async with Client(transport=FastMCPTransport(test_jira_mcp)) as client_instance:
+            yield client_instance
+
+
+@pytest.fixture
+async def assets_jira_client(mock_jira_fetcher):
+    """Create a client with the default-off Assets discovery tool enabled."""
+    from src.mcp_atlassian.servers.jira import discover
+
+    root_mcp = FastMCP(name="AssetsTestRoot")
+    jira_sub_mcp = FastMCP(name="AssetsTestJira")
+    jira_sub_mcp.add_tool(discover)
+    root_mcp.mount(jira_sub_mcp, namespace="jira")
+
+    with patch(
+        "src.mcp_atlassian.servers.jira.get_jira_fetcher",
+        AsyncMock(return_value=mock_jira_fetcher),
+    ):
+        async with Client(transport=FastMCPTransport(root_mcp)) as client_instance:
             yield client_instance
 
 
@@ -3919,6 +3944,63 @@ async def test_get_field_options_combined(jira_client, mock_jira_fetcher):
 
 
 @pytest.mark.anyio
+async def test_discover_asset_schemas(assets_jira_client, mock_jira_fetcher):
+    """jira_discover should expose Assets schemas through one meta-tool."""
+    mock_jira_fetcher.list_asset_schemas.return_value = [
+        {"id": "1", "name": "Hardware"},
+        {"id": "2", "name": "People"},
+    ]
+
+    response = await assets_jira_client.call_tool(
+        "jira_discover",
+        {"resource": "asset_schemas", "name_filter": "hard"},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content == {
+        "resource": "asset_schemas",
+        "schemas": [{"id": "1", "name": "Hardware"}],
+    }
+
+
+@pytest.mark.anyio
+async def test_discover_asset_object_types_requires_schema_id(
+    assets_jira_client, mock_jira_fetcher
+):
+    """Object-type discovery should explain its required selector."""
+    with pytest.raises(ToolError, match="schema_id is required"):
+        await assets_jira_client.call_tool(
+            "jira_discover",
+            {"resource": "asset_object_types"},
+        )
+
+    mock_jira_fetcher.list_asset_object_types.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_discover_asset_object_type_attributes(
+    assets_jira_client, mock_jira_fetcher
+):
+    """jira_discover should route attribute discovery by object type ID."""
+    mock_jira_fetcher.get_asset_object_type_attributes.return_value = [
+        {"id": "100", "name": "Name"}
+    ]
+
+    response = await assets_jira_client.call_tool(
+        "jira_discover",
+        {"resource": "asset_attributes", "object_type_id": "10"},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content == {
+        "resource": "asset_attributes",
+        "object_type_id": "10",
+        "attributes": [{"id": "100", "name": "Name"}],
+    }
+    mock_jira_fetcher.get_asset_object_type_attributes.assert_called_once_with("10")
+
+
+@pytest.mark.anyio
 async def test_get_issue_include_remote_links(jira_client, mock_jira_fetcher):
     """get_issue with include=remote_links fetches remote links."""
     mock_jira_fetcher.get_remote_issue_links.return_value = [
@@ -4028,6 +4110,48 @@ async def test_get_issue_include_worklogs(jira_client, mock_jira_fetcher):
         {"id": "10001", "time_spent": "1h", "time_spent_seconds": 3600}
     ]
     mock_jira_fetcher.get_worklogs.assert_called_once_with("TEST-123")
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_assets(jira_client, mock_jira_fetcher):
+    """get_issue should inline Assets objects connected to the issue."""
+    mock_jira_fetcher.config.is_cloud = False
+    mock_jira_fetcher.search_assets_aql.return_value = {
+        "objects": [{"id": "501", "object_key": "HW-501"}],
+        "total": 1,
+        "page": 1,
+        "page_size": 100,
+        "total_pages": 1,
+    }
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "assets"},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content["assets"] == [{"id": "501", "object_key": "HW-501"}]
+    mock_jira_fetcher.search_assets_aql.assert_called_once_with(
+        'object HAVING connectedTickets(key = "TEST-123")',
+        results_per_page=100,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_issue_include_assets_is_empty_on_cloud(
+    jira_client, mock_jira_fetcher
+):
+    """The Server/DC-only Assets enrichment should not call Assets on Cloud."""
+    mock_jira_fetcher.config.is_cloud = True
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "include": "assets"},
+    )
+
+    content = json.loads(response.content[0].text)
+    assert content["assets"] == []
+    mock_jira_fetcher.search_assets_aql.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/unit/servers/test_mcp_protocol.py
+++ b/tests/unit/servers/test_mcp_protocol.py
@@ -41,15 +41,7 @@ JIRA_CLOUD_ONLY_TOOL_NAMES = {
     "move_issue",
 }
 JIRA_SERVER_ONLY_TOOL_NAMES = {
-    "list_asset_schemas",
-    "list_asset_object_types",
-    "get_asset_object_type_attributes",
-    "search_assets",
-    "get_asset_object",
-    "get_asset_object_history",
-    "get_asset_connected_tickets",
-    "create_asset_object",
-    "update_asset_object",
+    "discover",
 }
 
 

--- a/tests/unit/servers/test_mcp_protocol.py
+++ b/tests/unit/servers/test_mcp_protocol.py
@@ -40,6 +40,17 @@ JIRA_CLOUD_ONLY_TOOL_NAMES = {
     "batch_get_changelogs",
     "move_issue",
 }
+JIRA_SERVER_ONLY_TOOL_NAMES = {
+    "list_asset_schemas",
+    "list_asset_object_types",
+    "get_asset_object_type_attributes",
+    "search_assets",
+    "get_asset_object",
+    "get_asset_object_history",
+    "get_asset_connected_tickets",
+    "create_asset_object",
+    "update_asset_object",
+}
 
 
 def _mock_tool(name, tags):
@@ -198,7 +209,12 @@ class TestMCPProtocolIntegration:
         """The production server advertises Cloud-only Jira tools only on Cloud."""
         jira_config = MagicMock(spec=JiraConfig)
         jira_config.is_cloud = is_cloud
-        app_context = MainAppContext(full_jira_config=jira_config)
+        # Enable the (default-off) jira_assets toolset so the deployment
+        # filter, not the toolset filter, decides whether its tools appear.
+        app_context = MainAppContext(
+            full_jira_config=jira_config,
+            enabled_toolsets={"jira_issues", "jira_assets"},
+        )
         request_context = MagicMock()
         request_context.request = None
         request_context.lifespan_context = {"app_lifespan_context": app_context}
@@ -213,6 +229,12 @@ class TestMCPProtocolIntegration:
         assert "jira_get_issue" in listed_tool_names
         assert listed_tool_names & expected_cloud_only_tools == (
             expected_cloud_only_tools if is_cloud else set()
+        )
+        expected_server_only_tools = {
+            f"jira_{name}" for name in JIRA_SERVER_ONLY_TOOL_NAMES
+        }
+        assert listed_tool_names & expected_server_only_tools == (
+            set() if is_cloud else expected_server_only_tools
         )
 
     async def test_tool_filtering_uses_header_based_jira_deployment(

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -98,7 +98,7 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 25 entries."""
+        """Verify ALL_TOOLSETS has exactly 26 entries."""
         assert len(ALL_TOOLSETS) == 26
 
     def test_all_toolsets_contains_jira_and_confluence(self):
@@ -262,7 +262,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 72, f"Expected 72 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 64, f"Expected 64 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -39,7 +39,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 25
+        assert len(result) == 26
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 25
+        assert len(result) == 26
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -99,13 +99,13 @@ class TestGetEnabledToolsets:
 
     def test_all_toolsets_count(self):
         """Verify ALL_TOOLSETS has exactly 25 entries."""
-        assert len(ALL_TOOLSETS) == 25
+        assert len(ALL_TOOLSETS) == 26
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
-        assert len(jira_toolsets) == 16
+        assert len(jira_toolsets) == 17
         assert len(confluence_toolsets) == 8
 
 
@@ -262,7 +262,7 @@ class TestToolsetTagCompleteness:
 
     def test_jira_tool_count(self, jira_tools):
         """Verify expected number of Jira tools."""
-        assert len(jira_tools) == 63, f"Expected 63 Jira tools, got {len(jira_tools)}"
+        assert len(jira_tools) == 72, f"Expected 72 Jira tools, got {len(jira_tools)}"
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""


### PR DESCRIPTION
## Description

Adds Jira Assets (formerly Insight) support for Jira Service Management Server/Data Center while keeping the MCP surface consolidated:

- `jira_discover` lists Assets schemas, object types, and attribute definitions through one read-only discovery tool.
- `jira_get_issue(include="assets")` returns up to 100 Assets objects connected to an issue.

This replaces the original nine low-level Assets tools with one discovery entry point plus issue-oriented enrichment, aligning the contribution with the tool-consolidation direction in #1104. Arbitrary Assets search, object CRUD, history, and connected-ticket tools are intentionally excluded from this PR.

Fixes #1639

## Changes

- Add an `AssetsMixin` to `JiraFetcher` for schema, object-type, and attribute discovery plus the internal AQL query used by issue enrichment.
- Support both `rest/assets/1.0` and the legacy `rest/insight/1.0` base through `JIRA_ASSETS_API_BASE`.
- Add the opt-in `jira_assets` toolset and a `server_only` deployment filter so `jira_discover` is hidden on Jira Cloud.
- Validate numeric Assets IDs before interpolating them into REST paths.
- Update generated tool documentation, configuration documentation, environment examples, and tool counts.

## Verification

- `3901 passed` in the unit suite, excluding only the two optional real-data modules so the run contains no skips.
- Focused Cloud live E2E: `1 passed` for `jira_get_issue(include="assets")` on a real Cloud issue.
- Focused Data Center live E2E: `2 passed` across the current Assets and legacy Insight REST prefixes.
- Ruff format/check, mypy, generated-doc checks, and `git diff --check` pass.

The full Cloud and Data Center lane attempts were blocked by unrelated shared Confluence health checks (Cloud returned 503; the local DC content fixture returned 404). The Jira Assets paths were exercised independently against both live editions without skips.
