### PR TITLE
fix(confluence): apply CONFLUENCE_SPACES_FILTER to space listings

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -306,3 +306,14 @@ class ConfluenceClient:
         return self.preprocessor.process_html_content(
             html_content, space_key, self.confluence
         )
+
+    def _get_allowed_spaces(self) -> set[str] | None:
+        """Return the configured ``CONFLUENCE_SPACES_FILTER`` allowlist.
+
+        Returns:
+            A set of allowed space keys, or None when no filter is configured.
+        """
+        filter_to_use = getattr(self.config, "spaces_filter", None)
+        if not isinstance(filter_to_use, str) or not filter_to_use:
+            return None
+        return {s.strip().upper() for s in filter_to_use.split(",") if s.strip()}

--- a/src/mcp_atlassian/confluence/spaces.py
+++ b/src/mcp_atlassian/confluence/spaces.py
@@ -25,8 +25,26 @@ class SpacesMixin(ConfluenceClient):
             Dictionary containing space information with results and metadata
         """
         spaces = self.confluence.get_all_spaces(start=start, limit=limit)
-        # Cast the return value to the expected type
-        return cast(dict[str, object], spaces)
+        spaces_result = cast(dict[str, object], spaces)
+        allowed_spaces = self._get_allowed_spaces()
+        if allowed_spaces is None or not isinstance(spaces_result, dict):
+            return spaces_result
+
+        results = spaces_result.get("results")
+        if not isinstance(results, list):
+            return spaces_result
+
+        filtered_results = [
+            space
+            for space in results
+            if isinstance(space, dict)
+            and str(space.get("key", "")).strip().upper() in allowed_spaces
+        ]
+        filtered_response = dict(spaces_result)
+        filtered_response["results"] = filtered_results
+        if "size" in filtered_response:
+            filtered_response["size"] = len(filtered_results)
+        return filtered_response
 
     def get_user_contributed_spaces(self, limit: int = 250) -> dict:
         """
@@ -74,8 +92,15 @@ class SpacesMixin(ConfluenceClient):
                     if url and url.startswith("/spaces/"):
                         space_key = url.split("/spaces/")[1].split("/")[0]
 
-                # Only add if we found a space key and it's not already in our results
-                if space_key and space_key not in spaces:
+                allowed_spaces = self._get_allowed_spaces()
+                if (
+                    space_key
+                    and (
+                        allowed_spaces is None
+                        or space_key.strip().upper() in allowed_spaces
+                    )
+                    and space_key not in spaces
+                ):
                     # Add some defaults if we couldn't extract all fields
                     space_name = space_name or f"Space {space_key}"
                     spaces[space_key] = {"key": space_key, "name": space_name}

--- a/src/mcp_atlassian/confluence/spaces.py
+++ b/src/mcp_atlassian/confluence/spaces.py
@@ -23,16 +23,22 @@ class SpacesMixin(ConfluenceClient):
 
         Returns:
             Dictionary containing space information with results and metadata
+
+        Raises:
+            ValueError: If the API response is malformed while a spaces filter is set
         """
         spaces = self.confluence.get_all_spaces(start=start, limit=limit)
         spaces_result = cast(dict[str, object], spaces)
         allowed_spaces = self._get_allowed_spaces()
-        if allowed_spaces is None or not isinstance(spaces_result, dict):
+        if allowed_spaces is None:
             return spaces_result
 
         results = spaces_result.get("results")
         if not isinstance(results, list):
-            return spaces_result
+            raise ValueError(
+                "Confluence get spaces returned a malformed response where "
+                "'results' is not a list"
+            )
 
         filtered_results = [
             space
@@ -57,6 +63,8 @@ class SpacesMixin(ConfluenceClient):
             Dictionary of space keys to space information
         """
         try:
+            allowed_spaces = self._get_allowed_spaces()
+
             # Use CQL to find content the user has contributed to
             cql = "contributor = currentUser() order by lastmodified DESC"
             results = self.confluence.cql(cql=cql, limit=limit)
@@ -92,7 +100,6 @@ class SpacesMixin(ConfluenceClient):
                     if url and url.startswith("/spaces/"):
                         space_key = url.split("/spaces/")[1].split("/")[0]
 
-                allowed_spaces = self._get_allowed_spaces()
                 if (
                     space_key
                     and (

--- a/tests/unit/confluence/test_spaces.py
+++ b/tests/unit/confluence/test_spaces.py
@@ -38,6 +38,21 @@ class TestSpacesMixin:
         )
         assert result == MOCK_SPACES_RESPONSE
 
+    def test_get_spaces_filters_disallowed_results(self, spaces_mixin):
+        spaces_mixin.config.spaces_filter = "TEST"
+        spaces_mixin.confluence.get_all_spaces.return_value = {
+            "results": [
+                {"key": "TEST", "name": "Allowed"},
+                {"key": "SECRET", "name": "Disallowed"},
+            ],
+            "size": 2,
+        }
+
+        result = spaces_mixin.get_spaces()
+
+        assert result["results"] == [{"key": "TEST", "name": "Allowed"}]
+        assert result["size"] == 1
+
     def test_get_user_contributed_spaces_success(self, spaces_mixin):
         """Test getting spaces that the user has contributed to."""
         # Arrange
@@ -130,6 +145,29 @@ class TestSpacesMixin:
         assert len(result) == 1
         assert "SPACE1" in result
         assert result["SPACE1"]["name"] == "Space 1"
+
+    def test_get_user_contributed_spaces_filters_disallowed_results(self, spaces_mixin):
+        spaces_mixin.config.spaces_filter = "ALLOWED"
+        spaces_mixin.confluence.cql.return_value = {
+            "results": [
+                {
+                    "resultGlobalContainer": {
+                        "title": "Allowed",
+                        "displayUrl": "/spaces/ALLOWED",
+                    }
+                },
+                {
+                    "resultGlobalContainer": {
+                        "title": "Secret",
+                        "displayUrl": "/spaces/SECRET",
+                    }
+                },
+            ]
+        }
+
+        result = spaces_mixin.get_user_contributed_spaces()
+
+        assert result == {"ALLOWED": {"key": "ALLOWED", "name": "Allowed"}}
 
     def test_get_user_contributed_spaces_api_error(self, spaces_mixin):
         """Test handling of API errors."""

--- a/tests/unit/confluence/test_spaces.py
+++ b/tests/unit/confluence/test_spaces.py
@@ -53,6 +53,16 @@ class TestSpacesMixin:
         assert result["results"] == [{"key": "TEST", "name": "Allowed"}]
         assert result["size"] == 1
 
+    def test_get_spaces_rejects_malformed_filtered_response(self, spaces_mixin):
+        spaces_mixin.config.spaces_filter = "TEST"
+        spaces_mixin.confluence.get_all_spaces.return_value = {
+            "results": {"key": "SECRET", "name": "Disallowed"},
+            "size": 1,
+        }
+
+        with pytest.raises(ValueError, match="'results' is not a list"):
+            spaces_mixin.get_spaces()
+
     def test_get_user_contributed_spaces_success(self, spaces_mixin):
         """Test getting spaces that the user has contributed to."""
         # Arrange


### PR DESCRIPTION
## Problem

`CONFLUENCE_SPACES_FILTER` is enforced in `confluence_search`, but `get_spaces` and `get_user_contributed_spaces` return every space the credentials can see, ignoring the configured allowlist.

**Scope, corrected after review (thanks @AmirF194):** no MCP tool calls either method today, so this is not a live tool disclosure. `SpacesMixin` is mixed into `ConfluenceFetcher`, which is exported in `__all__`, so the gap is reachable by library consumers calling the fetcher directly. This is public-API hardening, not a fix for an exposed tool path.

## Change

Adds `ConfluenceClient._get_allowed_spaces()`, which parses the configured allowlist once and returns `None` when no filter is set, and applies it in both listing methods. When no filter is configured the behaviour and the request count are unchanged.

## Verification

- `pytest tests/unit/confluence/` — 530 passed.
- Two new tests, both mutation-checked: disabling either filter call makes its test fail, so neither is decorative.
- `mypy` and `ruff format` clean on the touched files.

## Scope and sequencing

This replaces #1519, which tried to cover all Confluence tools in one 25-file change and was too large to review.

Review also showed my original split used the wrong seam. I cut where the code was convenient (methods already holding a space key, needing no extra API call) rather than where the impact is. Around 30 fetcher methods are actually reached by tools, and they are the page-ID and content-ID addressed ones: `get_page_content`, `get_page_by_title`, `get_page_labels`, `get_page_restrictions`, `get_page_comments`, `get_space_permissions`, `list_page_templates`. Enforcement there requires resolving an ID to a space first, which changes the request count for filtered clients, and that is the next slice.

If a maintainer would rather see the page-ID work first, I am happy to close this and lead with that instead.

Disclosure: written with AI assistance, reviewed by me before opening.
