### PR TITLE
fix(jira): preserve list markers before emphasis conversion

### DIFF
--- a/src/mcp_atlassian/preprocessing/jira.py
+++ b/src/mcp_atlassian/preprocessing/jira.py
@@ -272,6 +272,15 @@ class JiraPreprocessor(BasePreprocessor):
         # Block quotes
         output = re.sub(r"^bq\.(.*?)$", r"> \1\n", output, flags=re.MULTILINE)
 
+        # Convert list markers before emphasis so leading asterisks do not
+        # pair with bold delimiters or get counted as extra nesting (#1651).
+        output = re.sub(
+            r"^((?:#|-|\+|\*)+) (.*)$",
+            lambda match: self._convert_jira_list_to_markdown(match),
+            output,
+            flags=re.MULTILINE,
+        )
+
         # Text formatting (bold, italic). Delimiters preceded by a backslash
         # are wiki escapes (e.g. the intraword `\_` this module's
         # markdown_to_jira writes), not markup, so they must neither open nor
@@ -284,14 +293,6 @@ class JiraPreprocessor(BasePreprocessor):
                 + ("**" if match.group(1) == "*" else "*")
             ),
             output,
-        )
-
-        # Multi-level numbered list
-        output = re.sub(
-            r"^((?:#|-|\+|\*)+) (.*)$",
-            lambda match: self._convert_jira_list_to_markdown(match),
-            output,
-            flags=re.MULTILINE,
         )
 
         # Headers

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -312,6 +312,26 @@ For more information, see [our website|https://example.com].
     assert "[our website](https://example.com)" in converted
 
 
+@pytest.mark.parametrize(
+    ("wiki", "expected"),
+    [
+        ("* Item with *bold text*.", "- Item with **bold text**."),
+        ("* Item with *two* bold *spans*.", "- Item with **two** bold **spans**."),
+        ("* Item with a lone * asterisk.", "- Item with a lone * asterisk."),
+        ("** Level two.", "  - Level two."),
+        ("*** Level three.", "    - Level three."),
+        ("** Nested *bold* and _italic_.", "  - Nested **bold** and *italic*."),
+        ("*# Ordered *child*.", "  1. Ordered **child**."),
+        ("#* Unordered *child*.", "  - Unordered **child**."),
+    ],
+)
+def test_jira_to_markdown_list_markers_are_not_emphasis(
+    preprocessor_with_jira, wiki, expected
+):
+    """Preserve list depth and format emphasis within the item body (#1651)."""
+    assert preprocessor_with_jira.jira_to_markdown(wiki) == expected
+
+
 def test_jira_to_markdown_citation(preprocessor_with_jira):
     """Test citation markup conversion and that unmatched ?? does not cause ReDoS."""
     # Matched citation


### PR DESCRIPTION
## Description

Jira list markers are interpreted as emphasis delimiters before list conversion, corrupting bold text and inflating nesting depth. For example, `** Level two.` becomes a list item indented by six spaces instead of two.

Fixes #1651.

## Changes

- Run the existing list-marker conversion before emphasis conversion.
- Add eight regression cases covering bold text, literal asterisks, nested bullets, and mixed ordered/unordered markers.

## Testing

- [x] Unit tests added: all eight new cases fail before the fix and pass afterward.
- [x] Full preprocessing unit suite: 181 passed with no skips.
- [x] Full unit suite: 3,903 passed; 5 pre-existing environment-gated tests skipped.
- [x] Non-live integration smoke suite: 8 passed; live-service cases remained behind their explicit suite gates.
- [x] Ruff lint/format and mypy checks pass for both changed files.
- [x] Generated tool documentation is current (98 tools, 25 toolsets).
- [x] `git diff --check` passes.
- [x] GitHub checks pass on Python 3.10 through 3.13.

No live Jira or Confluence testing was performed. No tool signatures or generated documentation changed.
