### PR TITLE
fix(jira): describe wiki markup in tool schemas when translation is disabled

### DIFF
--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -14,7 +14,7 @@ Add a comment to a Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `body` | `string` | Yes | Comment text in Markdown format. |
+| `body` | `string` | Yes | Comment text in Markdown format |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
 | `public` | `boolean` | No | (Optional) For JSM/Service Desk issues only. Set to true for customer-visible comment, false for internal agent-only comment. Posted via the ServiceDesk API as a raw string; Jira Cloud renders it server-side and stores ADF (markdown observed to render on Cloud, without the client-side markdown-to-ADF guarantees of the regular comment path). Cannot be combined with visibility. If the issue's project is listed in JIRA_INTERNAL_ONLY_PROJECTS, only public=false is accepted — public=true or omitting this field is rejected. Issues in such a project that are not JSM customer requests (e.g. an agent-created Task) have no portal audience and are exempt: they post through the ordinary comment path and ignore this field. |
 **Example:**
@@ -41,7 +41,7 @@ Edit an existing comment on a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `comment_id` | `string` | Yes | The ID of the comment to edit |
-| `body` | `string` | Yes | Updated comment text in Markdown format. |
+| `body` | `string` | Yes | Updated comment text in Markdown format |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
 
 ---
@@ -70,7 +70,7 @@ Add a worklog entry to a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `time_spent` | `string` | Yes | Time spent in Jira format. Examples: '1h 30m' (1 hour and 30 minutes), '1d' (1 day), '30m' (30 minutes), '4h' (4 hours) |
-| `comment` | `string` | No | (Optional) Worklog comment in Markdown format. |
+| `comment` | `string` | No | (Optional) Comment for the worklog in Markdown format |
 | `started` | `string` | No | (Optional) Start time in ISO format. If not provided, the current time will be used. Example: '2023-08-01T12:00:00.000+0000' |
 | `original_estimate` | `string` | No | (Optional) New value for the original estimate |
 | `remaining_estimate` | `string` | No | (Optional) New value for the remaining estimate |

--- a/docs/tools/jira-comments-worklogs.mdx
+++ b/docs/tools/jira-comments-worklogs.mdx
@@ -14,7 +14,7 @@ Add a comment to a Jira issue.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
-| `body` | `string` | Yes | Comment text in Markdown format |
+| `body` | `string` | Yes | Comment text in Markdown format. |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
 | `public` | `boolean` | No | (Optional) For JSM/Service Desk issues only. Set to true for customer-visible comment, false for internal agent-only comment. Posted via the ServiceDesk API as a raw string; Jira Cloud renders it server-side and stores ADF (markdown observed to render on Cloud, without the client-side markdown-to-ADF guarantees of the regular comment path). Cannot be combined with visibility. If the issue's project is listed in JIRA_INTERNAL_ONLY_PROJECTS, only public=false is accepted — public=true or omitting this field is rejected. Issues in such a project that are not JSM customer requests (e.g. an agent-created Task) have no portal audience and are exempt: they post through the ordinary comment path and ignore this field. |
 **Example:**
@@ -41,7 +41,7 @@ Edit an existing comment on a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `comment_id` | `string` | Yes | The ID of the comment to edit |
-| `body` | `string` | Yes | Updated comment text in Markdown format |
+| `body` | `string` | Yes | Updated comment text in Markdown format. |
 | `visibility` | `string` | No | (Optional) Comment visibility as JSON string (e.g. '`{"type":"group","value":"jira-users"}`') |
 
 ---
@@ -70,7 +70,7 @@ Add a worklog entry to a Jira issue.
 |-----------|------|----------|-------------|
 | `issue_key` | `string` | Yes | Jira issue key (e.g., 'PROJ-123', 'ACV2-642') |
 | `time_spent` | `string` | Yes | Time spent in Jira format. Examples: '1h 30m' (1 hour and 30 minutes), '1d' (1 day), '30m' (30 minutes), '4h' (4 hours) |
-| `comment` | `string` | No | (Optional) Comment for the worklog in Markdown format |
+| `comment` | `string` | No | (Optional) Worklog comment in Markdown format. |
 | `started` | `string` | No | (Optional) Start time in ISO format. If not provided, the current time will be used. Example: '2023-08-01T12:00:00.000+0000' |
 | `original_estimate` | `string` | No | (Optional) New value for the original estimate |
 | `remaining_estimate` | `string` | No | (Optional) New value for the remaining estimate |

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -19,6 +19,7 @@ from ..utils.oauth import (
 )
 from ..utils.proxy import get_proxy_settings_from_env
 from ..utils.urls import is_atlassian_cloud_url
+from .constants import markup_translation_disabled
 
 logger = logging.getLogger("mcp-atlassian.jira.config")
 
@@ -345,9 +346,7 @@ class JiraConfig:
         passthrough_headers = get_header_names("JIRA_PASSTHROUGH_HEADERS")
 
         # Markup translation setting
-        disable_jira_markup_translation = (
-            os.getenv("DISABLE_JIRA_MARKUP_TRANSLATION", "false").lower() == "true"
-        )
+        disable_jira_markup_translation = markup_translation_disabled()
 
         # Client certificate settings
         client_cert = os.getenv("JIRA_CLIENT_CERT")

--- a/src/mcp_atlassian/jira/constants.py
+++ b/src/mcp_atlassian/jira/constants.py
@@ -312,3 +312,13 @@ DEFAULT_READ_JIRA_FIELDS: set[str] = {
     "updated",
     "issuetype",
 }
+
+
+def markup_translation_disabled() -> bool:
+    """Return True when DISABLE_JIRA_MARKUP_TRANSLATION turns markup conversion off.
+
+    Shared by JiraConfig and by the tool schema descriptions in
+    servers/jira.py so the format the schemas advertise can never disagree with
+    what the conversion layer actually does.
+    """
+    return os.getenv("DISABLE_JIRA_MARKUP_TRANSLATION", "false").lower() == "true"

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -12,7 +12,10 @@ from pydantic import AliasChoices, Field
 from requests.exceptions import HTTPError
 
 from mcp_atlassian.exceptions import MCPAtlassianAuthenticationError
-from mcp_atlassian.jira.constants import DEFAULT_READ_JIRA_FIELDS
+from mcp_atlassian.jira.constants import (
+    DEFAULT_READ_JIRA_FIELDS,
+    markup_translation_disabled,
+)
 from mcp_atlassian.jira.forms_common import convert_datetime_to_timestamp
 from mcp_atlassian.models.jira import JiraAttachment
 from mcp_atlassian.models.jira.common import JiraUser
@@ -46,6 +49,49 @@ ISSUE_KEY_PATTERN = get_regex_env(
     "JIRA_ISSUE_KEY_PATTERN", r"^[A-Z][A-Z0-9_]+-\d+(?:-\d+)*$"
 )
 PROJECT_KEY_PATTERN = get_regex_env("JIRA_PROJECT_KEY_PATTERN", r"^[A-Z][A-Z0-9_]+$")
+
+
+# With DISABLE_JIRA_MARKUP_TRANSLATION set, text is written to Jira exactly as
+# supplied, so on Server/DC the format Jira actually stores is wiki markup, not
+# Markdown. The schemas have to say so: the model writes whatever the description
+# asks for, and describing these fields as Markdown made it send Markdown that
+# was then stored as literal text (#1594). Read once at import time, like the key
+# patterns above, so it must be set in the environment (or .env) before start.
+_MARKUP_TRANSLATION_DISABLED = markup_translation_disabled()
+
+
+def _body_format(subject: str, *, brief: bool = False) -> str:
+    """Describe the markup format expected for a field written into Jira.
+
+    Args:
+        subject: How the field is named in the schema, e.g. "Comment text".
+        brief: Use the shorter pass-through wording, for fields where the
+            longer Cloud/ADF note would not earn its space.
+
+    Returns:
+        The description sentence for the current translation setting.
+    """
+    if not _MARKUP_TRANSLATION_DISABLED:
+        return f"{subject} in Markdown format."
+    if brief:
+        return (
+            f"{subject}. Server/DC: Jira wiki markup, passed through. Cloud: Markdown."
+        )
+    return (
+        f"{subject}. Server/DC: Jira wiki markup, passed through with no "
+        "conversion. Cloud: Markdown (converted to ADF)."
+    )
+
+
+# The worked example has to match the format the description just asked for, or
+# the model copies Markdown into a field that stores wiki markup verbatim.
+_UPDATE_FIELDS_EXAMPLE = (
+    'Example: \'{"assignee": "user@example.com", "summary": "New Summary", '
+    '"description": "h2. Updated\\nWiki text"}\''
+    if _MARKUP_TRANSLATION_DISABLED
+    else 'Example: \'{"assignee": "user@example.com", "summary": "New Summary", '
+    '"description": "## Updated\\nMarkdown text"}\''
+)
 
 jira_mcp = ErrorPreservingFastMCP(
     name="Jira MCP Service",
@@ -1758,7 +1804,7 @@ async def create_issue(
         str | None,
         Field(
             description=(
-                "Issue description in Markdown format. On Jira Cloud, use "
+                _body_format("Issue description") + " On Jira Cloud, use "
                 "'{expand:Title}...{expand}' for a collapsible section and "
                 "'{status:color=green|title=Done}' for an inline status "
                 "lozenge."
@@ -1797,7 +1843,7 @@ async def create_issue(
         summary: Summary/title of the issue.
         issue_type: Issue type (e.g., 'Task', 'Bug', 'Story', 'Epic', 'Subtask').
         assignee: Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...').
-        description: Issue description in Markdown format.
+        description: Issue description, in the markup format the parameter schema states.
         components: Comma-separated list of component names.
         additional_fields: JSON string of additional fields.
 
@@ -1849,7 +1895,9 @@ async def batch_create_issues(
                 "- project_key (required): The project key (e.g., 'PROJ')\n"
                 "- summary (required): Issue summary/title\n"
                 "- issue_type (required): Type of issue (e.g., 'Task', 'Bug')\n"
-                "- description (optional): Issue description in Markdown format\n"
+                "- description (optional): "
+                + _body_format("Issue description", brief=True)
+                + "\n"
                 "- assignee (optional): Assignee username or email\n"
                 "- components (optional): Array of component names\n"
                 "Example: [\n"
@@ -2006,7 +2054,9 @@ async def update_issue(
         Field(
             description=(
                 "JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). "
-                "For 'description', provide text in Markdown format; on Jira Cloud, "
+                "For 'description': "
+                + _body_format("provide text")
+                + " On Jira Cloud, "
                 "use '{expand:Title}...{expand}' for a collapsible section "
                 "and '{status:color=green|title=Done}' for an inline status "
                 "lozenge. "
@@ -2014,7 +2064,7 @@ async def update_issue(
                 '{"key": "PROJ-123"} to set the parent, or null to clear it. '
                 "On Server/DC, clear an Epic Link by updating its custom field "
                 'directly, such as {"customfield_10014": null}. '
-                'Example: \'{"assignee": "user@example.com", "summary": "New Summary", "description": "## Updated\\nMarkdown text"}\''
+                + _UPDATE_FIELDS_EXAMPLE
             ),
             default=None,
         ),
@@ -2067,7 +2117,7 @@ async def update_issue(
     comment: Annotated[
         str | None,
         Field(
-            description="(Optional) Comment text in Markdown format.",
+            description=_body_format("(Optional) Comment text", brief=True),
             default=None,
         ),
     ] = None,
@@ -2121,7 +2171,7 @@ async def update_issue(
         ctx: The FastMCP context.
         issue_key: Jira issue key.
         fields: Optional JSON string of fields to update. Text fields like
-            'description' should use Markdown format. On Jira Cloud only, use
+            'description' use the markup format the parameter schema states. On Jira Cloud only, use
             ``{"parent": null}`` to clear an issue's parent. On Server/DC,
             update the Epic Link custom field directly, such as
             ``{"customfield_10014": null}``.
@@ -2130,7 +2180,7 @@ async def update_issue(
         components: Comma-separated list of component names.
         attachments: Optional JSON array string or comma-separated list of file paths.
         transition: Optional transition name or ID.
-        comment: Optional issue comment in Markdown format.
+        comment: Optional issue comment, in the markup format the parameter schema states.
         comment_visibility: Optional JSON string restricting comment visibility.
         worklog: Optional time spent to log.
         worklog_started: Optional ISO datetime when the worklog started.
@@ -2495,7 +2545,7 @@ async def add_comment(
     body: Annotated[
         str,
         Field(
-            description="Comment text in Markdown format",
+            description=_body_format("Comment text", brief=True),
             validation_alias=AliasChoices("body", "comment"),
         ),
     ],
@@ -2538,7 +2588,7 @@ async def add_comment(
     Args:
         ctx: The FastMCP context.
         issue_key: Jira issue key.
-        body: Comment text in Markdown.
+        body: Comment text, in the markup format the parameter schema states.
         visibility: (Optional) Comment visibility as JSON string.
         public: (Optional) For JSM issues. True = customer-visible,
             False = internal/agent-only. Uses ServiceDesk API.
@@ -2583,7 +2633,9 @@ async def edit_comment(
         ),
     ],
     comment_id: Annotated[str, Field(description="The ID of the comment to edit")],
-    body: Annotated[str, Field(description="Updated comment text in Markdown format")],
+    body: Annotated[
+        str, Field(description=_body_format("Updated comment text", brief=True))
+    ],
     visibility: Annotated[
         str | None,
         Field(
@@ -2597,7 +2649,7 @@ async def edit_comment(
         ctx: The FastMCP context.
         issue_key: Jira issue key.
         comment_id: The ID of the comment to edit.
-        body: Updated comment text in Markdown.
+        body: Updated comment text, in the markup format the parameter schema states.
         visibility: (Optional) Comment visibility as JSON string.
 
     Returns:
@@ -2640,7 +2692,7 @@ async def add_worklog(
     ],
     comment: Annotated[
         str | None,
-        Field(description="(Optional) Comment for the worklog in Markdown format"),
+        Field(description=_body_format("(Optional) Worklog comment", brief=True)),
     ] = None,
     started: Annotated[
         str | None,
@@ -2665,7 +2717,7 @@ async def add_worklog(
         ctx: The FastMCP context.
         issue_key: Jira issue key.
         time_spent: Time spent in Jira format.
-        comment: Optional comment in Markdown.
+        comment: Optional comment, in the markup format the parameter schema states.
         started: Optional start time in ISO format.
         original_estimate: Optional new original estimate.
         remaining_estimate: Optional new remaining estimate.
@@ -2988,8 +3040,9 @@ async def transition_issue(
         str | None,
         Field(
             description=(
-                "(Optional) Comment to add during the transition in Markdown format. "
-                "This will be visible in the issue history. Rejected for projects "
+                _body_format("(Optional) Transition comment", brief=True)
+                + " This will be visible in the issue history. "
+                "Rejected for projects "
                 "listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be "
                 "customer-visible on JSM and cannot be forced internal): transition "
                 "without a comment, then post an internal note with "
@@ -3007,7 +3060,7 @@ async def transition_issue(
         issue_key: Jira issue key.
         transition_id: ID or name of the transition.
         fields: Optional JSON string of fields to update during transition.
-        comment: Optional comment for the transition in Markdown format.
+        comment: Optional transition comment, in the markup format the parameter schema states.
 
     Returns:
         JSON string representing the updated issue object.

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -60,19 +60,22 @@ PROJECT_KEY_PATTERN = get_regex_env("JIRA_PROJECT_KEY_PATTERN", r"^[A-Z][A-Z0-9_
 _MARKUP_TRANSLATION_DISABLED = markup_translation_disabled()
 
 
-def _body_format(subject: str, *, brief: bool = False) -> str:
+def _body_format(markdown: str, subject: str, *, brief: bool = False) -> str:
     """Describe the markup format expected for a field written into Jira.
 
     Args:
-        subject: How the field is named in the schema, e.g. "Comment text".
+        markdown: The existing description, returned unchanged while markup
+            translation is on, so the default tool schemas do not shift.
+        subject: How the field is named when describing the wiki case,
+            e.g. "Comment text".
         brief: Use the shorter pass-through wording, for fields where the
             longer Cloud/ADF note would not earn its space.
 
     Returns:
-        The description sentence for the current translation setting.
+        The description for the current translation setting.
     """
     if not _MARKUP_TRANSLATION_DISABLED:
-        return f"{subject} in Markdown format."
+        return markdown
     if brief:
         return (
             f"{subject}. Server/DC: Jira wiki markup, passed through. Cloud: Markdown."
@@ -1804,7 +1807,10 @@ async def create_issue(
         str | None,
         Field(
             description=(
-                _body_format("Issue description") + " On Jira Cloud, use "
+                _body_format(
+                    "Issue description in Markdown format.", "Issue description"
+                )
+                + " On Jira Cloud, use "
                 "'{expand:Title}...{expand}' for a collapsible section and "
                 "'{status:color=green|title=Done}' for an inline status "
                 "lozenge."
@@ -1896,7 +1902,11 @@ async def batch_create_issues(
                 "- summary (required): Issue summary/title\n"
                 "- issue_type (required): Type of issue (e.g., 'Task', 'Bug')\n"
                 "- description (optional): "
-                + _body_format("Issue description", brief=True)
+                + _body_format(
+                    "Issue description in Markdown format",
+                    "Issue description",
+                    brief=True,
+                )
                 + "\n"
                 "- assignee (optional): Assignee username or email\n"
                 "- components (optional): Array of component names\n"
@@ -2054,10 +2064,12 @@ async def update_issue(
         Field(
             description=(
                 "JSON string of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). "
-                "For 'description': "
-                + _body_format("provide text")
-                + " On Jira Cloud, "
-                "use '{expand:Title}...{expand}' for a collapsible section "
+                + _body_format(
+                    "For 'description', provide text in Markdown format; on Jira Cloud, ",
+                    "For 'description': provide text",
+                )
+                + ("" if not _MARKUP_TRANSLATION_DISABLED else " On Jira Cloud, ")
+                + "use '{expand:Title}...{expand}' for a collapsible section "
                 "and '{status:color=green|title=Done}' for an inline status "
                 "lozenge. "
                 "On Jira Cloud only, for 'parent', provide an issue key or "
@@ -2117,7 +2129,11 @@ async def update_issue(
     comment: Annotated[
         str | None,
         Field(
-            description=_body_format("(Optional) Comment text", brief=True),
+            description=_body_format(
+                "(Optional) Comment text in Markdown format.",
+                "(Optional) Comment text",
+                brief=True,
+            ),
             default=None,
         ),
     ] = None,
@@ -2545,7 +2561,9 @@ async def add_comment(
     body: Annotated[
         str,
         Field(
-            description=_body_format("Comment text", brief=True),
+            description=_body_format(
+                "Comment text in Markdown format", "Comment text", brief=True
+            ),
             validation_alias=AliasChoices("body", "comment"),
         ),
     ],
@@ -2634,7 +2652,14 @@ async def edit_comment(
     ],
     comment_id: Annotated[str, Field(description="The ID of the comment to edit")],
     body: Annotated[
-        str, Field(description=_body_format("Updated comment text", brief=True))
+        str,
+        Field(
+            description=_body_format(
+                "Updated comment text in Markdown format",
+                "Updated comment text",
+                brief=True,
+            )
+        ),
     ],
     visibility: Annotated[
         str | None,
@@ -2692,7 +2717,13 @@ async def add_worklog(
     ],
     comment: Annotated[
         str | None,
-        Field(description=_body_format("(Optional) Worklog comment", brief=True)),
+        Field(
+            description=_body_format(
+                "(Optional) Comment for the worklog in Markdown format",
+                "(Optional) Worklog comment",
+                brief=True,
+            )
+        ),
     ] = None,
     started: Annotated[
         str | None,
@@ -3040,7 +3071,11 @@ async def transition_issue(
         str | None,
         Field(
             description=(
-                _body_format("(Optional) Transition comment", brief=True)
+                _body_format(
+                    "(Optional) Comment to add during the transition in Markdown format.",
+                    "(Optional) Transition comment",
+                    brief=True,
+                )
                 + " This will be visible in the issue history. "
                 "Rejected for projects "
                 "listed in JIRA_INTERNAL_ONLY_PROJECTS (a transition comment may be "

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -2187,10 +2187,10 @@ async def update_issue(
         ctx: The FastMCP context.
         issue_key: Jira issue key.
         fields: Optional JSON string of fields to update. Text fields like
-            'description' use the markup format the parameter schema states. On Jira Cloud only, use
-            ``{"parent": null}`` to clear an issue's parent. On Server/DC,
-            update the Epic Link custom field directly, such as
-            ``{"customfield_10014": null}``.
+            'description' use the markup format the parameter schema states.
+            On Jira Cloud only, use ``{"parent": null}`` to clear an issue's
+            parent. On Server/DC, update the Epic Link custom field directly,
+            such as ``{"customfield_10014": null}``.
         additional_fields: Optional JSON string of additional fields. The same
             Cloud-only parent clearing and Server/DC Epic Link guidance applies.
         components: Comma-separated list of component names.

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -5010,7 +5010,16 @@ def test_schema_flag_matches_config_flag(monkeypatch, value, expected):
     If these ever diverge the schemas start advertising a format the
     conversion layer does not actually use, which is the bug in #1594.
     """
+    from mcp_atlassian.jira.config import JiraConfig
     from mcp_atlassian.jira.constants import markup_translation_disabled
 
+    monkeypatch.setenv("JIRA_URL", "https://example.atlassian.net")
+    monkeypatch.setenv("JIRA_USERNAME", "user@example.com")
+    monkeypatch.setenv("JIRA_API_TOKEN", "token")
     monkeypatch.setenv("DISABLE_JIRA_MARKUP_TRANSLATION", value)
+
     assert markup_translation_disabled() is expected
+    # The point of the test: the value the schemas advertise and the value the
+    # conversion layer acts on have to come out the same, so assert the config
+    # too rather than only the predicate it is supposed to agree with.
+    assert JiraConfig.from_env().disable_jira_markup_translation is expected

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -4990,7 +4990,6 @@ async def test_markup_schemas_say_wiki_when_translation_disabled(monkeypatch):
 
 
 @pytest.mark.anyio
-@pytest.mark.anyio
 async def test_update_issue_example_matches_advertised_format(monkeypatch):
     """The worked example must not show Markdown for a field that stores wiki."""
     on = await _markup_descriptions(monkeypatch, "false")

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -4920,3 +4920,98 @@ async def test_jira_analysis_tools_return_structured_errors(
 
     assert content["success"] is False
     assert content["error"] == "service unavailable"
+
+
+# Tool schemas must describe the markup format that is actually stored (#1594).
+# The env var is read at import time, so each case reloads the server module
+# under a patched environment rather than mutating a live one.
+
+_MARKUP_SCHEMA_FIELDS = [
+    ("create_issue", "description"),
+    ("batch_create_issues", "issues"),
+    ("update_issue", "fields"),
+    ("add_comment", "body"),
+    ("edit_comment", "body"),
+    ("add_worklog", "comment"),
+    ("transition_issue", "comment"),
+]
+
+
+async def _markup_descriptions(monkeypatch, value: str) -> dict[str, str]:
+    """Reload the Jira server with the flag set and return the described fields."""
+    import importlib
+
+    import mcp_atlassian.servers.jira as jira_server
+
+    monkeypatch.setenv("DISABLE_JIRA_MARKUP_TRANSLATION", value)
+    importlib.reload(jira_server)
+    try:
+        tools = {t.name: t for t in await jira_server.jira_mcp.list_tools()}
+        return {
+            f"{name}.{param}": tools[name].parameters["properties"][param][
+                "description"
+            ]
+            for name, param in _MARKUP_SCHEMA_FIELDS
+        }
+    finally:
+        monkeypatch.delenv("DISABLE_JIRA_MARKUP_TRANSLATION", raising=False)
+        importlib.reload(jira_server)
+
+
+@pytest.mark.anyio
+async def test_markup_schemas_say_markdown_by_default(monkeypatch):
+    """With translation on, every write field is still described as Markdown."""
+    described = await _markup_descriptions(monkeypatch, "false")
+
+    for field, description in described.items():
+        assert "Markdown" in description, f"{field} lost its Markdown wording"
+        assert "wiki markup" not in description, (
+            f"{field} advertises wiki markup while translation is enabled"
+        )
+
+
+@pytest.mark.anyio
+async def test_markup_schemas_say_wiki_when_translation_disabled(monkeypatch):
+    """With DISABLE_JIRA_MARKUP_TRANSLATION set, the text is stored verbatim.
+
+    On Server/DC that means wiki markup, so a schema that still says "in
+    Markdown format" tells the model to send the one format that gets stored
+    as literal text.
+    """
+    described = await _markup_descriptions(monkeypatch, "true")
+
+    for field, description in described.items():
+        assert "wiki markup" in description, (
+            f"{field} still advertises Markdown only: {description[:160]}"
+        )
+        assert "in Markdown format" not in description, (
+            f"{field} kept the misleading wording: {description[:160]}"
+        )
+
+
+@pytest.mark.anyio
+@pytest.mark.anyio
+async def test_update_issue_example_matches_advertised_format(monkeypatch):
+    """The worked example must not show Markdown for a field that stores wiki."""
+    on = await _markup_descriptions(monkeypatch, "false")
+    off = await _markup_descriptions(monkeypatch, "true")
+
+    assert "## Updated" in on["update_issue.fields"]
+    assert "h2. Updated" in off["update_issue.fields"]
+    assert "## Updated" not in off["update_issue.fields"]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("true", True), ("TRUE", True), ("false", False), ("", False), ("1", False)],
+)
+def test_schema_flag_matches_config_flag(monkeypatch, value, expected):
+    """The schema predicate and JiraConfig must read the flag identically.
+
+    If these ever diverge the schemas start advertising a format the
+    conversion layer does not actually use, which is the bug in #1594.
+    """
+    from mcp_atlassian.jira.constants import markup_translation_disabled
+
+    monkeypatch.setenv("DISABLE_JIRA_MARKUP_TRANSLATION", value)
+    assert markup_translation_disabled() is expected


### PR DESCRIPTION
Closes #1594.

## Problem

With `DISABLE_JIRA_MARKUP_TRANSLATION` set, text is written to Jira exactly as supplied. On Server/DC the format Jira actually stores is then wiki markup, not Markdown, but seven write tools still described their text fields as *"in Markdown format"*.

The model writes whatever the schema asks for, so it kept sending Markdown into a field that stores the bytes verbatim, and the Markdown ended up in the ticket as literal text. The schema was describing a format the server had been configured not to produce.

Affected: `jira_create_issue`, `jira_batch_create_issues`, `jira_update_issue`, `jira_add_comment`, `jira_edit_comment`, `jira_add_worklog`, `jira_transition_issue`.

## Change

Descriptions are built through a small `_body_format()` helper that switches on the setting, using the wording from the issue:

| Setting | `jira_add_comment.body` |
|---|---|
| default | `Comment text in Markdown format.` |
| `DISABLE_JIRA_MARKUP_TRANSLATION=true` | `Comment text. Server/DC: Jira wiki markup, passed through. Cloud: Markdown.` |

Two things beyond the literal ask, both in the same failure mode:

- **`jira_update_issue`'s worked example switches too.** It previously showed `"description": "## Updated\nMarkdown text"` regardless of the setting, and a worked example is the part a model is most likely to copy verbatim. It now shows `h2. Updated` when translation is off.
- **The flag moved into a shared `markup_translation_disabled()` helper** that both `JiraConfig` and the schemas call, so the format the schemas advertise cannot drift from what the conversion layer actually does. It deliberately keeps `JiraConfig`'s existing strict `== "true"` match rather than the looser `is_env_truthy()`, since changing that would alter runtime behaviour; a test pins that the two stay in agreement.

Docstring `Args:` lines that named Markdown are now format-neutral, since FastMCP surfaces the docstring as the tool description; the precise format lives in the parameter schema. The value is read once at import time, matching `ISSUE_KEY_PATTERN` directly above it.

The issue also floats detecting Server/DC vs Cloud at startup. I left that out: it needs a live connection, and these descriptions are built at import. The wording covers both deployments instead.

**No change in default behaviour** — with the flag unset every description is byte-identical to before. `scripts/generate_tool_docs.py --check` enforces this: `git diff origin/main -- docs/` is empty. (My first commit did not hold to that and shifted some default wording; the docs check caught it and it is reverted in a follow-up commit — see the comment below.)

## Testing

8 regression tests. Verified against the pre-fix code: 7 fail, and the 1 that passes is the default-behaviour test, which should pass either way.

- `tests/unit/servers/` + `tests/unit/jira/`: **2271 passed**. The one unrelated failure, `test_upload_attachment_success`, reproduces identically on unmodified `main` on this Windows machine (path separators) and is not related to this change.
- `ruff check` (with the repo's pre-commit ignore list) and `ruff format --check`: clean.
- `scripts/generate_tool_docs.py --check` passes, with the generated docs unchanged from `main`.

