### PR TITLE
ci(docker): verify injected package version before publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Release builds must carry a real package version. `.dockerignore` excludes
+      # .git, so uv-dynamic-versioning falls back to 0.0.0 unless VERSION is
+      # injected. A tag cut from a branch without that injection publishes 0.0.0
+      # silently, which makes every past advisory match in vulnerability scanners.
+      # Build the amd64 layer once (cached, reused by the push below) and assert
+      # the installed version before anything is published.
+      - name: Build amd64 image for version verification
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: mcp-atlassian:verify
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+
+      - name: Verify injected package version matches the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          expected='${{ steps.meta.outputs.version }}'
+          actual=$(docker run --rm --entrypoint sh mcp-atlassian:verify -c \
+            'ls /app/.venv/lib/python*/site-packages | sed -n "s/^mcp_atlassian-\(.*\)\.dist-info$/\1/p" | head -1')
+          echo "expected=${expected} actual=${actual}"
+          if [ -z "${actual}" ]; then
+            echo "::error::Could not determine the installed mcp-atlassian version from the image."
+            exit 1
+          fi
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error::Image reports version '${actual}' but the tag expects '${expected}'."
+            echo "::error::The VERSION build arg did not reach the build. Refusing to publish."
+            exit 1
+          fi
+
       - name: Build and push Docker image
         id: docker_build
         uses: docker/build-push-action@v5

--- a/tests/unit/test_docker_versioning.py
+++ b/tests/unit/test_docker_versioning.py
@@ -25,3 +25,31 @@ def test_docker_workflow_passes_version_and_guards_manual_tag() -> None:
     assert (
         "github.event_name == 'workflow_dispatch' && github.ref_type == 'branch'"
     ) in workflow
+
+
+def test_docker_workflow_verifies_injected_version_before_push() -> None:
+    """Release builds must assert the image's version before publishing.
+
+    Without this, a tag cut from a branch that lacks the VERSION injection
+    publishes an image reporting 0.0.0. That version sorts below every
+    "fixed in" release, so vulnerability scanners match every advisory ever
+    filed against the package.
+    """
+    workflow_path = ROOT / ".github" / "workflows" / "docker-publish.yml"
+    lines = workflow_path.read_text().splitlines()
+
+    verify_index = next(
+        i for i, line in enumerate(lines) if "Verify injected package version" in line
+    )
+    push_index = next(
+        i for i, line in enumerate(lines) if "Build and push Docker image" in line
+    )
+
+    assert verify_index < push_index, (
+        "version verification must run before the push step"
+    )
+
+    workflow = "\n".join(lines)
+    assert "mcp_atlassian-" in workflow
+    assert "Refusing to publish" in workflow
+    assert "startsWith(github.ref, 'refs/tags/v')" in workflow


### PR DESCRIPTION
## Description

Fixes: #1632

`.dockerignore` excludes `.git`, so `uv-dynamic-versioning` cannot resolve a version and falls back to `fallback-version = "0.0.0"`. The `VERSION` build arg added in #1553 is the only thing that overrides it.

When a tag is cut from a branch that predates that injection, the published image reports its version as `0.0.0`. Because `0.0.0` sorts below every "fixed in" release, Trivy, Grype and Harbor match **every advisory ever filed against `mcp-atlassian`** and report them as unremediated — including CVE-2026-27825 (Critical, 9.1), fixed in 0.17.0. That makes the published images unusable in scan-gated environments.

This is what happened with `v0.23.1`. Comparing that tag against the #1553 merge commit returns `status: diverged` (21 ahead, 2 behind, merge base `737b1b8` = the `v0.23.0` commit), so the tag was cut from a branch that forked before #1553 landed. Neither `ARG VERSION`, the `sed` guard, nor the workflow's `build-args` block exists at that tag.

The injection mechanism on `main` is correct — building `main` with `--build-arg VERSION=0.23.1` produces `mcp_atlassian-0.23.1.dist-info`. The gap is that nothing verifies the result, so a release cut from the wrong lineage publishes silently.

## Changes

- `.github/workflows/docker-publish.yml`: on tag pushes, build the amd64 layer with `load: true` and assert the installed `mcp_atlassian` dist-info version matches `steps.meta.outputs.version`, failing before the push step on mismatch
- Both new steps are gated on `startsWith(github.ref, 'refs/tags/v')`, so branch, PR and `workflow_dispatch` builds are unaffected
- `tests/unit/test_docker_versioning.py`: assert the verification step precedes the push step and that the guard's markers are present, so it cannot be removed unnoticed

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passed
- [x] Manual checks performed: `YAML parse, step ordering, and both failure paths of the assertion`

Details:

- `uv run pytest tests/unit/test_docker_versioning.py` — 3 passed.
- Parsed the workflow with `yaml.safe_load` and confirmed 8 steps in the expected order, with verification sitting between login and the push.
- Verified the assertion logic against real images: an image built with `--build-arg VERSION=0.23.1` yields `mcp_atlassian-0.23.1.dist-info` and passes; the published `ghcr.io/sooperset/mcp-atlassian:0.23.1` yields `0.0.0` and fails, which is the case this guard is meant to catch.
- `uv run pre-commit run --files .github/workflows/docker-publish.yml tests/unit/test_docker_versioning.py` — all hooks pass, including `mypy` and `check-yaml`.

Integration tests were not run; they require live Atlassian credentials and are unrelated to the build pipeline.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] All tests pass locally.
- [x] Documentation updated (if needed).