### PR TITLE
fix(jira): keep dash-only table rows when converting to ADF

### DIFF
--- a/src/mcp_atlassian/models/jira/adf.py
+++ b/src/mcp_atlassian/models/jira/adf.py
@@ -430,11 +430,14 @@ def markdown_to_adf(markdown_text: str, jira_base_url: str = "") -> dict[str, An
                 table_rows.append(lines[i])
                 i += 1
 
-            # Parse rows, skip separator (|---|---|)
+            # Parse rows, skip separator (|---|---|). The delimiter row is the
+            # second line of a table by definition, so only that line is
+            # eligible: a later row of dash-only cells is data, and a single
+            # "-" is a common way to write "not applicable".
             data_rows: list[list[str]] = []
-            for row_line in table_rows:
+            for row_index, row_line in enumerate(table_rows):
                 cells = [c.strip() for c in row_line.strip("|").split("|")]
-                if all(re.match(r"^:?-+:?$", c) for c in cells if c):
+                if row_index == 1 and all(re.match(r"^:?-+:?$", c) for c in cells if c):
                     continue
                 data_rows.append(cells)
 

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -796,6 +796,18 @@ class TestMarkdownToAdf:
         ]
         assert texts[2] == ["-", "-", "-"]
 
+    def test_keeps_empty_row(self):
+        """An empty row after the delimiter is data, not another delimiter."""
+        md = "| A | B |\n|---|---|\n| 1 | 2 |\n|  |  |\n| 3 | 4 |"
+        rows = next(n for n in markdown_to_adf(md)["content"] if n["type"] == "table")[
+            "content"
+        ]
+        texts = [
+            [c["content"][0]["content"][0]["text"] for c in row["content"]]
+            for row in rows
+        ]
+        assert texts == [["A", "B"], ["1", "2"], ["", ""], ["3", "4"]]
+
     def test_drops_delimiter_row(self):
         """Every delimiter spelling stays recognised at its own position."""
         for separator in ("|---|---|", "|:---|---:|", "|-|-|", "|:-:|:-:|"):

--- a/tests/unit/models/test_adf.py
+++ b/tests/unit/models/test_adf.py
@@ -773,6 +773,43 @@ class TestMarkdownToAdf:
         data_texts = [c["content"][0]["content"][0]["text"] for c in rows[1]["content"]]
         assert data_texts == ["Alice", "30"]
 
+    def test_keeps_dash_only_row(self):
+        """A later dash-only row is data, not a second delimiter.
+
+        A single "-" is a common way to write "not applicable", and dropping it
+        removes a row of real content with nothing logged.
+        """
+        md = (
+            "| Environment | Owner | Notes |\n"
+            "|---|---|---|\n"
+            "| prod | alice | migrated |\n"
+            "| - | - | - |\n"
+            "| dev | bob | migrated |"
+        )
+        rows = next(n for n in markdown_to_adf(md)["content"] if n["type"] == "table")[
+            "content"
+        ]
+        assert len(rows) == 4  # header + 3 data rows
+        texts = [
+            [c["content"][0]["content"][0]["text"] for c in row["content"]]
+            for row in rows
+        ]
+        assert texts[2] == ["-", "-", "-"]
+
+    def test_drops_delimiter_row(self):
+        """Every delimiter spelling stays recognised at its own position."""
+        for separator in ("|---|---|", "|:---|---:|", "|-|-|", "|:-:|:-:|"):
+            md = f"| A | B |\n{separator}\n| 1 | 2 |"
+            rows = next(
+                n for n in markdown_to_adf(md)["content"] if n["type"] == "table"
+            )["content"]
+            assert len(rows) == 2, f"{separator} was not treated as a delimiter"
+            texts = [
+                [c["content"][0]["content"][0]["text"] for c in row["content"]]
+                for row in rows
+            ]
+            assert texts == [["A", "B"], ["1", "2"]]
+
     def test_table_with_inline_formatting(self):
         """Table cells preserve inline formatting (bold, code)."""
         md = "| Feature | Status |\n|---|---|\n| **Auth** | `done` |"


### PR DESCRIPTION
Closes #1629

## Problem

The ADF table parser treats any row whose cells are all dashes as the delimiter:

```python
if all(re.match(r"^:?-+:?$", c) for c in cells if c):
    continue
```

There is no position check, so a data row of `| - | - | - |` is dropped. A single `-` is a common way to write "not applicable", so a row of real content leaves the document with nothing logged and the tool call reporting success. The same predicate also drops an all-empty spacer row. It reaches `jira_create_issue`, `jira_update_issue`, `jira_add_comment`, `jira_add_worklog` and the transition comment.

Reproduced with the script in the issue: four rows in, three out.

```
tableRow nodes: 3
['Environment', 'Owner', 'Notes']
['prod', 'alice', 'migrated']
['dev', 'bob', 'migrated']
```

## Change

A delimiter row is the second line of a table by definition, so only that line is eligible. `src/mcp_atlassian/models/jira/adf.py`, one condition:

```python
for row_index, row_line in enumerate(table_rows):
    cells = [c.strip() for c in row_line.strip("|").split("|")]
    if row_index == 1 and all(re.match(r"^:?-+:?$", c) for c in cells if c):
        continue
    data_rows.append(cells)
```

After: four rows in, four out, with the delimiter still dropped. Later all-empty spacer rows are preserved as well.

## What still behaves the same

Checked each delimiter spelling at its own position, and all are still recognised: `|---|---|`, `|:---|---:|`, `|-|-|`, `|:-:|:-:|`.

A dash-only row directly after the header is genuinely ambiguous, since that is where a delimiter belongs. It is still read as the delimiter, so nothing changes there.

## Tests

`tests/unit/models/test_adf.py`: one test for the dropped dash-only data row, one for the dropped all-empty spacer row, and one asserting every delimiter spelling is still skipped.

```bash
uv run pytest tests/unit/models/ tests/unit/jira/test_comments.py -q
uv run ruff format --check src/mcp_atlassian/models/jira/adf.py tests/unit/models/test_adf.py
uv run ruff check --ignore=BLE001,EM102,FBT001,FBT002,E501,F841,S112,S113,B904 src/mcp_atlassian/models/jira/adf.py tests/unit/models/test_adf.py
uv run pre-commit run mypy --all-files
uv run python scripts/generate_tool_docs.py --check
```

437 passed, 5 skipped. Formatting, lint, mypy, and generated-doc checks pass.

A live Jira Cloud create/read/delete round-trip preserved all five rows in a table containing both an all-empty spacer row and a dash-only data row. Cleanup passed.
