### PR TITLE
fix(jira): support localized Epic issue types

### DIFF
--- a/src/mcp_atlassian/jira/epics.py
+++ b/src/mcp_atlassian/jira/epics.py
@@ -135,7 +135,10 @@ class EpicsMixin(
             required_fields = {}
             if project_key:
                 try:
-                    required_fields = self.get_required_fields("Epic", project_key)
+                    epic_type_id = self._find_epic_issue_type_id(project_key)
+                    required_fields = self.get_required_fields(
+                        epic_type_id or "Epic", project_key
+                    )
                     logger.debug(
                         f"Required fields for Epic in project {project_key}: {list(required_fields.keys())}"
                     )
@@ -290,6 +293,29 @@ class EpicsMixin(
         logger.debug("Could not determine Epic Color field ID")
         return None
 
+    def _is_epic_issue(self, issue: dict[str, Any]) -> bool:
+        """Return whether project metadata identifies an issue as an Epic."""
+        fields = issue.get("fields", {})
+        if not isinstance(fields, dict):
+            return False
+
+        issue_type = fields.get("issuetype", {})
+        if not isinstance(issue_type, dict):
+            return False
+
+        project = fields.get("project", {})
+        project_key = project.get("key") if isinstance(project, dict) else None
+        issue_type_id = issue_type.get("id")
+        if isinstance(project_key, str) and project_key and issue_type_id is not None:
+            epic_type_id = self._find_epic_issue_type_id(project_key)
+            if epic_type_id is not None:
+                return str(issue_type_id) == epic_type_id
+
+        issue_type_name = issue_type.get("name", "")
+        return isinstance(issue_type_name, str) and self._is_epic_issue_type(
+            issue_type_name
+        )
+
     def link_issue_to_epic(self, issue_key: str, epic_key: str) -> JiraIssue:
         """
         Link an existing issue to an epic.
@@ -323,10 +349,7 @@ class EpicsMixin(
                 raise TypeError(msg)
 
             # Check if the epic key corresponds to an actual epic
-            fields = epic.get("fields", {})
-            issue_type = fields.get("issuetype", {}).get("name", "").lower()
-
-            if issue_type != "epic":
+            if not self._is_epic_issue(epic):
                 error_msg = f"Error linking issue to epic: {epic_key} is not an Epic"
                 raise ValueError(error_msg)
 
@@ -461,12 +484,7 @@ class EpicsMixin(
             issuetype_data = fields_data.get("issuetype", {})
             issue_type_name = issuetype_data.get("name", "")
 
-            # Check if it's an Epic by looking for "epic" in the name (case-insensitive)
-            # This handles localized names like "에픽", "エピック", etc.
-            if "epic" not in issue_type_name.lower() and issue_type_name not in [
-                "에픽",
-                "エピック",
-            ]:
+            if not self._is_epic_issue(epic):
                 # Try to verify via JQL as a fallback
                 is_epic = False
                 try:

--- a/src/mcp_atlassian/jira/fields.py
+++ b/src/mcp_atlassian/jira/fields.py
@@ -183,7 +183,7 @@ class FieldsMixin(JiraClient, EpicOperationsProto, UsersOperationsProto):
         Get required fields for creating an issue of a specific type in a project.
 
         Args:
-            issue_type: The issue type (e.g., 'Bug', 'Story', 'Epic')
+            issue_type: The issue type name or ID (e.g., 'Bug' or '10001')
             project_key: The project key (e.g., 'PROJ')
 
         Returns:
@@ -202,7 +202,7 @@ class FieldsMixin(JiraClient, EpicOperationsProto, UsersOperationsProto):
             return self._required_fields_cache[cache_key]
 
         try:
-            # Step 1: Get the ID for the given issue type name within the project
+            # Step 1: Resolve the issue type by stable ID or display name.
             if not hasattr(self, "get_project_issue_types"):
                 logger.error(
                     "get_project_issue_types method not available. Cannot resolve issue type ID."
@@ -212,8 +212,13 @@ class FieldsMixin(JiraClient, EpicOperationsProto, UsersOperationsProto):
             all_issue_types = self.get_project_issue_types(project_key)
             issue_type_id = None
             for it in all_issue_types:
-                if it.get("name", "").lower() == issue_type.lower():
-                    issue_type_id = it.get("id")
+                candidate_id = it.get("id")
+                candidate_name = it.get("name", "")
+                if (candidate_id is not None and str(candidate_id) == issue_type) or (
+                    isinstance(candidate_name, str)
+                    and candidate_name.lower() == issue_type.lower()
+                ):
+                    issue_type_id = candidate_id
                     break
 
             if not issue_type_id:

--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -30,6 +30,7 @@ logger = logging.getLogger("mcp-jira")
 
 # Friendly aliases that users may pass for the epic link custom field
 _EPIC_LINK_ALIASES = frozenset({"epickey", "epic_link", "epiclink", "epic link"})
+_EPIC_NAME_FIELD_SCHEMA = "com.pyxis.greenhopper.jira:gh-epic-label"
 
 
 class IssuesMixin(
@@ -803,14 +804,13 @@ class IssuesMixin(
         return issue_type.lower() in epic_names or "epic" in issue_type.lower()
 
     def _find_epic_issue_type_id(self, project_key: str) -> str | None:
-        """
-        Find the actual Epic issue type name for a project.
+        """Find the Epic issue type ID for a project.
 
         Args:
             project_key: The project key
 
         Returns:
-            The Epic issue type name if found, None otherwise
+            The Epic issue type ID if found, None otherwise
         """
         try:
             issue_types = self.get_project_issue_types(project_key)
@@ -818,12 +818,35 @@ class IssuesMixin(
             for issue_type in issue_types:
                 type_name = issue_type.get("name", "")
                 if type_name.lower() == "epic":
-                    return issue_type.get("id")
-            # Second pass: fallback to any type containing "epic"
+                    type_id = issue_type.get("id")
+                    return str(type_id) if type_id is not None else None
+
+            # Second pass: identify the type structurally from its create fields.
+            # Jira Server/DC localizes issue type names but keeps the GreenHopper
+            # Epic Name field schema stable.
+            for issue_type in issue_types:
+                if issue_type.get("subtask") is True:
+                    continue
+                type_id = issue_type.get("id")
+                if type_id is None:
+                    continue
+                type_id_str = str(type_id)
+                create_fields = self.get_create_fields(project_key, type_id_str)
+                for field in create_fields:
+                    schema = field.get("schema", {})
+                    if (
+                        isinstance(schema, dict)
+                        and schema.get("custom") == _EPIC_NAME_FIELD_SCHEMA
+                    ):
+                        return type_id_str
+
+            # Final pass: retain the existing localized-name heuristic when
+            # create metadata is unavailable (for example, some Cloud projects).
             for issue_type in issue_types:
                 type_name = issue_type.get("name", "")
                 if self._is_epic_issue_type(type_name):
-                    return issue_type.get("id")
+                    type_id = issue_type.get("id")
+                    return str(type_id) if type_id is not None else None
             return None
         except Exception as e:
             logger.warning(f"Could not get issue types for project {project_key}: {e}")

--- a/src/mcp_atlassian/jira/protocols.py
+++ b/src/mcp_atlassian/jira/protocols.py
@@ -77,6 +77,14 @@ class IssueOperationsProto(Protocol):
     ) -> JiraIssue:
         """Get a Jira issue by key."""
 
+    @abstractmethod
+    def _find_epic_issue_type_id(self, project_key: str) -> str | None:
+        """Find the Epic issue type ID for a project."""
+
+    @abstractmethod
+    def _is_epic_issue_type(self, issue_type: str) -> bool:
+        """Return whether an issue type name is recognized as an Epic."""
+
 
 class SearchOperationsProto(Protocol):
     """Protocol defining search operations interface."""
@@ -210,7 +218,7 @@ class FieldsOperationsProto(Protocol):
         Get required fields for creating an issue of a specific type in a project.
 
         Args:
-            issue_type: The issue type (e.g., 'Bug', 'Story', 'Epic')
+            issue_type: The issue type name or ID (e.g., 'Bug' or '10001')
             project_key: The project key (e.g., 'PROJ')
 
         Returns:
@@ -233,6 +241,12 @@ class ProjectsOperationsProto(Protocol):
         Returns:
             List of issue type data dictionaries
         """
+
+    @abstractmethod
+    def get_create_fields(
+        self, project_key: str, issue_type_id: str
+    ) -> list[dict[str, Any]]:
+        """Get fields available when creating an issue of a given type."""
 
 
 @runtime_checkable

--- a/tests/unit/jira/test_epics.py
+++ b/tests/unit/jira/test_epics.py
@@ -233,6 +233,7 @@ class TestEpicsMixin:
 
     def test_prepare_epic_fields_with_required_epic_name(self, epics_mixin: EpicsMixin):
         """Test Epic field preparation when Epic Name is a required field."""
+        epics_mixin._find_epic_issue_type_id = MagicMock(return_value="10001")
         # Mock get_field_ids_to_epic to return field IDs
         epics_mixin.get_field_ids_to_epic = MagicMock(
             return_value={
@@ -266,7 +267,7 @@ class TestEpicsMixin:
         assert kwargs["__epic_color_value"] == "blue"
 
         # Verify get_required_fields was called with correct parameters
-        epics_mixin.get_required_fields.assert_called_once_with("Epic", "TEST")
+        epics_mixin.get_required_fields.assert_called_once_with("10001", "TEST")
 
     def test_prepare_epic_fields_with_optional_epic_name(self, epics_mixin: EpicsMixin):
         """Test Epic field preparation when Epic Name is not a required field."""
@@ -580,6 +581,28 @@ class TestEpicsMixin:
         ):
             epics_mixin.link_issue_to_epic("TEST-123", "TEST-456")
 
+    def test_link_issue_to_localized_epic_by_issue_type_id(
+        self, epics_mixin: EpicsMixin
+    ):
+        """Accept a localized Epic when its stable issue type ID matches."""
+        epics_mixin.jira.get_issue.side_effect = [
+            {"key": "TEST-123"},
+            {
+                "key": "EPIC-456",
+                "fields": {
+                    "project": {"key": "TEST"},
+                    "issuetype": {"id": "10001", "name": "Эпик"},
+                },
+            },
+        ]
+        epics_mixin._find_epic_issue_type_id = MagicMock(return_value="10001")
+        epics_mixin.get_field_ids_to_epic = MagicMock(return_value={})
+
+        result = epics_mixin.link_issue_to_epic("TEST-123", "EPIC-456")
+
+        assert result == epics_mixin.get_issue.return_value
+        epics_mixin._find_epic_issue_type_id.assert_called_once_with("TEST")
+
     def test_link_issue_to_epic_all_methods_fail(self, epics_mixin: EpicsMixin):
         """Test link_issue_to_epic when all linking methods fail."""
         # Setup mocks
@@ -676,6 +699,36 @@ class TestEpicsMixin:
             ValueError, match="Issue TEST-123 is not an Epic, it is a Task"
         ):
             epics_mixin.get_epic_issues("TEST-123")
+
+    def test_get_epic_issues_accepts_localized_epic_by_issue_type_id(
+        self, epics_mixin: EpicsMixin
+    ):
+        """Accept a localized Epic when project metadata identifies its type ID."""
+        from mcp_atlassian.models.jira import JiraSearchResult
+
+        epics_mixin.jira.get_issue.return_value = {
+            "key": "EPIC-123",
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"id": "10001", "name": "Эпик"},
+            },
+        }
+        epics_mixin._find_epic_issue_type_id = MagicMock(return_value="10001")
+        epics_mixin.get_field_ids_to_epic = MagicMock(
+            return_value={"epic_link": "customfield_10014"}
+        )
+        epics_mixin.search_issues = MagicMock(
+            return_value=JiraSearchResult(
+                issues=[JiraIssue(key="TEST-456", summary="Issue 1")],
+                total=1,
+                start_at=0,
+            )
+        )
+
+        result = epics_mixin.get_epic_issues("EPIC-123")
+
+        assert [issue.key for issue in result] == ["TEST-456"]
+        epics_mixin._find_epic_issue_type_id.assert_called_once_with("TEST")
 
     def test_get_epic_issues_no_results(self, epics_mixin):
         """Test get_epic_issues when no results are found."""

--- a/tests/unit/jira/test_fields.py
+++ b/tests/unit/jira/test_fields.py
@@ -267,6 +267,42 @@ class TestFieldsMixin:
             project="TEST", issue_type_id="10001"
         )
 
+    def test_get_required_fields_accepts_issue_type_id(self, fields_mixin: FieldsMixin):
+        """Resolve required fields by stable ID for localized issue types."""
+        fields_mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Эпик"}]
+        )
+        fields_mixin.jira.issue_createmeta_fieldtypes.return_value = {
+            "values": [
+                {
+                    "required": True,
+                    "fieldId": "customfield_10103",
+                    "name": "Epic Name",
+                    "schema": {
+                        "type": "string",
+                        "custom": "com.pyxis.greenhopper.jira:gh-epic-label",
+                    },
+                }
+            ]
+        }
+
+        result = fields_mixin.get_required_fields("10001", "TEST")
+
+        assert result == {
+            "customfield_10103": {
+                "required": True,
+                "fieldId": "customfield_10103",
+                "name": "Epic Name",
+                "schema": {
+                    "type": "string",
+                    "custom": "com.pyxis.greenhopper.jira:gh-epic-label",
+                },
+            }
+        }
+        fields_mixin.jira.issue_createmeta_fieldtypes.assert_called_once_with(
+            project="TEST", issue_type_id="10001"
+        )
+
     def test_get_required_fields_not_found(self, fields_mixin: FieldsMixin):
         """Test get_required_fields handles project/issue type not found."""
         # Scenario 1: Issue type not found in project

--- a/tests/unit/jira/test_issue_creation_logic.py
+++ b/tests/unit/jira/test_issue_creation_logic.py
@@ -40,6 +40,9 @@ class ConcreteIssuesMixin(
     def get_project_issue_types(self, project_key):
         pass
 
+    def get_create_fields(self, project_key, issue_type_id):
+        pass
+
     def get_required_fields(self, project_key, issue_type_name):
         pass
 
@@ -77,6 +80,7 @@ def issues_mixin():
         mixin.config = mock_config
         # Mock methods that are not part of the mixin but are called by it
         mixin.get_project_issue_types = MagicMock()
+        mixin.get_create_fields = MagicMock(return_value=[])
         mixin._markdown_to_jira = MagicMock(side_effect=lambda x: x)
         mixin._get_account_id = MagicMock(return_value="account_id_123")
         mixin._add_assignee_to_fields = MagicMock()
@@ -176,6 +180,28 @@ def test_find_epic_issue_type_id_prefers_exact_match(issues_mixin):
     ]
 
     epic_id = issues_mixin._find_epic_issue_type_id("PROJ")
+    assert epic_id == "10001"
+
+
+def test_find_epic_issue_type_id_uses_epic_name_schema(issues_mixin):
+    """Identify a localized Epic from its project-scoped Epic Name field."""
+    issues_mixin.get_project_issue_types.return_value = [
+        {"id": "10099", "name": "Team Epic", "subtask": False},
+        {"id": "10001", "name": "Initiative", "subtask": False},
+    ]
+    issues_mixin.get_create_fields.side_effect = lambda _project, type_id: (
+        [
+            {
+                "fieldId": "customfield_10103",
+                "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-label"},
+            }
+        ]
+        if type_id == "10001"
+        else []
+    )
+
+    epic_id = issues_mixin._find_epic_issue_type_id("PROJ")
+
     assert epic_id == "10001"
 
 


### PR DESCRIPTION
## Description

Fixes #1552

Jira Server/Data Center can localize issue type display names, so Epic operations cannot rely on the English name `Epic`. This change keeps the exact English fast path used by Jira Cloud, discovers the project Epic structurally from the stable Epic Name field schema when needed, and retains the existing localized-name fallback when create metadata is unavailable.

## Changes

- Discover the project Epic issue type from `com.pyxis.greenhopper.jira:gh-epic-label` before falling back to name heuristics.
- Allow required create fields to be resolved by issue type ID and use the discovered Epic ID during field preparation.
- Validate localized Epic targets by project and issue type ID in linking and Epic issue retrieval.
- Add offline regression coverage for schema discovery, ID-based required fields, and Russian `Эпик` operations.

## Testing

- [x] Unit tests added/updated
- [x] Jira Server/Data Center verification passed
- [x] Jira Cloud smoke verification passed
- [x] Generated tool documentation is current

```text
uv run pytest tests/unit/jira -q
1158 passed

uv run python scripts/generate_tool_docs.py --check
OK: generated tool documentation is up to date.
```

Maintainer verification used Jira Data Center 10.3.22. A temporary Scrum project confirmed that real DC create metadata exposes the stable Epic Name schema, structural Epic discovery resolves the correct type ID, Epic creation succeeds, and task-to-Epic linking succeeds. The created issues and temporary project were removed afterward.

A direct Jira Cloud check also created and deleted an Epic successfully. The combined Cloud pytest fixture could not start because its unrelated Confluence health check returned 503, so the Jira-only path was verified directly with the same configured Cloud credentials.

## Checklist

- [x] Code follows project style guidelines (linting passes).
- [x] Tests added/updated for changes.
- [x] Relevant tests pass.
- [x] Documentation updated (not needed; no tool signatures or registrations changed).
